### PR TITLE
feat: 会话列表 + Trajectory + 审批/Steer 对齐 dsh

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -17,7 +17,9 @@
 11. **Web：agents 驱动输入** — 发送走 `/api/sessions/:id/messages`，可取消；WS 收 `session` / `agent` / `approval`。
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
+14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；工具行可 `inspectCall` 跳到对应 seq 并高亮。
 
 ## 刻意不吸收
 
-多层 profile/bundle/patch、巨型 ToolRuntime、符号后门调度、仓库级 verify 矩阵、完整 ConversationNode 引擎 / `__DSH_BOOT__` 动态 client 包 / Trajectory 虚表。扩展继续用薄 Service + 单测证明。
+多层 profile/bundle/patch、巨型 ToolRuntime、符号后门调度、仓库级 verify 矩阵、完整 ConversationNode 引擎 / `__DSH_BOOT__` 动态 client 包 / Trajectory 虚表与工作区 dock。扩展继续用薄 Service + 单测证明。

--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -19,6 +19,22 @@
 13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
 15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；工具行可 `inspectCall` 跳到对应 seq 并高亮。
+16. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
+17. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
+
+## 功能级差异（相对官方 client，优点对齐后）
+
+| 能力 | 本仓 | 官方 | 策略 |
+|---|---|---|---|
+| 会话列表 / New / Fork | 有 | 有 | 已对齐（瘦） |
+| Chat 事件投影 | 有 | ConversationNode | 已对齐（瘦投影） |
+| Trajectory 账本 + inspect | 有 | ui-trajectory | 已对齐（无虚表） |
+| 审批 dock + mode | 有 | Permission + ApprovalPanel | 已对齐（瘦） |
+| 运行中 inject | 有 | steer/queue | 已对齐（无队列编辑 UI） |
+| Trajectory 虚表/搜索 | 无 | 有 | **不吸收** |
+| Workspace dock | 无 | ui-workspace | **不吸收** |
+| Goals / Plan / Attachments | 无 | 对应 ui-* | 需 host 域；暂不吸收 |
+| Jobs / Subagent 导航 | host 有、Web 薄 | ui-jobs / ui-subagent | 后续可选薄面 |
 
 ## 刻意不吸收
 

--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -103,10 +103,41 @@ export function apply(ctx: Context) {
     const record = await ctx.sessions.create()
     route.send(201, { id: record.id, version: record.version })
   })
+  ctx.http.route('GET', '/api/sessions', async (route) => {
+    const ids = await ctx.sessions.list()
+    const items = []
+    for (const id of ids) {
+      const record = await ctx.sessions.get(id)
+      if (!record) continue
+      const users = record.events.filter((event) => event.type === 'user/message')
+      const lastUser = users.at(-1)
+      const title =
+        lastUser && 'text' in lastUser && typeof lastUser.text === 'string'
+          ? lastUser.text.slice(0, 48) || id.slice(0, 8)
+          : id.slice(0, 8)
+      items.push({
+        id,
+        version: record.version,
+        eventCount: record.events.length,
+        title,
+        updatedAt: record.events.at(-1)?.ts ?? 0,
+      })
+    }
+    items.sort((a, b) => b.updatedAt - a.updatedAt)
+    route.send(200, { sessions: items })
+  })
   ctx.http.route('GET', '/api/sessions/:id', async (route) => {
     const record = await ctx.sessions.get(route.params.id)
     if (!record) return route.send(404, { error: 'unknown session' })
     route.send(200, { id: record.id, version: record.version, events: record.events, messages: ctx.sessions.deriveMessages(record.id) })
+  })
+  ctx.http.route('POST', '/api/sessions/:id/fork', async (route) => {
+    try {
+      const child = await ctx.sessions.fork(route.params.id)
+      route.send(201, { id: child.id, version: child.version, parentId: route.params.id })
+    } catch (error) {
+      route.send(400, { error: String(error) })
+    }
   })
   ctx.http.route('POST', '/api/sessions/:id/messages', async (route) => {
     const payload = (await route.json()) as { text?: string; kind?: 'wake' | 'inject' }

--- a/src/plugins/contributors/chat/approvals.tsx
+++ b/src/plugins/contributors/chat/approvals.tsx
@@ -5,11 +5,29 @@ export function ApprovalsRail(props: SlotProps) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const sessionView = props.sessionView as SessionViewService
   const approvals = useSessionView((state) => state.approvals)
-
-  if (!approvals.length) return null
+  const approvalMode = useSessionView((state) => state.approvalMode)
 
   return (
     <div className="mx-auto w-full max-w-[calc(var(--dsw-chat-width)+32px)] space-y-2">
+      <div className="flex items-center justify-between gap-2 px-1 text-[11px] text-[var(--dsw-label-3)]">
+        <span>Tool approvals</span>
+        <div className="flex overflow-hidden rounded-full border border-[var(--dsw-border)]">
+          {(['auto', 'hold'] as const).map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              className={`px-2.5 py-1 capitalize ${
+                approvalMode === mode
+                  ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
+                  : 'hover:bg-black/[0.03]'
+              }`}
+              onClick={() => void sessionView.setApprovalMode(mode)}
+            >
+              {mode}
+            </button>
+          ))}
+        </div>
+      </div>
       {approvals.map((item) => (
         <div
           key={item.id}

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -11,10 +11,10 @@ export function ChatComposer(props: SlotProps) {
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
     const content = input.trim()
-    if (!content || pending) return
+    if (!content) return
     setInput('')
     try {
-      await sessionView.send(content)
+      await sessionView.send(content, pending ? 'inject' : 'wake')
     } catch {
       /* error 已写入 sessionView */
     }
@@ -30,8 +30,7 @@ export function ChatComposer(props: SlotProps) {
         className="max-h-40 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3.5 pb-2 text-[15px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)]"
         value={input}
         rows={1}
-        disabled={pending}
-        placeholder="Message DeepSeek Harness…"
+        placeholder={pending ? 'Steer while running…' : 'Message DeepSeek Harness…'}
         aria-label="对话输入"
         onChange={(event) => setInput(event.target.value)}
         onKeyDown={(event) => {
@@ -43,13 +42,23 @@ export function ChatComposer(props: SlotProps) {
       />
       <div className="flex items-center justify-end gap-2 px-3 pb-3">
         {pending ? (
-          <button
-            className="rounded-full border border-[var(--dsw-border)] px-3 py-1.5 text-xs text-[var(--dsw-label-2)] hover:bg-black/5"
-            type="button"
-            onClick={() => void sessionView.cancel()}
-          >
-            Cancel
-          </button>
+          <>
+            <button
+              className="rounded-full border border-[var(--dsw-border)] px-3 py-1.5 text-xs text-[var(--dsw-label-2)] hover:bg-black/5"
+              type="button"
+              onClick={() => void sessionView.cancel()}
+            >
+              Cancel
+            </button>
+            <button
+              className="rounded-full px-3 py-1.5 text-xs text-white disabled:opacity-40"
+              style={{ background: 'var(--dsw-business)' }}
+              type="submit"
+              disabled={!input.trim()}
+            >
+              Steer
+            </button>
+          </>
         ) : (
           <button
             className="grid size-8 place-items-center rounded-full text-white disabled:opacity-40"

--- a/src/plugins/contributors/chat/index.test.ts
+++ b/src/plugins/contributors/chat/index.test.ts
@@ -8,7 +8,7 @@ import * as sessionView from '../../infrastructure/session-view.ts'
 import * as chat from './index.ts'
 import * as shell from '../shell.tsx'
 
-test('one plugin fills thread, composer, approvals dock and settings', async () => {
+test('one plugin fills thread, trajectory, composer, approvals dock and settings', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
@@ -18,6 +18,7 @@ test('one plugin fills thread, composer, approvals dock and settings', async () 
   await ctx.plugin(shell)
   assert.equal(ctx.slots.list('composer')[0]?.id, 'chat')
   assert.equal(ctx.slots.list('stage').some((item) => item.id === 'chat-thread'), true)
+  assert.equal(ctx.slots.list('trajectory').some((item) => item.id === 'trajectory'), true)
   assert.equal(ctx.slots.list('dock').some((item) => item.id === 'approvals'), true)
   assert.equal(ctx.slots.list('settings')[0]?.id, 'chat-config')
 })

--- a/src/plugins/contributors/chat/index.ts
+++ b/src/plugins/contributors/chat/index.ts
@@ -4,6 +4,7 @@ import { ApprovalsRail } from './approvals.tsx'
 import { ChatComposer } from './composer.tsx'
 import { ChatConfig } from './config.tsx'
 import { ChatThread } from './thread.tsx'
+import { TrajectoryView } from './trajectory.tsx'
 
 export const name = 'chat-ui'
 export const inject = ['slots', 'sessionView']
@@ -15,6 +16,7 @@ export function apply(ctx: Context) {
     sessionView: view,
   })
   ctx.slots.place('stage', ChatThread, { key: 'chat-thread', order: 1, props })
+  ctx.slots.place('trajectory', TrajectoryView, { key: 'trajectory', order: 1, props })
   ctx.slots.place('composer', ChatComposer, { key: 'chat', order: 10, props })
   ctx.slots.place('dock', ApprovalsRail, { key: 'approvals', order: 5, props })
   ctx.slots.place('settings', ChatConfig, { key: 'chat-config', order: 10 })

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -4,28 +4,43 @@ import { bindSessionView, type SessionViewService } from '../../infrastructure/s
 import type { ChatNode } from '../../infrastructure/session-project.ts'
 import { FishLogo } from '../brand.tsx'
 
-function ToolRow({ node }: { node: Extract<ChatNode, { kind: 'tool' }> }) {
+function ToolRow({
+  node,
+  onInspect,
+}: {
+  node: Extract<ChatNode, { kind: 'tool' }>
+  onInspect: (callId: string) => void
+}) {
   const [open, setOpen] = useState(false)
   const summary = node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…'
   return (
     <div className="w-full max-w-[var(--dsw-chat-width)] self-stretch">
-      <button
-        type="button"
-        className="flex w-full items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-black/[0.03]"
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span className="grid size-4 place-items-center text-[10px] text-[var(--dsw-label-3)]">{open ? '▾' : '▸'}</span>
-        <span className="font-medium">{node.name}</span>
-        <span className="text-[var(--dsw-label-3)]">·</span>
-        <span className="min-w-0 flex-1 truncate text-[var(--dsw-label-3)]">{summary}</span>
-        {node.result ? (
-          <span className={node.result.ok ? 'text-[var(--dsw-ok)]' : 'text-[var(--dsw-danger)]'}>
-            {node.result.ok ? 'ok' : 'fail'}
-          </span>
-        ) : (
-          <span className="text-[var(--dsw-label-3)]">running</span>
-        )}
-      </button>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-black/[0.03]"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="grid size-4 place-items-center text-[10px] text-[var(--dsw-label-3)]">{open ? '▾' : '▸'}</span>
+          <span className="font-medium">{node.name}</span>
+          <span className="text-[var(--dsw-label-3)]">·</span>
+          <span className="min-w-0 flex-1 truncate text-[var(--dsw-label-3)]">{summary}</span>
+          {node.result ? (
+            <span className={node.result.ok ? 'text-[var(--dsw-ok)]' : 'text-[var(--dsw-danger)]'}>
+              {node.result.ok ? 'ok' : 'fail'}
+            </span>
+          ) : (
+            <span className="text-[var(--dsw-label-3)]">running</span>
+          )}
+        </button>
+        <button
+          type="button"
+          className="shrink-0 rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-business)] hover:bg-[var(--dsw-business-soft)]"
+          onClick={() => onInspect(node.callId)}
+        >
+          Trajectory
+        </button>
+      </div>
       {open ? (
         <div className="mt-1 space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] p-3 font-mono text-xs">
           {node.arguments ? <pre className="whitespace-pre-wrap text-[var(--dsw-label-2)]">{node.arguments}</pre> : null}
@@ -36,7 +51,7 @@ function ToolRow({ node }: { node: Extract<ChatNode, { kind: 'tool' }> }) {
   )
 }
 
-function NodeView({ node }: { node: ChatNode }) {
+function NodeView({ node, onInspect }: { node: ChatNode; onInspect: (callId: string) => void }) {
   if (node.kind === 'user') {
     return (
       <div className="flex w-full justify-end">
@@ -58,7 +73,7 @@ function NodeView({ node }: { node: ChatNode }) {
       </div>
     )
   }
-  if (node.kind === 'tool') return <ToolRow node={node} />
+  if (node.kind === 'tool') return <ToolRow node={node} onInspect={onInspect} />
   return <div className="self-center text-xs text-[var(--dsw-label-3)]">{node.text}</div>
 }
 
@@ -86,6 +101,7 @@ function EmptyHero() {
 
 export function ChatThread(props: SlotProps) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
+  const sessionView = props.sessionView as SessionViewService
   const nodes = useSessionView((state) => state.nodes)
   const pending = useSessionView((state) => state.pending)
   const agentStatus = useSessionView((state) => state.agentStatus)
@@ -104,7 +120,7 @@ export function ChatThread(props: SlotProps) {
         <span>{agentStatus === 'running' ? `Running${agentStep != null ? ` · step ${agentStep}` : ''}` : 'Idle'}</span>
       </div>
       {nodes.map((node) => (
-        <NodeView key={node.id} node={node} />
+        <NodeView key={node.id} node={node} onInspect={(callId) => sessionView.inspectCall(callId)} />
       ))}
       {error ? (
         <div className="rounded-[12px] bg-red-50 px-3 py-2 text-sm text-[var(--dsw-danger)]">{error}</div>

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import type { SlotProps } from '../../registry/slots.ts'
+import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
+
+export function TrajectoryView(props: SlotProps) {
+  const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
+  const rows = useSessionView((state) => state.trajectory)
+  const focusCallId = useSessionView((state) => state.focusCallId)
+  const sessionId = useSessionView((state) => state.sessionId)
+
+  useEffect(() => {
+    if (!focusCallId) return
+    document.getElementById(`traj-call-${focusCallId}`)?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+  }, [focusCallId, rows])
+
+  if (!sessionId) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-[var(--dsw-label-3)]">
+        Open or create a session to inspect its trajectory.
+      </div>
+    )
+  }
+
+  if (!rows.length) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-[var(--dsw-label-3)]">
+        No session events yet. Trajectory projects the append-only log.
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[var(--dsw-chat-width)] overflow-hidden rounded-[12px] border border-[var(--dsw-border)]">
+      <div className="grid grid-cols-[56px_56px_140px_minmax(0,1fr)] gap-2 border-b border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] px-3 py-2 text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">
+        <span>seq</span>
+        <span>turn</span>
+        <span>type</span>
+        <span>summary</span>
+      </div>
+      <div className="max-h-[calc(100vh-220px)] overflow-y-auto font-mono text-[12px]">
+        {rows.map((row) => {
+          const focused = Boolean(focusCallId && row.callId === focusCallId)
+          return (
+            <div
+              key={row.id}
+              id={row.callId ? `traj-call-${row.callId}` : undefined}
+              className={`grid grid-cols-[56px_56px_140px_minmax(0,1fr)] gap-2 border-b border-[var(--dsw-border)] px-3 py-2 last:border-0 ${
+                focused ? 'bg-[var(--dsw-business-soft)]' : 'hover:bg-black/[0.02]'
+              }`}
+            >
+              <span className="text-[var(--dsw-label-3)]">{row.seq}</span>
+              <span className="text-[var(--dsw-label-3)]">{row.turn ?? '—'}</span>
+              <span className="truncate text-[var(--dsw-business)]">{row.type}</span>
+              <span className="truncate text-[var(--dsw-label)]" title={row.summary}>
+                {row.summary}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export function trajectoryProps(view: SessionViewService) {
+  return { useSessionView: bindSessionView(view) }
+}

--- a/src/plugins/contributors/hello.test.ts
+++ b/src/plugins/contributors/hello.test.ts
@@ -4,12 +4,14 @@ import { Context } from 'cordis'
 import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
+import * as sessionView from '../infrastructure/session-view.ts'
 import * as hello from './hello.tsx'
 import * as shell from './shell.tsx'
 
 test('fills demos after shell opens it', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
+  await ctx.plugin(sessionView)
   await ctx.plugin(snapshot)
   await ctx.plugin(hello)
   assert.equal(ctx.slots.list('demos').length, 0)

--- a/src/plugins/contributors/nav.test.ts
+++ b/src/plugins/contributors/nav.test.ts
@@ -4,12 +4,14 @@ import { Context } from 'cordis'
 import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
+import * as sessionView from '../infrastructure/session-view.ts'
 import * as nav from './nav.tsx'
 import * as shell from './shell.tsx'
 
 test('fills sidebar', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
+  await ctx.plugin(sessionView)
   await ctx.plugin(snapshot)
   await ctx.plugin(nav)
   await ctx.plugin(shell)

--- a/src/plugins/contributors/shell.test.ts
+++ b/src/plugins/contributors/shell.test.ts
@@ -4,17 +4,20 @@ import { Context } from 'cordis'
 import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
+import * as sessionView from '../infrastructure/session-view.ts'
 import * as shell from './shell.tsx'
 
-test('declares dsh-like sidebar, demos, dock, stage, composer', async () => {
+test('declares dsh-like sidebar, demos, dock, stage, trajectory, composer', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
+  await ctx.plugin(sessionView)
   await ctx.plugin(snapshot)
   await ctx.plugin(shell)
   assert.equal(ctx.slots.specOf('sidebar')?.kind, 'single')
   assert.equal(ctx.slots.specOf('demos')?.kind, 'list')
   assert.equal(ctx.slots.specOf('dock')?.kind, 'list')
   assert.equal(ctx.slots.specOf('stage')?.kind, 'list')
+  assert.equal(ctx.slots.specOf('trajectory')?.kind, 'list')
   assert.equal(ctx.slots.specOf('composer')?.kind, 'single')
   assert.equal(ctx.slots.specOf('settings')?.kind, 'list')
   assert.equal(ctx.slots.specOf('log')?.kind, 'single')

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -1,22 +1,30 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
 import { bindSnapshot, type Snapshot, type SnapshotService } from '../infrastructure/snapshot.ts'
+import { bindSessionView, type SessionViewService } from '../infrastructure/session-view.ts'
 import { BrandWordmark, FishLogo } from './brand.tsx'
 
 export const name = 'shell'
-export const inject = ['slots', 'snapshot']
+export const inject = ['slots', 'snapshot', 'sessionView']
 
 function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
+  const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
+  const sessionView = props.sessionView as SessionViewService
   const snap = useSnapshot((state: Snapshot) => state)
   const live = snap.plugins.some((plugin) => plugin.enabled)
+  const sessions = useSessionView((state) => state.sessions)
+  const sessionId = useSessionView((state) => state.sessionId)
+  const view = useSessionView((state) => state.view)
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const sessionHint = snap.lastSessionId?.slice(0, 8)
+
+  useEffect(() => {
+    void sessionView.refreshSessions()
+  }, [sessionView])
 
   return (
     <div className="grid min-h-screen grid-cols-[280px_minmax(0,1fr)] bg-[var(--dsw-bg)] text-[var(--dsw-label)]">
-      {/* Left sidebar — DSH: brand / new session / list / settings */}
       <aside className="flex flex-col border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
         <div className="flex items-center justify-between px-4 pt-4 pb-3">
           <BrandWordmark />
@@ -25,25 +33,47 @@ function Shell(props: SlotProps) {
           <button
             type="button"
             className="flex w-full items-center justify-center gap-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-2 text-sm font-medium hover:bg-[var(--dsw-business-soft)]"
-            onClick={() => location.reload()}
+            onClick={() => void sessionView.newSession()}
           >
             <span className="text-lg leading-none">+</span>
             New Session
           </button>
         </div>
         <div className="flex-1 overflow-y-auto px-3">
-          <div className="mb-2 px-1 text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">
-            Sessions
+          <div className="mb-2 flex items-center justify-between px-1">
+            <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Sessions</span>
+            {sessionId ? (
+              <button
+                type="button"
+                className="text-[11px] text-[var(--dsw-business)] hover:underline"
+                onClick={() => void sessionView.forkCurrent()}
+              >
+                Fork
+              </button>
+            ) : null}
           </div>
-          <button
-            type="button"
-            className="mb-1 w-full rounded-[12px] bg-[var(--dsw-business-soft)] px-3 py-2 text-left text-sm text-[var(--dsw-business)]"
-          >
-            {sessionHint ? `session ${sessionHint}` : 'Current session'}
-          </button>
-          <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">
-            会话列表由 session log 投影；此处为 lean 占位。
-          </p>
+          {sessions.length === 0 ? (
+            <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No sessions yet. Send a message or create one.</p>
+          ) : (
+            sessions.map((item) => {
+              const active = item.id === sessionId
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  className={`mb-1 w-full rounded-[12px] px-3 py-2 text-left text-sm ${
+                    active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
+                  }`}
+                  onClick={() => void sessionView.load(item.id)}
+                >
+                  <div className="truncate font-medium">{item.title}</div>
+                  <div className="mt-0.5 font-mono text-[10px] opacity-70">
+                    {item.id.slice(0, 8)} · {item.eventCount} events
+                  </div>
+                </button>
+              )
+            })
+          )}
         </div>
         <div className="flex items-center justify-between gap-2 border-t border-[var(--dsw-border)] px-3 py-3">
           <span
@@ -69,25 +99,40 @@ function Shell(props: SlotProps) {
         </div>
       </aside>
 
-      {/* Center conversation */}
       <main className="flex min-w-0 flex-col">
         <header className="flex h-12 items-center gap-4 border-b border-[var(--dsw-border)] px-6">
-          <div className="relative pb-3 pt-3 text-[13px] font-medium text-[var(--dsw-business)]">
+          <button
+            type="button"
+            className={`relative pb-3 pt-3 text-[13px] font-medium ${view === 'chat' ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`}
+            onClick={() => sessionView.setView('chat')}
+          >
             Chat
-            <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" />
-          </div>
-          <div className="pb-3 pt-3 text-[13px] font-medium text-[var(--dsw-label-3)]">Trajectory</div>
+            {view === 'chat' ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+          </button>
+          <button
+            type="button"
+            className={`relative pb-3 pt-3 text-[13px] font-medium ${view === 'trajectory' ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`}
+            onClick={() => sessionView.setView('trajectory')}
+          >
+            Trajectory
+            {view === 'trajectory' ? (
+              <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" />
+            ) : null}
+          </button>
         </header>
         <div className="mx-auto flex w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col px-4 pb-4">
-          <div className="flex flex-1 flex-col overflow-y-auto py-4">{props.renderSlot('stage')}</div>
-          <div className="sticky bottom-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
-            {props.renderSlot('dock')}
-            {props.renderSlot('composer')}
+          <div className="flex flex-1 flex-col overflow-y-auto py-4">
+            {view === 'chat' ? props.renderSlot('stage') : props.renderSlot('trajectory')}
           </div>
+          {view === 'chat' ? (
+            <div className="sticky bottom-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
+              {props.renderSlot('dock')}
+              {props.renderSlot('composer')}
+            </div>
+          ) : null}
         </div>
       </main>
 
-      {/* Settings modal — DSH uses centered panel; demos + plugins live here */}
       <div
         className={`fixed inset-0 z-20 flex items-center justify-center bg-black/40 ${settingsOpen ? '' : 'hidden'}`}
         onClick={() => setSettingsOpen(false)}
@@ -157,11 +202,16 @@ export function apply(ctx: Context) {
       demos: { kind: 'list' },
       dock: { kind: 'list' },
       stage: { kind: 'list' },
+      trajectory: { kind: 'list' },
       composer: { kind: 'single' },
       settings: { kind: 'list' },
       log: { kind: 'single' },
       routes: { kind: 'single' },
     },
-    props: () => ({ useSnapshot: bindSnapshot(ctx.snapshot as SnapshotService) }),
+    props: () => ({
+      useSnapshot: bindSnapshot(ctx.snapshot as SnapshotService),
+      useSessionView: bindSessionView(ctx.sessionView as SessionViewService),
+      sessionView: ctx.sessionView as SessionViewService,
+    }),
   })
 }

--- a/src/plugins/infrastructure/react-host.test.ts
+++ b/src/plugins/infrastructure/react-host.test.ts
@@ -5,6 +5,7 @@ import { Context } from 'cordis'
 import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from './snapshot.ts'
+import * as sessionView from './session-view.ts'
 import * as reactHost from './react-host.ts'
 import * as shell from '../contributors/shell.tsx'
 
@@ -12,6 +13,7 @@ test('paints shell into el', async () => {
   const el = document.createElement('div')
   const ctx = new Context()
   await ctx.plugin(slots)
+  await ctx.plugin(sessionView)
   await ctx.plugin(snapshot)
   await act(async () => {
     await ctx.plugin(reactHost, { el })

--- a/src/plugins/infrastructure/renderer.test.ts
+++ b/src/plugins/infrastructure/renderer.test.ts
@@ -5,6 +5,7 @@ import { Context } from 'cordis'
 import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from './snapshot.ts'
+import * as sessionView from './session-view.ts'
 import * as shell from '../contributors/shell.tsx'
 import * as hello from '../contributors/hello.tsx'
 import * as quotes from '../contributors/quotes.tsx'
@@ -13,6 +14,7 @@ import { renderRoot } from './renderer.tsx'
 test('list sorts by order; demos show after shell opens', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
+  await ctx.plugin(sessionView)
   await ctx.plugin(snapshot)
   await ctx.plugin(quotes)
   await ctx.plugin(hello)

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { projectNodes, type SessionEvent } from './session-project.ts'
+import { projectNodes, projectTrajectory, type SessionEvent } from './session-project.ts'
 
 test('projects user, streaming assistant, tool call/result from session events', () => {
   const events: SessionEvent[] = [
@@ -29,4 +29,21 @@ test('turn/end non-complete becomes a status row', () => {
   ])
   assert.equal(nodes[0]?.kind, 'turn')
   assert.match(nodes[0]?.kind === 'turn' ? nodes[0].text : '', /cancelled/)
+})
+
+test('projectTrajectory keeps seq ledger and tool callIds for inspect', () => {
+  const events: SessionEvent[] = [
+    { type: 'session/open', version: 1, seq: 0, ts: 1 },
+    { type: 'turn/start', turn: 1, seq: 1, ts: 2 },
+    { type: 'user/message', text: 'run bash', seq: 2, ts: 3 },
+    { type: 'tool/call', id: 'c1', name: 'bash', arguments: '{"command":"ls"}', seq: 3, ts: 4 },
+    { type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 4, ts: 5 },
+    { type: 'turn/end', turn: 1, reason: 'complete', seq: 5, ts: 6 },
+  ]
+  const rows = projectTrajectory(events)
+  assert.equal(rows.some((row) => row.type === 'session/open'), false)
+  const call = rows.find((row) => row.type === 'tool/call')
+  assert.equal(call?.callId, 'c1')
+  assert.equal(call?.turn, 1)
+  assert.match(call?.summary ?? '', /bash/)
 })

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -94,3 +94,47 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
   }
   return nodes
 }
+
+/** Lean Trajectory 行：官方 ui-trajectory 的瘦投影，不搬虚表/搜索索引。 */
+export interface TrajectoryRow {
+  id: string
+  seq: number
+  turn: number | null
+  type: SessionEvent['type']
+  summary: string
+  callId?: string
+}
+
+export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
+  let turn: number | null = null
+  const rows: TrajectoryRow[] = []
+  for (const event of events) {
+    if (event.type === 'turn/start') turn = event.turn
+    if (event.type === 'session/open') continue
+    let summary: string = event.type
+    let callId: string | undefined
+    if (event.type === 'user/message' || event.type === 'assistant/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
+      summary = event.text.slice(0, 120)
+    } else if (event.type === 'tool/call') {
+      callId = event.id
+      summary = `${event.name}(${event.arguments.slice(0, 80)})`
+    } else if (event.type === 'tool/result') {
+      callId = event.id
+      summary = `${event.name} → ${event.ok ? 'ok' : 'fail'}: ${event.detail.slice(0, 80)}`
+    } else if (event.type === 'turn/end') {
+      summary = `end · ${event.reason}`
+    } else if (event.type === 'step/start' || event.type === 'step/end') {
+      summary = `step ${event.step}`
+    }
+    rows.push({
+      id: `tr-${event.seq}`,
+      seq: event.seq,
+      turn,
+      type: event.type,
+      summary,
+      callId,
+    })
+    if (event.type === 'turn/end') turn = null
+  }
+  return rows
+}

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -1,0 +1,91 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import '../../types.ts'
+import * as sessionView from './session-view.ts'
+import { SessionViewService } from './session-view.ts'
+
+function mockFetch(handlers: Record<string, (init?: RequestInit) => unknown>) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    calls.push({ url, init })
+    for (const [prefix, handler] of Object.entries(handlers)) {
+      if (url.includes(prefix)) {
+        const body = handler(init)
+        return {
+          ok: true,
+          status: 200,
+          json: async () => body,
+        } as Response
+      }
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+  return calls
+}
+
+test('refreshApprovals rehydrates mode and pending', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({
+      mode: 'hold',
+      pending: [{ id: 'a1', name: 'bash', args: { command: 'ls' } }],
+    }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshApprovals()
+  assert.equal(view.get().approvalMode, 'hold')
+  assert.equal(view.get().approvals[0]?.id, 'a1')
+})
+
+test('setApprovalMode posts and updates state', async () => {
+  const calls = mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals/mode': () => ({ mode: 'hold' }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.setApprovalMode('hold')
+  assert.equal(view.get().approvalMode, 'hold')
+  assert.equal(
+    calls.some((call) => call.url.includes('/api/approvals/mode') && call.init?.method === 'POST'),
+    true,
+  )
+})
+
+test('send inject posts kind without clearing running state', async () => {
+  const calls = mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+    '/api/sessions/s1/messages': () => ({ sessionId: 's1', queued: true }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.setAgentStatus('running', 1)
+  await view.send('nudge', 'inject')
+  const injectCall = calls.find((call) => call.url.includes('/messages'))
+  assert.ok(injectCall)
+  assert.match(String(injectCall!.init?.body), /"kind":"inject"/)
+  assert.equal(view.get().agentStatus, 'running')
+  assert.equal(view.get().pending, true)
+})
+
+test('inspectCall switches to trajectory with focus', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.inspectCall('c1')
+  assert.equal(view.get().view, 'trajectory')
+  assert.equal(view.get().focusCallId, 'c1')
+})

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -22,6 +22,7 @@ export interface SessionListItem {
 }
 
 export type ConversationView = 'chat' | 'trajectory'
+export type ApprovalMode = 'auto' | 'hold'
 
 export interface SessionViewState {
   sessionId: string | null
@@ -34,6 +35,7 @@ export interface SessionViewState {
   agentStatus: 'idle' | 'running'
   agentStep?: number
   pending: boolean
+  approvalMode: ApprovalMode
   approvals: ApprovalItem[]
   error?: string
 }
@@ -47,6 +49,7 @@ const empty: SessionViewState = {
   view: 'chat',
   agentStatus: 'idle',
   pending: false,
+  approvalMode: 'auto',
   approvals: [],
 }
 
@@ -57,6 +60,7 @@ export class SessionViewService extends Service {
   constructor(ctx: Context) {
     super(ctx, 'sessionView')
     void this.refreshSessions()
+    void this.refreshApprovals()
   }
 
   subscribe = (listener: () => void) => {
@@ -115,12 +119,40 @@ export class SessionViewService extends Service {
     }
   }
 
+  async refreshApprovals() {
+    try {
+      const res = await fetch('/api/approvals')
+      if (!res.ok) return
+      const body = (await res.json()) as {
+        mode?: ApprovalMode
+        pending?: ApprovalItem[]
+      }
+      this.replace({
+        approvalMode: body.mode === 'hold' ? 'hold' : 'auto',
+        approvals: Array.isArray(body.pending) ? body.pending : [],
+      })
+    } catch {
+      /* host 未就绪时忽略 */
+    }
+  }
+
+  async setApprovalMode(mode: ApprovalMode) {
+    const res = await fetch('/api/approvals/mode', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mode }),
+    })
+    const body = (await res.json()) as { mode?: ApprovalMode }
+    if (!res.ok) throw new Error('failed to set approval mode')
+    this.replace({ approvalMode: body.mode === 'hold' ? 'hold' : 'auto' })
+  }
+
   async newSession() {
     const res = await fetch('/api/sessions', { method: 'POST' })
     const body = (await res.json()) as { id?: string }
     if (!body.id) throw new Error('无法创建 session')
     await this.load(body.id)
-    this.replace({ view: 'chat', focusCallId: undefined, approvals: [] })
+    this.replace({ view: 'chat', focusCallId: undefined })
     await this.refreshSessions()
     return body.id
   }
@@ -143,9 +175,9 @@ export class SessionViewService extends Service {
       error: undefined,
       pending: false,
       agentStatus: 'idle',
-      approvals: [],
     })
     await this.refreshSessions()
+    await this.refreshApprovals()
   }
 
   async forkCurrent() {
@@ -159,10 +191,23 @@ export class SessionViewService extends Service {
     return body.id
   }
 
-  async send(text: string) {
+  async send(text: string, kind: 'wake' | 'inject' = 'wake') {
     const content = text.trim()
     if (!content) return
     const sessionId = await this.ensureSession()
+    if (kind === 'inject') {
+      const res = await fetch(`/api/sessions/${sessionId}/messages`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text: content, kind: 'inject' }),
+      })
+      const data = (await res.json()) as { error?: string }
+      if (!res.ok) {
+        this.replace({ error: data.error || `注入失败：${res.status}` })
+        throw new Error(data.error || `注入失败：${res.status}`)
+      }
+      return
+    }
     this.replace({ pending: true, agentStatus: 'running', error: undefined })
     try {
       const res = await fetch(`/api/sessions/${sessionId}/messages`, {

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -1,6 +1,12 @@
 import { useSyncExternalStore } from 'react'
 import { Service, type Context } from 'cordis'
-import { projectNodes, type ChatNode, type SessionEvent } from './session-project.ts'
+import {
+  projectNodes,
+  projectTrajectory,
+  type ChatNode,
+  type SessionEvent,
+  type TrajectoryRow,
+} from './session-project.ts'
 
 export interface ApprovalItem {
   id: string
@@ -8,10 +14,23 @@ export interface ApprovalItem {
   args: Record<string, unknown>
 }
 
+export interface SessionListItem {
+  id: string
+  title: string
+  eventCount: number
+  updatedAt: number
+}
+
+export type ConversationView = 'chat' | 'trajectory'
+
 export interface SessionViewState {
   sessionId: string | null
   events: SessionEvent[]
   nodes: ChatNode[]
+  trajectory: TrajectoryRow[]
+  sessions: SessionListItem[]
+  view: ConversationView
+  focusCallId?: string
   agentStatus: 'idle' | 'running'
   agentStep?: number
   pending: boolean
@@ -23,6 +42,9 @@ const empty: SessionViewState = {
   sessionId: null,
   events: [],
   nodes: [],
+  trajectory: [],
+  sessions: [],
+  view: 'chat',
   agentStatus: 'idle',
   pending: false,
   approvals: [],
@@ -34,6 +56,7 @@ export class SessionViewService extends Service {
 
   constructor(ctx: Context) {
     super(ctx, 'sessionView')
+    void this.refreshSessions()
   }
 
   subscribe = (listener: () => void) => {
@@ -43,15 +66,28 @@ export class SessionViewService extends Service {
 
   get = () => this.value
 
+  setView(view: ConversationView) {
+    this.replace({ view, focusCallId: view === 'chat' ? undefined : this.value.focusCallId })
+  }
+
+  inspectCall(callId: string) {
+    this.replace({ view: 'trajectory', focusCallId: callId })
+  }
+
   ingest(sessionId: string, event: SessionEvent) {
-    if (this.value.sessionId && this.value.sessionId !== sessionId) return
+    if (this.value.sessionId && this.value.sessionId !== sessionId) {
+      void this.refreshSessions()
+      return
+    }
     const events = upsertEvent(this.value.sessionId === sessionId ? this.value.events : [], event)
     this.replace({
       sessionId,
       events,
       nodes: projectNodes(events),
+      trajectory: projectTrajectory(events),
       error: undefined,
     })
+    void this.refreshSessions()
   }
 
   setAgentStatus(status: 'idle' | 'running', step?: number) {
@@ -68,13 +104,30 @@ export class SessionViewService extends Service {
     this.replace({ approvals: this.value.approvals.filter((row) => row.id !== id) })
   }
 
-  async ensureSession() {
-    if (this.value.sessionId) return this.value.sessionId
+  async refreshSessions() {
+    try {
+      const res = await fetch('/api/sessions')
+      if (!res.ok) return
+      const body = (await res.json()) as { sessions?: SessionListItem[] }
+      this.replace({ sessions: Array.isArray(body.sessions) ? body.sessions : [] })
+    } catch {
+      /* host 未就绪时忽略 */
+    }
+  }
+
+  async newSession() {
     const res = await fetch('/api/sessions', { method: 'POST' })
     const body = (await res.json()) as { id?: string }
     if (!body.id) throw new Error('无法创建 session')
     await this.load(body.id)
+    this.replace({ view: 'chat', focusCallId: undefined, approvals: [] })
+    await this.refreshSessions()
     return body.id
+  }
+
+  async ensureSession() {
+    if (this.value.sessionId) return this.value.sessionId
+    return this.newSession()
   }
 
   async load(sessionId: string) {
@@ -86,10 +139,24 @@ export class SessionViewService extends Service {
       sessionId: body.id,
       events,
       nodes: projectNodes(events),
+      trajectory: projectTrajectory(events),
       error: undefined,
       pending: false,
       agentStatus: 'idle',
+      approvals: [],
     })
+    await this.refreshSessions()
+  }
+
+  async forkCurrent() {
+    const sessionId = this.value.sessionId
+    if (!sessionId) throw new Error('no session')
+    const res = await fetch(`/api/sessions/${sessionId}/fork`, { method: 'POST' })
+    const body = (await res.json()) as { id?: string; error?: string }
+    if (!res.ok || !body.id) throw new Error(body.error || 'fork failed')
+    await this.load(body.id)
+    this.replace({ view: 'chat' })
+    return body.id
   }
 
   async send(text: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
按官方 deepseek-harness **代码级功能面**补齐（不看截图）：可恢复会话、Trajectory、审批控制、运行中 Steer。

## 已对齐（优点、瘦实现）
- **Host**：`GET /api/sessions`、`POST /api/sessions/:id/fork`
- **会话**：侧栏列表 + New Session / Fork
- **Trajectory**：`projectTrajectory` 事件账本；Chat/Trajectory 切换；工具行 `inspectCall` 高亮滚动
- **审批**：`auto`/`hold` 切换；启动/`load` 时 `GET /api/approvals` 重水合 pending
- **Steer**：agent 忙时输入可用，`kind: 'inject'`（不搬完整 QueueDock）

## 刻意不吸收
Trajectory 虚表/搜索、Workspace dock、完整 ConversationNode、Goals/Plan/Attachments（需额外 host 域）。

## 验证
- `npx tsc --noEmit`
- `npm test`（55 passed）

差异表见 `docs/dsh-advantages.md`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

