### PR TITLE
fix: Assistant 配置持久化（重启后仍生效）

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { ChatMessage } from './chat-types.ts'
@@ -11,6 +13,10 @@ interface ChatConfig {
   apiKey: string
   model: string
   systemPrompt: string
+}
+
+function configPath() {
+  return join(process.cwd(), '.cordis', 'chat-config.json')
 }
 
 function defaults(): ChatConfig {
@@ -29,8 +35,46 @@ function hint(key: string) {
   return `${key.slice(0, 3)}…${key.slice(-4)}`
 }
 
+function readPersisted(): Partial<ChatConfig> | null {
+  try {
+    return JSON.parse(readFileSync(configPath(), 'utf8')) as Partial<ChatConfig>
+  } catch {
+    return null
+  }
+}
+
+function writePersisted(config: ChatConfig) {
+  const dir = join(process.cwd(), '.cordis')
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(
+    configPath(),
+    `${JSON.stringify(
+      {
+        provider: config.provider,
+        model: config.model,
+        systemPrompt: config.systemPrompt,
+        apiKey: config.apiKey,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  )
+}
+
+function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): ChatConfig {
+  if (!saved) return base
+  const envKey = Boolean(process.env.DEEPSEEK_API_KEY || process.env.OPENAI_API_KEY)
+  return {
+    provider: saved.provider === 'openai' || saved.provider === 'deepseek' ? saved.provider : base.provider,
+    model: !process.env.CHAT_MODEL && typeof saved.model === 'string' && saved.model.trim() ? saved.model.trim() : base.model,
+    systemPrompt: typeof saved.systemPrompt === 'string' ? saved.systemPrompt : base.systemPrompt,
+    apiKey: !envKey && typeof saved.apiKey === 'string' && saved.apiKey.trim() ? saved.apiKey.trim() : base.apiKey,
+  }
+}
+
 export class ChatService extends Service {
-  private config = defaults()
+  private config = mergePersisted(defaults(), readPersisted())
 
   constructor(ctx: Context) {
     super(ctx, 'chat')
@@ -48,12 +92,19 @@ export class ChatService extends Service {
     }
   }
 
-  patch(next: Partial<{ provider: ChatProvider; apiKey: string; model: string; systemPrompt: string }>) {
+  patch(next: Partial<{ provider: ChatProvider; apiKey: string; model: string; systemPrompt: string }>, opts?: { persist?: boolean }) {
     if (next.provider) this.config.provider = next.provider
     if (typeof next.model === 'string' && next.model.trim()) this.config.model = next.model.trim()
     if (typeof next.systemPrompt === 'string') this.config.systemPrompt = next.systemPrompt
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) this.config.apiKey = next.apiKey.trim()
     this.syncLlm()
+    if (opts?.persist !== false) {
+      try {
+        writePersisted(this.config)
+      } catch (error) {
+        console.warn('[chat] failed to persist config', error)
+      }
+    }
     return this.publicView()
   }
 
@@ -149,7 +200,8 @@ export function apply(ctx: Context) {
   ctx.http.route('POST', '/api/sessions/:id/messages', async (route) => {
     const payload = (await route.json()) as { text?: string; kind?: 'wake' | 'inject' }
     const agent = await ctx.agents.create(route.params.id)
-    chat.patch({})
+    // re-sync in-memory LLM without rewriting disk
+    chat.patch({}, { persist: false })
     if (payload.kind === 'inject') {
       agent.inject(payload.text ?? '')
       return route.send(200, { sessionId: agent.sessionId, queued: true })

--- a/host/plugins/core/sessions.test.ts
+++ b/host/plugins/core/sessions.test.ts
@@ -21,7 +21,30 @@ test('append-only log projects model history; version is 1', async () => {
   assert.deepEqual(deriveMessages((await ctx.sessions.require(record.id)).events), [
     { role: 'system', content: 'sys' },
     { role: 'user', content: 'hi' },
-    { role: 'assistant', content: 'yo', tool_calls: undefined },
+    { role: 'assistant', content: 'yo' },
+  ])
+})
+
+test('tool_calls assistant uses null content for API history', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create()
+  await ctx.sessions.append(record.id, { type: 'user/message', text: 'run', kind: 'wake' })
+  await ctx.sessions.append(record.id, {
+    type: 'assistant/message',
+    text: '',
+    tool_calls: [{ id: '1', name: 'clock_now', arguments: '{}' }],
+  })
+  await ctx.sessions.append(record.id, { type: 'tool/result', id: '1', name: 'clock_now', ok: true, detail: 'now' })
+  assert.deepEqual(deriveMessages((await ctx.sessions.require(record.id)).events), [
+    { role: 'user', content: 'run' },
+    {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: '1', type: 'function', function: { name: 'clock_now', arguments: '{}' } }],
+    },
+    { role: 'tool', tool_call_id: '1', content: 'now' },
   ])
 })
 

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -1,6 +1,6 @@
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
-import type { LlmMessage } from '../orchestration/llm.ts'
+import { assistantContentForApi, type LlmMessage } from '../orchestration/llm.ts'
 import {
   SESSION_FORMAT_VERSION,
   type SessionEvent,
@@ -20,14 +20,19 @@ export function deriveMessages(events: SessionEvent[]): LlmMessage[] {
     } else if (event.type === 'user/message') {
       messages.push({ role: 'user', content: event.text })
     } else if (event.type === 'assistant/message') {
+      const hasToolCalls = Boolean(event.tool_calls?.length)
       messages.push({
         role: 'assistant',
-        content: event.text,
-        tool_calls: event.tool_calls?.map((call) => ({
-          id: call.id,
-          type: 'function',
-          function: { name: call.name, arguments: call.arguments },
-        })),
+        content: assistantContentForApi(event.text, hasToolCalls),
+        ...(hasToolCalls
+          ? {
+              tool_calls: event.tool_calls!.map((call) => ({
+                id: call.id,
+                type: 'function',
+                function: { name: call.name, arguments: call.arguments },
+              })),
+            }
+          : {}),
       })
     } else if (event.type === 'tool/result') {
       messages.push({ role: 'tool', tool_call_id: event.id, content: event.detail })

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -79,9 +79,16 @@ export class AgentLoop implements AgentRunner {
       } catch (error) {
         if (this.signal.aborted) {
           await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
+          this.ctx.emit('agent/status', { status: 'idle' })
           throw new Error('cancelled')
         }
-        throw error
+        const detail = String(error)
+        const text = `模型调用失败：${detail}`
+        await session.append(this.sessionId, { type: 'assistant/message', text })
+        await session.append(this.sessionId, { type: 'step/end', turn, step })
+        await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'llm-error' })
+        this.ctx.emit('agent/status', { status: 'idle' })
+        return { text, steps }
       }
       if (reply.content) {
         await session.append(this.sessionId, { type: 'assistant/chunk', text: reply.content })

--- a/host/plugins/orchestration/llm.ts
+++ b/host/plugins/orchestration/llm.ts
@@ -14,6 +14,12 @@ export interface LlmMessage {
   tool_call_id?: string
 }
 
+/** OpenAI/DeepSeek：带 tool_calls 时 content 宜为 null，空字符串可能导致后续回合拒答。 */
+export function assistantContentForApi(text: string | undefined | null, hasToolCalls: boolean): string | null {
+  if (hasToolCalls && !text) return null
+  return text ?? null
+}
+
 export interface ToolCall {
   id: string
   name: string

--- a/host/plugins/registry/http.ts
+++ b/host/plugins/registry/http.ts
@@ -120,7 +120,10 @@ export class HttpService extends Service {
   private async dispatch(req: IncomingMessage, res: ServerResponse) {
     const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`)
     const method = (req.method ?? 'GET').toUpperCase() as Method
-    const match = [...this.routes].reverse().find((route) => route.method === method && route.regexp.test(url.pathname))
+    // 静态段优先于 :param，避免 `/api/approvals/mode` 被 `/api/approvals/:id` 吃掉
+    const match = this.routes
+      .filter((route) => route.method === method && route.regexp.test(url.pathname))
+      .sort((a, b) => a.keys.length - b.keys.length || b.pattern.length - a.pattern.length)[0]
     if (match) {
       const result = url.pathname.match(match.regexp)
       const params: Record<string, string> = {}

--- a/src/plugins/contributors/chat/config-banner.tsx
+++ b/src/plugins/contributors/chat/config-banner.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import type { SlotProps } from '../../registry/slots.ts'
+
+/** 未配置 API Key 时在对话区提示，避免用户以为模型「没响应」。 */
+export function ChatConfigBanner(_props: SlotProps) {
+  const [configured, setConfigured] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const res = await fetch('/api/chat/config')
+        const data = (await res.json()) as { configured?: boolean }
+        if (!cancelled) setConfigured(Boolean(data.configured))
+      } catch {
+        if (!cancelled) setConfigured(null)
+      }
+    }
+    void load()
+    const timer = window.setInterval(() => void load(), 5000)
+    return () => {
+      cancelled = true
+      window.clearInterval(timer)
+    }
+  }, [])
+
+  if (configured !== false) return null
+
+  return (
+    <div
+      className="mx-auto w-full max-w-[calc(var(--dsw-chat-width)+32px)] border border-[var(--dsw-border)] bg-[var(--dsw-input)] px-4 py-2 text-xs text-[var(--dsw-label-2)]"
+      style={{ borderRadius: 'var(--dsw-radius-bubble)' }}
+      role="status"
+    >
+      尚未配置 API Key：消息会本地回声，不会调用模型。打开 Settings → Assistant，填写 Key 后点「Save Assistant」。
+    </div>
+  )
+}

--- a/src/plugins/contributors/chat/config.tsx
+++ b/src/plugins/contributors/chat/config.tsx
@@ -17,6 +17,7 @@ export function ChatConfig(_props: SlotProps) {
   const [hint, setHint] = useState('')
   const [configured, setConfigured] = useState(false)
   const [status, setStatus] = useState('')
+  const [error, setError] = useState('')
 
   async function load() {
     const res = await fetch('/api/chat/config')
@@ -34,6 +35,12 @@ export function ChatConfig(_props: SlotProps) {
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
+    setError('')
+    setStatus('')
+    if (!configured && !apiKey.trim()) {
+      setError('请先填写 API Key，否则会走本地回声，不会调用模型。')
+      return
+    }
     const res = await fetch('/api/chat/config', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -44,22 +51,34 @@ export function ChatConfig(_props: SlotProps) {
         ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
       }),
     })
+    if (!res.ok) {
+      setError(`保存失败：HTTP ${res.status}`)
+      return
+    }
     const data = (await res.json()) as ChatPublicConfig
     setHint(data.hint)
     setConfigured(data.configured)
     setApiKey('')
-    setStatus('Saved on host (full key never returned)')
+    setStatus(
+      data.configured
+        ? `已保存到 host（.cordis/chat-config.json），重启后仍生效。当前 ${data.hint}`
+        : '已保存，但尚未配置 API Key',
+    )
   }
 
   const field =
     'mt-1 w-full rounded-[12px] border border-[var(--dsw-border)] bg-white px-2 py-2 text-sm text-[var(--dsw-label)] outline-none'
 
   return (
-    <form className="space-y-3 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3" onSubmit={onSubmit}>
+    <form
+      className="space-y-3 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3"
+      data-testid="assistant-config"
+      onSubmit={onSubmit}
+    >
       <h3 className="m-0 text-sm font-medium">Assistant</h3>
       <p className="m-0 text-xs leading-5 text-[var(--dsw-label-3)]">
-        Keys live in the Node host. Leave blank to keep the current key.
-        {configured ? ` Current ${hint}` : ' No key yet.'}
+        Key 保存在 Node host 的 <code>.cordis/chat-config.json</code>（已 gitignore）。留空表示保留当前 Key。
+        {configured ? ` 当前 ${hint}` : ' 尚未配置 Key —— 发消息只会本地回声。'}
       </p>
       <label className="block text-xs text-[var(--dsw-label-3)]">
         Provider
@@ -95,10 +114,15 @@ export function ChatConfig(_props: SlotProps) {
         System prompt
         <textarea className={`${field} min-h-20`} value={systemPrompt} onChange={(event) => setSystemPrompt(event.target.value)} />
       </label>
-      <button className="rounded-[12px] px-3 py-2 text-sm text-white" style={{ background: 'var(--dsw-business)' }} type="submit">
-        Save
+      <button
+        className="rounded-[12px] px-3 py-2 text-sm text-white"
+        style={{ background: 'var(--dsw-business)' }}
+        type="submit"
+      >
+        Save Assistant
       </button>
       {status ? <p className="m-0 text-xs text-[var(--dsw-ok)]">{status}</p> : null}
+      {error ? <p className="m-0 text-xs text-[var(--dsw-danger,#b42318)]">{error}</p> : null}
     </form>
   )
 }

--- a/src/plugins/contributors/chat/index.ts
+++ b/src/plugins/contributors/chat/index.ts
@@ -3,6 +3,7 @@ import { bindSessionView, type SessionViewService } from '../../infrastructure/s
 import { ApprovalsRail } from './approvals.tsx'
 import { ChatComposer } from './composer.tsx'
 import { ChatConfig } from './config.tsx'
+import { ChatConfigBanner } from './config-banner.tsx'
 import { ChatThread } from './thread.tsx'
 import { TrajectoryView } from './trajectory.tsx'
 
@@ -18,6 +19,7 @@ export function apply(ctx: Context) {
   ctx.slots.place('stage', ChatThread, { key: 'chat-thread', order: 1, props })
   ctx.slots.place('trajectory', TrajectoryView, { key: 'trajectory', order: 1, props })
   ctx.slots.place('composer', ChatComposer, { key: 'chat', order: 10, props })
+  ctx.slots.place('dock', ChatConfigBanner, { key: 'chat-config-banner', order: 1 })
   ctx.slots.place('dock', ApprovalsRail, { key: 'approvals', order: 5, props })
   ctx.slots.place('settings', ChatConfig, { key: 'chat-config', order: 10 })
 }

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -111,7 +111,7 @@ export function ChatThread(props: SlotProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const error = useSessionView((state) => state.error)
 
-  if (nodes.length === 0 && !pending) return <EmptyHero />
+  if (nodes.length === 0 && !pending && !error) return <EmptyHero />
 
   return (
     <div className="mx-auto flex w-full max-w-[var(--dsw-chat-width)] flex-col gap-4">

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -137,8 +137,12 @@ export class SessionViewService extends Service {
   }
 
   setAgentStatus(status: 'idle' | 'running', step?: number) {
-    this.replace({ agentStatus: status, agentStep: step, pending: status === 'running' || this.value.pending })
-    if (status === 'idle') this.replace({ pending: false })
+    // pending 由 send()/cancel() 拥有；WS 的 idle 不能提前清掉，否则会像「agent 没响应」
+    if (status === 'running') {
+      this.replace({ agentStatus: 'running', agentStep: step, pending: true })
+      return
+    }
+    this.replace({ agentStatus: 'idle', agentStep: step })
   }
 
   upsertApproval(item: ApprovalItem) {
@@ -284,11 +288,19 @@ export class SessionViewService extends Service {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ text: content }),
       })
-      const data = (await res.json()) as { error?: string; sessionId?: string }
+      const data = (await res.json()) as { error?: string; sessionId?: string; text?: string }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)
       if (data.sessionId && data.sessionId !== sessionId) await this.load(data.sessionId)
       else await this.load(sessionId)
+      if (typeof data.text === 'string' && data.text.startsWith('模型调用失败：')) {
+        this.replace({ error: data.text })
+      }
     } catch (error) {
+      try {
+        await this.load(sessionId)
+      } catch {
+        /* 加载失败时仍展示下方 error */
+      }
       this.replace({ error: String(error), pending: false, agentStatus: 'idle' })
       throw error
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
用户反馈：配置了 API token 后 LLM agent 无法正常响应。

## 实测
用同一 Key 走完整链路时，agent **可以**正常回复（含 tool 调用如 `clock_now` / `bash`）。更常见的是失败被「吞掉」或状态错乱，表现为没响应。

## 本 PR 修复
1. **配置持久化**：Settings 保存写入 `.cordis/chat-config.json`，重启不丢 Key（否则会回声）
2. **路由**：`POST /api/approvals/mode` 不再被 `/api/approvals/:id` 吃掉（Hold/Auto 失效）
3. **LLM 失败可见**：鉴权失败等写入 session 助手消息 `模型调用失败：…`，不再静默 500
4. **pending 竞态**：WS `idle` 不再提前清掉 `send()` 的 pending
5. **tool_calls history**：空 content 改为 `null`，降低后续回合拒答风险
6. UI：未配置横幅；错误在空会话时也能显示

## 验证
- `npm test` 62 passed
- Hold/Auto API + UI 正常
- 好 Key → `ok`；坏 Key → 线程内可见失败文案
- Playwright：tool 调用后助手正常回复

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

