### PR TITLE
ui: 项目绑定收进顶栏 + Trajectory 折叠 + cache 进度额度

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -18,15 +18,15 @@
 12. **Web：审批可观察** — hold 待批出现在 composer dock，允许/拒绝回调 host。
 13. **Web 壳对标 dsh 观感** — 最左 **VS Code 式 Activity Bar**（纯图标切换 Agent / Workspace…）；Agent 下再挂 Side Bar（Sessions）+ Chat / Trajectory；演示插件进 Settings modal。
 14. **Web：可恢复会话列表 + 真 New Session / Fork** — `GET /api/sessions` 列出会话；Agent 侧栏切换 `load`；Fork 走 `POST /api/sessions/:id/fork`。
-15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从日志投影结构化行（**跳过** `assistant/chunk`，对齐 dsh：chunk 只服务 Chat 流式，message 为权威）；点击行打开事件详情；`assistant/message` 详情用 `deriveMessages(seq 前缀)` 投影本步 request；工具行可 `inspectCall`；`usage` 写入事件并显示。客户端 `compactSessionEvents` / ingest 合并连续 chunk，避免轨道与重渲染被 delta 淹没。
+15. **Web：Trajectory 事件账本** — Chat/Trajectory 可切换；`projectTrajectory` 从日志投影结构化行（**跳过** `assistant/chunk`）；turn / step 可折叠（小三角 ▸）；点击行打开事件详情；`usage` 的 Input 包成胶囊，缓存命中用进度背景比例显示。
 16. **Web：Chat Markdown** — 用户/助手气泡用 `react-markdown` + `remark-gfm` 渲染。
 17. **Web：审批 mode + 重水合** — `auto`/`hold` 可切换；启动与 `load` 时 `GET /api/approvals` 恢复 pending，不只依赖 WS。
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
 19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。**单壳常驻**：路由变化不卸载 `AppShell`；Agent/Workspace 与 Chat/Trajectory 用保活叠层（`visibility`，避免 `display:none` 丢掉大 Markdown 布局）；slot props / `renderSlot` 稳定 + Chat/Markdown `memo`，避免切换时重解析。
 20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
-21. **Web：Session 绑定本地项目文件夹** — Agent Chat 右侧 Project 面板 `Open folder`（File System Access API）；文件夹名写入 session.project，句柄按 sessionId 存 IndexedDB；可浏览/编辑/保存文本文件。
-22. **Agent mode（Standard / Minimal）** — Settings 可选；`minimal` 对齐 dsh：模型侧只暴露 `bash` + `str_replace_editor`（view/create/str_replace/insert）；模式写入 `.cordis/chat-config.json`，`tools.schemas()` / `names()` / `invoke` 统一过滤。
-23. **Session 绑定 host 工作区（对齐 dsh）** — Project 点 Open folder 弹出系统选目录对话框并自动绑定；该 Session 的 bash / str_replace_editor 直接以该目录为 cwd。
+21. **Web：Session 绑定项目** — Agent 顶栏右侧紧凑 **Bind project** chip（不再占大右侧栏）；点选系统目录绑定为 Session cwd。
+22. **Agent mode（Standard / Minimal）** — Settings 可选；`minimal` 对齐 dsh：模型侧只暴露 `bash` + `str_replace_editor`；模式写入 `.cordis/chat-config.json`。
+23. **Session host cwd（对齐 dsh）** — Bind project 后 bash / str_replace_editor 以该目录为 cwd。
 
 ## 功能级差异（相对官方 client，优点对齐后）
 

--- a/src/plugins/contributors/chat/project-panel.tsx
+++ b/src/plugins/contributors/chat/project-panel.tsx
@@ -1,7 +1,7 @@
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindProjectView, type ProjectViewService } from '../../infrastructure/project-view.ts'
 
-/** Session 绑定 host 工作区：点 Open folder 弹出系统目录框并自动绑定（对齐 dsh）。 */
+/** 紧凑项目绑定：挂在 Chat 顶栏右侧，像「绑定一个项目」而不是整栏面板。 */
 export function SessionProjectPanel(props: SlotProps) {
   const useProjectView = props.useProjectView as ReturnType<typeof bindProjectView>
   const projectView = props.projectView as ProjectViewService
@@ -12,57 +12,47 @@ export function SessionProjectPanel(props: SlotProps) {
 
   if (!sessionId) {
     return (
-      <div className="project-panel project-panel-empty">
-        <p className="text-sm text-[var(--dsw-label-3)]">先创建或打开一个 Session，再选择工作区文件夹。</p>
+      <div className="project-chip project-chip-muted" title="先打开一个 Session">
+        <FolderGlyph />
+        <span>No session</span>
       </div>
     )
   }
 
   return (
-    <div className="project-panel">
-      <header className="project-panel-head">
-        <div className="min-w-0">
-          <div className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Workspace</div>
-          <div className="truncate text-sm font-semibold" title={project?.path ?? project?.name}>
-            {project?.name ?? '未绑定'}
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {project ? (
-            <button
-              type="button"
-              className="rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-label-3)] hover:bg-black/5"
-              disabled={busy}
-              onClick={() => void projectView.unbindFolder()}
-            >
-              Unbind
-            </button>
-          ) : null}
-          <button
-            type="button"
-            className="rounded-[8px] bg-[var(--dsw-business)] px-2.5 py-1 text-[11px] font-medium text-white disabled:opacity-50"
-            disabled={busy}
-            onClick={() => void projectView.openFolderForSession(sessionId).catch(() => undefined)}
-          >
-            {project ? 'Rebind' : 'Open folder'}
-          </button>
-        </div>
-      </header>
-
-      <p className="project-panel-hint">
-        点击 Open folder，在系统对话框里选目录即自动绑定。之后本 Session 的 bash / str_replace_editor 直接读写该目录。
-      </p>
-
-      {project?.path ? (
-        <p className="project-panel-hint truncate" title={project.path}>
-          当前 cwd：{project.path}
-        </p>
-      ) : (
-        <div className="project-panel-empty">
-          <p className="text-sm leading-6 text-[var(--dsw-label-2)]">尚未绑定工作区。选择一个本机项目文件夹开始。</p>
-        </div>
-      )}
-      {error ? <p className="project-panel-error">{error}</p> : null}
+    <div className="project-chip-wrap">
+      <button
+        type="button"
+        className={`project-chip${project ? '' : ' project-chip-empty'}${busy ? ' is-busy' : ''}`}
+        disabled={busy}
+        title={project?.path ?? '选择本机文件夹并绑定为 Session cwd'}
+        onClick={() => void projectView.openFolderForSession(sessionId).catch(() => undefined)}
+      >
+        <FolderGlyph />
+        <span className="project-chip-name">{project?.name ?? 'Bind project'}</span>
+        {project ? <span className="project-chip-hint">cwd</span> : null}
+      </button>
+      {project ? (
+        <button
+          type="button"
+          className="project-chip-unbind"
+          disabled={busy}
+          title="Unbind workspace"
+          aria-label="Unbind workspace"
+          onClick={() => void projectView.unbindFolder()}
+        >
+          ×
+        </button>
+      ) : null}
+      {error ? <span className="project-chip-error" title={error}>!</span> : null}
     </div>
+  )
+}
+
+function FolderGlyph() {
+  return (
+    <svg viewBox="0 0 24 24" className="project-chip-icon" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.5 8.5V18a1.5 1.5 0 0 0 1.5 1.5h14A1.5 1.5 0 0 0 20.5 18V10A1.5 1.5 0 0 0 19 8.5h-7.2L10 6.5H5A1.5 1.5 0 0 0 3.5 8v.5z" />
+    </svg>
   )
 }

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useState, type CSSProperties } from 'react'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
@@ -36,12 +36,34 @@ function formatTok(n: number) {
   return n.toLocaleString('en-US')
 }
 
+function cacheHitPct(usage: TrajectoryUsage): number | null {
+  if (!usage.inputTokens || !usage.cacheReadTokens) return null
+  return Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100))
+}
+
+/** Input 包成胶囊；缓存命中用进度背景铺在 Input 上。 */
 function UsageInline({ usage, empty = '—' }: { usage?: TrajectoryUsage; empty?: string }) {
   if (!usage) return <span className="traj-usage-empty">{empty}</span>
+  const pct = cacheHitPct(usage)
+  const inStyle: CSSProperties | undefined =
+    pct != null
+      ? {
+          backgroundImage: `linear-gradient(90deg, rgba(34, 140, 90, 0.28) 0%, rgba(34, 140, 90, 0.28) ${pct}%, rgba(15, 17, 21, 0.06) ${pct}%, rgba(15, 17, 21, 0.06) 100%)`,
+        }
+      : undefined
   return (
     <span className="traj-usage" title={formatTrajectoryUsage(usage)}>
-      <span className="traj-usage-in" title="input tokens">
-        {formatTok(usage.inputTokens)}
+      <span
+        className={`traj-usage-in-wrap${pct != null ? ' has-cache' : ''}`}
+        style={inStyle}
+        title={
+          pct != null
+            ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct}% (${formatTok(usage.cacheReadTokens!)})`
+            : `input ${formatTok(usage.inputTokens)}`
+        }
+      >
+        <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
+        {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
       </span>
       <span className="traj-usage-arrow" aria-hidden>
         →
@@ -49,28 +71,29 @@ function UsageInline({ usage, empty = '—' }: { usage?: TrajectoryUsage; empty?
       <span className="traj-usage-out" title="output tokens">
         {formatTok(usage.outputTokens)}
       </span>
-      {usage.cacheReadTokens ? (
-        <span className="traj-usage-cache" title="cache read tokens">
-          c{formatTok(usage.cacheReadTokens)}
-        </span>
-      ) : null}
     </span>
   )
 }
 
 function UsageCard({ usage, label = 'Token usage' }: { usage: TrajectoryUsage; label?: string }) {
   const total = usage.totalTokens ?? usage.inputTokens + usage.outputTokens
-  const cacheRatio =
-    usage.inputTokens > 0 && usage.cacheReadTokens
-      ? Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100))
-      : null
+  const pct = cacheHitPct(usage)
+  const inStyle: CSSProperties | undefined =
+    pct != null
+      ? {
+          backgroundImage: `linear-gradient(90deg, rgba(34, 140, 90, 0.22) 0%, rgba(34, 140, 90, 0.22) ${pct}%, rgba(15, 17, 21, 0.04) ${pct}%, rgba(15, 17, 21, 0.04) 100%)`,
+        }
+      : undefined
   return (
     <section className="traj-usage-card" aria-label={label}>
       <div className="traj-usage-card-title">{label}</div>
       <div className="traj-usage-grid">
-        <div className="traj-usage-stat traj-usage-stat-in">
-          <span>Input</span>
+        <div className="traj-usage-stat traj-usage-stat-in" style={inStyle}>
+          <span>Input{pct != null ? ` · cache ${pct}%` : ''}</span>
           <strong>{formatTok(usage.inputTokens)}</strong>
+          {usage.cacheReadTokens ? (
+            <em className="traj-usage-stat-sub">cache {formatTok(usage.cacheReadTokens)}</em>
+          ) : null}
         </div>
         <div className="traj-usage-stat traj-usage-stat-out">
           <span>Output</span>
@@ -80,14 +103,16 @@ function UsageCard({ usage, label = 'Token usage' }: { usage: TrajectoryUsage; l
           <span>Total</span>
           <strong>{formatTok(total)}</strong>
         </div>
-        {usage.cacheReadTokens != null && usage.cacheReadTokens > 0 ? (
-          <div className="traj-usage-stat traj-usage-stat-cache">
-            <span>Cache read{cacheRatio != null ? ` · ${cacheRatio}%` : ''}</span>
-            <strong>{formatTok(usage.cacheReadTokens)}</strong>
-          </div>
-        ) : null}
       </div>
     </section>
+  )
+}
+
+function FoldCaret({ open }: { open: boolean }) {
+  return (
+    <span className={`traj-caret${open ? ' is-open' : ''}`} aria-hidden>
+      ▸
+    </span>
   )
 }
 
@@ -98,6 +123,10 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
   const focusCallId = useSessionView((state) => state.focusCallId)
   const sessionId = useSessionView((state) => state.sessionId)
   const [selectedSeq, setSelectedSeq] = useState<number | null>(null)
+  /** turn key → collapsed */
+  const [collapsedTurns, setCollapsedTurns] = useState<Record<string, boolean>>({})
+  /** `${turn}:${step}` → collapsed */
+  const [collapsedSteps, setCollapsedSteps] = useState<Record<string, boolean>>({})
 
   const groups = useMemo(() => groupByTurn(rows), [rows])
   const cumulative = useMemo(() => sumTrajectoryUsage(events), [events])
@@ -158,43 +187,81 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
         </div>
 
         <div className="traj-list" role="rowgroup">
-          {groups.map((group) => (
-            <div key={group.key} className="traj-group">
-              <div className="traj-group-bar">
-                <span>{group.turn == null ? 'meta' : `Turn ${group.turn}`}</span>
-                <span>{group.rows.length}</span>
+          {groups.map((group) => {
+            const turnKey = group.key
+            const turnCollapsed = Boolean(collapsedTurns[turnKey])
+            const visibleRows = turnCollapsed
+              ? []
+              : filterCollapsedSteps(group.rows, group.turn, collapsedSteps)
+            return (
+              <div key={group.key} className={`traj-group${turnCollapsed ? ' is-collapsed' : ''}`}>
+                <button
+                  type="button"
+                  className="traj-group-bar"
+                  aria-expanded={!turnCollapsed}
+                  onClick={() =>
+                    setCollapsedTurns((prev) => ({ ...prev, [turnKey]: !prev[turnKey] }))
+                  }
+                >
+                  <span className="traj-group-bar-left">
+                    <FoldCaret open={!turnCollapsed} />
+                    <span>{group.turn == null ? 'meta' : `Turn ${group.turn}`}</span>
+                  </span>
+                  <span>{group.rows.length}</span>
+                </button>
+                {visibleRows.map((row) => {
+                  const focused = Boolean(focusCallId && row.callId === focusCallId) || selectedSeq === row.seq
+                  const tone = toneOf(row.type)
+                  const isStepStart = row.type === 'step/start'
+                  const stepKey =
+                    isStepStart && row.turn != null && row.step != null ? `${row.turn}:${row.step}` : null
+                  const stepCollapsed = stepKey ? Boolean(collapsedSteps[stepKey]) : false
+                  return (
+                    <div key={row.id} className="traj-row-wrap">
+                      {isStepStart && stepKey ? (
+                        <button
+                          type="button"
+                          className="traj-step-fold"
+                          aria-expanded={!stepCollapsed}
+                          aria-label={stepCollapsed ? 'Expand step' : 'Collapse step'}
+                          onClick={(event) => {
+                            event.stopPropagation()
+                            setCollapsedSteps((prev) => ({ ...prev, [stepKey]: !prev[stepKey] }))
+                          }}
+                        >
+                          <FoldCaret open={!stepCollapsed} />
+                        </button>
+                      ) : (
+                        <span className="traj-step-fold-spacer" aria-hidden />
+                      )}
+                      <button
+                        type="button"
+                        id={row.callId ? `traj-call-${row.callId}` : undefined}
+                        role="row"
+                        className={`traj-row traj-depth-${row.depth}${focused ? ' traj-row-focus' : ''}${
+                          row.type === 'assistant/message' ? ' traj-row-assistant' : ''
+                        }`}
+                        onClick={() => setSelectedSeq(row.seq)}
+                      >
+                        <span className="traj-col-seq">{row.seq}</span>
+                        <span className="traj-col-type">
+                          <span className={toneClass[tone]} title={row.type}>
+                            {row.type}
+                          </span>
+                        </span>
+                        <span className="traj-col-summary" title={row.summary}>
+                          {row.summary}
+                        </span>
+                        <span className="traj-col-usage">
+                          <UsageInline usage={row.usage} />
+                        </span>
+                      </button>
+                    </div>
+                  )
+                })}
               </div>
-              {group.rows.map((row) => {
-                const focused = Boolean(focusCallId && row.callId === focusCallId) || selectedSeq === row.seq
-                const tone = toneOf(row.type)
-                return (
-                  <button
-                    key={row.id}
-                    type="button"
-                    id={row.callId ? `traj-call-${row.callId}` : undefined}
-                    role="row"
-                    className={`traj-row traj-depth-${row.depth}${focused ? ' traj-row-focus' : ''}${
-                      row.type === 'assistant/message' ? ' traj-row-assistant' : ''
-                    }`}
-                    onClick={() => setSelectedSeq(row.seq)}
-                  >
-                    <span className="traj-col-seq">{row.seq}</span>
-                    <span className="traj-col-type">
-                      <span className={toneClass[tone]} title={row.type}>
-                        {row.type}
-                      </span>
-                    </span>
-                    <span className="traj-col-summary" title={row.summary}>
-                      {row.summary}
-                    </span>
-                    <span className="traj-col-usage">
-                      <UsageInline usage={row.usage} />
-                    </span>
-                  </button>
-                )
-              })}
-            </div>
-          ))}
+            )
+          })}
         </div>
       </div>
 
@@ -215,6 +282,30 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
     </div>
   )
 })
+
+/** 折叠的 step：隐藏 step/start 之后到对应 step/end（含）之间的行，start 行本身保留。 */
+function filterCollapsedSteps(
+  rows: TrajectoryRow[],
+  turn: number | null,
+  collapsedSteps: Record<string, boolean>,
+): TrajectoryRow[] {
+  const out: TrajectoryRow[] = []
+  let hiding: string | null = null
+  for (const row of rows) {
+    if (hiding) {
+      if (row.type === 'step/end' && turn != null && row.step != null && `${turn}:${row.step}` === hiding) {
+        hiding = null
+      }
+      continue
+    }
+    out.push(row)
+    if (row.type === 'step/start' && turn != null && row.step != null) {
+      const key = `${turn}:${row.step}`
+      if (collapsedSteps[key]) hiding = key
+    }
+  }
+  return out
+}
 
 function EventDetailBody({ event, events }: { event: SessionEvent; events: SessionEvent[] }) {
   const fields = detailFields(event, events)

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -104,8 +104,8 @@ function WorkspaceModule() {
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
       <h1 className="text-xl font-semibold tracking-tight text-[var(--dsw-label)]">Workspace</h1>
       <p className="max-w-md text-sm leading-6 text-[var(--dsw-label-3)]">
-        本地项目文件夹绑定在 <strong className="font-semibold text-[var(--dsw-label-2)]">Agent Session</strong>{' '}
-        上：进入 Agent → 打开/新建 Session → 右侧 Project 面板 Open folder。每个 Session 对应一个文件夹。
+        项目绑定在 Agent 顶栏右侧的 <strong className="font-semibold text-[var(--dsw-label-2)]">Bind project</strong>{' '}
+        ：选目录后作为该 Session 的 cwd。无需单独大面板。
       </p>
     </div>
   )
@@ -287,6 +287,7 @@ function Shell(props: SlotProps) {
                 </>
               )}
             </NavLink>
+            <div className="ml-auto flex min-w-0 items-center">{props.renderSlot('project')}</div>
           </header>
           <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
             {/*
@@ -308,9 +309,6 @@ function Shell(props: SlotProps) {
                   {props.renderSlot('composer')}
                 </div>
               </div>
-              <aside className="project-pane hidden min-h-0 w-[min(420px,42vw)] shrink-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] md:flex">
-                {props.renderSlot('project')}
-              </aside>
             </div>
             <div
               className={`absolute inset-0 min-h-0 overflow-hidden ${

--- a/src/style.css
+++ b/src/style.css
@@ -210,50 +210,105 @@ body {
   border: 0;
 }
 
-/* Session-bound local project panel (Agent chat) */
-.project-pane {
-  display: none;
-}
-
-@media (min-width: 768px) {
-  .project-pane {
-    display: flex;
-  }
-}
-
-.project-panel {
-  display: flex;
-  min-height: 0;
-  flex: 1;
-  flex-direction: column;
-}
-
-.project-panel-head {
-  display: flex;
+/* Compact project bind chip (Agent header) */
+.project-chip-wrap {
+  display: inline-flex;
+  max-width: min(280px, 42vw);
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  border-bottom: 1px solid var(--dsw-border);
-  padding: 12px 12px 10px;
+  gap: 2px;
 }
 
-.project-panel-hint,
-.project-panel-error,
-.project-panel-empty {
-  padding: 12px;
+.project-chip {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 999px;
+  background: #fff;
+  padding: 4px 10px 4px 8px;
+  color: var(--dsw-label-2);
   font-size: 12px;
-  line-height: 1.5;
+  line-height: 1.2;
+  cursor: pointer;
 }
 
-.project-panel-hint {
+.project-chip:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--dsw-business) 35%, var(--dsw-border));
+  background: var(--dsw-business-soft);
+  color: var(--dsw-business);
+}
+
+.project-chip:disabled,
+.project-chip.is-busy {
+  opacity: 0.55;
+  cursor: wait;
+}
+
+.project-chip-empty {
   color: var(--dsw-label-3);
 }
 
-.project-panel-error {
+.project-chip-muted {
+  border-style: dashed;
+  color: var(--dsw-label-3);
+  cursor: default;
+}
+
+.project-chip-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.project-chip-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 550;
+}
+
+.project-chip-hint {
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: rgba(15, 17, 21, 0.06);
+  padding: 1px 6px;
+  color: var(--dsw-label-3);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.project-chip-unbind {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.project-chip-unbind:hover:not(:disabled) {
+  background: rgba(0, 0, 0, 0.05);
   color: var(--dsw-danger);
 }
 
-.project-panel-body {
+.project-chip-error {
+  color: var(--dsw-danger);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+/* legacy panel styles kept minimal for tests / empty states */
+.project-panel {
   display: flex;
   min-height: 0;
   flex: 1;
@@ -408,21 +463,85 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 20px;
-  padding: 0 12px;
+  width: 100%;
+  height: 24px;
+  border: 0;
   border-bottom: 1px solid var(--dsw-border);
   background: rgba(15, 17, 21, 0.03);
+  padding: 0 12px;
   color: var(--dsw-label-2);
+  font: inherit;
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
+  cursor: pointer;
+}
+
+.traj-group-bar:hover {
+  background: rgba(65, 118, 230, 0.06);
+}
+
+.traj-group-bar-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.traj-caret {
+  display: inline-block;
+  width: 10px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 120ms ease;
+}
+
+.traj-caret.is-open {
+  transform: rotate(90deg);
+}
+
+.traj-row-wrap {
+  display: flex;
+  align-items: stretch;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.traj-step-fold,
+.traj-step-fold-spacer {
+  display: grid;
+  width: 18px;
+  flex-shrink: 0;
+  place-items: center;
+}
+
+.traj-step-fold {
+  border: 0;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+  padding: 0;
+}
+
+.traj-step-fold:hover {
+  color: var(--dsw-business);
+  background: rgba(65, 118, 230, 0.06);
+}
+
+.traj-row-wrap .traj-row {
+  flex: 1;
+  min-width: 0;
+  border-bottom: 0;
+}
+
+.traj-head {
+  padding-left: 18px;
 }
 
 .traj-row {
   width: 100%;
   border: 0;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
   color: var(--dsw-label);
   background: transparent;
   text-align: left;
@@ -499,7 +618,7 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 3px;
+  gap: 4px;
   max-width: 100%;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -509,9 +628,31 @@ body {
   color: var(--dsw-label-3);
 }
 
-.traj-usage-in {
+.traj-usage-in-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  border-radius: 999px;
+  background: rgba(15, 17, 21, 0.06);
+  padding: 1px 7px;
   color: var(--dsw-label-2);
   font-weight: 600;
+}
+
+.traj-usage-in-wrap.has-cache {
+  color: var(--dsw-label);
+}
+
+.traj-usage-in {
+  color: inherit;
+  font-weight: 600;
+}
+
+.traj-usage-cache-pct {
+  color: var(--dsw-ok);
+  font-size: 10px;
+  font-weight: 700;
 }
 
 .traj-usage-arrow {
@@ -521,16 +662,6 @@ body {
 
 .traj-usage-out {
   color: var(--dsw-business);
-  font-weight: 600;
-}
-
-.traj-usage-cache {
-  margin-left: 2px;
-  border-radius: 3px;
-  padding: 0 4px;
-  background: rgba(34, 140, 90, 0.12);
-  color: var(--dsw-ok);
-  font-size: 10px;
   font-weight: 600;
 }
 
@@ -578,20 +709,19 @@ body {
 }
 
 .traj-usage-stat-in strong {
-  color: var(--dsw-label-2);
+  color: var(--dsw-label);
 }
 
 .traj-usage-stat-out strong {
   color: var(--dsw-business);
 }
 
-.traj-usage-stat-cache {
-  grid-column: 1 / -1;
-  background: rgba(34, 140, 90, 0.08);
-}
-
-.traj-usage-stat-cache strong {
+.traj-usage-stat-sub {
+  margin-top: 2px;
   color: var(--dsw-ok);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 600;
 }
 
 .traj-io-card {
@@ -1005,7 +1135,7 @@ body {
     border-top: 1px solid var(--dsw-border);
   }
 
-  .traj-usage-cache {
+  .traj-usage-cache-pct {
     display: none;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
按反馈收紧 UI：

1. **去掉大右侧 Workspace 栏** — `Bind project` 紧凑 chip 挂在 Agent 顶栏右侧（Chat/Trajectory 旁边），点选目录绑定 cwd  
2. **Trajectory 可折叠** — Turn / Step 带小三角 ▸，可折叠展开  
3. **Usage** — Input 包成胶囊；有 cache 时用进度背景表示命中比例，并显示 `%`

## Test plan
- [x] vitest shell / chat / renderer
- [ ] 手动：顶栏绑定项目；Trajectory 折叠 turn/step；有 cache 的 usage 行看进度底

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

