### PR TITLE
perf: 流式 chunk 合并与渲染减负

### DIFF
--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -84,7 +84,14 @@ export class SessionsService extends Service {
     const record = await this.require(id)
     const event: SessionEvent = { ...body, seq: record.events.length, ts: Date.now() }
     record.events.push(event)
-    await this.persist(record)
+    this.cache.set(id, record)
+    // chunk 极高频：先内存追加并广播，落盘合并到下一帧/定时器，避免每 token 全量 JSON 写盘
+    if (body.type === 'assistant/chunk') {
+      this.schedulePersist(id)
+    } else {
+      this.clearPersistTimer(id)
+      await this.persist(record)
+    }
     this.ctx.emit('session/event', { sessionId: id, event })
     return event
   }
@@ -124,8 +131,30 @@ export class SessionsService extends Service {
   }
 
   async delete(id: string) {
+    this.clearPersistTimer(id)
     this.cache.delete(id)
     return this.ctx.sessionStore.delete(id)
+  }
+
+  private persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  private schedulePersist(id: string) {
+    if (this.persistTimers.has(id)) return
+    this.persistTimers.set(
+      id,
+      setTimeout(() => {
+        this.persistTimers.delete(id)
+        const record = this.cache.get(id)
+        if (record) void this.persist(record)
+      }, 80),
+    )
+  }
+
+  private clearPersistTimer(id: string) {
+    const timer = this.persistTimers.get(id)
+    if (timer == null) return
+    clearTimeout(timer)
+    this.persistTimers.delete(id)
   }
 
   private async persist(record: SessionRecord) {

--- a/host/plugins/orchestration/agent-loop.test.ts
+++ b/host/plugins/orchestration/agent-loop.test.ts
@@ -48,9 +48,10 @@ test('loop appends multiple assistant/chunk deltas from onDelta', async () => {
   const turn = await loop.run([{ kind: 'wake', text: 'hi' }])
   assert.equal(turn.text, 'Hello')
   const chunks = (await ctx.sessions.require(sessionId)).events.filter((event) => event.type === 'assistant/chunk')
+  // onDelta 在 ~48ms 窗口内合并后再 append，同一步内多次 delta 落成一条 chunk
   assert.deepEqual(
     chunks.map((event) => (event.type === 'assistant/chunk' ? event.text : '')),
-    ['Hel', 'lo'],
+    ['Hello'],
   )
   const message = (await ctx.sessions.require(sessionId)).events.find((event) => event.type === 'assistant/message')
   assert.equal(message?.type === 'assistant/message' && message.usage?.inputTokens, 1)

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -65,9 +65,37 @@ export class AgentLoop implements AgentRunner {
 
     const steps: AgentTurn['steps'] = []
     let final = '（空回复）'
+    let chunkBuf = ''
+    let chunkFlush: Promise<void> = Promise.resolve()
+    let chunkTimer: ReturnType<typeof setTimeout> | null = null
+
+    const flushChunks = () => {
+      if (chunkTimer != null) {
+        clearTimeout(chunkTimer)
+        chunkTimer = null
+      }
+      if (!chunkBuf) return chunkFlush
+      const text = chunkBuf
+      chunkBuf = ''
+      chunkFlush = chunkFlush.then(() =>
+        session.append(this.sessionId, { type: 'assistant/chunk', text }),
+      )
+      return chunkFlush
+    }
+
+    const queueChunk = (text: string) => {
+      if (!text) return
+      chunkBuf += text
+      if (chunkTimer != null) return
+      chunkTimer = setTimeout(() => {
+        chunkTimer = null
+        void flushChunks()
+      }, 48)
+    }
 
     for (let step = 0; ; step++) {
       if (this.signal.aborted) {
+        await flushChunks()
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
         throw new Error('cancelled')
       }
@@ -79,10 +107,12 @@ export class AgentLoop implements AgentRunner {
       try {
         reply = await this.llm.chat(messages, this.ctx.tools.schemas(), this.signal, {
           onDelta: async (text) => {
-            if (text) await session.append(this.sessionId, { type: 'assistant/chunk', text })
+            queueChunk(text)
           },
         })
+        await flushChunks()
       } catch (error) {
+        await flushChunks()
         if (this.signal.aborted) {
           await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
           this.ctx.emit('agent/status', { status: 'idle' })

--- a/host/plugins/registry/hub.ts
+++ b/host/plugins/registry/hub.ts
@@ -23,6 +23,12 @@ export class HubService extends Service {
     super(ctx, 'hub')
     ctx.on('internal/dispatch', (mode, name, args) => {
       if (name.startsWith('internal/')) return
+      // 流式 delta 极高频，不进 hub event 总线（避免 Settings EventLog 拖垮主线程）
+      if (name === 'llm/stream') return
+      if (name === 'session/event') {
+        const payload = args[0] as { event?: { type?: string } } | undefined
+        if (payload?.event?.type === 'assistant/chunk') return
+      }
       this.events.unshift({ ts: Date.now(), mode, name, args: clone(args) })
       this.events.splice(80)
       ctx.http.broadcast(HUB_CHANNEL_EVENT, this.events[0])

--- a/src/plugins/contributors/chat/markdown.tsx
+++ b/src/plugins/contributors/chat/markdown.tsx
@@ -2,18 +2,30 @@ import { memo } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
+const REMARK_PLUGINS = [remarkGfm]
+
 /** 对话气泡内的 Markdown 渲染（GFM：表格/任务列表/删除线等）。 */
 export const MarkdownBody = memo(function MarkdownBody({
   text,
   className = '',
+  streaming = false,
 }: {
   text: string
   className?: string
+  /** 流式中跳过 remark，避免每帧全量重解析 */
+  streaming?: boolean
 }) {
   if (!text) return null
+  if (streaming) {
+    return (
+      <div className={`chat-md chat-md-stream ${className}`.trim()}>
+        <pre className="chat-md-stream-pre">{text}</pre>
+      </div>
+    )
+  }
   return (
     <div className={`chat-md ${className}`.trim()}>
-      <Markdown remarkPlugins={[remarkGfm]}>{text}</Markdown>
+      <Markdown remarkPlugins={REMARK_PLUGINS}>{text}</Markdown>
     </div>
   )
 })

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -87,7 +87,7 @@ function NodeView({ node, onInspect }: { node: ChatNode; onInspect: (callId: str
   if (node.kind === 'assistant') {
     return (
       <div className="w-full max-w-[var(--dsw-chat-width)] self-start text-[15px] leading-7 text-[var(--dsw-label)]">
-        {node.text ? <MarkdownBody text={node.text} /> : node.streaming ? '…' : null}
+        {node.text ? <MarkdownBody text={node.text} streaming={Boolean(node.streaming)} /> : node.streaming ? '…' : null}
         {node.streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
       </div>
     )
@@ -169,7 +169,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       scrollRef.current = parent
       setScrollEpoch((value) => value + 1)
     }
-  })
+  }, [sessionId])
 
   const virtualizer = useVirtualizer({
     count: virtualize ? nodes.length : 0,
@@ -200,15 +200,19 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     return () => parent.removeEventListener('scroll', onScroll)
   }, [sessionId, scrollEpoch, virtualize])
 
+  const lastNode = nodes.at(-1)
+  // 流式时按 ~96 字符步进 stickKey，避免每个 delta 都触发布局滚动
+  const stickKey =
+    lastNode?.kind === 'assistant'
+      ? `${lastNode.id}:${lastNode.streaming ? Math.floor(lastNode.text.length / 96) : lastNode.text.length}:${lastNode.streaming ? 1 : 0}`
+      : `${nodes.length}:${pending ? 1 : 0}:${error ?? ''}`
+
   useLayoutEffect(() => {
     if (!stickToBottomRef.current || nodes.length === 0) return
-    if (virtualize) {
-      virtualizer.scrollToIndex(nodes.length - 1, { align: 'end' })
-      return
-    }
     const parent = scrollRef.current
+    // 流式时直接改 scrollTop，避免 virtualizer.scrollToIndex 每帧重测布局
     if (parent) parent.scrollTop = parent.scrollHeight
-  }, [nodes, pending, error, agentStatus, agentStep, virtualize, virtualizer])
+  }, [stickKey, nodes.length])
 
   if (nodes.length === 0 && !pending && !error) return <EmptyHero />
 

--- a/src/plugins/contributors/plugin-tree.tsx
+++ b/src/plugins/contributors/plugin-tree.tsx
@@ -8,10 +8,10 @@ export const inject = ['slots', 'snapshot']
 function PluginTree(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const setEnabled = props.setEnabled as (id: string, enabled: boolean) => Promise<void>
-  const snap = useSnapshot((state: Snapshot) => state)
+  const snap = useSnapshot((state: Snapshot) => state.plugins)
   return (
     <ul className="m-0 list-none space-y-2 p-0">
-      {snap.plugins.map((plugin) => (
+      {snap.map((plugin) => (
         <li className="rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3" key={plugin.id}>
           <div className="flex items-start justify-between gap-3">
             <div>

--- a/src/plugins/infrastructure/snapshot.ts
+++ b/src/plugins/infrastructure/snapshot.ts
@@ -84,7 +84,10 @@ export class SnapshotService extends Service {
         if (parsed.type === 'session') {
           const detail = parsed.payload as { sessionId?: string; event?: SessionEventLike }
           if (detail.sessionId && detail.event && typeof detail.event.seq === 'number') {
-            this.replace({ lastSessionId: detail.sessionId, lastSessionEvent: detail.event.type })
+            // chunk 不写 snapshot 元数据，避免 Settings 里订阅整表 snapshot 的组件跟着抖
+            if (detail.event.type !== 'assistant/chunk') {
+              this.replace({ lastSessionId: detail.sessionId, lastSessionEvent: detail.event.type })
+            }
             const view = this.ctx.get('sessionView') as
               | { ingest: (sessionId: string, event: SessionEventLike) => void }
               | undefined

--- a/src/style.css
+++ b/src/style.css
@@ -1005,6 +1005,18 @@ body {
   overflow-wrap: anywhere;
 }
 
+.chat-md-stream-pre {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .chat-md > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
流式输出时仍然卡：主机侧每 token 全量落盘、hub EventLog 广播、前端 Markdown 重解析与滚动 thrash。

### 改动
- **Host `agent-loop`**：`onDelta` 约 48ms 合并后再 `append` `assistant/chunk`
- **Host `sessions`**：chunk 内存追加 + ~80ms 防抖落盘；非 chunk 立即 flush
- **Hub**：跳过 `llm/stream`，以及 `session/event` 中的 chunk（避免 Settings EventLog 拖主线程）
- **Chat**：流式阶段用纯文本 `<pre>`，跳过 remark；stick-to-bottom 按 ~96 字符步进
- **Snapshot / PluginTree**：chunk 不更新 `lastSession*`；PluginTree 只订 `plugins`

### 测试
全量 `vitest` 83 passed。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

