### PR TITLE
feat: Trajectory 详情展示每步 LLM request messages

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -18,7 +18,7 @@
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
-15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；工具行可 `inspectCall` 跳到对应 seq 并高亮；`assistant/message` 摘要可见（含空 content 的 tool_calls）；provider `usage` 写入事件并显示。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情展示本步 `request`（当时发给模型的 messages）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -2,6 +2,14 @@ export const SESSION_FORMAT_VERSION = 1
 
 export type InboxKind = 'wake' | 'inject'
 
+/** 某次 llm.chat 的请求快照（挂在 assistant/message 上，不参与 deriveMessages）。 */
+export interface SessionRequestMessage {
+  role: string
+  content?: string | null
+  tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
+  tool_call_id?: string
+}
+
 /** 写入 append 的正文（不含 seq/ts）；与 SessionEvent 判别联合一一对应。 */
 export type SessionEventBody =
   | { type: 'session/open'; version: number }
@@ -21,6 +29,8 @@ export type SessionEventBody =
         totalTokens?: number
         cacheReadTokens?: number
       }
+      /** 本步发起 llm.chat 时的 messages 快照 */
+      request?: SessionRequestMessage[]
     }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }

--- a/host/plugins/orchestration/agent-loop.test.ts
+++ b/host/plugins/orchestration/agent-loop.test.ts
@@ -54,6 +54,8 @@ test('loop appends multiple assistant/chunk deltas from onDelta', async () => {
   )
   const message = (await ctx.sessions.require(sessionId)).events.find((event) => event.type === 'assistant/message')
   assert.equal(message?.type === 'assistant/message' && message.usage?.inputTokens, 1)
+  assert.equal(message?.type === 'assistant/message' && message.request?.[0]?.role, 'system')
+  assert.equal(message?.type === 'assistant/message' && message.request?.some((item) => item.role === 'user' && item.content === 'hi'), true)
 })
 
 test('loop invokes tools then asks the model again', async () => {

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -73,6 +73,7 @@ export class AgentLoop implements AgentRunner {
       await session.append(this.sessionId, { type: 'step/start', turn, step })
 
       const messages = session.deriveMessages(this.sessionId)
+      const request = snapshotRequest(messages)
       let reply: AssistantReply
       try {
         reply = await this.llm.chat(messages, this.ctx.tools.schemas(), this.signal, {
@@ -88,7 +89,7 @@ export class AgentLoop implements AgentRunner {
         }
         const detail = String(error)
         const text = `模型调用失败：${detail}`
-        await session.append(this.sessionId, { type: 'assistant/message', text })
+        await session.append(this.sessionId, { type: 'assistant/message', text, request })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'llm-error' })
         this.ctx.emit('agent/status', { status: 'idle' })
@@ -100,6 +101,7 @@ export class AgentLoop implements AgentRunner {
         await session.append(this.sessionId, {
           type: 'assistant/message',
           text: final,
+          request,
           ...(reply.usage ? { usage: reply.usage } : {}),
         })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
@@ -112,6 +114,7 @@ export class AgentLoop implements AgentRunner {
         type: 'assistant/message',
         text: reply.content ?? '',
         tool_calls: reply.toolCalls,
+        request,
         ...(reply.usage ? { usage: reply.usage } : {}),
       })
 
@@ -183,6 +186,15 @@ function stringify(value: unknown) {
   } catch {
     return String(value)
   }
+}
+
+function snapshotRequest(messages: LlmMessage[]) {
+  return messages.map((item) => ({
+    role: item.role,
+    ...(item.content !== undefined ? { content: item.content } : {}),
+    ...(item.tool_calls ? { tool_calls: item.tool_calls } : {}),
+    ...(item.tool_call_id ? { tool_call_id: item.tool_call_id } : {}),
+  }))
 }
 
 export const name = 'agent-loop'

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -217,6 +217,7 @@ export function TrajectoryView(props: SlotProps) {
 function EventDetailBody({ event }: { event: SessionEvent }) {
   const fields = detailFields(event)
   const usage = event.type === 'assistant/message' ? event.usage : undefined
+  const request = event.type === 'assistant/message' ? event.request : undefined
   return (
     <div className="traj-detail-body">
       <dl className="traj-detail-meta">
@@ -236,15 +237,61 @@ function EventDetailBody({ event }: { event: SessionEvent }) {
         ))}
       </dl>
       {usage ? <UsageCard usage={usage} /> : null}
-      <pre className="traj-detail-json">{JSON.stringify(omitUsage(event), null, 2)}</pre>
+      {request?.length ? <RequestPanel messages={request} /> : null}
+      {event.type === 'assistant/message' ? (
+        <ResponsePanel event={event} />
+      ) : (
+        <pre className="traj-detail-json">{JSON.stringify(event, null, 2)}</pre>
+      )}
     </div>
   )
 }
 
-function omitUsage(event: SessionEvent): SessionEvent | Record<string, unknown> {
-  if (event.type !== 'assistant/message' || !event.usage) return event
-  const { usage: _usage, ...rest } = event
-  return rest
+function RequestPanel({
+  messages,
+}: {
+  messages: NonNullable<Extract<SessionEvent, { type: 'assistant/message' }>['request']>
+}) {
+  return (
+    <section className="traj-io-card" aria-label="LLM request">
+      <div className="traj-io-card-title">Request · messages ({messages.length})</div>
+      <div className="traj-io-list">
+        {messages.map((message, index) => (
+          <article key={`${message.role}-${index}`} className="traj-io-msg">
+            <header className="traj-io-msg-head">
+              <span className={`traj-io-role traj-io-role-${message.role}`}>{message.role}</span>
+              {message.tool_call_id ? <span className="traj-io-meta">#{message.tool_call_id}</span> : null}
+              {message.tool_calls?.length ? (
+                <span className="traj-io-meta">{message.tool_calls.length} tool_calls</span>
+              ) : null}
+            </header>
+            {message.content ? <pre className="traj-io-msg-body">{message.content}</pre> : null}
+            {message.tool_calls?.length ? (
+              <pre className="traj-io-msg-body traj-io-msg-tools">
+                {JSON.stringify(message.tool_calls, null, 2)}
+              </pre>
+            ) : null}
+            {!message.content && !message.tool_calls?.length ? (
+              <pre className="traj-io-msg-body traj-io-msg-empty">(empty content)</pre>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ResponsePanel({ event }: { event: Extract<SessionEvent, { type: 'assistant/message' }> }) {
+  return (
+    <section className="traj-io-card" aria-label="LLM response">
+      <div className="traj-io-card-title">Response · assistant/message</div>
+      {event.text ? <pre className="traj-io-msg-body">{event.text}</pre> : null}
+      {event.tool_calls?.length ? (
+        <pre className="traj-io-msg-body traj-io-msg-tools">{JSON.stringify(event.tool_calls, null, 2)}</pre>
+      ) : null}
+      {!event.text && !event.tool_calls?.length ? <pre className="traj-io-msg-body traj-io-msg-empty">(empty)</pre> : null}
+    </section>
+  )
 }
 
 function detailFields(event: SessionEvent): Array<{ label: string; value: string }> {
@@ -257,6 +304,7 @@ function detailFields(event: SessionEvent): Array<{ label: string; value: string
   if (event.type === 'assistant/message') {
     const rows = [{ label: 'text', value: `${event.text.length} chars` }]
     if (event.tool_calls?.length) rows.push({ label: 'tool_calls', value: String(event.tool_calls.length) })
+    if (event.request?.length) rows.push({ label: 'request', value: `${event.request.length} messages` })
     return rows
   }
   if (event.type === 'tool/call') {

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -20,6 +20,12 @@ export type SessionEvent = {
         totalTokens?: number
         cacheReadTokens?: number
       }
+      request?: Array<{
+        role: string
+        content?: string | null
+        tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
+        tool_call_id?: string
+      }>
     }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }

--- a/src/style.css
+++ b/src/style.css
@@ -366,6 +366,101 @@ body {
   color: var(--dsw-ok);
 }
 
+.traj-io-card {
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #fff;
+}
+
+.traj-io-card-title {
+  margin-bottom: 8px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.traj-io-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.traj-io-msg {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(15, 17, 21, 0.02);
+}
+
+.traj-io-msg-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+.traj-io-role {
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.traj-io-role-system {
+  color: var(--dsw-label-2);
+  background: rgba(15, 17, 21, 0.06);
+}
+
+.traj-io-role-user {
+  color: var(--dsw-ok);
+  background: rgba(34, 140, 90, 0.12);
+}
+
+.traj-io-role-assistant {
+  color: var(--dsw-business);
+  background: var(--dsw-business-soft);
+}
+
+.traj-io-role-tool {
+  color: rgb(180, 110, 20);
+  background: rgba(180, 110, 20, 0.12);
+}
+
+.traj-io-meta {
+  color: var(--dsw-label-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.traj-io-msg-body {
+  margin: 0;
+  max-height: 220px;
+  overflow: auto;
+  padding: 8px;
+  color: var(--dsw-label);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.traj-io-msg-tools {
+  border-top: 1px dashed rgba(0, 0, 0, 0.08);
+  color: var(--dsw-label-2);
+}
+
+.traj-io-msg-empty {
+  color: var(--dsw-label-3);
+  font-style: italic;
+}
+
 .traj-row-assistant .traj-col-summary {
   color: var(--dsw-label);
   font-weight: 500;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
Trajectory 里点开 `assistant/message` 只能看到模型回复，看不到该 step 发起 `llm.chat` 时实际送入的 messages。

## 改动
- Host：每次 `llm.chat` 前对 `deriveMessages(...)` 做快照，挂到对应 `assistant/message.request`（成功 / llm-error 路径都写）
- `request` 仅作存储与 UI 展示，不参与后续 `deriveMessages`
- FE：详情面板增加 **Request · messages**（按 role 展示 content / tool_calls），并保留 Response / Usage

## 验证
- `npm test`（70 passed）
- 说明：旧 session 没有 `request` 字段；新产生的 turn 才会有

## 使用
1. 发一条新消息跑完 turn
2. 打开 Trajectory → 点任意 `assistant/message`
3. 详情中可见当时的 system / user / assistant / tool messages

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

