### PR TITLE
feat: Agent Standard / Minimal 模式（对齐 dsh 双工具）

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -25,6 +25,7 @@
 19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
 20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
 21. **Web：Session 绑定本地项目文件夹** — Agent Chat 右侧 Project 面板 `Open folder`（File System Access API）；文件夹名写入 session.project，句柄按 sessionId 存 IndexedDB；可浏览/编辑/保存文本文件。
+22. **Agent mode（Standard / Minimal）** — Settings 可选；`minimal` 对齐 dsh：模型侧只暴露 `bash` + `str_replace_editor`（view/create/str_replace/insert）；模式写入 `.cordis/chat-config.json`，`tools.schemas()` / `names()` / `invoke` 统一过滤。
 
 ## 功能级差异（相对官方 client，优点对齐后）
 
@@ -33,8 +34,9 @@
 | 会话列表 / New / Fork | 有 | 有 | 已对齐（瘦） |
 | Chat 事件投影 | 有 | ConversationNode | 已对齐（瘦投影） |
 | Trajectory 账本 + inspect | 有 | ui-trajectory | 已对齐（无虚表） |
-| 审批 dock + mode | 有 | Permission + ApprovalPanel | 已对齐（瘦） |
+| 审批 dock + mode | 有 | Permission + QueuePanel | 已对齐（瘦） |
 | 运行中 inject | 有 | steer/queue | 已对齐（无队列编辑 UI） |
+| Agent Minimal 双工具 | 有 | minimal preset | 已对齐（瘦：工具过滤 + editor，无 profile 叠层） |
 | Trajectory 虚表/搜索 | 无 | 有 | **不吸收** |
 | Workspace dock | 无 | ui-workspace | **不吸收** |
 | Goals / Plan / Attachments | 无 | 对应 ui-* | 需 host 域；暂不吸收 |

--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -3,16 +3,19 @@ import { join } from 'node:path'
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { ChatMessage } from './chat-types.ts'
+import type { AgentToolMode } from '../registry/tools.ts'
 
 export type { ChatMessage }
 
 export type ChatProvider = 'deepseek' | 'openai'
+export type { AgentToolMode }
 
 interface ChatConfig {
   provider: ChatProvider
   apiKey: string
   model: string
   systemPrompt: string
+  agentMode: AgentToolMode
 }
 
 function configPath() {
@@ -26,6 +29,7 @@ function defaults(): ChatConfig {
     apiKey: process.env.DEEPSEEK_API_KEY || process.env.OPENAI_API_KEY || '',
     model: process.env.CHAT_MODEL || (deepseek || !process.env.OPENAI_API_KEY ? 'deepseek-chat' : 'gpt-4o-mini'),
     systemPrompt: '你是控制台里的助手。需要时调用当前已注册的 tools；插件卸载后对应 tool 会消失。回答简洁。',
+    agentMode: 'standard',
   }
 }
 
@@ -53,6 +57,7 @@ function writePersisted(config: ChatConfig) {
         provider: config.provider,
         model: config.model,
         systemPrompt: config.systemPrompt,
+        agentMode: config.agentMode,
         apiKey: config.apiKey,
       },
       null,
@@ -62,6 +67,10 @@ function writePersisted(config: ChatConfig) {
   )
 }
 
+function parseAgentMode(value: unknown, fallback: AgentToolMode): AgentToolMode {
+  return value === 'minimal' || value === 'standard' ? value : fallback
+}
+
 function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): ChatConfig {
   if (!saved) return base
   const envKey = Boolean(process.env.DEEPSEEK_API_KEY || process.env.OPENAI_API_KEY)
@@ -69,6 +78,7 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     provider: saved.provider === 'openai' || saved.provider === 'deepseek' ? saved.provider : base.provider,
     model: !process.env.CHAT_MODEL && typeof saved.model === 'string' && saved.model.trim() ? saved.model.trim() : base.model,
     systemPrompt: typeof saved.systemPrompt === 'string' ? saved.systemPrompt : base.systemPrompt,
+    agentMode: parseAgentMode(saved.agentMode, base.agentMode),
     apiKey: !envKey && typeof saved.apiKey === 'string' && saved.apiKey.trim() ? saved.apiKey.trim() : base.apiKey,
   }
 }
@@ -80,6 +90,7 @@ export class ChatService extends Service {
     super(ctx, 'chat')
     ctx.systemPrompt.register('chat.persona', () => this.config.systemPrompt)
     this.syncLlm()
+    this.syncToolsMode()
   }
 
   publicView() {
@@ -87,17 +98,30 @@ export class ChatService extends Service {
       provider: this.config.provider,
       model: this.config.model,
       systemPrompt: this.config.systemPrompt,
+      agentMode: this.config.agentMode,
       configured: Boolean(this.config.apiKey),
       hint: hint(this.config.apiKey),
+      tools: this.ctx.tools.names(),
     }
   }
 
-  patch(next: Partial<{ provider: ChatProvider; apiKey: string; model: string; systemPrompt: string }>, opts?: { persist?: boolean }) {
+  patch(
+    next: Partial<{
+      provider: ChatProvider
+      apiKey: string
+      model: string
+      systemPrompt: string
+      agentMode: AgentToolMode
+    }>,
+    opts?: { persist?: boolean },
+  ) {
     if (next.provider) this.config.provider = next.provider
     if (typeof next.model === 'string' && next.model.trim()) this.config.model = next.model.trim()
     if (typeof next.systemPrompt === 'string') this.config.systemPrompt = next.systemPrompt
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) this.config.apiKey = next.apiKey.trim()
+    if (next.agentMode === 'standard' || next.agentMode === 'minimal') this.config.agentMode = next.agentMode
     this.syncLlm()
+    this.syncToolsMode()
     if (opts?.persist !== false) {
       try {
         writePersisted(this.config)
@@ -110,6 +134,7 @@ export class ChatService extends Service {
 
   async complete(messages: ChatMessage[], sessionId?: string) {
     this.syncLlm()
+    this.syncToolsMode()
     const last = messages.filter((item) => item.role === 'user').at(-1)?.content?.trim() ?? ''
     const agent = await this.ctx.agents.create(sessionId)
     const result = await agent.send(last)
@@ -123,10 +148,14 @@ export class ChatService extends Service {
       model: this.config.model,
     })
   }
+
+  private syncToolsMode() {
+    this.ctx.tools.setMode(this.config.agentMode)
+  }
 }
 
 export const name = 'chat'
-export const inject = ['http', 'hub', 'agents', 'sessions', 'systemPrompt']
+export const inject = ['http', 'hub', 'agents', 'sessions', 'systemPrompt', 'tools']
 
 export function apply(ctx: Context) {
   const chat = new ChatService(ctx)
@@ -147,6 +176,7 @@ export function apply(ctx: Context) {
       apiKey: string
       model: string
       systemPrompt: string
+      agentMode: AgentToolMode
     }>
     route.send(200, chat.patch(payload ?? {}))
   })

--- a/host/plugins/orchestration/approvals.ts
+++ b/host/plugins/orchestration/approvals.ts
@@ -51,7 +51,7 @@ export class ApprovalsService extends Service {
 }
 
 function sensitive(name: string) {
-  return /^(fs_write|bash|job_start|terminal_write|lsp_start|subagent_spawn|mcp_add_stdio)$/.test(name)
+  return /^(fs_write|str_replace_editor|bash|job_start|terminal_write|lsp_start|subagent_spawn|mcp_add_stdio)$/.test(name)
 }
 
 export const name = 'approvals'

--- a/host/plugins/registry/tools.test.ts
+++ b/host/plugins/registry/tools.test.ts
@@ -50,3 +50,26 @@ test('guard can deny before execute', async () => {
   ctx.tools.guard((req) => ({ ...req, deny: 'denied: boom' }))
   await assert.rejects(() => ctx.tools.invoke('boom'), /denied: boom/)
 })
+
+test('minimal mode only exposes bash and str_replace_editor', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  for (const name of ['bash', 'str_replace_editor', 'fs_read', 'fs_write']) {
+    ctx.tools.register({
+      name,
+      description: name,
+      parameters: { type: 'object', properties: {} },
+      execute: () => name,
+    })
+  }
+  assert.deepEqual(ctx.tools.names().sort(), ['bash', 'fs_read', 'fs_write', 'str_replace_editor'])
+  ctx.tools.setMode('minimal')
+  assert.equal(ctx.tools.getMode(), 'minimal')
+  assert.deepEqual(ctx.tools.names().sort(), ['bash', 'str_replace_editor'])
+  assert.deepEqual(
+    ctx.tools.schemas().map((item) => item.function.name).sort(),
+    ['bash', 'str_replace_editor'],
+  )
+  assert.equal(await ctx.tools.invoke('bash'), 'bash')
+  await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in minimal mode/)
+})

--- a/host/plugins/registry/tools.ts
+++ b/host/plugins/registry/tools.ts
@@ -16,12 +16,34 @@ export interface ToolRequest {
 
 export type ToolGuard = (req: ToolRequest) => ToolRequest | Promise<ToolRequest>
 
+/** 对齐 dsh：standard 暴露全部已注册工具；minimal 仅 bash + str_replace_editor。 */
+export type AgentToolMode = 'standard' | 'minimal'
+
+export const MINIMAL_TOOL_NAMES = ['bash', 'str_replace_editor'] as const
+
 export class ToolsService extends Service {
   private tools = new Map<string, ToolSpec>()
   private guards: ToolGuard[] = []
+  private mode: AgentToolMode = 'standard'
 
   constructor(ctx: Context) {
     super(ctx, 'tools')
+  }
+
+  getMode() {
+    return this.mode
+  }
+
+  setMode(mode: AgentToolMode) {
+    if (mode !== 'standard' && mode !== 'minimal') throw new Error(`unknown agent tool mode: ${mode}`)
+    if (this.mode === mode) return
+    this.mode = mode
+    this.ctx.emit('hub/change')
+  }
+
+  private visible(name: string) {
+    if (this.mode === 'standard') return true
+    return (MINIMAL_TOOL_NAMES as readonly string[]).includes(name)
   }
 
   register(spec: ToolSpec) {
@@ -46,21 +68,26 @@ export class ToolsService extends Service {
   }
 
   schemas() {
-    return [...this.tools.values()].map((tool) => ({
-      type: 'function' as const,
-      function: {
-        name: tool.name,
-        description: tool.description,
-        parameters: tool.parameters,
-      },
-    }))
+    return [...this.tools.values()]
+      .filter((tool) => this.visible(tool.name))
+      .map((tool) => ({
+        type: 'function' as const,
+        function: {
+          name: tool.name,
+          description: tool.description,
+          parameters: tool.parameters,
+        },
+      }))
   }
 
   names() {
-    return [...this.tools.keys()]
+    return [...this.tools.keys()].filter((name) => this.visible(name))
   }
 
   async invoke(name: string, args: Record<string, unknown> = {}, signal: AbortSignal = new AbortController().signal) {
+    if (!this.visible(name)) {
+      throw new Error(`tool not available in ${this.mode} mode: ${name}`)
+    }
     let req: ToolRequest = { name, args }
     for (const guard of this.guards) req = await guard(req)
     req = this.ctx.waterfall('tools/pre-execute', req, () => req)

--- a/host/plugins/seams/fs.ts
+++ b/host/plugins/seams/fs.ts
@@ -1,7 +1,12 @@
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises'
-import { dirname, join, normalize, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, normalize, relative, resolve } from 'node:path'
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
+import {
+  STR_REPLACE_EDITOR_DESCRIPTION,
+  STR_REPLACE_EDITOR_PARAMETERS,
+  runStrReplaceEditor,
+} from './str-replace-editor.ts'
 
 export class FsService extends Service {
   constructor(
@@ -13,9 +18,12 @@ export class FsService extends Service {
   }
 
   resolve(rel: string) {
-    const full = resolve(this.root, rel)
+    const input = String(rel)
+    const full = isAbsolute(input) ? resolve(input) : resolve(this.root, input)
     const relToRoot = relative(this.root, full)
-    if (relToRoot.startsWith('..') || normalize(rel).startsWith('..')) throw new Error('path escapes workspace')
+    if (relToRoot.startsWith('..') || (!isAbsolute(input) && normalize(input).startsWith('..'))) {
+      throw new Error('path escapes workspace')
+    }
     return full
   }
 
@@ -68,5 +76,11 @@ export function apply(ctx: Context, config: { root?: string } = {}) {
     description: '列出工作区目录',
     parameters: { type: 'object', properties: { path: { type: 'string' } } },
     execute: (args) => fs.list(String(args.path || '.')),
+  })
+  ctx.tools.register({
+    name: 'str_replace_editor',
+    description: STR_REPLACE_EDITOR_DESCRIPTION,
+    parameters: { ...STR_REPLACE_EDITOR_PARAMETERS },
+    execute: (args) => runStrReplaceEditor(fs, args),
   })
 }

--- a/host/plugins/seams/str-replace-editor.test.ts
+++ b/host/plugins/seams/str-replace-editor.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import '../../types.ts'
+import * as tools from '../registry/tools.ts'
+import * as fs from './fs.ts'
+
+async function setup() {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'cordis-editor-'))
+  await ctx.plugin(fs, { root })
+  return { ctx, root }
+}
+
+test('str_replace_editor view/create/str_replace/insert', async () => {
+  const { ctx, root } = await setup()
+  await mkdir(join(root, 'src'), { recursive: true })
+  await writeFile(join(root, 'src', 'a.ts'), 'const x = 1\nconst y = 2\n', 'utf8')
+
+  const viewed = String(
+    await ctx.tools.invoke('str_replace_editor', { command: 'view', path: 'src/a.ts', view_range: [1, 1] }),
+  )
+  assert.match(viewed, /1\tconst x = 1/)
+
+  const tree = String(await ctx.tools.invoke('str_replace_editor', { command: 'view', path: '.' }))
+  assert.match(tree, /src\//)
+
+  await ctx.tools.invoke('str_replace_editor', {
+    command: 'create',
+    path: 'src/b.ts',
+    file_text: 'export const b = 1\n',
+  })
+  assert.equal(await ctx.fs.read('src/b.ts'), 'export const b = 1\n')
+  await assert.rejects(
+    () => ctx.tools.invoke('str_replace_editor', { command: 'create', path: 'src/b.ts', file_text: 'x' }),
+    /already exists/,
+  )
+
+  await ctx.tools.invoke('str_replace_editor', {
+    command: 'str_replace',
+    path: 'src/a.ts',
+    old_str: 'const x = 1',
+    new_str: 'const x = 3',
+  })
+  assert.match(await ctx.fs.read('src/a.ts'), /const x = 3/)
+
+  await ctx.tools.invoke('str_replace_editor', {
+    command: 'insert',
+    path: 'src/a.ts',
+    insert_line: 1,
+    new_str: '// inserted',
+  })
+  const afterInsert = await ctx.fs.read('src/a.ts')
+  assert.match(afterInsert, /const x = 3\n\/\/ inserted\nconst y = 2/)
+})
+
+test('str_replace_editor rejects absolute path outside workspace', async () => {
+  const { ctx } = await setup()
+  await assert.rejects(
+    () => ctx.tools.invoke('str_replace_editor', { command: 'view', path: '/etc/passwd' }),
+    /escapes/,
+  )
+})

--- a/host/plugins/seams/str-replace-editor.ts
+++ b/host/plugins/seams/str-replace-editor.ts
@@ -1,0 +1,196 @@
+import { access, constants, readdir, stat } from 'node:fs/promises'
+import { join, relative } from 'node:path'
+import type { FsService } from './fs.ts'
+
+const MAX_OUTPUT = 16_000
+
+export type EditorCommand = 'view' | 'create' | 'str_replace' | 'insert'
+
+export async function runStrReplaceEditor(fs: FsService, args: Record<string, unknown>): Promise<string> {
+  const command = String(args.command ?? '') as EditorCommand
+  const pathArg = String(args.path ?? '')
+  if (!pathArg) throw new Error('path is required')
+  if (!['view', 'create', 'str_replace', 'insert'].includes(command)) {
+    throw new Error(`unsupported command: ${command}`)
+  }
+
+  const abs = fs.resolve(pathArg)
+  const rel = relative(fs.root, abs) || '.'
+
+  switch (command) {
+    case 'view':
+      return truncate(await view(fs, abs, rel, args.view_range))
+    case 'create':
+      return truncate(await create(fs, abs, rel, args.file_text))
+    case 'str_replace':
+      return truncate(await strReplace(fs, abs, rel, args.old_str, args.new_str))
+    case 'insert':
+      return truncate(await insert(fs, abs, rel, args.insert_line, args.new_str))
+  }
+}
+
+async function view(fs: FsService, abs: string, rel: string, viewRange: unknown) {
+  const info = await safeStat(abs)
+  if (!info) throw new Error(`path does not exist: ${rel}`)
+  if (info.isDirectory()) return listTree(abs, rel)
+  const content = await fs.read(rel)
+  const lines = content.split('\n')
+  // trailing empty from final newline is kept as an empty last line for cat -n parity when file ends with \n
+  const numbered = numberLines(lines)
+  const range = parseViewRange(viewRange, numbered.length)
+  if (!range) return numbered.join('\n')
+  return numbered.slice(range.start - 1, range.end).join('\n')
+}
+
+async function create(fs: FsService, abs: string, rel: string, fileText: unknown) {
+  if (await exists(abs)) throw new Error(`file already exists: ${rel}`)
+  if (typeof fileText !== 'string') throw new Error('file_text is required for create')
+  await fs.write(rel, fileText)
+  return `File created successfully at: ${rel}`
+}
+
+async function strReplace(fs: FsService, abs: string, rel: string, oldStr: unknown, newStr: unknown) {
+  if (typeof oldStr !== 'string') throw new Error('old_str is required for str_replace')
+  if (!(await exists(abs))) throw new Error(`file does not exist: ${rel}`)
+  const content = await fs.read(rel)
+  const occurrences = countOccurrences(content, oldStr)
+  if (occurrences === 0) throw new Error(`old_str not found in ${rel}`)
+  if (occurrences > 1) throw new Error(`old_str is not unique in ${rel} (${occurrences} matches)`)
+  const next = content.replace(oldStr, typeof newStr === 'string' ? newStr : '')
+  await fs.write(rel, next)
+  return `The file ${rel} has been edited. Please review the changes and make sure they are correct.`
+}
+
+async function insert(fs: FsService, abs: string, rel: string, insertLine: unknown, newStr: unknown) {
+  if (typeof newStr !== 'string') throw new Error('new_str is required for insert')
+  const line = Number(insertLine)
+  if (!Number.isInteger(line) || line < 0) throw new Error('insert_line must be a non-negative integer')
+  if (!(await exists(abs))) throw new Error(`file does not exist: ${rel}`)
+  const content = await fs.read(rel)
+  const lines = content.split('\n')
+  // insert AFTER insert_line (1-based); 0 inserts before the first line
+  if (line > lines.length) throw new Error(`insert_line ${line} is beyond end of file (${lines.length} lines)`)
+  lines.splice(line, 0, newStr)
+  await fs.write(rel, lines.join('\n'))
+  return `The file ${rel} has been edited. Please review the changes and make sure they are correct.`
+}
+
+function numberLines(lines: string[]) {
+  const width = String(lines.length).length
+  return lines.map((line, index) => `${String(index + 1).padStart(width)}\t${line}`)
+}
+
+function parseViewRange(viewRange: unknown, lineCount: number): { start: number; end: number } | null {
+  if (!Array.isArray(viewRange) || viewRange.length === 0) return null
+  const start = Number(viewRange[0])
+  const endRaw = viewRange.length > 1 ? Number(viewRange[1]) : start
+  if (!Number.isInteger(start) || start < 1) throw new Error('view_range start must be a positive integer')
+  const end = endRaw === -1 ? lineCount : endRaw
+  if (!Number.isInteger(end) || end < start) throw new Error('invalid view_range')
+  return { start, end: Math.min(end, lineCount) }
+}
+
+async function listTree(abs: string, rel: string) {
+  const rows: string[] = [`${rel}/`]
+  await walk(abs, '', 0, rows)
+  return rows.join('\n')
+}
+
+async function walk(dir: string, prefix: string, depth: number, rows: string[]) {
+  if (depth >= 2) return
+  const entries = (await readdir(dir, { withFileTypes: true }))
+    .filter((entry) => !entry.name.startsWith('.'))
+    .sort((a, b) => a.name.localeCompare(b.name))
+  for (const entry of entries) {
+    const label = entry.isDirectory() ? `${entry.name}/` : entry.name
+    rows.push(`${prefix}- ${label}`)
+    if (entry.isDirectory()) await walk(join(dir, entry.name), `${prefix}  `, depth + 1, rows)
+  }
+}
+
+function countOccurrences(haystack: string, needle: string) {
+  if (!needle) return 0
+  let count = 0
+  let from = 0
+  while (true) {
+    const idx = haystack.indexOf(needle, from)
+    if (idx === -1) break
+    count += 1
+    from = idx + needle.length
+  }
+  return count
+}
+
+async function exists(abs: string) {
+  try {
+    await access(abs, constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function safeStat(abs: string) {
+  try {
+    return await stat(abs)
+  } catch {
+    return null
+  }
+}
+
+function truncate(text: string) {
+  if (text.length <= MAX_OUTPUT) return text
+  return `${text.slice(0, MAX_OUTPUT)}\n<response clipped>`
+}
+
+export const STR_REPLACE_EDITOR_DESCRIPTION = [
+  'Custom editing tool for viewing, creating and editing files',
+  '* State is persistent across command calls and discussions with the user',
+  '* If `path` is a file, `view` displays the result of applying `cat -n`. If `path` is a directory, `view` lists non-hidden files and directories up to 2 levels deep',
+  '* The `create` command cannot be used if the specified `path` already exists as a file',
+  '* Paths are resolved inside the workspace (relative or absolute under the workspace root)',
+  '',
+  'Notes for using the `str_replace` command:',
+  '* The `old_str` parameter should match EXACTLY one or more consecutive lines from the original file. Be mindful of whitespaces!',
+  '* If the `old_str` parameter is not unique in the file, the replacement will not be performed. Make sure to include enough context in `old_str` to make it unique',
+  '* The `new_str` parameter should contain the edited lines that should replace the `old_str`',
+].join('\n')
+
+export const STR_REPLACE_EDITOR_PARAMETERS = {
+  type: 'object',
+  properties: {
+    command: {
+      type: 'string',
+      description: 'The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`.',
+      enum: ['view', 'create', 'str_replace', 'insert'],
+    },
+    path: {
+      type: 'string',
+      description: 'Path to file or directory inside the workspace, e.g. `src/app.ts` or an absolute path under the workspace root.',
+    },
+    file_text: {
+      type: 'string',
+      description: 'Required parameter of `create` command, with the content of the file to be created.',
+    },
+    insert_line: {
+      type: 'integer',
+      description: 'Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.',
+    },
+    new_str: {
+      type: 'string',
+      description:
+        'Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.',
+    },
+    old_str: {
+      type: 'string',
+      description: 'Required parameter of `str_replace` command containing the string in `path` to replace.',
+    },
+    view_range: {
+      type: 'array',
+      description:
+        'Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.',
+      items: { type: 'integer' },
+    },
+  },
+  required: ['command', 'path'],
+} as const

--- a/src/plugins/contributors/chat/config.tsx
+++ b/src/plugins/contributors/chat/config.tsx
@@ -1,21 +1,27 @@
 import { useEffect, useState, type FormEvent } from 'react'
 import type { SlotProps } from '../../registry/slots.ts'
 
+type AgentMode = 'standard' | 'minimal'
+
 interface ChatPublicConfig {
   provider: 'deepseek' | 'openai'
   model: string
   systemPrompt: string
+  agentMode: AgentMode
   configured: boolean
   hint: string
+  tools?: string[]
 }
 
 export function ChatConfig(_props: SlotProps) {
   const [provider, setProvider] = useState<'deepseek' | 'openai'>('deepseek')
   const [model, setModel] = useState('deepseek-chat')
   const [systemPrompt, setSystemPrompt] = useState('')
+  const [agentMode, setAgentMode] = useState<AgentMode>('standard')
   const [apiKey, setApiKey] = useState('')
   const [hint, setHint] = useState('')
   const [configured, setConfigured] = useState(false)
+  const [tools, setTools] = useState<string[]>([])
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
 
@@ -25,8 +31,10 @@ export function ChatConfig(_props: SlotProps) {
     setProvider(data.provider)
     setModel(data.model)
     setSystemPrompt(data.systemPrompt)
+    setAgentMode(data.agentMode === 'minimal' ? 'minimal' : 'standard')
     setHint(data.hint)
     setConfigured(data.configured)
+    setTools(Array.isArray(data.tools) ? data.tools : [])
   }
 
   useEffect(() => {
@@ -48,6 +56,7 @@ export function ChatConfig(_props: SlotProps) {
         provider,
         model,
         systemPrompt,
+        agentMode,
         ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
       }),
     })
@@ -58,6 +67,8 @@ export function ChatConfig(_props: SlotProps) {
     const data = (await res.json()) as ChatPublicConfig
     setHint(data.hint)
     setConfigured(data.configured)
+    setAgentMode(data.agentMode === 'minimal' ? 'minimal' : 'standard')
+    setTools(Array.isArray(data.tools) ? data.tools : [])
     setApiKey('')
     setStatus(
       data.configured
@@ -99,6 +110,23 @@ export function ChatConfig(_props: SlotProps) {
         Model
         <input className={field} value={model} onChange={(event) => setModel(event.target.value)} />
       </label>
+      <label className="block text-xs text-[var(--dsw-label-3)]">
+        Agent mode
+        <select
+          className={field}
+          value={agentMode}
+          onChange={(event) => setAgentMode(event.target.value as AgentMode)}
+          data-testid="agent-mode"
+        >
+          <option value="standard">Standard — 全部已注册工具</option>
+          <option value="minimal">Minimal — 对齐 dsh：仅 bash + str_replace_editor</option>
+        </select>
+      </label>
+      {tools.length ? (
+        <p className="m-0 text-xs leading-5 text-[var(--dsw-label-3)]">
+          当前对模型可见工具：{tools.join(', ')}
+        </p>
+      ) : null}
       <label className="block text-xs text-[var(--dsw-label-3)]">
         API Key
         <input


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 新增 Agent mode：`standard`（全部已注册工具）与 `minimal`（对齐 DeepSeek Harness，仅 `bash` + `str_replace_editor`）。
- 实现 `str_replace_editor`：`view` / `create` / `str_replace` / `insert`，工作区路径约束。
- 模式写入 `.cordis/chat-config.json`，Settings → Assistant 可切换；`tools.schemas()` / `names()` / `invoke` 统一过滤。

## Test plan
- [x] `npm test`（77 tests passed，含 tools minimal filter、str_replace_editor）
- [ ] Settings 切到 Minimal → 保存 → `/api/chat/config` 返回 `agentMode: minimal` 且 `tools` 仅两项
- [ ] Minimal 下发消息，模型侧不应再看到 `fs_read` 等工具
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

