### PR TITLE
feat: 左侧模块轨，Agent 降为应用模块之一

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -16,14 +16,14 @@
 10. **Web：session/event 投影对话** — 浏览器不持能力；线程从 append-only 日志投影 user / assistant / tool 节点；LLM SSE 增量 `assistant/chunk` 经 WS 实时投影。
 11. **Web：agents 驱动输入** — 发送走 `/api/sessions/:id/messages`，可取消；WS 收 `session` / `agent` / `approval`。
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
-13. **Web 壳对标 dsh 观感** — 最左 **模块轨**（Agent / Workspace…）；Agent 模块内再挂 Sessions 侧栏 + Chat hero / Trajectory；演示插件进 Settings modal。
+13. **Web 壳对标 dsh 观感** — 最左 **VS Code 式 Activity Bar**（纯图标切换 Agent / Workspace…）；Agent 下再挂 Side Bar（Sessions）+ Chat / Trajectory；演示插件进 Settings modal。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；Agent 侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
 15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request（不另持久化 messages 快照）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
 19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
-20. **Web：应用模块轨** — Agent 仅为模块之一；切到 Workspace 等其它模块不卸载 session 投影，切回 Agent 会话仍在。
+20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
 
 ## 功能级差异（相对官方 client，优点对齐后）
 

--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -16,13 +16,14 @@
 10. **Web：session/event 投影对话** — 浏览器不持能力；线程从 append-only 日志投影 user / assistant / tool 节点；LLM SSE 增量 `assistant/chunk` 经 WS 实时投影。
 11. **Web：agents 驱动输入** — 发送走 `/api/sessions/:id/messages`，可取消；WS 收 `session` / `agent` / `approval`。
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
-13. **Web 壳对标 dsh 观感** — 左栏 Wordmark+HARNESS / New Session；中栏 Chat hero + 浅蓝气泡 + 胶囊 composer；演示插件进 Settings modal（对照官方 `ui-layout` / `ui-sidebar` / `ui-conversation`，不搬整包）。
-14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
+13. **Web 壳对标 dsh 观感** — 最左 **模块轨**（Agent / Workspace…）；Agent 模块内再挂 Sessions 侧栏 + Chat hero / Trajectory；演示插件进 Settings modal。
+14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；Agent 侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
 15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request（不另持久化 messages 快照）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
-19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
+19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
+20. **Web：应用模块轨** — Agent 仅为模块之一；切到 Workspace 等其它模块不卸载 session 投影，切回 Agent 会话仍在。
 
 ## 功能级差异（相对官方 client，优点对齐后）
 

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -5,10 +5,74 @@ import type { SlotProps } from '../registry/slots.ts'
 import { bindSnapshot, type Snapshot, type SnapshotService } from '../infrastructure/snapshot.ts'
 import { bindSessionView, type SessionViewService } from '../infrastructure/session-view.ts'
 import { parseAppPath } from '../infrastructure/session-route.ts'
+import {
+  APP_MODULES,
+  moduleIdFromPath,
+  type AppModuleId,
+} from '../infrastructure/app-modules.ts'
 import { BrandWordmark, FishLogo } from './brand.tsx'
 
 export const name = 'shell'
 export const inject = ['slots', 'snapshot', 'sessionView']
+
+function ModuleIcon({ id }: { id: AppModuleId }) {
+  if (id === 'workspace') {
+    return (
+      <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 7.5h16M4 12h16M4 16.5h10" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7 4.5h10a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2v-11a2 2 0 0 1 2-2z" />
+      </svg>
+    )
+  }
+  return (
+    <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8 9h8M8 13h5M7 5h10a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2h-3.5L9 19v-3H7a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"
+      />
+    </svg>
+  )
+}
+
+function ModuleRail({ active, agentHref }: { active: AppModuleId; agentHref: string }) {
+  return (
+    <nav className="app-module-rail" aria-label="App modules">
+      <Link to={agentHref} className="app-module-brand" title="HARNESS" aria-label="Home">
+        <FishLogo size={20} />
+      </Link>
+      <div className="app-module-list">
+        {APP_MODULES.map((module) => {
+          const to = module.id === 'agent' ? agentHref : module.path
+          const isActive = module.id === active
+          return (
+            <Link
+              key={module.id}
+              to={to}
+              className={`app-module-item${isActive ? ' is-active' : ''}`}
+              title={module.description}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              <ModuleIcon id={module.id} />
+              <span className="app-module-label">{module.label}</span>
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}
+
+function WorkspaceModule() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
+      <h1 className="text-xl font-semibold tracking-tight text-[var(--dsw-label)]">Workspace</h1>
+      <p className="max-w-md text-sm leading-6 text-[var(--dsw-label-3)]">
+        占位模块：后续可挂项目文件、上下文与其它工作台能力。左侧模块轨里，Agent 只是其中一个入口。
+      </p>
+    </div>
+  )
+}
 
 function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
@@ -22,6 +86,8 @@ function Shell(props: SlotProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const view = useSessionView((state) => state.view)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const activeModule = moduleIdFromPath(location.pathname)
+  const agentHref = sessionId ? `/s/${sessionId}${view === 'trajectory' ? '/trajectory' : ''}` : '/'
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -36,162 +102,178 @@ function Shell(props: SlotProps) {
   }, [sessionView])
 
   return (
-    <div className="grid h-screen grid-cols-[280px_minmax(0,1fr)] overflow-hidden bg-[var(--dsw-bg)] text-[var(--dsw-label)]">
-      <aside className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
-        <div className="flex shrink-0 items-center justify-between px-4 pt-4 pb-3">
-          <BrandWordmark />
-        </div>
-        <div className="shrink-0 px-3 pb-3">
-          <button
-            type="button"
-            className="flex w-full items-center justify-center gap-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-2 text-sm font-medium hover:bg-[var(--dsw-business-soft)]"
-            onClick={() => {
-              void sessionView.newSession().then((id) => navigate(`/s/${id}`))
-            }}
-          >
-            <span className="text-lg leading-none">+</span>
-            New Session
-          </button>
-        </div>
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3">
-          <div className="mb-2 flex items-center justify-between px-1">
-            <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Sessions</span>
-            {sessionId ? (
-              <button
-                type="button"
-                className="text-[11px] text-[var(--dsw-business)] hover:underline"
-                onClick={() => {
-                  void sessionView.forkCurrent().then((id) => navigate(`/s/${id}`))
-                }}
-              >
-                Fork
-              </button>
-            ) : null}
+    <div
+      className={`app-shell${activeModule === 'agent' ? ' app-shell-agent' : ' app-shell-module'}`}
+    >
+      <ModuleRail active={activeModule} agentHref={agentHref} />
+
+      {activeModule === 'agent' ? (
+        <aside className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
+          <div className="flex shrink-0 flex-col gap-2 px-4 pt-4 pb-2">
+            <BrandWordmark />
+            <div>
+              <div className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Module</div>
+              <div className="mt-0.5 text-[15px] font-semibold tracking-tight">Agent</div>
+            </div>
           </div>
-          {sessions.length === 0 ? (
-            <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No sessions yet. Send a message or create one.</p>
-          ) : (
-            sessions.map((item) => {
-              const active = item.id === sessionId
-              return (
-                <div
-                  key={item.id}
-                  className={`group mb-1 flex w-full items-stretch rounded-[12px] ${
-                    active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
-                  }`}
+          <div className="shrink-0 px-3 pb-3">
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-2 text-sm font-medium hover:bg-[var(--dsw-business-soft)]"
+              onClick={() => {
+                void sessionView.newSession().then((id) => navigate(`/s/${id}`))
+              }}
+            >
+              <span className="text-lg leading-none">+</span>
+              New Session
+            </button>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3">
+            <div className="mb-2 flex items-center justify-between px-1">
+              <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Sessions</span>
+              {sessionId ? (
+                <button
+                  type="button"
+                  className="text-[11px] text-[var(--dsw-business)] hover:underline"
+                  onClick={() => {
+                    void sessionView.forkCurrent().then((id) => navigate(`/s/${id}`))
+                  }}
                 >
-                  <Link
-                    to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
-                    className="min-w-0 flex-1 px-3 py-2 text-left text-sm"
+                  Fork
+                </button>
+              ) : null}
+            </div>
+            {sessions.length === 0 ? (
+              <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No sessions yet. Send a message or create one.</p>
+            ) : (
+              sessions.map((item) => {
+                const active = item.id === sessionId
+                return (
+                  <div
+                    key={item.id}
+                    className={`group mb-1 flex w-full items-stretch rounded-[12px] ${
+                      active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
+                    }`}
                   >
-                    <div className="truncate font-medium">{item.title}</div>
-                    <div className="mt-0.5 font-mono text-[10px] opacity-70">
-                      {item.id.slice(0, 8)} · {item.eventCount} events
-                    </div>
-                  </Link>
-                  <button
-                    type="button"
-                    className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
-                    aria-label={`Delete session ${item.title}`}
-                    title="Delete"
-                    onClick={(event) => {
-                      event.preventDefault()
-                      event.stopPropagation()
-                      if (!window.confirm(`Delete session “${item.title}”?`)) return
-                      const wasActive = item.id === sessionId
-                      void sessionView.deleteSession(item.id).then(() => {
-                        if (!wasActive) return
-                        const next = sessionView.get().sessionId
-                        navigate(next ? `/s/${next}` : '/')
-                      })
-                    }}
-                  >
-                    <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
-                    </svg>
-                  </button>
-                </div>
-              )
-            })
-          )}
-        </div>
-        <div className="flex shrink-0 items-center justify-between gap-2 border-t border-[var(--dsw-border)] px-3 py-3">
-          <span
-            className={`rounded-full px-2 py-0.5 text-[11px] ${live ? 'bg-emerald-50 text-emerald-700' : 'bg-black/5 text-[var(--dsw-label-3)]'}`}
-          >
-            {live ? 'Live' : 'Connecting'}
-          </span>
-          <button
-            type="button"
-            className="grid size-9 place-items-center rounded-full text-[var(--dsw-label-2)] hover:bg-black/5"
-            aria-label="Settings"
-            onClick={() => setSettingsOpen(true)}
-          >
-            <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.8">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M10.3 3.2a1.8 1.8 0 0 1 3.4 0l.2 1a1.8 1.8 0 0 0 2.5 1.1l.9-.5a1.8 1.8 0 0 1 2.5 2.5l-.5.9a1.8 1.8 0 0 0 1.1 2.5l1 .2a1.8 1.8 0 0 1 0 3.4l-1 .2a1.8 1.8 0 0 0-1.1 2.5l.5.9a1.8 1.8 0 0 1-2.5 2.5l-.9-.5a1.8 1.8 0 0 0-2.5 1.1l-.2 1a1.8 1.8 0 0 1-3.4 0l-.2-1a1.8 1.8 0 0 0-2.5-1.1l-.9.5a1.8 1.8 0 0 1-2.5-2.5l.5-.9a1.8 1.8 0 0 0-1.1-2.5l-1-.2a1.8 1.8 0 0 1 0-3.4l1-.2a1.8 1.8 0 0 0 1.1-2.5l-.5-.9a1.8 1.8 0 0 1 2.5-2.5l.9.5a1.8 1.8 0 0 0 2.5-1.1z"
-              />
-              <circle cx="12" cy="12" r="2.4" />
-            </svg>
-          </button>
-        </div>
-      </aside>
+                    <Link
+                      to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
+                      className="min-w-0 flex-1 px-3 py-2 text-left text-sm"
+                    >
+                      <div className="truncate font-medium">{item.title}</div>
+                      <div className="mt-0.5 font-mono text-[10px] opacity-70">
+                        {item.id.slice(0, 8)} · {item.eventCount} events
+                      </div>
+                    </Link>
+                    <button
+                      type="button"
+                      className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
+                      aria-label={`Delete session ${item.title}`}
+                      title="Delete"
+                      onClick={(event) => {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        if (!window.confirm(`Delete session “${item.title}”?`)) return
+                        const wasActive = item.id === sessionId
+                        void sessionView.deleteSession(item.id).then(() => {
+                          if (!wasActive) return
+                          const next = sessionView.get().sessionId
+                          navigate(next ? `/s/${next}` : '/')
+                        })
+                      }}
+                    >
+                      <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
+                      </svg>
+                    </button>
+                  </div>
+                )
+              })
+            )}
+          </div>
+          <div className="flex shrink-0 items-center justify-between gap-2 border-t border-[var(--dsw-border)] px-3 py-3">
+            <span
+              className={`rounded-full px-2 py-0.5 text-[11px] ${live ? 'bg-emerald-50 text-emerald-700' : 'bg-black/5 text-[var(--dsw-label-3)]'}`}
+            >
+              {live ? 'Live' : 'Connecting'}
+            </span>
+            <button
+              type="button"
+              className="grid size-9 place-items-center rounded-full text-[var(--dsw-label-2)] hover:bg-black/5"
+              aria-label="Settings"
+              onClick={() => setSettingsOpen(true)}
+            >
+              <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.8">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.3 3.2a1.8 1.8 0 0 1 3.4 0l.2 1a1.8 1.8 0 0 0 2.5 1.1l.9-.5a1.8 1.8 0 0 1 2.5 2.5l-.5.9a1.8 1.8 0 0 0 1.1 2.5l1 .2a1.8 1.8 0 0 1 0 3.4l-1 .2a1.8 1.8 0 0 0-1.1 2.5l.5.9a1.8 1.8 0 0 1-2.5 2.5l-.9-.5a1.8 1.8 0 0 0-2.5 1.1l-.2 1a1.8 1.8 0 0 1-3.4 0l-.2-1a1.8 1.8 0 0 0-2.5-1.1l-.9.5a1.8 1.8 0 0 1-2.5-2.5l.5-.9a1.8 1.8 0 0 0-1.1-2.5l-1-.2a1.8 1.8 0 0 1 0-3.4l1-.2a1.8 1.8 0 0 0 1.1-2.5l-.5-.9a1.8 1.8 0 0 1 2.5-2.5l.9.5a1.8 1.8 0 0 0 2.5-1.1z"
+                />
+                <circle cx="12" cy="12" r="2.4" />
+              </svg>
+            </button>
+          </div>
+        </aside>
+      ) : null}
 
       <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
-        <header className="flex h-12 shrink-0 items-center gap-4 border-b border-[var(--dsw-border)] px-6">
-          <NavLink
-            to={sessionId ? `/s/${sessionId}` : '/'}
-            end
-            className={({ isActive }) =>
-              `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
-            }
-          >
-            {({ isActive }) => (
-              <>
-                Chat
-                {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
-              </>
-            )}
-          </NavLink>
-          <NavLink
-            to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
-            className={({ isActive }) =>
-              `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
-            }
-          >
-            {({ isActive }) => (
-              <>
-                Trajectory
-                {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
-              </>
-            )}
-          </NavLink>
-        </header>
-        <div
-          className={
-            view === 'chat'
-              ? 'mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4'
-              : 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
-          }
-        >
-          <div
-            className={
-              view === 'chat'
-                ? 'flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4'
-                : 'flex min-h-0 flex-1 flex-col overflow-hidden'
-            }
-          >
-            {view === 'chat' ? props.renderSlot('stage') : props.renderSlot('trajectory')}
-          </div>
-          {view === 'chat' ? (
-            <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
-              {props.renderSlot('dock')}
-              {props.renderSlot('composer')}
+        {activeModule === 'agent' ? (
+          <>
+            <header className="flex h-12 shrink-0 items-center gap-4 border-b border-[var(--dsw-border)] px-6">
+              <NavLink
+                to={sessionId ? `/s/${sessionId}` : '/'}
+                end
+                className={({ isActive }) =>
+                  `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
+                }
+              >
+                {({ isActive }) => (
+                  <>
+                    Chat
+                    {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                  </>
+                )}
+              </NavLink>
+              <NavLink
+                to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
+                className={({ isActive }) =>
+                  `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
+                }
+              >
+                {({ isActive }) => (
+                  <>
+                    Trajectory
+                    {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                  </>
+                )}
+              </NavLink>
+            </header>
+            <div
+              className={
+                view === 'chat'
+                  ? 'mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4'
+                  : 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
+              }
+            >
+              <div
+                className={
+                  view === 'chat'
+                    ? 'flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4'
+                    : 'flex min-h-0 flex-1 flex-col overflow-hidden'
+                }
+              >
+                {view === 'chat' ? props.renderSlot('stage') : props.renderSlot('trajectory')}
+              </div>
+              {view === 'chat' ? (
+                <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
+                  {props.renderSlot('dock')}
+                  {props.renderSlot('composer')}
+                </div>
+              ) : null}
             </div>
-          ) : null}
-        </div>
+          </>
+        ) : (
+          <WorkspaceModule />
+        )}
       </main>
 
       <div

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -35,13 +35,23 @@ function ModuleIcon({ id }: { id: AppModuleId }) {
   )
 }
 
-function ModuleRail({ active, agentHref }: { active: AppModuleId; agentHref: string }) {
+function ModuleRail({
+  active,
+  agentHref,
+  live,
+  onSettings,
+}: {
+  active: AppModuleId
+  agentHref: string
+  live: boolean
+  onSettings: () => void
+}) {
   return (
-    <nav className="app-module-rail" aria-label="App modules">
-      <Link to={agentHref} className="app-module-brand" title="HARNESS" aria-label="Home">
-        <FishLogo size={20} />
+    <nav className="app-activity-bar" aria-label="Activity bar">
+      <Link to={agentHref} className="app-activity-brand" title="HARNESS" aria-label="Home">
+        <FishLogo size={18} />
       </Link>
-      <div className="app-module-list">
+      <div className="app-activity-list">
         {APP_MODULES.map((module) => {
           const to = module.id === 'agent' ? agentHref : module.path
           const isActive = module.id === active
@@ -49,15 +59,40 @@ function ModuleRail({ active, agentHref }: { active: AppModuleId; agentHref: str
             <Link
               key={module.id}
               to={to}
-              className={`app-module-item${isActive ? ' is-active' : ''}`}
-              title={module.description}
+              className={`app-activity-item${isActive ? ' is-active' : ''}`}
+              title={module.label}
+              aria-label={module.label}
               aria-current={isActive ? 'page' : undefined}
             >
+              <span className="app-activity-indicator" aria-hidden />
               <ModuleIcon id={module.id} />
-              <span className="app-module-label">{module.label}</span>
+              <span className="sr-only">{module.label}</span>
             </Link>
           )
         })}
+      </div>
+      <div className="app-activity-footer">
+        <span
+          className={`app-activity-live${live ? ' is-live' : ''}`}
+          title={live ? 'Live' : 'Connecting'}
+          aria-label={live ? 'Live' : 'Connecting'}
+        />
+        <button
+          type="button"
+          className="app-activity-item app-activity-settings"
+          title="Settings"
+          aria-label="Settings"
+          onClick={onSettings}
+        >
+          <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.7">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.3 3.2a1.8 1.8 0 0 1 3.4 0l.2 1a1.8 1.8 0 0 0 2.5 1.1l.9-.5a1.8 1.8 0 0 1 2.5 2.5l-.5.9a1.8 1.8 0 0 0 1.1 2.5l1 .2a1.8 1.8 0 0 1 0 3.4l-1 .2a1.8 1.8 0 0 0-1.1 2.5l.5.9a1.8 1.8 0 0 1-2.5 2.5l-.9-.5a1.8 1.8 0 0 0-2.5 1.1l-.2 1a1.8 1.8 0 0 1-3.4 0l-.2-1a1.8 1.8 0 0 0-2.5-1.1l-.9.5a1.8 1.8 0 0 1-2.5-2.5l.5-.9a1.8 1.8 0 0 0-1.1-2.5l-1-.2a1.8 1.8 0 0 1 0-3.4l1-.2a1.8 1.8 0 0 0 1.1-2.5l-.5-.9a1.8 1.8 0 0 1 2.5-2.5l.9.5a1.8 1.8 0 0 0 2.5-1.1z"
+            />
+            <circle cx="12" cy="12" r="2.4" />
+          </svg>
+        </button>
       </div>
     </nav>
   )
@@ -105,16 +140,18 @@ function Shell(props: SlotProps) {
     <div
       className={`app-shell${activeModule === 'agent' ? ' app-shell-agent' : ' app-shell-module'}`}
     >
-      <ModuleRail active={activeModule} agentHref={agentHref} />
+      <ModuleRail
+        active={activeModule}
+        agentHref={agentHref}
+        live={live}
+        onSettings={() => setSettingsOpen(true)}
+      />
 
       {activeModule === 'agent' ? (
-        <aside className="flex min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
+        <aside className="app-side-bar flex min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
           <div className="flex shrink-0 flex-col gap-2 px-4 pt-4 pb-2">
             <BrandWordmark />
-            <div>
-              <div className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Module</div>
-              <div className="mt-0.5 text-[15px] font-semibold tracking-tight">Agent</div>
-            </div>
+            <div className="text-[13px] font-semibold tracking-tight">Agent</div>
           </div>
           <div className="shrink-0 px-3 pb-3">
             <button
@@ -189,28 +226,6 @@ function Shell(props: SlotProps) {
                 )
               })
             )}
-          </div>
-          <div className="flex shrink-0 items-center justify-between gap-2 border-t border-[var(--dsw-border)] px-3 py-3">
-            <span
-              className={`rounded-full px-2 py-0.5 text-[11px] ${live ? 'bg-emerald-50 text-emerald-700' : 'bg-black/5 text-[var(--dsw-label-3)]'}`}
-            >
-              {live ? 'Live' : 'Connecting'}
-            </span>
-            <button
-              type="button"
-              className="grid size-9 place-items-center rounded-full text-[var(--dsw-label-2)] hover:bg-black/5"
-              aria-label="Settings"
-              onClick={() => setSettingsOpen(true)}
-            >
-              <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.8">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M10.3 3.2a1.8 1.8 0 0 1 3.4 0l.2 1a1.8 1.8 0 0 0 2.5 1.1l.9-.5a1.8 1.8 0 0 1 2.5 2.5l-.5.9a1.8 1.8 0 0 0 1.1 2.5l1 .2a1.8 1.8 0 0 1 0 3.4l-1 .2a1.8 1.8 0 0 0-1.1 2.5l.5.9a1.8 1.8 0 0 1-2.5 2.5l-.9-.5a1.8 1.8 0 0 0-2.5 1.1l-.2 1a1.8 1.8 0 0 1-3.4 0l-.2-1a1.8 1.8 0 0 0-2.5-1.1l-.9.5a1.8 1.8 0 0 1-2.5-2.5l.5-.9a1.8 1.8 0 0 0-1.1-2.5l-1-.2a1.8 1.8 0 0 1 0-3.4l1-.2a1.8 1.8 0 0 0 1.1-2.5l-.5-.9a1.8 1.8 0 0 1 2.5-2.5l.9.5a1.8 1.8 0 0 0 2.5-1.1z"
-                />
-                <circle cx="12" cy="12" r="2.4" />
-              </svg>
-            </button>
           </div>
         </aside>
       ) : null}

--- a/src/plugins/infrastructure/app-modules.test.ts
+++ b/src/plugins/infrastructure/app-modules.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { APP_MODULES, isAgentPath, moduleById, moduleIdFromPath } from './app-modules.ts'
+
+test('APP_MODULES lists agent first', () => {
+  assert.equal(APP_MODULES[0]?.id, 'agent')
+  assert.equal(moduleById('workspace').path, '/workspace')
+})
+
+test('moduleIdFromPath maps agent and workspace routes', () => {
+  assert.equal(moduleIdFromPath('/'), 'agent')
+  assert.equal(moduleIdFromPath('/s/abc'), 'agent')
+  assert.equal(moduleIdFromPath('/s/abc/trajectory'), 'agent')
+  assert.equal(moduleIdFromPath('/workspace'), 'workspace')
+  assert.equal(moduleIdFromPath('/workspace/'), 'workspace')
+  assert.equal(isAgentPath('/s/x'), true)
+  assert.equal(isAgentPath('/workspace'), false)
+})

--- a/src/plugins/infrastructure/app-modules.ts
+++ b/src/plugins/infrastructure/app-modules.ts
@@ -1,0 +1,40 @@
+/** 应用级模块：Agent 只是其中之一，路由决定当前模块。 */
+export type AppModuleId = 'agent' | 'workspace'
+
+export interface AppModule {
+  id: AppModuleId
+  label: string
+  /** 模块首页 path */
+  path: string
+  description: string
+}
+
+export const APP_MODULES: AppModule[] = [
+  {
+    id: 'agent',
+    label: 'Agent',
+    path: '/',
+    description: 'Session chat, tools, and trajectory ledger',
+  },
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    path: '/workspace',
+    description: 'Project files and context (placeholder)',
+  },
+]
+
+export function moduleById(id: AppModuleId): AppModule {
+  return APP_MODULES.find((item) => item.id === id) ?? APP_MODULES[0]!
+}
+
+/** Agent 相关 path（含历史 `/s/:id`）→ agent；其余按模块 path。 */
+export function moduleIdFromPath(pathname: string): AppModuleId {
+  const path = pathname.replace(/\/+$/, '') || '/'
+  if (path === '/workspace' || path.startsWith('/workspace/')) return 'workspace'
+  return 'agent'
+}
+
+export function isAgentPath(pathname: string) {
+  return moduleIdFromPath(pathname) === 'agent'
+}

--- a/src/plugins/infrastructure/renderer.tsx
+++ b/src/plugins/infrastructure/renderer.tsx
@@ -42,6 +42,7 @@ export function renderRoot(slots: SlotsService): ReactNode {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<AppShell slots={slots} />} />
+        <Route path="/workspace" element={<AppShell slots={slots} />} />
         <Route path="/s/:sessionId" element={<AppShell slots={slots} />} />
         <Route path="/s/:sessionId/chat" element={<AppShell slots={slots} />} />
         <Route path="/s/:sessionId/trajectory" element={<AppShell slots={slots} />} />

--- a/src/plugins/infrastructure/session-route.test.ts
+++ b/src/plugins/infrastructure/session-route.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { buildAppPath, parseAppPath, routeFromState } from './session-route.ts'
 
-test('parseAppPath covers home, session chat, and trajectory', () => {
+test('parseAppPath covers home, session chat, trajectory, and workspace module', () => {
   assert.deepEqual(parseAppPath('/'), { kind: 'home' })
   assert.deepEqual(parseAppPath('/s/abc'), { kind: 'session', sessionId: 'abc', view: 'chat' })
   assert.deepEqual(parseAppPath('/s/abc/'), { kind: 'session', sessionId: 'abc', view: 'chat' })
@@ -12,6 +12,7 @@ test('parseAppPath covers home, session chat, and trajectory', () => {
     sessionId: 'abc',
     view: 'trajectory',
   })
+  assert.deepEqual(parseAppPath('/workspace'), { kind: 'module', moduleId: 'workspace' })
   assert.deepEqual(parseAppPath('/unknown'), { kind: 'home' })
 })
 
@@ -20,6 +21,7 @@ test('buildAppPath round-trips with parseAppPath', () => {
     { kind: 'home' as const },
     { kind: 'session' as const, sessionId: 's1', view: 'chat' as const },
     { kind: 'session' as const, sessionId: 's1', view: 'trajectory' as const },
+    { kind: 'module' as const, moduleId: 'workspace' as const },
   ]
   for (const route of routes) {
     assert.deepEqual(parseAppPath(buildAppPath(route)), route)

--- a/src/plugins/infrastructure/session-route.ts
+++ b/src/plugins/infrastructure/session-route.ts
@@ -1,12 +1,14 @@
-/** `/` | `/s/:id` | `/s/:id/trajectory`（`/chat` 可省略） */
+/** `/` | `/s/:id` | `/s/:id/trajectory` | `/workspace` */
 export type RouteView = 'chat' | 'trajectory'
 
 export type AppRoute =
   | { kind: 'home' }
   | { kind: 'session'; sessionId: string; view: RouteView }
+  | { kind: 'module'; moduleId: 'workspace' }
 
 export function parseAppPath(pathname: string): AppRoute {
   const path = normalizePath(pathname)
+  if (path === '/workspace') return { kind: 'module', moduleId: 'workspace' }
   if (path === '/') return { kind: 'home' }
   const match = path.match(/^\/s\/([^/]+)(?:\/(chat|trajectory))?$/)
   if (!match?.[1]) return { kind: 'home' }
@@ -19,6 +21,7 @@ export function parseAppPath(pathname: string): AppRoute {
 
 export function buildAppPath(route: AppRoute): string {
   if (route.kind === 'home') return '/'
+  if (route.kind === 'module') return route.moduleId === 'workspace' ? '/workspace' : '/'
   if (route.view === 'trajectory') return `/s/${encodeURIComponent(route.sessionId)}/trajectory`
   return `/s/${encodeURIComponent(route.sessionId)}`
 }

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -81,6 +81,10 @@ export class SessionViewService extends Service {
 
   /** URL → 状态：只由路由层调用，不回写 URL */
   async applyRoute(route: AppRoute) {
+    if (route.kind === 'module') {
+      // 其它模块不碰 agent session 投影，切回 Agent 时会话仍在。
+      return
+    }
     if (route.kind === 'home') {
       if (!this.value.sessionId && this.value.view === 'chat') return
       this.replace({

--- a/src/style.css
+++ b/src/style.css
@@ -98,6 +98,81 @@ body {
   background: radial-gradient(ellipse at center, rgba(65, 118, 230, 0.16), transparent 70%);
 }
 
+/* App shell — module rail + optional agent session sidebar */
+.app-shell {
+  display: grid;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--dsw-bg);
+  color: var(--dsw-label);
+}
+
+.app-shell-agent {
+  grid-template-columns: 72px 280px minmax(0, 1fr);
+}
+
+.app-shell-module {
+  grid-template-columns: 72px minmax(0, 1fr);
+}
+
+.app-module-rail {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  border-right: 1px solid var(--dsw-border);
+  background: #f3f4f6;
+  padding: 12px 8px;
+}
+
+.app-module-brand {
+  display: grid;
+  height: 40px;
+  place-items: center;
+  border-radius: 12px;
+  color: var(--dsw-label);
+}
+
+.app-module-brand:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.app-module-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.app-module-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  border-radius: 12px;
+  padding: 10px 4px 8px;
+  color: var(--dsw-label-3);
+  text-decoration: none;
+}
+
+.app-module-item:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--dsw-label-2);
+}
+
+.app-module-item.is-active {
+  background: var(--dsw-business-soft);
+  color: var(--dsw-business);
+}
+
+.app-module-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
 /* Trajectory — compact profiler-style ledger (full bleed, no outer card) */
 .traj-root {
   display: flex;

--- a/src/style.css
+++ b/src/style.css
@@ -98,7 +98,7 @@ body {
   background: radial-gradient(ellipse at center, rgba(65, 118, 230, 0.16), transparent 70%);
 }
 
-/* App shell — module rail + optional agent session sidebar */
+/* App shell — VS Code-like activity bar + optional side bar */
 .app-shell {
   display: grid;
   height: 100vh;
@@ -108,69 +108,106 @@ body {
 }
 
 .app-shell-agent {
-  grid-template-columns: 72px 280px minmax(0, 1fr);
+  grid-template-columns: 48px 280px minmax(0, 1fr);
 }
 
 .app-shell-module {
-  grid-template-columns: 72px minmax(0, 1fr);
+  grid-template-columns: 48px minmax(0, 1fr);
 }
 
-.app-module-rail {
+.app-activity-bar {
   display: flex;
   min-height: 0;
   flex-direction: column;
   align-items: stretch;
-  gap: 8px;
   border-right: 1px solid var(--dsw-border);
-  background: #f3f4f6;
-  padding: 12px 8px;
+  background: #eceef1;
 }
 
-.app-module-brand {
+.app-activity-brand {
   display: grid;
-  height: 40px;
+  height: 48px;
   place-items: center;
-  border-radius: 12px;
   color: var(--dsw-label);
 }
 
-.app-module-brand:hover {
-  background: rgba(0, 0, 0, 0.04);
-}
-
-.app-module-list {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.app-module-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  border-radius: 12px;
-  padding: 10px 4px 8px;
-  color: var(--dsw-label-3);
-  text-decoration: none;
-}
-
-.app-module-item:hover {
-  background: rgba(0, 0, 0, 0.04);
-  color: var(--dsw-label-2);
-}
-
-.app-module-item.is-active {
-  background: var(--dsw-business-soft);
+.app-activity-brand:hover {
   color: var(--dsw-business);
 }
 
-.app-module-label {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  line-height: 1;
+.app-activity-list {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 2px;
+  padding-top: 4px;
+}
+
+.app-activity-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 10px;
+}
+
+.app-activity-item {
+  position: relative;
+  display: grid;
+  width: 100%;
+  height: 48px;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.app-activity-item:hover {
+  color: var(--dsw-label);
+}
+
+.app-activity-item.is-active {
+  color: var(--dsw-label);
+}
+
+.app-activity-indicator {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  width: 2px;
+  border-radius: 0 2px 2px 0;
+  background: transparent;
+}
+
+.app-activity-item.is-active .app-activity-indicator {
+  background: var(--dsw-business);
+}
+
+.app-activity-live {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.app-activity-live.is-live {
+  background: var(--dsw-ok);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Trajectory — compact profiler-style ledger (full bleed, no outer card) */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
原先整页就是 Agent。需要类似 **VS Code Activity Bar** 的最左窄栏，用来切换不同页面；Agent 只是其中一个视图。

## 改动
- 最左 **48px Activity Bar**：纯图标（Agent / Workspace），左侧激活指示条
- 底部：Live 点 + Settings（对标 VS Code）
- **Agent** 选中时右侧再出 Side Bar（Sessions + New Session / Fork）
- **Workspace**：`/workspace` 占位页
- 切页不卸载 session；切回 Agent 会话仍在

## 验证
- `npm test`（73 passed）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

