### PR TITLE
fix: 路由切换单壳常驻，避免整树重挂卡顿

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -22,7 +22,7 @@
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
-19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。
+19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。**单壳常驻**：路由变化不卸载 `AppShell`；Agent/Workspace 与 Chat/Trajectory 用 `hidden` 保活，避免整树重挂导致切换卡顿。
 20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
 21. **Web：Session 绑定本地项目文件夹** — Agent Chat 右侧 Project 面板 `Open folder`（File System Access API）；文件夹名写入 session.project，句柄按 sessionId 存 IndexedDB；可浏览/编辑/保存文本文件。
 22. **Agent mode（Standard / Minimal）** — Settings 可选；`minimal` 对齐 dsh：模型侧只暴露 `bash` + `str_replace_editor`（view/create/str_replace/insert）；模式写入 `.cordis/chat-config.json`，`tools.schemas()` / `names()` / `invoke` 统一过滤。

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -118,8 +118,7 @@ function Shell(props: SlotProps) {
   const projectView = props.projectView as ProjectViewService
   const navigate = useNavigate()
   const location = useLocation()
-  const snap = useSnapshot((state: Snapshot) => state)
-  const live = snap.plugins.some((plugin) => plugin.enabled)
+  const live = useSnapshot((state: Snapshot) => state.plugins.some((plugin) => plugin.enabled))
   const sessions = useSessionView((state) => state.sessions)
   const sessionId = useSessionView((state) => state.sessionId)
   const project = useSessionView((state) => state.project)
@@ -151,7 +150,9 @@ function Shell(props: SlotProps) {
         sessionView.setProjectMeta(state.project)
       }
     })
-    return unsub
+    return () => {
+      unsub()
+    }
   }, [projectView, sessionView])
 
   return (
@@ -165,152 +166,160 @@ function Shell(props: SlotProps) {
         onSettings={() => setSettingsOpen(true)}
       />
 
-      {activeModule === 'agent' ? (
-        <aside className="app-side-bar flex min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
-          <div className="flex shrink-0 flex-col gap-2 px-4 pt-4 pb-2">
-            <BrandWordmark />
-            <div className="text-[13px] font-semibold tracking-tight">Agent</div>
+      {/* 模块切换用 hidden 保活，避免卸载重挂导致路由体感慢 */}
+      <aside
+        className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] ${
+          activeModule === 'agent' ? 'flex' : 'hidden'
+        }`}
+        aria-hidden={activeModule !== 'agent'}
+      >
+        <div className="flex shrink-0 flex-col gap-2 px-4 pt-4 pb-2">
+          <BrandWordmark />
+          <div className="text-[13px] font-semibold tracking-tight">Agent</div>
+        </div>
+        <div className="shrink-0 px-3 pb-3">
+          <button
+            type="button"
+            className="flex w-full items-center justify-center gap-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-2 text-sm font-medium hover:bg-[var(--dsw-business-soft)]"
+            onClick={() => {
+              void sessionView.newSession().then((id) => navigate(`/s/${id}`))
+            }}
+          >
+            <span className="text-lg leading-none">+</span>
+            New Session
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3">
+          <div className="mb-2 flex items-center justify-between px-1">
+            <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Sessions</span>
+            {sessionId ? (
+              <button
+                type="button"
+                className="text-[11px] text-[var(--dsw-business)] hover:underline"
+                onClick={() => {
+                  void sessionView.forkCurrent().then((id) => navigate(`/s/${id}`))
+                }}
+              >
+                Fork
+              </button>
+            ) : null}
           </div>
-          <div className="shrink-0 px-3 pb-3">
-            <button
-              type="button"
-              className="flex w-full items-center justify-center gap-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-2 text-sm font-medium hover:bg-[var(--dsw-business-soft)]"
-              onClick={() => {
-                void sessionView.newSession().then((id) => navigate(`/s/${id}`))
-              }}
-            >
-              <span className="text-lg leading-none">+</span>
-              New Session
-            </button>
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3">
-            <div className="mb-2 flex items-center justify-between px-1">
-              <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Sessions</span>
-              {sessionId ? (
-                <button
-                  type="button"
-                  className="text-[11px] text-[var(--dsw-business)] hover:underline"
-                  onClick={() => {
-                    void sessionView.forkCurrent().then((id) => navigate(`/s/${id}`))
-                  }}
+          {sessions.length === 0 ? (
+            <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No sessions yet. Send a message or create one.</p>
+          ) : (
+            sessions.map((item) => {
+              const active = item.id === sessionId
+              return (
+                <div
+                  key={item.id}
+                  className={`group mb-1 flex w-full items-stretch rounded-[12px] ${
+                    active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
+                  }`}
                 >
-                  Fork
-                </button>
-              ) : null}
-            </div>
-            {sessions.length === 0 ? (
-              <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No sessions yet. Send a message or create one.</p>
-            ) : (
-              sessions.map((item) => {
-                const active = item.id === sessionId
-                return (
-                  <div
-                    key={item.id}
-                    className={`group mb-1 flex w-full items-stretch rounded-[12px] ${
-                      active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
-                    }`}
+                  <Link
+                    to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
+                    className="min-w-0 flex-1 px-3 py-2 text-left text-sm"
                   >
-                    <Link
-                      to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
-                      className="min-w-0 flex-1 px-3 py-2 text-left text-sm"
-                    >
-                      <div className="truncate font-medium">{item.title}</div>
-                      <div className="mt-0.5 font-mono text-[10px] opacity-70">
-                        {item.id.slice(0, 8)} · {item.eventCount} events
-                        {item.project ? ` · ${item.project.name}` : ''}
-                      </div>
-                    </Link>
-                    <button
-                      type="button"
-                      className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
-                      aria-label={`Delete session ${item.title}`}
-                      title="Delete"
-                      onClick={(event) => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        if (!window.confirm(`Delete session “${item.title}”?`)) return
-                        const wasActive = item.id === sessionId
-                        void sessionView.deleteSession(item.id).then(() => {
-                          if (!wasActive) return
-                          const next = sessionView.get().sessionId
-                          navigate(next ? `/s/${next}` : '/')
-                        })
-                      }}
-                    >
-                      <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
-                      </svg>
-                    </button>
-                  </div>
-                )
-              })
-            )}
-          </div>
-        </aside>
-      ) : null}
+                    <div className="truncate font-medium">{item.title}</div>
+                    <div className="mt-0.5 font-mono text-[10px] opacity-70">
+                      {item.id.slice(0, 8)} · {item.eventCount} events
+                      {item.project ? ` · ${item.project.name}` : ''}
+                    </div>
+                  </Link>
+                  <button
+                    type="button"
+                    className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
+                    aria-label={`Delete session ${item.title}`}
+                    title="Delete"
+                    onClick={(event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      if (!window.confirm(`Delete session “${item.title}”?`)) return
+                      const wasActive = item.id === sessionId
+                      void sessionView.deleteSession(item.id).then(() => {
+                        if (!wasActive) return
+                        const next = sessionView.get().sessionId
+                        navigate(next ? `/s/${next}` : '/')
+                      })
+                    }}
+                  >
+                    <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
+                    </svg>
+                  </button>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </aside>
 
       <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
-        {activeModule === 'agent' ? (
-          <>
-            <header className="flex h-12 shrink-0 items-center gap-4 border-b border-[var(--dsw-border)] px-6">
-              <NavLink
-                to={sessionId ? `/s/${sessionId}` : '/'}
-                end
-                className={({ isActive }) =>
-                  `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
-                }
-              >
-                {({ isActive }) => (
-                  <>
-                    Chat
-                    {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
-                  </>
-                )}
-              </NavLink>
-              <NavLink
-                to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
-                className={({ isActive }) =>
-                  `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
-                }
-              >
-                {({ isActive }) => (
-                  <>
-                    Trajectory
-                    {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
-                  </>
-                )}
-              </NavLink>
-            </header>
-            <div
-              className={
-                view === 'chat'
-                  ? 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
-                  : 'flex min-h-0 w-full flex-1 flex-col overflow-hidden'
+        <div
+          className={`min-h-0 min-w-0 flex-col overflow-hidden ${activeModule === 'agent' ? 'flex flex-1' : 'hidden'}`}
+          aria-hidden={activeModule !== 'agent'}
+        >
+          <header className="flex h-12 shrink-0 items-center gap-4 border-b border-[var(--dsw-border)] px-6">
+            <NavLink
+              to={sessionId ? `/s/${sessionId}` : '/'}
+              end
+              className={({ isActive }) =>
+                `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
               }
             >
-              {view === 'chat' ? (
-                <div className="flex min-h-0 flex-1 overflow-hidden">
-                  <div className="mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4">
-                    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4">
-                      {props.renderSlot('stage')}
-                    </div>
-                    <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
-                      {props.renderSlot('dock')}
-                      {props.renderSlot('composer')}
-                    </div>
-                  </div>
-                  <aside className="project-pane hidden min-h-0 w-[min(420px,42vw)] shrink-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] md:flex">
-                    {props.renderSlot('project')}
-                  </aside>
-                </div>
-              ) : (
-                props.renderSlot('trajectory')
+              {({ isActive }) => (
+                <>
+                  Chat
+                  {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                </>
               )}
+            </NavLink>
+            <NavLink
+              to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
+              className={({ isActive }) =>
+                `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
+              }
+            >
+              {({ isActive }) => (
+                <>
+                  Trajectory
+                  {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                </>
+              )}
+            </NavLink>
+          </header>
+          <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+            <div
+              className={`min-h-0 flex-1 overflow-hidden ${view === 'chat' ? 'flex' : 'hidden'}`}
+              aria-hidden={view !== 'chat'}
+            >
+              <div className="mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4">
+                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4">
+                  {props.renderSlot('stage')}
+                </div>
+                <div className="shrink-0 space-y-2 bg-[var(--dsw-bg)] pt-1 pb-3">
+                  {props.renderSlot('dock')}
+                  {props.renderSlot('composer')}
+                </div>
+              </div>
+              <aside className="project-pane hidden min-h-0 w-[min(420px,42vw)] shrink-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] md:flex">
+                {props.renderSlot('project')}
+              </aside>
             </div>
-          </>
-        ) : (
+            <div
+              className={`min-h-0 flex-1 overflow-hidden ${view === 'trajectory' ? 'flex flex-col' : 'hidden'}`}
+              aria-hidden={view !== 'trajectory'}
+            >
+              {props.renderSlot('trajectory')}
+            </div>
+          </div>
+        </div>
+        <div
+          className={activeModule === 'workspace' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}
+          aria-hidden={activeModule !== 'workspace'}
+        >
           <WorkspaceModule />
-        )}
+        </div>
       </main>
 
       <div

--- a/src/plugins/infrastructure/renderer.tsx
+++ b/src/plugins/infrastructure/renderer.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore, type ReactNode } from 'react'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, useLocation } from 'react-router-dom'
 import { SlotEvent, type SlotEntry, type SlotKind, type SlotsService } from '../registry/slots.ts'
+import { isKnownAppPath } from './session-route.ts'
 
 function Outlet({ slots, name, kind }: { slots: SlotsService; name: string; kind?: SlotKind }) {
   useSyncExternalStore(
@@ -37,17 +38,19 @@ function AppShell({ slots }: { slots: SlotsService }) {
   return <Outlet slots={slots} name="root" kind="single" />
 }
 
+/** 单壳常驻：路由变化不卸载 Shell，避免 Chat/Trajectory/模块切换整树重挂。 */
+function Root({ slots }: { slots: SlotsService }) {
+  const location = useLocation()
+  if (!isKnownAppPath(location.pathname)) {
+    return <Navigate to="/" replace />
+  }
+  return <AppShell slots={slots} />
+}
+
 export function renderRoot(slots: SlotsService): ReactNode {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<AppShell slots={slots} />} />
-        <Route path="/workspace" element={<AppShell slots={slots} />} />
-        <Route path="/s/:sessionId" element={<AppShell slots={slots} />} />
-        <Route path="/s/:sessionId/chat" element={<AppShell slots={slots} />} />
-        <Route path="/s/:sessionId/trajectory" element={<AppShell slots={slots} />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+      <Root slots={slots} />
     </BrowserRouter>
   )
 }

--- a/src/plugins/infrastructure/session-route.test.ts
+++ b/src/plugins/infrastructure/session-route.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { buildAppPath, parseAppPath, routeFromState } from './session-route.ts'
+import { buildAppPath, isKnownAppPath, parseAppPath, routeFromState } from './session-route.ts'
 
 test('parseAppPath covers home, session chat, trajectory, and workspace module', () => {
   assert.deepEqual(parseAppPath('/'), { kind: 'home' })
@@ -14,6 +14,16 @@ test('parseAppPath covers home, session chat, trajectory, and workspace module',
   })
   assert.deepEqual(parseAppPath('/workspace'), { kind: 'module', moduleId: 'workspace' })
   assert.deepEqual(parseAppPath('/unknown'), { kind: 'home' })
+})
+
+test('isKnownAppPath accepts app surfaces and rejects noise', () => {
+  assert.equal(isKnownAppPath('/'), true)
+  assert.equal(isKnownAppPath('/workspace'), true)
+  assert.equal(isKnownAppPath('/s/abc'), true)
+  assert.equal(isKnownAppPath('/s/abc/chat'), true)
+  assert.equal(isKnownAppPath('/s/abc/trajectory'), true)
+  assert.equal(isKnownAppPath('/unknown'), false)
+  assert.equal(isKnownAppPath('/s/abc/extra'), false)
 })
 
 test('buildAppPath round-trips with parseAppPath', () => {

--- a/src/plugins/infrastructure/session-route.ts
+++ b/src/plugins/infrastructure/session-route.ts
@@ -19,6 +19,13 @@ export function parseAppPath(pathname: string): AppRoute {
   }
 }
 
+/** 已知应用 path（未知则 Navigate 回 `/`，且不拆 Shell）。 */
+export function isKnownAppPath(pathname: string): boolean {
+  const path = normalizePath(pathname)
+  if (path === '/' || path === '/workspace') return true
+  return /^\/s\/[^/]+(?:\/(chat|trajectory))?$/.test(path)
+}
+
 export function buildAppPath(route: AppRoute): string {
   if (route.kind === 'home') return '/'
   if (route.kind === 'module') return route.moduleId === 'workspace' ? '/workspace' : '/'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
路由切换（Chat ↔ Trajectory、Agent ↔ Workspace）体感慢，根因是 **每个 path 各自挂了一个 `AppShell`**，React Router 切换时整棵壳（侧栏 + Chat + Trajectory + Project）卸载重挂，并重新跑 `refreshSessions` 等 effect。

## Fix
- `renderer`：**单壳常驻**，未知 path 再 `Navigate` 回 `/`
- Shell：Agent / Workspace、Chat / Trajectory 用 **`hidden` 保活**，不再条件卸载
- 收窄 `useSnapshot` 订阅（只取 `live`）

## Test plan
- [x] session-route / renderer unit tests
- [ ] 手动：同 session 下 Chat↔Trajectory 应即时；Agent↔Workspace 再回 Agent 不应白屏重载会话

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

