### PR TITLE
fix: coalesce assistant/chunk；Trajectory 不再逐条展示

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -18,7 +18,7 @@
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 最左 **VS Code 式 Activity Bar**（纯图标切换 Agent / Workspace…）；Agent 下再挂 Side Bar（Sessions）+ Chat / Trajectory；演示插件进 Settings modal。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；Agent 侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
-15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从 append-only 日志投影；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request（不另持久化 messages 快照）与 response；工具行可 `inspectCall` 跳到对应 seq 并高亮；provider `usage` 写入事件并显示。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从日志投影结构化行（**跳过** `assistant/chunk`，对齐 dsh：chunk 只服务 Chat 流式，message 为权威）；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request；工具行可 `inspectCall`；`usage` 写入事件并显示。客户端 `compactSessionEvents` / ingest 合并连续 chunk，避免轨道与重渲染被 delta 淹没。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import {
+  compactSessionEvents,
   formatTrajectoryUsage,
   projectNodes,
   projectRequestMessages,
@@ -36,6 +37,35 @@ test('turn/end non-complete becomes a status row', () => {
   ])
   assert.equal(nodes[0]?.kind, 'turn')
   assert.match(nodes[0]?.kind === 'turn' ? nodes[0].text : '', /cancelled/)
+})
+
+test('projectTrajectory skips assistant/chunk (dsh-style; message is authoritative)', () => {
+  const rows = projectTrajectory([
+    { type: 'turn/start', turn: 1, seq: 1, ts: 1 },
+    { type: 'user/message', text: 'hi', seq: 2, ts: 2 },
+    { type: 'assistant/chunk', text: 'hel', seq: 3, ts: 3 },
+    { type: 'assistant/chunk', text: 'lo', seq: 4, ts: 4 },
+    { type: 'assistant/message', text: 'hello', seq: 5, ts: 5 },
+    { type: 'turn/end', turn: 1, reason: 'complete', seq: 6, ts: 6 },
+  ])
+  assert.equal(rows.some((row) => row.type === 'assistant/chunk'), false)
+  assert.equal(rows.filter((row) => row.type === 'assistant/message').length, 1)
+  assert.equal(rows.find((row) => row.type === 'assistant/message')?.summary, 'hello')
+})
+
+test('compactSessionEvents coalesces chunks and drops ones superseded by message', () => {
+  const compacted = compactSessionEvents([
+    { type: 'user/message', text: 'hi', seq: 1, ts: 1 },
+    { type: 'assistant/chunk', text: 'a', seq: 2, ts: 2 },
+    { type: 'assistant/chunk', text: 'b', seq: 3, ts: 3 },
+    { type: 'assistant/message', text: 'ab', seq: 4, ts: 4 },
+    { type: 'assistant/chunk', text: 'partial', seq: 5, ts: 5 },
+  ])
+  assert.deepEqual(
+    compacted.map((event) => event.type),
+    ['user/message', 'assistant/message', 'assistant/chunk'],
+  )
+  assert.equal(compacted[2]?.type === 'assistant/chunk' && compacted[2].text, 'partial')
 })
 
 test('projectTrajectory keeps seq ledger and tool callIds for inspect', () => {

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -214,6 +214,38 @@ function assistantSummary(event: Extract<SessionEvent, { type: 'assistant/messag
   return '(empty assistant message)'
 }
 
+/**
+ * 前端事件压缩（对齐 dsh：chunk 仅服务流式投影，不膨胀 UI 账本）。
+ * - 连续 `assistant/chunk` 合并为一条
+ * - 已被同段 `assistant/message` 覆盖的 chunk 丢弃（message 为权威全文）
+ * 不改 host append-only 落盘；仅瘦客户端内存视图。
+ */
+export function compactSessionEvents(events: SessionEvent[]): SessionEvent[] {
+  const coalesced: SessionEvent[] = []
+  for (const event of events) {
+    if (event.type === 'assistant/chunk') {
+      const prev = coalesced.at(-1)
+      if (prev?.type === 'assistant/chunk') {
+        coalesced[coalesced.length - 1] = {
+          ...prev,
+          text: prev.text + event.text,
+          ts: event.ts,
+        }
+        continue
+      }
+    }
+    coalesced.push(event)
+  }
+  const out: SessionEvent[] = []
+  for (let i = 0; i < coalesced.length; i++) {
+    const event = coalesced[i]!
+    const next = coalesced[i + 1]
+    if (event.type === 'assistant/chunk' && next?.type === 'assistant/message') continue
+    out.push(event)
+  }
+  return out
+}
+
 export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
   let turn: number | null = null
   let step: number | null = null
@@ -225,7 +257,8 @@ export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
       step = null
       inStep = false
     }
-    if (event.type === 'session/open') continue
+    // 与 dsh ConversationNode / deriveMessages 一致：chunk 不进轨迹行（流式只在 Chat 合并）
+    if (event.type === 'session/open' || event.type === 'assistant/chunk') continue
     if (event.type === 'step/start') {
       step = event.step
       inStep = true
@@ -237,7 +270,7 @@ export function projectTrajectory(events: SessionEvent[]): TrajectoryRow[] {
     if (event.type === 'assistant/message') {
       summary = assistantSummary(event)
       usage = event.usage
-    } else if (event.type === 'user/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
+    } else if (event.type === 'user/message' || event.type === 'system/prompt') {
       summary = event.text.slice(0, 160)
     } else if (event.type === 'tool/call') {
       callId = event.id

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -90,6 +90,70 @@ test('inspectCall switches to trajectory with focus', async () => {
   assert.equal(view.get().focusCallId, 'c1')
 })
 
+test('ingest coalesces consecutive chunks and omits them from trajectory', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.ingest('s1', { type: 'user/message', text: 'hi', seq: 1, ts: 2 })
+  view.ingest('s1', { type: 'assistant/chunk', text: 'hel', seq: 2, ts: 3 })
+  view.ingest('s1', { type: 'assistant/chunk', text: 'lo', seq: 3, ts: 4 })
+  assert.equal(view.get().events.filter((event) => event.type === 'assistant/chunk').length, 1)
+  assert.equal(
+    view.get().events.find((event) => event.type === 'assistant/chunk')?.type === 'assistant/chunk' &&
+      (view.get().events.find((event) => event.type === 'assistant/chunk') as { text: string }).text,
+    'hello',
+  )
+  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/chunk'), false)
+  const assistant = view.get().nodes.find((node) => node.kind === 'assistant')
+  assert.equal(assistant?.kind === 'assistant' && assistant.text, 'hello')
+  assert.equal(assistant?.kind === 'assistant' && assistant.streaming, true)
+
+  view.ingest('s1', { type: 'assistant/message', text: 'hello', seq: 4, ts: 5 })
+  assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
+  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/message'), true)
+})
+
+test('load compacts historical chunks from host log', async () => {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.match(/\/api\/sessions\/s1$/)) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          events: [
+            { type: 'session/open', version: 1, seq: 0, ts: 1 },
+            { type: 'user/message', text: 'hi', seq: 1, ts: 2 },
+            { type: 'assistant/chunk', text: 'a', seq: 2, ts: 3 },
+            { type: 'assistant/chunk', text: 'b', seq: 3, ts: 4 },
+            { type: 'assistant/message', text: 'ab', seq: 4, ts: 5 },
+          ],
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.load('s1')
+  assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
+  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/chunk'), false)
+  assert.equal(view.get().nodes.some((node) => node.kind === 'assistant' && node.text === 'ab'), true)
+})
+
 test('deleteSession clears active session when list empty', async () => {
   const calls: Array<{ url: string; method?: string }> = []
   let sessions: Array<{ id: string; title: string; eventCount: number; updatedAt: number }> = [

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
 import { Service, type Context } from 'cordis'
 import {
+  compactSessionEvents,
   projectNodes,
   projectTrajectory,
   type ChatNode,
@@ -140,7 +141,8 @@ export class SessionViewService extends Service {
       trajectory: projectTrajectory(events),
       error: undefined,
     })
-    void this.refreshSessions()
+    // chunk 高频；列表刷新留给 turn/message/tool 等结构化事件
+    if (event.type !== 'assistant/chunk') void this.refreshSessions()
   }
 
   setAgentStatus(status: 'idle' | 'running', step?: number) {
@@ -223,7 +225,7 @@ export class SessionViewService extends Service {
       events: SessionEvent[]
       project?: { name: string; path?: string; boundAt: number }
     }
-    const events = Array.isArray(body.events) ? body.events : []
+    const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
     this.replace({
       sessionId: body.id,
       events,
@@ -353,6 +355,22 @@ export class SessionViewService extends Service {
 
 function upsertEvent(events: SessionEvent[], event: SessionEvent) {
   if (events.some((item) => item.seq === event.seq)) return events
+  if (event.type === 'assistant/chunk') {
+    const last = events.at(-1)
+    if (last?.type === 'assistant/chunk') {
+      // 合并连续 delta，保持首条 chunk 的 seq（Chat 流式节点 id 稳定）
+      return [
+        ...events.slice(0, -1),
+        { ...last, text: last.text + event.text, ts: event.ts },
+      ]
+    }
+  }
+  if (event.type === 'assistant/message') {
+    const last = events.at(-1)
+    if (last?.type === 'assistant/chunk') {
+      return [...events.slice(0, -1), event]
+    }
+  }
   return [...events, event].sort((a, b) => a.seq - b.seq)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **问题**：`assistant/chunk` 过多时 Trajectory 被 delta 行淹没，且每次 WS ingest 都重投影/刷新，前端卡顿。
- **dsh 做法**：日志仍存 chunk（回放保真）；`deriveMessages` / ConversationNode 不把 chunk 当成独立消息行；轨迹是 step 聚合视图，不是 raw event dump；长列表可虚拟化。
- **本 PR（瘦对齐）**：
  - `projectTrajectory` **跳过** `assistant/chunk`（`assistant/message` 为权威全文）
  - 客户端 `compactSessionEvents` / `upsertEvent`：合并连续 chunk；message 到达后丢弃已覆盖的 chunk
  - chunk ingest 不再触发 `refreshSessions`
  - Chat 流式仍由 `projectNodes` 合并展示

## Test plan
- [x] `vitest` session-project / session-view
- [ ] 手动：长流式回复时 Trajectory 不应出现大量 chunk 行；Chat 仍实时出字

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

