### PR TITLE
refactor: Trajectory request 改为事件前缀投影，不再持久化

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -18,7 +18,7 @@
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
-15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情展示本步 `request`（当时发给模型的 messages）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request（不另持久化 messages 快照）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -2,14 +2,6 @@ export const SESSION_FORMAT_VERSION = 1
 
 export type InboxKind = 'wake' | 'inject'
 
-/** 某次 llm.chat 的请求快照（挂在 assistant/message 上，不参与 deriveMessages）。 */
-export interface SessionRequestMessage {
-  role: string
-  content?: string | null
-  tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
-  tool_call_id?: string
-}
-
 /** 写入 append 的正文（不含 seq/ts）；与 SessionEvent 判别联合一一对应。 */
 export type SessionEventBody =
   | { type: 'session/open'; version: number }
@@ -29,8 +21,6 @@ export type SessionEventBody =
         totalTokens?: number
         cacheReadTokens?: number
       }
-      /** 本步发起 llm.chat 时的 messages 快照 */
-      request?: SessionRequestMessage[]
     }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }

--- a/host/plugins/orchestration/agent-loop.test.ts
+++ b/host/plugins/orchestration/agent-loop.test.ts
@@ -54,8 +54,6 @@ test('loop appends multiple assistant/chunk deltas from onDelta', async () => {
   )
   const message = (await ctx.sessions.require(sessionId)).events.find((event) => event.type === 'assistant/message')
   assert.equal(message?.type === 'assistant/message' && message.usage?.inputTokens, 1)
-  assert.equal(message?.type === 'assistant/message' && message.request?.[0]?.role, 'system')
-  assert.equal(message?.type === 'assistant/message' && message.request?.some((item) => item.role === 'user' && item.content === 'hi'), true)
 })
 
 test('loop invokes tools then asks the model again', async () => {

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -73,7 +73,6 @@ export class AgentLoop implements AgentRunner {
       await session.append(this.sessionId, { type: 'step/start', turn, step })
 
       const messages = session.deriveMessages(this.sessionId)
-      const request = snapshotRequest(messages)
       let reply: AssistantReply
       try {
         reply = await this.llm.chat(messages, this.ctx.tools.schemas(), this.signal, {
@@ -89,7 +88,7 @@ export class AgentLoop implements AgentRunner {
         }
         const detail = String(error)
         const text = `模型调用失败：${detail}`
-        await session.append(this.sessionId, { type: 'assistant/message', text, request })
+        await session.append(this.sessionId, { type: 'assistant/message', text })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'llm-error' })
         this.ctx.emit('agent/status', { status: 'idle' })
@@ -101,7 +100,6 @@ export class AgentLoop implements AgentRunner {
         await session.append(this.sessionId, {
           type: 'assistant/message',
           text: final,
-          request,
           ...(reply.usage ? { usage: reply.usage } : {}),
         })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
@@ -114,7 +112,6 @@ export class AgentLoop implements AgentRunner {
         type: 'assistant/message',
         text: reply.content ?? '',
         tool_calls: reply.toolCalls,
-        request,
         ...(reply.usage ? { usage: reply.usage } : {}),
       })
 
@@ -186,15 +183,6 @@ function stringify(value: unknown) {
   } catch {
     return String(value)
   }
-}
-
-function snapshotRequest(messages: LlmMessage[]) {
-  return messages.map((item) => ({
-    role: item.role,
-    ...(item.content !== undefined ? { content: item.content } : {}),
-    ...(item.tool_calls ? { tool_calls: item.tool_calls } : {}),
-    ...(item.tool_call_id ? { tool_call_id: item.tool_call_id } : {}),
-  }))
 }
 
 export const name = 'agent-loop'

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -3,7 +3,9 @@ import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
   formatTrajectoryUsage,
+  projectRequestMessages,
   sumTrajectoryUsage,
+  type DerivedMessage,
   type SessionEvent,
   type TrajectoryRow,
   type TrajectoryUsage,
@@ -207,17 +209,18 @@ export function TrajectoryView(props: SlotProps) {
               Close
             </button>
           </div>
-          <EventDetailBody event={selected} />
+          <EventDetailBody event={selected} events={events} />
         </aside>
       ) : null}
     </div>
   )
 }
 
-function EventDetailBody({ event }: { event: SessionEvent }) {
-  const fields = detailFields(event)
+function EventDetailBody({ event, events }: { event: SessionEvent; events: SessionEvent[] }) {
+  const fields = detailFields(event, events)
   const usage = event.type === 'assistant/message' ? event.usage : undefined
-  const request = event.type === 'assistant/message' ? event.request : undefined
+  const request =
+    event.type === 'assistant/message' ? projectRequestMessages(events, event.seq) : undefined
   return (
     <div className="traj-detail-body">
       <dl className="traj-detail-meta">
@@ -237,7 +240,7 @@ function EventDetailBody({ event }: { event: SessionEvent }) {
         ))}
       </dl>
       {usage ? <UsageCard usage={usage} /> : null}
-      {request?.length ? <RequestPanel messages={request} /> : null}
+      {request ? <RequestPanel messages={request} /> : null}
       {event.type === 'assistant/message' ? (
         <ResponsePanel event={event} />
       ) : (
@@ -247,14 +250,10 @@ function EventDetailBody({ event }: { event: SessionEvent }) {
   )
 }
 
-function RequestPanel({
-  messages,
-}: {
-  messages: NonNullable<Extract<SessionEvent, { type: 'assistant/message' }>['request']>
-}) {
+function RequestPanel({ messages }: { messages: DerivedMessage[] }) {
   return (
     <section className="traj-io-card" aria-label="LLM request">
-      <div className="traj-io-card-title">Request · messages ({messages.length})</div>
+      <div className="traj-io-card-title">Request · derived ({messages.length})</div>
       <div className="traj-io-list">
         {messages.map((message, index) => (
           <article key={`${message.role}-${index}`} className="traj-io-msg">
@@ -294,7 +293,7 @@ function ResponsePanel({ event }: { event: Extract<SessionEvent, { type: 'assist
   )
 }
 
-function detailFields(event: SessionEvent): Array<{ label: string; value: string }> {
+function detailFields(event: SessionEvent, events: SessionEvent[]): Array<{ label: string; value: string }> {
   if (event.type === 'user/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
     return [
       ...(event.type === 'user/message' && event.kind ? [{ label: 'kind', value: event.kind }] : []),
@@ -304,7 +303,8 @@ function detailFields(event: SessionEvent): Array<{ label: string; value: string
   if (event.type === 'assistant/message') {
     const rows = [{ label: 'text', value: `${event.text.length} chars` }]
     if (event.tool_calls?.length) rows.push({ label: 'tool_calls', value: String(event.tool_calls.length) })
-    if (event.request?.length) rows.push({ label: 'request', value: `${event.request.length} messages` })
+    const requestCount = projectRequestMessages(events, event.seq).length
+    rows.push({ label: 'request', value: `${requestCount} messages (derived)` })
     return rows
   }
   if (event.type === 'tool/call') {

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   formatTrajectoryUsage,
   projectNodes,
+  projectRequestMessages,
   projectTrajectory,
   sumTrajectoryUsage,
   type SessionEvent,
@@ -104,4 +105,22 @@ test('assistant/message with empty text still has a visible tool_calls summary a
     totalTokens: 42,
     cacheReadTokens: 4,
   })
+})
+
+test('projectRequestMessages derives llm.chat input from event prefix', () => {
+  const events: SessionEvent[] = [
+    { type: 'session/open', version: 1, seq: 0, ts: 1 },
+    { type: 'turn/start', turn: 1, seq: 1, ts: 2 },
+    { type: 'user/message', text: 'hi', kind: 'wake', seq: 2, ts: 3 },
+    { type: 'system/prompt', text: 'you are helpful', seq: 3, ts: 4 },
+    { type: 'step/start', turn: 1, step: 0, seq: 4, ts: 5 },
+    { type: 'assistant/message', text: 'hello', seq: 5, ts: 6 },
+  ]
+  const request = projectRequestMessages(events, 5)
+  assert.deepEqual(
+    request.map((item) => item.role),
+    ['system', 'user'],
+  )
+  assert.equal(request[0]?.content, 'you are helpful')
+  assert.equal(request[1]?.content, 'hi')
 })

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -20,12 +20,6 @@ export type SessionEvent = {
         totalTokens?: number
         cacheReadTokens?: number
       }
-      request?: Array<{
-        role: string
-        content?: string | null
-        tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
-        tool_call_id?: string
-      }>
     }
   | { type: 'assistant/chunk'; text: string }
   | { type: 'tool/call'; id: string; name: string; arguments: string }
@@ -45,6 +39,54 @@ export type ChatNode =
       result?: { ok: boolean; detail: string }
     }
   | { id: string; kind: 'turn'; text: string }
+
+/** 与 host deriveMessages 对齐：从事件日志投影模型可见 messages。 */
+export interface DerivedMessage {
+  role: string
+  content?: string | null
+  tool_calls?: Array<{ id: string; type: string; function: { name: string; arguments: string } }>
+  tool_call_id?: string
+}
+
+function assistantContentForApi(text: string | undefined | null, hasToolCalls: boolean): string | null {
+  if (hasToolCalls && !text) return null
+  return text ?? null
+}
+
+export function deriveMessages(events: SessionEvent[]): DerivedMessage[] {
+  let system = ''
+  const messages: DerivedMessage[] = []
+  for (const event of events) {
+    if (event.type === 'system/prompt') {
+      system = event.text
+    } else if (event.type === 'user/message') {
+      messages.push({ role: 'user', content: event.text })
+    } else if (event.type === 'assistant/message') {
+      const hasToolCalls = Boolean(event.tool_calls?.length)
+      messages.push({
+        role: 'assistant',
+        content: assistantContentForApi(event.text, hasToolCalls),
+        ...(hasToolCalls
+          ? {
+              tool_calls: event.tool_calls!.map((call) => ({
+                id: call.id,
+                type: 'function',
+                function: { name: call.name, arguments: call.arguments },
+              })),
+            }
+          : {}),
+      })
+    } else if (event.type === 'tool/result') {
+      messages.push({ role: 'tool', tool_call_id: event.id, content: event.detail })
+    }
+  }
+  return system ? [{ role: 'system', content: system }, ...messages] : messages
+}
+
+/** 某条 assistant/message 发起 llm.chat 时的 request = 其 seq 之前的事件投影。 */
+export function projectRequestMessages(events: SessionEvent[], assistantSeq: number): DerivedMessage[] {
+  return deriveMessages(events.filter((event) => event.seq < assistantSeq))
+}
 
 export function projectNodes(events: SessionEvent[]): ChatNode[] {
   const nodes: ChatNode[] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
#16 把每步 `llm.chat` 的 messages 快照持久化到 `assistant/message.request`。对齐 dsh 后更合理的做法是：**账本里已有表面事件，详情用投影即可**，不必冗余存一份。

本 PR 取代 #17（修持久化写入）的方向。

## 改动
- Host：去掉 `request` 字段与 `snapshotRequest` 写入
- FE：`projectRequestMessages(events, assistantSeq)` = `deriveMessages(seq < assistantSeq)`，与 host 投影规则对齐
- Trajectory 详情标题改为 **Request · derived**；旧会话也能看（只要有完整事件）

## 验证
- `npm test`（71 passed）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

