### PR TITLE
perf: 聊天输入框防抖（不受控 + 按钮态）

### DIFF
--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -1,21 +1,60 @@
-import { memo, useState, type FormEvent } from 'react'
+import { memo, useEffect, useRef, useState, type FormEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 
+/** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
+const INPUT_DEBOUNCE_MS = 120
+
 export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
-  const [input, setInput] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const canSubmitRef = useRef(false)
+  const [canSubmit, setCanSubmit] = useState(false)
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
   const sessionView = props.sessionView as SessionViewService
   const navigate = useNavigate()
   const location = useLocation()
 
+  useEffect(
+    () => () => {
+      if (debounceRef.current != null) clearTimeout(debounceRef.current)
+    },
+    [],
+  )
+
+  function scheduleCanSubmit(value: string) {
+    const next = Boolean(value.trim())
+    if (debounceRef.current != null) clearTimeout(debounceRef.current)
+    if (next === canSubmitRef.current) return
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null
+      canSubmitRef.current = next
+      setCanSubmit(next)
+    }, INPUT_DEBOUNCE_MS)
+  }
+
+  function clearInput() {
+    if (debounceRef.current != null) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    const el = textareaRef.current
+    if (el) el.value = ''
+    canSubmitRef.current = false
+    setCanSubmit(false)
+  }
+
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
-    const content = input.trim()
+    if (debounceRef.current != null) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    const content = (textareaRef.current?.value ?? '').trim()
     if (!content) return
-    setInput('')
+    clearInput()
     try {
       await sessionView.send(content, pending ? 'inject' : 'wake')
       const id = sessionView.get().sessionId
@@ -32,12 +71,13 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       onSubmit={onSubmit}
     >
       <textarea
+        ref={textareaRef}
         className="max-h-40 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3.5 pb-2 text-[15px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)]"
-        value={input}
+        defaultValue=""
         rows={1}
         placeholder={pending ? 'Steer while running…' : 'Message DeepSeek Harness…'}
         aria-label="对话输入"
-        onChange={(event) => setInput(event.target.value)}
+        onChange={(event) => scheduleCanSubmit(event.target.value)}
         onKeyDown={(event) => {
           if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault()
@@ -59,7 +99,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               className="rounded-full px-3 py-1.5 text-xs text-white disabled:opacity-40"
               style={{ background: 'var(--dsw-business)' }}
               type="submit"
-              disabled={!input.trim()}
+              disabled={!canSubmit}
             >
               Steer
             </button>
@@ -69,7 +109,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             className="grid size-8 place-items-center rounded-full text-white disabled:opacity-40"
             style={{ background: 'var(--dsw-business)' }}
             type="submit"
-            disabled={!input.trim()}
+            disabled={!canSubmit}
             aria-label="Send"
           >
             <svg viewBox="0 0 24 24" className="size-4" fill="currentColor">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天输入框每个字符都走受控 `setState`，在 agent 流式占主线程时更容易体感卡顿。

### 改动
- textarea 改为 **不受控**（`defaultValue` + ref），按键不再驱动 React value
- 仅对发送 / Steer 按钮的 `canSubmit` 做 **~120ms 防抖**；内容不变则跳过
- 提交时直接读 `textarea.value` 并清空，不依赖防抖结果

回车发送在防抖窗口内仍可用（读的是 DOM 当前值）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

