### PR TITLE
feat: Session 绑定本地文件夹，Chat 内浏览编辑

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -24,6 +24,7 @@
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
 19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
 20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
+21. **Web：Session 绑定本地项目文件夹** — Agent Chat 右侧 Project 面板 `Open folder`（File System Access API）；文件夹名写入 session.project，句柄按 sessionId 存 IndexedDB；可浏览/编辑/保存文本文件。
 
 ## 功能级差异（相对官方 client，优点对齐后）
 

--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -172,6 +172,7 @@ export function apply(ctx: Context) {
         eventCount: record.events.length,
         title,
         updatedAt: record.events.at(-1)?.ts ?? 0,
+        ...(record.project ? { project: record.project } : {}),
       })
     }
     items.sort((a, b) => b.updatedAt - a.updatedAt)
@@ -180,7 +181,26 @@ export function apply(ctx: Context) {
   ctx.http.route('GET', '/api/sessions/:id', async (route) => {
     const record = await ctx.sessions.get(route.params.id)
     if (!record) return route.send(404, { error: 'unknown session' })
-    route.send(200, { id: record.id, version: record.version, events: record.events, messages: ctx.sessions.deriveMessages(record.id) })
+    route.send(200, {
+      id: record.id,
+      version: record.version,
+      events: record.events,
+      messages: ctx.sessions.deriveMessages(record.id),
+      ...(record.project ? { project: record.project } : {}),
+    })
+  })
+  ctx.http.route('PUT', '/api/sessions/:id/project', async (route) => {
+    const payload = (await route.json()) as { name?: string | null }
+    try {
+      if (payload.name == null || payload.name === '') {
+        await ctx.sessions.setProject(route.params.id, null)
+        return route.send(200, { ok: true, project: null })
+      }
+      const project = await ctx.sessions.setProject(route.params.id, { name: String(payload.name).slice(0, 200) })
+      route.send(200, { ok: true, project })
+    } catch (error) {
+      route.send(404, { error: String(error) })
+    }
   })
   ctx.http.route('POST', '/api/sessions/:id/fork', async (route) => {
     try {

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -35,6 +35,8 @@ export interface SessionRecord {
   id: string
   version: number
   events: SessionEvent[]
+  /** 本 session 绑定的本地项目文件夹名（句柄在浏览器 IndexedDB）。 */
+  project?: { name: string; boundAt: number }
 }
 
 export interface SessionStore {

--- a/host/plugins/core/sessions.test.ts
+++ b/host/plugins/core/sessions.test.ts
@@ -77,6 +77,20 @@ test('fork copies the append-only log into a child session', async () => {
   assert.equal((await ctx.sessions.require(parent.id)).events.some((item) => item.type === 'assistant/message'), false)
 })
 
+test('setProject binds and clears session project folder name', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create()
+  const project = await ctx.sessions.setProject(record.id, { name: 'demo-app' })
+  assert.equal(project?.name, 'demo-app')
+  assert.equal((await ctx.sessions.require(record.id)).project?.name, 'demo-app')
+  const child = await ctx.sessions.fork(record.id)
+  assert.equal(child.project?.name, 'demo-app')
+  assert.equal(await ctx.sessions.setProject(record.id, null), undefined)
+  assert.equal((await ctx.sessions.require(record.id)).project, undefined)
+})
+
 test('delete removes session from store and cache', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'memory' })

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -93,9 +93,21 @@ export class SessionsService extends Service {
       id: childId,
       version: source.version,
       events: source.events.map((event) => ({ ...event })),
+      ...(source.project ? { project: { ...source.project } } : {}),
     }
     await this.persist(record)
     return record
+  }
+
+  async setProject(id: string, project: { name: string } | null) {
+    const record = await this.require(id)
+    if (project) {
+      record.project = { name: project.name, boundAt: Date.now() }
+    } else {
+      delete record.project
+    }
+    await this.persist(record)
+    return record.project
   }
 
   list() {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,7 @@ import './style.css'
 import * as slots from './plugins/registry/slots.ts'
 import * as snapshot from './plugins/infrastructure/snapshot.ts'
 import * as sessionView from './plugins/infrastructure/session-view.ts'
+import * as projectView from './plugins/infrastructure/project-view.ts'
 import * as reactHost from './plugins/infrastructure/react-host.ts'
 import * as shell from './plugins/contributors/shell.tsx'
 import * as pluginTree from './plugins/contributors/plugin-tree.tsx'
@@ -17,6 +18,7 @@ if (!el) throw new Error('#app missing')
 const ctx = new Context()
 ctx.plugin(slots)
 ctx.plugin(sessionView)
+ctx.plugin(projectView)
 ctx.plugin(snapshot)
 ctx.plugin(reactHost, { el })
 ctx.plugin(shell)

--- a/src/plugins/contributors/chat/index.test.ts
+++ b/src/plugins/contributors/chat/index.test.ts
@@ -5,13 +5,15 @@ import '../../../types.ts'
 import * as slots from '../../registry/slots.ts'
 import * as snapshot from '../../infrastructure/snapshot.ts'
 import * as sessionView from '../../infrastructure/session-view.ts'
+import * as projectView from '../../infrastructure/project-view.ts'
 import * as chat from './index.ts'
 import * as shell from '../shell.tsx'
 
-test('one plugin fills thread, trajectory, composer, approvals dock and settings', async () => {
+test('one plugin fills thread, trajectory, project, composer, approvals dock and settings', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await ctx.plugin(chat)
   assert.equal(ctx.slots.list('composer').length, 0)
@@ -19,6 +21,7 @@ test('one plugin fills thread, trajectory, composer, approvals dock and settings
   assert.equal(ctx.slots.list('composer')[0]?.id, 'chat')
   assert.equal(ctx.slots.list('stage').some((item) => item.id === 'chat-thread'), true)
   assert.equal(ctx.slots.list('trajectory').some((item) => item.id === 'trajectory'), true)
+  assert.equal(ctx.slots.list('project').some((item) => item.id === 'session-project'), true)
   assert.equal(ctx.slots.list('dock').some((item) => item.id === 'approvals'), true)
   assert.equal(ctx.slots.list('settings')[0]?.id, 'chat-config')
 })

--- a/src/plugins/contributors/chat/index.ts
+++ b/src/plugins/contributors/chat/index.ts
@@ -6,18 +6,24 @@ import { ChatConfig } from './config.tsx'
 import { ChatConfigBanner } from './config-banner.tsx'
 import { ChatThread } from './thread.tsx'
 import { TrajectoryView } from './trajectory.tsx'
+import { SessionProjectPanel } from './project-panel.tsx'
+import { bindProjectView, type ProjectViewService } from '../../infrastructure/project-view.ts'
 
 export const name = 'chat-ui'
-export const inject = ['slots', 'sessionView']
+export const inject = ['slots', 'sessionView', 'projectView']
 
 export function apply(ctx: Context) {
   const view = ctx.sessionView as SessionViewService
+  const project = ctx.projectView as ProjectViewService
   const props = () => ({
     useSessionView: bindSessionView(view),
     sessionView: view,
+    useProjectView: bindProjectView(project),
+    projectView: project,
   })
   ctx.slots.place('stage', ChatThread, { key: 'chat-thread', order: 1, props })
   ctx.slots.place('trajectory', TrajectoryView, { key: 'trajectory', order: 1, props })
+  ctx.slots.place('project', SessionProjectPanel, { key: 'session-project', order: 1, props })
   ctx.slots.place('composer', ChatComposer, { key: 'chat', order: 10, props })
   ctx.slots.place('dock', ChatConfigBanner, { key: 'chat-config-banner', order: 1 })
   ctx.slots.place('dock', ApprovalsRail, { key: 'approvals', order: 5, props })

--- a/src/plugins/contributors/chat/project-panel.tsx
+++ b/src/plugins/contributors/chat/project-panel.tsx
@@ -1,0 +1,175 @@
+import type { SlotProps } from '../../registry/slots.ts'
+import { bindProjectView, type ProjectViewService } from '../../infrastructure/project-view.ts'
+import type { DirEntry } from '../../infrastructure/session-folder.ts'
+
+function TreeRows({
+  entries,
+  depth,
+  expanded,
+  childrenMap,
+  openPath,
+  onToggle,
+  onOpen,
+}: {
+  entries: DirEntry[]
+  depth: number
+  expanded: string[]
+  childrenMap: Record<string, DirEntry[]>
+  openPath?: string
+  onToggle: (path: string) => void
+  onOpen: (path: string) => void
+}) {
+  return (
+    <>
+      {entries.map((entry) => {
+        const isOpen = expanded.includes(entry.path)
+        const active = openPath === entry.path
+        return (
+          <div key={entry.path}>
+            <button
+              type="button"
+              className={`project-tree-row${active ? ' is-active' : ''}`}
+              style={{ paddingLeft: 8 + depth * 12 }}
+              onClick={() => {
+                if (entry.kind === 'directory') onToggle(entry.path)
+                else onOpen(entry.path)
+              }}
+            >
+              <span className="project-tree-icon" aria-hidden>
+                {entry.kind === 'directory' ? (isOpen ? '▾' : '▸') : '·'}
+              </span>
+              <span className="truncate">{entry.name}</span>
+            </button>
+            {entry.kind === 'directory' && isOpen && childrenMap[entry.path] ? (
+              <TreeRows
+                entries={childrenMap[entry.path]!}
+                depth={depth + 1}
+                expanded={expanded}
+                childrenMap={childrenMap}
+                openPath={openPath}
+                onToggle={onToggle}
+                onOpen={onOpen}
+              />
+            ) : null}
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+/** Session 绑定的本地项目：树 + 文本编辑。 */
+export function SessionProjectPanel(props: SlotProps) {
+  const useProjectView = props.useProjectView as ReturnType<typeof bindProjectView>
+  const projectView = props.projectView as ProjectViewService
+  const sessionId = useProjectView((state) => state.sessionId)
+  const project = useProjectView((state) => state.project)
+  const handleReady = useProjectView((state) => state.handleReady)
+  const entries = useProjectView((state) => state.entries)
+  const expanded = useProjectView((state) => state.expanded)
+  const children = useProjectView((state) => state.children)
+  const openPath = useProjectView((state) => state.openPath)
+  const content = useProjectView((state) => state.content)
+  const dirty = useProjectView((state) => state.dirty)
+  const busy = useProjectView((state) => state.busy)
+  const error = useProjectView((state) => state.error)
+  const supported = projectView.supported()
+
+  if (!sessionId) {
+    return (
+      <div className="project-panel project-panel-empty">
+        <p className="text-sm text-[var(--dsw-label-3)]">先创建或打开一个 Session，再绑定本地文件夹。</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="project-panel">
+      <header className="project-panel-head">
+        <div className="min-w-0">
+          <div className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Project</div>
+          <div className="truncate text-sm font-semibold" title={project?.name}>
+            {project?.name ?? '未绑定文件夹'}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {project && handleReady ? (
+            <button
+              type="button"
+              className="rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-label-3)] hover:bg-black/5"
+              disabled={busy}
+              onClick={() => void projectView.unbindFolder()}
+            >
+              Unbind
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="rounded-[8px] bg-[var(--dsw-business)] px-2.5 py-1 text-[11px] font-medium text-white disabled:opacity-50"
+            disabled={busy || !supported}
+            onClick={() => void projectView.openFolderForSession(sessionId).catch(() => undefined)}
+          >
+            {project ? 'Rebind' : 'Open folder'}
+          </button>
+        </div>
+      </header>
+
+      {!supported ? (
+        <p className="project-panel-hint">需要 Chromium 系浏览器的 File System Access API 才能打开本地文件夹。</p>
+      ) : null}
+      {error ? <p className="project-panel-error">{error}</p> : null}
+
+      {!project ? (
+        <div className="project-panel-empty">
+          <p className="text-sm leading-6 text-[var(--dsw-label-2)]">
+            为本 Session 打开一个本地文件夹，即可浏览与编辑文件。每个 Session 绑定一个项目目录。
+          </p>
+        </div>
+      ) : !handleReady ? (
+        <div className="project-panel-empty">
+          <p className="text-sm leading-6 text-[var(--dsw-label-2)]">
+            已记录项目「{project.name}」，但浏览器句柄未授权。请点 Rebind 重新选择同一文件夹。
+          </p>
+        </div>
+      ) : (
+        <div className="project-panel-body">
+          <div className="project-tree">
+            <TreeRows
+              entries={entries}
+              depth={0}
+              expanded={expanded}
+              childrenMap={children}
+              openPath={openPath}
+              onToggle={(path) => void projectView.toggleDir(path)}
+              onOpen={(path) => void projectView.openFile(path)}
+            />
+          </div>
+          <div className="project-editor">
+            <div className="project-editor-toolbar">
+              <span className="min-w-0 truncate font-mono text-[11px] text-[var(--dsw-label-3)]">
+                {openPath ?? 'Select a file'}
+                {dirty ? ' · unsaved' : ''}
+              </span>
+              <button
+                type="button"
+                className="rounded-[8px] px-2 py-1 text-[11px] font-medium text-[var(--dsw-business)] hover:bg-[var(--dsw-business-soft)] disabled:opacity-40"
+                disabled={!openPath || !dirty || busy}
+                onClick={() => void projectView.save()}
+              >
+                Save
+              </button>
+            </div>
+            <textarea
+              className="project-editor-textarea"
+              value={openPath ? content : ''}
+              disabled={!openPath || busy}
+              spellCheck={false}
+              onChange={(event) => projectView.setContent(event.target.value)}
+              placeholder={openPath ? '' : '从左侧选择文件开始编辑'}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -106,7 +106,7 @@ function EmptyHero() {
           </span>
         </div>
         <p className="max-w-md text-sm text-[var(--dsw-label-3)]">
-          对话由 append-only session 投影，经 agents 驱动。Everything is a plugin.
+          对话由 append-only session 投影。右侧 Project 可为本 Session 打开本地文件夹并编辑文件。
         </p>
       </div>
     </div>

--- a/src/plugins/contributors/hello.test.ts
+++ b/src/plugins/contributors/hello.test.ts
@@ -5,6 +5,7 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
 import * as sessionView from '../infrastructure/session-view.ts'
+import * as projectView from '../infrastructure/project-view.ts'
 import * as hello from './hello.tsx'
 import * as shell from './shell.tsx'
 
@@ -12,6 +13,7 @@ test('fills demos after shell opens it', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await ctx.plugin(hello)
   assert.equal(ctx.slots.list('demos').length, 0)

--- a/src/plugins/contributors/nav.test.ts
+++ b/src/plugins/contributors/nav.test.ts
@@ -5,6 +5,7 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
 import * as sessionView from '../infrastructure/session-view.ts'
+import * as projectView from '../infrastructure/project-view.ts'
 import * as nav from './nav.tsx'
 import * as shell from './shell.tsx'
 
@@ -12,6 +13,7 @@ test('fills sidebar', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await ctx.plugin(nav)
   await ctx.plugin(shell)

--- a/src/plugins/contributors/shell.test.ts
+++ b/src/plugins/contributors/shell.test.ts
@@ -5,12 +5,14 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
 import * as sessionView from '../infrastructure/session-view.ts'
+import * as projectView from '../infrastructure/project-view.ts'
 import * as shell from './shell.tsx'
 
-test('declares dsh-like sidebar, demos, dock, stage, trajectory, composer', async () => {
+test('declares dsh-like sidebar, demos, dock, stage, trajectory, project, composer', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await ctx.plugin(shell)
   assert.equal(ctx.slots.specOf('sidebar')?.kind, 'single')
@@ -18,6 +20,7 @@ test('declares dsh-like sidebar, demos, dock, stage, trajectory, composer', asyn
   assert.equal(ctx.slots.specOf('dock')?.kind, 'list')
   assert.equal(ctx.slots.specOf('stage')?.kind, 'list')
   assert.equal(ctx.slots.specOf('trajectory')?.kind, 'list')
+  assert.equal(ctx.slots.specOf('project')?.kind, 'single')
   assert.equal(ctx.slots.specOf('composer')?.kind, 'single')
   assert.equal(ctx.slots.specOf('settings')?.kind, 'list')
   assert.equal(ctx.slots.specOf('log')?.kind, 'single')

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -4,6 +4,7 @@ import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
 import { bindSnapshot, type Snapshot, type SnapshotService } from '../infrastructure/snapshot.ts'
 import { bindSessionView, type SessionViewService } from '../infrastructure/session-view.ts'
+import { bindProjectView, type ProjectViewService } from '../infrastructure/project-view.ts'
 import { parseAppPath } from '../infrastructure/session-route.ts'
 import {
   APP_MODULES,
@@ -13,7 +14,7 @@ import {
 import { BrandWordmark, FishLogo } from './brand.tsx'
 
 export const name = 'shell'
-export const inject = ['slots', 'snapshot', 'sessionView']
+export const inject = ['slots', 'snapshot', 'sessionView', 'projectView']
 
 function ModuleIcon({ id }: { id: AppModuleId }) {
   if (id === 'workspace') {
@@ -103,7 +104,8 @@ function WorkspaceModule() {
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
       <h1 className="text-xl font-semibold tracking-tight text-[var(--dsw-label)]">Workspace</h1>
       <p className="max-w-md text-sm leading-6 text-[var(--dsw-label-3)]">
-        占位模块：后续可挂项目文件、上下文与其它工作台能力。左侧模块轨里，Agent 只是其中一个入口。
+        本地项目文件夹绑定在 <strong className="font-semibold text-[var(--dsw-label-2)]">Agent Session</strong>{' '}
+        上：进入 Agent → 打开/新建 Session → 右侧 Project 面板 Open folder。每个 Session 对应一个文件夹。
       </p>
     </div>
   )
@@ -113,12 +115,14 @@ function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const sessionView = props.sessionView as SessionViewService
+  const projectView = props.projectView as ProjectViewService
   const navigate = useNavigate()
   const location = useLocation()
   const snap = useSnapshot((state: Snapshot) => state)
   const live = snap.plugins.some((plugin) => plugin.enabled)
   const sessions = useSessionView((state) => state.sessions)
   const sessionId = useSessionView((state) => state.sessionId)
+  const project = useSessionView((state) => state.project)
   const view = useSessionView((state) => state.view)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const activeModule = moduleIdFromPath(location.pathname)
@@ -135,6 +139,20 @@ function Shell(props: SlotProps) {
   useEffect(() => {
     void sessionView.refreshSessions()
   }, [sessionView])
+
+  useEffect(() => {
+    void projectView.attachSession(sessionId, project)
+  }, [sessionId, project, projectView])
+
+  useEffect(() => {
+    const unsub = projectView.subscribe(() => {
+      const state = projectView.get()
+      if (state.sessionId && state.sessionId === sessionView.get().sessionId) {
+        sessionView.setProjectMeta(state.project)
+      }
+    })
+    return unsub
+  }, [projectView, sessionView])
 
   return (
     <div
@@ -199,6 +217,7 @@ function Shell(props: SlotProps) {
                       <div className="truncate font-medium">{item.title}</div>
                       <div className="mt-0.5 font-mono text-[10px] opacity-70">
                         {item.id.slice(0, 8)} · {item.eventCount} events
+                        {item.project ? ` · ${item.project.name}` : ''}
                       </div>
                     </Link>
                     <button
@@ -265,25 +284,28 @@ function Shell(props: SlotProps) {
             <div
               className={
                 view === 'chat'
-                  ? 'mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4'
+                  ? 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
                   : 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
               }
             >
-              <div
-                className={
-                  view === 'chat'
-                    ? 'flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4'
-                    : 'flex min-h-0 flex-1 flex-col overflow-hidden'
-                }
-              >
-                {view === 'chat' ? props.renderSlot('stage') : props.renderSlot('trajectory')}
-              </div>
               {view === 'chat' ? (
-                <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
-                  {props.renderSlot('dock')}
-                  {props.renderSlot('composer')}
+                <div className="flex min-h-0 flex-1 overflow-hidden">
+                  <div className="mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4">
+                    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4">
+                      {props.renderSlot('stage')}
+                    </div>
+                    <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
+                      {props.renderSlot('dock')}
+                      {props.renderSlot('composer')}
+                    </div>
+                  </div>
+                  <aside className="project-pane hidden min-h-0 w-[min(420px,42vw)] shrink-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] md:flex">
+                    {props.renderSlot('project')}
+                  </aside>
                 </div>
-              ) : null}
+              ) : (
+                props.renderSlot('trajectory')
+              )}
             </div>
           </>
         ) : (
@@ -361,6 +383,7 @@ export function apply(ctx: Context) {
       dock: { kind: 'list' },
       stage: { kind: 'list' },
       trajectory: { kind: 'list' },
+      project: { kind: 'single' },
       composer: { kind: 'single' },
       settings: { kind: 'list' },
       log: { kind: 'single' },
@@ -370,6 +393,8 @@ export function apply(ctx: Context) {
       useSnapshot: bindSnapshot(ctx.snapshot as SnapshotService),
       useSessionView: bindSessionView(ctx.sessionView as SessionViewService),
       sessionView: ctx.sessionView as SessionViewService,
+      projectView: ctx.projectView as ProjectViewService,
+      useProjectView: bindProjectView(ctx.projectView as ProjectViewService),
     }),
   })
 }

--- a/src/plugins/infrastructure/project-view.ts
+++ b/src/plugins/infrastructure/project-view.ts
@@ -1,0 +1,236 @@
+import { useSyncExternalStore } from 'react'
+import { Service, type Context } from 'cordis'
+import {
+  canPickDirectory,
+  deleteSessionDirHandle,
+  listDirectory,
+  loadSessionDirHandle,
+  pickDirectory,
+  readTextFile,
+  saveSessionDirHandle,
+  writeTextFile,
+  type DirEntry,
+  type FsDirHandle,
+} from './session-folder.ts'
+
+export interface SessionProjectMeta {
+  name: string
+  boundAt: number
+}
+
+export interface ProjectViewState {
+  sessionId: string | null
+  project?: SessionProjectMeta
+  handleReady: boolean
+  entries: DirEntry[]
+  expanded: string[]
+  children: Record<string, DirEntry[]>
+  openPath?: string
+  content: string
+  dirty: boolean
+  busy: boolean
+  error?: string
+}
+
+const empty: ProjectViewState = {
+  sessionId: null,
+  handleReady: false,
+  entries: [],
+  expanded: [],
+  children: {},
+  content: '',
+  dirty: false,
+  busy: false,
+}
+
+export class ProjectViewService extends Service {
+  private value: ProjectViewState = empty
+  private listeners = new Set<() => void>()
+  private root: FsDirHandle | null = null
+
+  constructor(ctx: Context) {
+    super(ctx, 'projectView')
+  }
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  get = () => this.value
+
+  /** 跟随当前 chat session；切换时加载绑定与句柄。 */
+  async attachSession(sessionId: string | null, project?: SessionProjectMeta) {
+    if (this.value.sessionId === sessionId && this.value.project?.name === project?.name && this.root) {
+      this.replace({ project, error: undefined })
+      return
+    }
+    this.root = null
+    this.replace({
+      ...empty,
+      sessionId,
+      project,
+      busy: Boolean(sessionId && project),
+    })
+    if (!sessionId || !project) return
+    try {
+      const handle = await loadSessionDirHandle(sessionId)
+      if (!handle) {
+        this.replace({
+          busy: false,
+          handleReady: false,
+          error: '浏览器尚未授权该文件夹，请重新 Open folder',
+        })
+        return
+      }
+      this.root = handle
+      const entries = await listDirectory(handle)
+      this.replace({
+        handleReady: true,
+        entries,
+        busy: false,
+        error: undefined,
+        expanded: [],
+        children: {},
+        openPath: undefined,
+        content: '',
+        dirty: false,
+      })
+    } catch (error) {
+      this.replace({ busy: false, handleReady: false, error: String(error) })
+    }
+  }
+
+  async openFolderForSession(sessionId: string) {
+    this.replace({ busy: true, error: undefined })
+    try {
+      const handle = await pickDirectory()
+      await saveSessionDirHandle(sessionId, handle)
+      const res = await fetch(`/api/sessions/${sessionId}/project`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: handle.name }),
+      })
+      const body = (await res.json()) as { project?: SessionProjectMeta; error?: string }
+      if (!res.ok) throw new Error(body.error || `绑定失败：${res.status}`)
+      this.root = handle
+      const entries = await listDirectory(handle)
+      this.replace({
+        sessionId,
+        project: body.project ?? { name: handle.name, boundAt: Date.now() },
+        handleReady: true,
+        entries,
+        expanded: [],
+        children: {},
+        openPath: undefined,
+        content: '',
+        dirty: false,
+        busy: false,
+        error: undefined,
+      })
+      return this.value.project
+    } catch (error) {
+      const message = error instanceof DOMException && error.name === 'AbortError' ? undefined : String(error)
+      this.replace({ busy: false, error: message })
+      throw error
+    }
+  }
+
+  async unbindFolder() {
+    const sessionId = this.value.sessionId
+    if (!sessionId) return
+    this.replace({ busy: true, error: undefined })
+    try {
+      await deleteSessionDirHandle(sessionId)
+      await fetch(`/api/sessions/${sessionId}/project`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: null }),
+      })
+      this.root = null
+      this.replace({ ...empty, sessionId, busy: false })
+    } catch (error) {
+      this.replace({ busy: false, error: String(error) })
+    }
+  }
+
+  async toggleDir(path: string) {
+    if (!this.root) return
+    const expanded = new Set(this.value.expanded)
+    if (expanded.has(path)) {
+      expanded.delete(path)
+      this.replace({ expanded: [...expanded] })
+      return
+    }
+    expanded.add(path)
+    if (!this.value.children[path]) {
+      try {
+        const parts = path.split('/')
+        let dir = this.root
+        for (const part of parts) dir = await dir.getDirectoryHandle(part)
+        const rows = await listDirectory(dir, path)
+        this.replace({ expanded: [...expanded], children: { ...this.value.children, [path]: rows } })
+        return
+      } catch (error) {
+        this.replace({ error: String(error) })
+        return
+      }
+    }
+    this.replace({ expanded: [...expanded] })
+  }
+
+  async openFile(path: string) {
+    if (!this.root) return
+    if (this.value.dirty && this.value.openPath && this.value.openPath !== path) {
+      if (!window.confirm('当前文件未保存，切换将丢弃修改。继续？')) return
+    }
+    this.replace({ busy: true, error: undefined })
+    try {
+      const content = await readTextFile(this.root, path)
+      this.replace({ openPath: path, content, dirty: false, busy: false })
+    } catch (error) {
+      this.replace({ busy: false, error: String(error) })
+    }
+  }
+
+  setContent(content: string) {
+    this.replace({ content, dirty: true })
+  }
+
+  async save() {
+    if (!this.root || !this.value.openPath) return
+    this.replace({ busy: true, error: undefined })
+    try {
+      await writeTextFile(this.root, this.value.openPath, this.value.content)
+      this.replace({ dirty: false, busy: false })
+    } catch (error) {
+      this.replace({ busy: false, error: String(error) })
+    }
+  }
+
+  supported() {
+    return canPickDirectory()
+  }
+
+  private replace(patch: Partial<ProjectViewState>) {
+    this.value = { ...this.value, ...patch }
+    for (const listener of this.listeners) listener()
+  }
+}
+
+export function bindProjectView(service: ProjectViewService) {
+  return function useProjectView<T>(selector: (state: ProjectViewState) => T): T {
+    return useSyncExternalStore(
+      service.subscribe,
+      () => selector(service.get()),
+      () => selector(service.get()),
+    )
+  }
+}
+
+export const name = 'project-view'
+export const inject = []
+
+export function apply(ctx: Context) {
+  new ProjectViewService(ctx)
+}

--- a/src/plugins/infrastructure/react-host.test.ts
+++ b/src/plugins/infrastructure/react-host.test.ts
@@ -6,6 +6,7 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from './snapshot.ts'
 import * as sessionView from './session-view.ts'
+import * as projectView from './project-view.ts'
 import * as reactHost from './react-host.ts'
 import * as shell from '../contributors/shell.tsx'
 
@@ -14,6 +15,7 @@ test('paints shell into el', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await act(async () => {
     await ctx.plugin(reactHost, { el })

--- a/src/plugins/infrastructure/renderer.test.ts
+++ b/src/plugins/infrastructure/renderer.test.ts
@@ -6,6 +6,7 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from './snapshot.ts'
 import * as sessionView from './session-view.ts'
+import * as projectView from './project-view.ts'
 import * as shell from '../contributors/shell.tsx'
 import * as hello from '../contributors/hello.tsx'
 import * as quotes from '../contributors/quotes.tsx'
@@ -15,6 +16,7 @@ test('list sorts by order; demos show after shell opens', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   await ctx.plugin(quotes)
   await ctx.plugin(hello)

--- a/src/plugins/infrastructure/session-folder.ts
+++ b/src/plugins/infrastructure/session-folder.ts
@@ -1,0 +1,130 @@
+/** Minimal File System Access API types (Chromium). */
+export interface FsFileHandle {
+  kind: 'file'
+  name: string
+  getFile(): Promise<File>
+  createWritable(): Promise<{ write(data: string): Promise<void>; close(): Promise<void> }>
+}
+
+export interface FsDirHandle {
+  kind: 'directory'
+  name: string
+  values(): AsyncIterableIterator<FsFileHandle | FsDirHandle>
+  getDirectoryHandle(name: string, options?: { create?: boolean }): Promise<FsDirHandle>
+  getFileHandle(name: string, options?: { create?: boolean }): Promise<FsFileHandle>
+}
+
+declare global {
+  interface Window {
+    showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<FsDirHandle>
+  }
+}
+
+const DB_NAME = 'cordis-session-projects'
+const STORE = 'handles'
+const DB_VERSION = 1
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE)
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error ?? new Error('idb open failed'))
+  })
+}
+
+export async function saveSessionDirHandle(sessionId: string, handle: FsDirHandle) {
+  const db = await openDb()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    tx.objectStore(STORE).put(handle, sessionId)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error ?? new Error('idb put failed'))
+  })
+  db.close()
+}
+
+export async function loadSessionDirHandle(sessionId: string): Promise<FsDirHandle | undefined> {
+  const db = await openDb()
+  const handle = await new Promise<FsDirHandle | undefined>((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readonly')
+    const req = tx.objectStore(STORE).get(sessionId)
+    req.onsuccess = () => resolve(req.result as FsDirHandle | undefined)
+    req.onerror = () => reject(req.error ?? new Error('idb get failed'))
+  })
+  db.close()
+  return handle
+}
+
+export async function deleteSessionDirHandle(sessionId: string) {
+  const db = await openDb()
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE, 'readwrite')
+    tx.objectStore(STORE).delete(sessionId)
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error ?? new Error('idb delete failed'))
+  })
+  db.close()
+}
+
+export function canPickDirectory() {
+  return typeof window !== 'undefined' && typeof window.showDirectoryPicker === 'function'
+}
+
+export async function pickDirectory(): Promise<FsDirHandle> {
+  if (!canPickDirectory()) {
+    throw new Error('当前浏览器不支持打开本地文件夹（需要 Chromium 系）')
+  }
+  return window.showDirectoryPicker!({ mode: 'readwrite' })
+}
+
+export interface DirEntry {
+  name: string
+  path: string
+  kind: 'file' | 'directory'
+}
+
+export async function listDirectory(dir: FsDirHandle, prefix = ''): Promise<DirEntry[]> {
+  const rows: DirEntry[] = []
+  for await (const entry of dir.values()) {
+    const path = prefix ? `${prefix}/${entry.name}` : entry.name
+    rows.push({ name: entry.name, path, kind: entry.kind })
+  }
+  rows.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'directory' ? -1 : 1
+    return a.name.localeCompare(b.name)
+  })
+  return rows
+}
+
+export async function resolveDir(root: FsDirHandle, dirPath: string): Promise<FsDirHandle> {
+  if (!dirPath) return root
+  let cur = root
+  for (const part of dirPath.split('/').filter(Boolean)) {
+    cur = await cur.getDirectoryHandle(part)
+  }
+  return cur
+}
+
+export async function readTextFile(root: FsDirHandle, filePath: string): Promise<string> {
+  const parts = filePath.split('/').filter(Boolean)
+  const name = parts.pop()
+  if (!name) throw new Error('empty path')
+  const dir = await resolveDir(root, parts.join('/'))
+  const file = await (await dir.getFileHandle(name)).getFile()
+  return file.text()
+}
+
+export async function writeTextFile(root: FsDirHandle, filePath: string, text: string) {
+  const parts = filePath.split('/').filter(Boolean)
+  const name = parts.pop()
+  if (!name) throw new Error('empty path')
+  const dir = await resolveDir(root, parts.join('/'))
+  const handle = await dir.getFileHandle(name, { create: true })
+  const writable = await handle.createWritable()
+  await writable.write(text)
+  await writable.close()
+}

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -20,6 +20,7 @@ export interface SessionListItem {
   title: string
   eventCount: number
   updatedAt: number
+  project?: { name: string; boundAt: number }
 }
 
 export type ConversationView = 'chat' | 'trajectory'
@@ -38,6 +39,7 @@ export interface SessionViewState {
   pending: boolean
   approvalMode: ApprovalMode
   approvals: ApprovalItem[]
+  project?: { name: string; boundAt: number }
   error?: string
 }
 
@@ -96,6 +98,7 @@ export class SessionViewService extends Service {
         focusCallId: undefined,
         pending: false,
         agentStatus: 'idle',
+        project: undefined,
         error: undefined,
       })
       return
@@ -215,19 +218,32 @@ export class SessionViewService extends Service {
   async load(sessionId: string) {
     const res = await fetch(`/api/sessions/${sessionId}`)
     if (!res.ok) throw new Error(`加载 session 失败：${res.status}`)
-    const body = (await res.json()) as { id: string; events: SessionEvent[] }
+    const body = (await res.json()) as {
+      id: string
+      events: SessionEvent[]
+      project?: { name: string; boundAt: number }
+    }
     const events = Array.isArray(body.events) ? body.events : []
     this.replace({
       sessionId: body.id,
       events,
       nodes: projectNodes(events),
       trajectory: projectTrajectory(events),
+      project: body.project,
       error: undefined,
       pending: false,
       agentStatus: 'idle',
     })
     await this.refreshSessions()
     await this.refreshApprovals()
+  }
+
+  setProjectMeta(project?: { name: string; boundAt: number }) {
+    this.replace({ project })
+    const sessions = this.value.sessions.map((item) =>
+      item.id === this.value.sessionId ? { ...item, project } : item,
+    )
+    this.replace({ sessions })
   }
 
   async forkCurrent() {
@@ -264,6 +280,7 @@ export class SessionViewService extends Service {
       agentStatus: 'idle',
       view: 'chat',
       focusCallId: undefined,
+      project: undefined,
       error: undefined,
     })
   }

--- a/src/plugins/orchestration/ui-hub.test.ts
+++ b/src/plugins/orchestration/ui-hub.test.ts
@@ -5,6 +5,7 @@ import '../../types.ts'
 import * as slots from '../registry/slots.ts'
 import * as snapshot from '../infrastructure/snapshot.ts'
 import * as sessionView from '../infrastructure/session-view.ts'
+import * as projectView from '../infrastructure/project-view.ts'
 import * as uiHub from './ui-hub.ts'
 
 const Dummy = () => null
@@ -26,12 +27,14 @@ test('ui-hub mounts hello and chat from snapshot', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(sessionView)
+  await ctx.plugin(projectView)
   await ctx.plugin(snapshot)
   ctx.slots.fill('root', Dummy, {
     children: {
       stage: { kind: 'list' },
       demos: { kind: 'list' },
       dock: { kind: 'list' },
+      project: { kind: 'single' },
       composer: { kind: 'single' },
       settings: { kind: 'list' },
     },

--- a/src/style.css
+++ b/src/style.css
@@ -210,6 +210,122 @@ body {
   border: 0;
 }
 
+/* Session-bound local project panel (Agent chat) */
+.project-pane {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .project-pane {
+    display: flex;
+  }
+}
+
+.project-panel {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.project-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 12px 12px 10px;
+}
+
+.project-panel-hint,
+.project-panel-error,
+.project-panel-empty {
+  padding: 12px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.project-panel-hint {
+  color: var(--dsw-label-3);
+}
+
+.project-panel-error {
+  color: var(--dsw-danger);
+}
+
+.project-panel-body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.project-tree {
+  max-height: 40%;
+  overflow: auto;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 6px 0;
+}
+
+.project-tree-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  padding: 4px 10px 4px 8px;
+  color: var(--dsw-label-2);
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+}
+
+.project-tree-row:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.project-tree-row.is-active {
+  background: var(--dsw-business-soft);
+  color: var(--dsw-business);
+}
+
+.project-tree-icon {
+  width: 12px;
+  color: var(--dsw-label-3);
+  font-size: 10px;
+}
+
+.project-editor {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.project-editor-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 6px 10px;
+}
+
+.project-editor-textarea {
+  min-height: 0;
+  flex: 1;
+  resize: none;
+  border: 0;
+  background: #fff;
+  padding: 10px 12px;
+  color: var(--dsw-label);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  outline: none;
+}
+
 /* Trajectory — compact profiler-style ledger (full bleed, no outer card) */
 .traj-root {
   display: flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { SnapshotService } from './plugins/infrastructure/snapshot.ts'
 import { SessionViewService } from './plugins/infrastructure/session-view.ts'
+import { ProjectViewService } from './plugins/infrastructure/project-view.ts'
 import { SlotsService } from './plugins/registry/slots.ts'
 
 declare module 'cordis' {
@@ -7,5 +8,6 @@ declare module 'cordis' {
     slots: SlotsService
     snapshot: SnapshotService
     sessionView: SessionViewService
+    projectView: ProjectViewService
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 背景
需要的是：**在 Agent 聊天里为当前 Session 打开本地文件夹**，浏览/编辑文件；**一个 Session 绑定一个文件夹**。不是独立的 Workspace 模块文件管理器。

## 改动
- Host：`session.project = { name, boundAt }`；`PUT /api/sessions/:id/project`；列表/详情带回 project；fork 复制绑定名
- FE：Chat 右侧 **Project** 面板 → `Open folder`（Chromium File System Access API）
- 目录句柄按 `sessionId` 存 IndexedDB；可展开目录、打开文本文件、编辑、Save、Unbind/Rebind
- Sessions 列表显示绑定的文件夹名

## 使用
1. Agent → New Session / 选中会话
2. 右侧 Project → **Open folder**
3. 选本地目录后即可浏览编辑；换 Session 换项目

## 验证
- `npm test`（74 passed）
- 需 Chromium 系浏览器

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

