### PR TITLE
fix: 取消 agent step 最大步数限制

### DIFF
--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -27,15 +27,12 @@ export interface AgentRunner {
 
 export type AgentLoopFactory = (config: LlmConfig, sessionId: string, signal: AbortSignal) => AgentRunner
 
-const MAX_STEPS = 8
-
 export class AgentLoop implements AgentRunner {
   constructor(
     private ctx: Context,
     private llm: LlmClient,
     private sessionId: string,
     private signal: AbortSignal,
-    private maxSteps = MAX_STEPS,
   ) {}
 
   async run(claimed: ClaimedInput[]): Promise<AgentTurn> {
@@ -69,7 +66,7 @@ export class AgentLoop implements AgentRunner {
     const steps: AgentTurn['steps'] = []
     let final = '（空回复）'
 
-    for (let step = 0; step < this.maxSteps; step++) {
+    for (let step = 0; ; step++) {
       if (this.signal.aborted) {
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
         throw new Error('cancelled')
@@ -142,10 +139,6 @@ export class AgentLoop implements AgentRunner {
       await session.append(this.sessionId, { type: 'step/end', turn, step })
       final = steps.at(-1)?.detail ?? final
     }
-
-    await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'max-steps' })
-    this.ctx.emit('agent/status', { status: 'idle', step: this.maxSteps })
-    return { text: '工具轮次过多，已停止。', steps }
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
取消 Agent loop 的 step 上限（原 `MAX_STEPS = 8`）。

现在会一直跑工具轮次，直到模型给出无 tool_calls 的最终回复，或取消 / LLM 错误。

## Test plan
- [x] agent-loop unit tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

