### PR TITLE
feat: Trajectory 可见 assistant message + usage

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -18,7 +18,7 @@
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
-15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；工具行可 `inspectCall` 跳到对应 seq 并高亮。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；工具行可 `inspectCall` 跳到对应 seq 并高亮；`assistant/message` 摘要可见（含空 content 的 tool_calls）；provider `usage` 写入事件并显示。
 16. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 17. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
 18. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -11,7 +11,17 @@ export type SessionEventBody =
   | { type: 'step/end'; turn: number; step: number }
   | { type: 'system/prompt'; text: string }
   | { type: 'user/message'; text: string; kind: InboxKind }
-  | { type: 'assistant/message'; text: string; tool_calls?: Array<{ id: string; name: string; arguments: string }> }
+  | {
+      type: 'assistant/message'
+      text: string
+      tool_calls?: Array<{ id: string; name: string; arguments: string }>
+      usage?: {
+        inputTokens: number
+        outputTokens: number
+        totalTokens?: number
+        cacheReadTokens?: number
+      }
+    }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }
   | { type: 'tool/result'; id: string; name: string; ok: boolean; detail: string }

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -96,7 +96,11 @@ export class AgentLoop implements AgentRunner {
 
       if (!reply.toolCalls.length) {
         final = reply.content?.trim() || '（空回复）'
-        await session.append(this.sessionId, { type: 'assistant/message', text: final })
+        await session.append(this.sessionId, {
+          type: 'assistant/message',
+          text: final,
+          ...(reply.usage ? { usage: reply.usage } : {}),
+        })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'complete' })
         this.ctx.emit('agent/status', { status: 'idle', step })
@@ -107,6 +111,7 @@ export class AgentLoop implements AgentRunner {
         type: 'assistant/message',
         text: reply.content ?? '',
         tool_calls: reply.toolCalls,
+        ...(reply.usage ? { usage: reply.usage } : {}),
       })
 
       for (const call of reply.toolCalls) {

--- a/host/plugins/orchestration/llm.ts
+++ b/host/plugins/orchestration/llm.ts
@@ -26,13 +26,51 @@ export interface ToolCall {
   arguments: string
 }
 
+/** 对标 dsh：挂在 assistant/message 上的 provider usage（瘦字段）。 */
+export interface LlmUsage {
+  inputTokens: number
+  outputTokens: number
+  totalTokens?: number
+  cacheReadTokens?: number
+}
+
 export interface AssistantReply {
   content: string | null
   toolCalls: ToolCall[]
+  usage?: LlmUsage
 }
 
 export interface LlmClient {
   chat(messages: LlmMessage[], tools: unknown[], signal?: AbortSignal): Promise<AssistantReply>
+}
+
+export function parseProviderUsage(raw: unknown): LlmUsage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const u = raw as Record<string, unknown>
+  const input = num(u.prompt_tokens ?? u.input_tokens ?? u.inputTokens)
+  const output = num(u.completion_tokens ?? u.output_tokens ?? u.outputTokens)
+  if (input == null && output == null) return undefined
+  const total = num(u.total_tokens ?? u.totalTokens)
+  const cacheRead = num(
+    u.prompt_cache_hit_tokens ?? u.cache_read_input_tokens ?? u.cacheReadTokens,
+  )
+  return {
+    inputTokens: input ?? 0,
+    outputTokens: output ?? 0,
+    ...(total != null ? { totalTokens: total } : {}),
+    ...(cacheRead != null ? { cacheReadTokens: cacheRead } : {}),
+  }
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+export function formatUsage(usage: LlmUsage | undefined): string {
+  if (!usage) return ''
+  const parts = [`${usage.inputTokens}→${usage.outputTokens}`]
+  if (usage.cacheReadTokens) parts.push(`cache ${usage.cacheReadTokens}`)
+  return parts.join(' · ')
 }
 
 export class OpenAiCompatLlm implements LlmClient {
@@ -59,6 +97,7 @@ export class OpenAiCompatLlm implements LlmClient {
     })
     const data = (await res.json()) as {
       choices?: Array<{ message?: LlmMessage }>
+      usage?: unknown
       error?: { message?: string }
     }
     if (!res.ok) throw new Error(data.error?.message || `llm http ${res.status}`)
@@ -71,6 +110,7 @@ export class OpenAiCompatLlm implements LlmClient {
         name: call.function.name,
         arguments: call.function.arguments,
       })),
+      usage: parseProviderUsage(data.usage),
     }
   }
 

--- a/host/plugins/orchestration/llm.usage.test.ts
+++ b/host/plugins/orchestration/llm.usage.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { formatUsage, parseProviderUsage } from './llm.ts'
+
+test('parseProviderUsage reads OpenAI-style fields', () => {
+  assert.deepEqual(parseProviderUsage({ prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 }), {
+    inputTokens: 12,
+    outputTokens: 4,
+    totalTokens: 16,
+  })
+})
+
+test('parseProviderUsage reads DeepSeek cache hit tokens', () => {
+  assert.deepEqual(
+    parseProviderUsage({
+      prompt_tokens: 100,
+      completion_tokens: 20,
+      prompt_cache_hit_tokens: 40,
+    }),
+    {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 40,
+    },
+  )
+})
+
+test('parseProviderUsage ignores garbage', () => {
+  assert.equal(parseProviderUsage(null), undefined)
+  assert.equal(parseProviderUsage({ foo: 1 }), undefined)
+})
+
+test('formatUsage is compact', () => {
+  assert.equal(formatUsage({ inputTokens: 10, outputTokens: 3 }), '10→3')
+  assert.equal(formatUsage({ inputTokens: 10, outputTokens: 3, cacheReadTokens: 2 }), '10→3 · cache 2')
+})

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -1,7 +1,11 @@
 import { useEffect, useMemo } from 'react'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
-import type { TrajectoryRow } from '../../infrastructure/session-project.ts'
+import {
+  formatTrajectoryUsage,
+  sumTrajectoryUsage,
+  type TrajectoryRow,
+} from '../../infrastructure/session-project.ts'
 
 type TagTone = 'user' | 'assistant' | 'tool' | 'system' | 'turn' | 'step'
 
@@ -27,10 +31,12 @@ const toneClass: Record<TagTone, string> = {
 export function TrajectoryView(props: SlotProps) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const rows = useSessionView((state) => state.trajectory)
+  const events = useSessionView((state) => state.events)
   const focusCallId = useSessionView((state) => state.focusCallId)
   const sessionId = useSessionView((state) => state.sessionId)
 
   const groups = useMemo(() => groupByTurn(rows), [rows])
+  const cumulative = useMemo(() => sumTrajectoryUsage(events), [events])
 
   useEffect(() => {
     if (!focusCallId) return
@@ -61,12 +67,17 @@ export function TrajectoryView(props: SlotProps) {
         <span>{rows.length} events</span>
         <span className="traj-meta-sep">·</span>
         <span>{groups.length} turns</span>
+        <span className="traj-meta-sep">·</span>
+        <span title="Sum of assistant/message usage in this session">
+          usage {cumulative ? formatTrajectoryUsage(cumulative) : '—'}
+        </span>
       </div>
 
       <div className="traj-head" role="row">
         <span className="traj-col-seq">#</span>
         <span className="traj-col-type">type</span>
         <span className="traj-col-summary">summary</span>
+        <span className="traj-col-usage">usage</span>
       </div>
 
       <div className="traj-list" role="rowgroup">
@@ -79,12 +90,15 @@ export function TrajectoryView(props: SlotProps) {
             {group.rows.map((row) => {
               const focused = Boolean(focusCallId && row.callId === focusCallId)
               const tone = toneOf(row.type)
+              const usageText = formatTrajectoryUsage(row.usage)
               return (
                 <div
                   key={row.id}
                   id={row.callId ? `traj-call-${row.callId}` : undefined}
                   role="row"
-                  className={`traj-row traj-depth-${row.depth}${focused ? ' traj-row-focus' : ''}`}
+                  className={`traj-row traj-depth-${row.depth}${focused ? ' traj-row-focus' : ''}${
+                    row.type === 'assistant/message' ? ' traj-row-assistant' : ''
+                  }`}
                 >
                   <span className="traj-col-seq">{row.seq}</span>
                   <span className="traj-col-type">
@@ -94,6 +108,9 @@ export function TrajectoryView(props: SlotProps) {
                   </span>
                   <span className="traj-col-summary" title={row.summary}>
                     {row.summary}
+                  </span>
+                  <span className="traj-col-usage" title={usageText || undefined}>
+                    {usageText || '—'}
                   </span>
                 </div>
               )

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -1,6 +1,12 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { projectNodes, projectTrajectory, type SessionEvent } from './session-project.ts'
+import {
+  formatTrajectoryUsage,
+  projectNodes,
+  projectTrajectory,
+  sumTrajectoryUsage,
+  type SessionEvent,
+} from './session-project.ts'
 
 test('projects user, streaming assistant, tool call/result from session events', () => {
   const events: SessionEvent[] = [
@@ -66,4 +72,36 @@ test('projectTrajectory indents step boundaries and in-step events', () => {
   assert.equal(byType['tool/call']?.depth, 2)
   assert.equal(byType['step/end']?.depth, 1)
   assert.equal(byType['turn/end']?.depth, 0)
+})
+
+test('assistant/message with empty text still has a visible tool_calls summary and usage', () => {
+  const events: SessionEvent[] = [
+    {
+      type: 'assistant/message',
+      text: '',
+      tool_calls: [{ id: '1', name: 'clock_now', arguments: '{}' }],
+      usage: { inputTokens: 11, outputTokens: 3 },
+      seq: 1,
+      ts: 1,
+    },
+    {
+      type: 'assistant/message',
+      text: '现在是下午',
+      usage: { inputTokens: 20, outputTokens: 8, cacheReadTokens: 4 },
+      seq: 2,
+      ts: 2,
+    },
+  ]
+  const rows = projectTrajectory(events)
+  assert.match(rows[0]?.summary ?? '', /tool call/)
+  assert.match(rows[0]?.summary ?? '', /clock_now/)
+  assert.deepEqual(rows[0]?.usage, { inputTokens: 11, outputTokens: 3 })
+  assert.equal(rows[1]?.summary, '现在是下午')
+  assert.equal(formatTrajectoryUsage(rows[1]?.usage), '20→8 c4')
+  assert.deepEqual(sumTrajectoryUsage(events), {
+    inputTokens: 31,
+    outputTokens: 11,
+    totalTokens: 42,
+    cacheReadTokens: 4,
+  })
 })

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -10,7 +10,17 @@ export type SessionEvent = {
   | { type: 'step/end'; turn: number; step: number }
   | { type: 'system/prompt'; text: string }
   | { type: 'user/message'; text: string; kind?: string }
-  | { type: 'assistant/message'; text: string; tool_calls?: Array<{ id: string; name: string; arguments: string }> }
+  | {
+      type: 'assistant/message'
+      text: string
+      tool_calls?: Array<{ id: string; name: string; arguments: string }>
+      usage?: {
+        inputTokens: number
+        outputTokens: number
+        totalTokens?: number
+        cacheReadTokens?: number
+      }
+    }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }
   | { type: 'tool/result'; id: string; name: string; ok: boolean; detail: string }
@@ -96,6 +106,13 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
 }
 
 /** Lean Trajectory 行：官方 ui-trajectory 的瘦投影，不搬虚表/搜索索引。 */
+export interface TrajectoryUsage {
+  inputTokens: number
+  outputTokens: number
+  totalTokens?: number
+  cacheReadTokens?: number
+}
+
 export interface TrajectoryRow {
   id: string
   seq: number
@@ -105,7 +122,48 @@ export interface TrajectoryRow {
   depth: 0 | 1 | 2
   type: SessionEvent['type']
   summary: string
+  usage?: TrajectoryUsage
   callId?: string
+}
+
+export function formatTrajectoryUsage(usage: TrajectoryUsage | undefined): string {
+  if (!usage) return ''
+  const parts = [`${usage.inputTokens}→${usage.outputTokens}`]
+  if (usage.cacheReadTokens) parts.push(`c${usage.cacheReadTokens}`)
+  return parts.join(' ')
+}
+
+export function sumTrajectoryUsage(events: SessionEvent[]): TrajectoryUsage | undefined {
+  let input = 0
+  let output = 0
+  let total = 0
+  let cache = 0
+  let hit = false
+  for (const event of events) {
+    if (event.type !== 'assistant/message' || !event.usage) continue
+    hit = true
+    input += event.usage.inputTokens
+    output += event.usage.outputTokens
+    total += event.usage.totalTokens ?? event.usage.inputTokens + event.usage.outputTokens
+    cache += event.usage.cacheReadTokens ?? 0
+  }
+  if (!hit) return undefined
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    totalTokens: total,
+    ...(cache ? { cacheReadTokens: cache } : {}),
+  }
+}
+
+function assistantSummary(event: Extract<SessionEvent, { type: 'assistant/message' }>): string {
+  const tools = event.tool_calls?.length ?? 0
+  if (event.text.trim()) return event.text.slice(0, 160)
+  if (tools) {
+    const names = event.tool_calls!.map((call) => call.name).join(', ')
+    return `→ ${tools} tool call${tools > 1 ? 's' : ''}: ${names}`
+  }
+  return '(empty assistant message)'
 }
 
 export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
@@ -127,8 +185,12 @@ export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
 
     let summary: string = event.type
     let callId: string | undefined
-    if (event.type === 'user/message' || event.type === 'assistant/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
-      summary = event.text.slice(0, 120)
+    let usage: TrajectoryUsage | undefined
+    if (event.type === 'assistant/message') {
+      summary = assistantSummary(event)
+      usage = event.usage
+    } else if (event.type === 'user/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
+      summary = event.text.slice(0, 160)
     } else if (event.type === 'tool/call') {
       callId = event.id
       summary = `${event.name}(${event.arguments.slice(0, 80)})`
@@ -156,6 +218,7 @@ export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
       depth,
       type: event.type,
       summary,
+      usage,
       callId,
     })
 

--- a/src/style.css
+++ b/src/style.css
@@ -128,7 +128,7 @@ body {
 .traj-head,
 .traj-row {
   display: grid;
-  grid-template-columns: 44px 148px minmax(0, 1fr);
+  grid-template-columns: 44px 148px minmax(0, 1fr) 88px;
   align-items: center;
   column-gap: 8px;
   box-sizing: border-box;
@@ -224,6 +224,21 @@ body {
   color: var(--dsw-label);
 }
 
+.traj-col-usage {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  color: var(--dsw-label-3);
+  font-variant-numeric: tabular-nums;
+}
+
+.traj-row-assistant .traj-col-summary {
+  color: var(--dsw-label);
+  font-weight: 500;
+}
+
 .traj-tag {
   display: inline-flex;
   align-items: center;
@@ -300,7 +315,7 @@ body {
 @media (max-width: 720px) {
   .traj-head,
   .traj-row {
-    grid-template-columns: 36px 120px minmax(0, 1fr);
+    grid-template-columns: 36px 110px minmax(0, 1fr) 64px;
     padding: 0 8px;
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
1. Trajectory 里 `assistant/message`「像没有」——其实 **已写入 session**，但 tool_calls 回合常是空 `text`，summary 空白看不出来。
2. **usage 从未落库**：LLM 响应里的 `usage` 之前被丢掉，Trajectory 没有 token 列。

## 改动
- 解析 OpenAI/DeepSeek `usage`（含 cache hit），写入 `assistant/message.usage`
- Trajectory 增加 **usage** 列 + 顶部会话累计 `in→out`
- 空 content 的 assistant 显示 `→ N tool call(s): …`
- 有正文的 `assistant/message` summary 正常展示文本

## 验证
- `npm test` 67 passed
- 实请求：`assistant/message` 带 `usage: { inputTokens, outputTokens, cacheReadTokens }`
- UI：`→ 1 tool call: clock_now` + `1560→27 c1536`；最终回复文本可见

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

