### PR TITLE
fix: Trajectory 展示完整事件类型名

### DIFF
--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -15,11 +15,6 @@ function toneOf(type: TrajectoryRow['type']): TagTone {
   return 'system'
 }
 
-function shortType(type: TrajectoryRow['type']) {
-  const parts = type.split('/')
-  return parts[parts.length - 1] || type
-}
-
 const toneClass: Record<TagTone, string> = {
   user: 'traj-tag traj-tag-user',
   assistant: 'traj-tag traj-tag-assistant',
@@ -94,7 +89,7 @@ export function TrajectoryView(props: SlotProps) {
                   <span className="traj-col-seq">{row.seq}</span>
                   <span className="traj-col-type">
                     <span className={toneClass[tone]} title={row.type}>
-                      {shortType(row.type)}
+                      {row.type}
                     </span>
                   </span>
                   <span className="traj-col-summary" title={row.summary}>

--- a/src/style.css
+++ b/src/style.css
@@ -128,7 +128,7 @@ body {
 .traj-head,
 .traj-row {
   display: grid;
-  grid-template-columns: 44px 88px minmax(0, 1fr);
+  grid-template-columns: 44px 148px minmax(0, 1fr);
   align-items: center;
   column-gap: 8px;
   box-sizing: border-box;
@@ -300,7 +300,7 @@ body {
 @media (max-width: 720px) {
   .traj-head,
   .traj-row {
-    grid-template-columns: 36px 72px minmax(0, 1fr);
+    grid-template-columns: 36px 120px minmax(0, 1fr);
     padding: 0 8px;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
Trajectory type 列改为展示完整事件名（如 `user/message`、`assistant/chunk`、`tool/call`），不再截成 `message` / `chunk`。

并加宽 type 列以容纳完整名称。

## 验证
- `npm test` 61 passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

