### PR TITLE
perf: session 接口按 turn 分页轻量化

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -4,6 +4,7 @@ import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { ChatMessage } from './chat-types.ts'
 import type { AgentToolMode } from '../registry/tools.ts'
+import { DEFAULT_TAIL_TURNS, sliceBeforeTurns, sliceTailTurns } from '../core/session-window.ts'
 
 export type { ChatMessage }
 
@@ -211,12 +212,45 @@ export function apply(ctx: Context) {
   ctx.http.route('GET', '/api/sessions/:id', async (route) => {
     const record = await ctx.sessions.get(route.params.id)
     if (!record) return route.send(404, { error: 'unknown session' })
+    const turnsRaw = route.query.get('turns')
+    const limitTurns =
+      turnsRaw == null || turnsRaw === ''
+        ? DEFAULT_TAIL_TURNS
+        : turnsRaw === 'all'
+          ? 0
+          : Math.max(0, Number(turnsRaw) || DEFAULT_TAIL_TURNS)
+    const window = sliceTailTurns(record.events, limitTurns)
     route.send(200, {
       id: record.id,
       version: record.version,
-      events: record.events,
-      messages: ctx.sessions.deriveMessages(record.id),
+      events: window.events,
+      hasMore: window.hasMore,
+      totalTurns: window.totalTurns,
+      totalEvents: window.totalEvents,
+      oldestSeq: window.oldestSeq,
+      newestSeq: window.newestSeq,
       ...(record.project ? { project: record.project } : {}),
+    })
+  })
+  ctx.http.route('GET', '/api/sessions/:id/events', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const beforeSeq = Number(route.query.get('beforeSeq'))
+    if (!Number.isFinite(beforeSeq)) return route.send(400, { error: 'beforeSeq required' })
+    const turnsRaw = route.query.get('turns')
+    const limitTurns =
+      turnsRaw == null || turnsRaw === ''
+        ? DEFAULT_TAIL_TURNS
+        : Math.max(1, Number(turnsRaw) || DEFAULT_TAIL_TURNS)
+    const window = sliceBeforeTurns(record.events, beforeSeq, limitTurns)
+    route.send(200, {
+      id: record.id,
+      events: window.events,
+      hasMore: window.hasMore,
+      totalTurns: window.totalTurns,
+      totalEvents: window.totalEvents,
+      oldestSeq: window.oldestSeq,
+      newestSeq: window.newestSeq,
     })
   })
   ctx.http.route('PUT', '/api/sessions/:id/project', async (route) => {

--- a/host/plugins/core/session-window.test.ts
+++ b/host/plugins/core/session-window.test.ts
@@ -1,0 +1,58 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import type { SessionEvent } from './session-types.ts'
+import { compactSessionEvents, sliceBeforeTurns, sliceTailTurns } from './session-window.ts'
+
+function ev(partial: Omit<SessionEvent, 'ts'> & { ts?: number }): SessionEvent {
+  return { ts: partial.ts ?? partial.seq, ...partial } as SessionEvent
+}
+
+test('compactSessionEvents drops chunks superseded by message', () => {
+  const out = compactSessionEvents([
+    ev({ type: 'user/message', text: 'hi', seq: 1 }),
+    ev({ type: 'assistant/chunk', text: 'a', seq: 2 }),
+    ev({ type: 'assistant/chunk', text: 'b', seq: 3 }),
+    ev({ type: 'assistant/message', text: 'ab', seq: 4 }),
+  ])
+  assert.deepEqual(
+    out.map((item) => item.type),
+    ['user/message', 'assistant/message'],
+  )
+})
+
+test('sliceTailTurns returns only last N user turns with preamble', () => {
+  const raw: SessionEvent[] = [
+    ev({ type: 'session/open', version: 1, seq: 0 }),
+    ev({ type: 'system/prompt', text: 'sys', seq: 1 }),
+  ]
+  for (let turn = 0; turn < 5; turn++) {
+    raw.push(ev({ type: 'user/message', text: `u${turn}`, seq: 10 + turn * 2 }))
+    raw.push(ev({ type: 'assistant/message', text: `a${turn}`, seq: 11 + turn * 2 }))
+  }
+  const window = sliceTailTurns(raw, 2)
+  assert.equal(window.hasMore, true)
+  assert.equal(window.totalTurns, 5)
+  assert.equal(window.events.some((item) => item.type === 'session/open'), true)
+  assert.equal(window.events.some((item) => item.type === 'system/prompt'), true)
+  const users = window.events.filter((item) => item.type === 'user/message')
+  assert.deepEqual(
+    users.map((item) => (item.type === 'user/message' ? item.text : '')),
+    ['u3', 'u4'],
+  )
+})
+
+test('sliceBeforeTurns pages older turns', () => {
+  const raw: SessionEvent[] = [ev({ type: 'session/open', version: 1, seq: 0 })]
+  for (let turn = 0; turn < 6; turn++) {
+    raw.push(ev({ type: 'user/message', text: `u${turn}`, seq: 10 + turn * 2 }))
+    raw.push(ev({ type: 'assistant/message', text: `a${turn}`, seq: 11 + turn * 2 }))
+  }
+  const tail = sliceTailTurns(raw, 2)
+  const older = sliceBeforeTurns(raw, tail.events.find((item) => item.type === 'user/message')!.seq, 2)
+  const users = older.events.filter((item) => item.type === 'user/message')
+  assert.deepEqual(
+    users.map((item) => (item.type === 'user/message' ? item.text : '')),
+    ['u2', 'u3'],
+  )
+  assert.equal(older.hasMore, true)
+})

--- a/host/plugins/core/session-window.ts
+++ b/host/plugins/core/session-window.ts
@@ -1,0 +1,103 @@
+import type { SessionEvent } from './session-types.ts'
+
+export const DEFAULT_TAIL_TURNS = 24
+
+export interface SessionWindow {
+  events: SessionEvent[]
+  hasMore: boolean
+  totalTurns: number
+  totalEvents: number
+  oldestSeq: number | null
+  newestSeq: number | null
+}
+
+/** 连续 chunk 合并，并丢掉已被 assistant/message 覆盖的 chunk（瘦 API 载荷）。 */
+export function compactSessionEvents(events: SessionEvent[]): SessionEvent[] {
+  const coalesced: SessionEvent[] = []
+  for (const event of events) {
+    if (event.type === 'assistant/chunk') {
+      const prev = coalesced.at(-1)
+      if (prev?.type === 'assistant/chunk') {
+        coalesced[coalesced.length - 1] = {
+          ...prev,
+          text: prev.text + event.text,
+          ts: event.ts,
+        }
+        continue
+      }
+    }
+    coalesced.push(event)
+  }
+  const out: SessionEvent[] = []
+  for (let i = 0; i < coalesced.length; i++) {
+    const event = coalesced[i]!
+    const next = coalesced[i + 1]
+    if (event.type === 'assistant/chunk' && next?.type === 'assistant/message') continue
+    out.push(event)
+  }
+  return out
+}
+
+function turnBoundaryIndexes(events: SessionEvent[]): number[] {
+  const starts: number[] = []
+  const users: number[] = []
+  for (let i = 0; i < events.length; i++) {
+    const type = events[i]!.type
+    if (type === 'turn/start') starts.push(i)
+    else if (type === 'user/message') users.push(i)
+  }
+  // 有 turn/start 时以它为准，避免再把 user/message 算成第二轮
+  return starts.length ? starts : users
+}
+
+function preambleBefore(events: SessionEvent[], startIndex: number): SessionEvent[] {
+  const head: SessionEvent[] = []
+  let lastPrompt: SessionEvent | undefined
+  for (let i = 0; i < startIndex; i++) {
+    const event = events[i]!
+    if (event.type === 'session/open') head.push(event)
+    else if (event.type === 'system/prompt') lastPrompt = event
+  }
+  if (lastPrompt) head.push(lastPrompt)
+  return head
+}
+
+function meta(events: SessionEvent[], hasMore: boolean, totalTurns: number, totalEvents: number): SessionWindow {
+  return {
+    events,
+    hasMore,
+    totalTurns,
+    totalEvents,
+    oldestSeq: events[0]?.seq ?? null,
+    newestSeq: events.at(-1)?.seq ?? null,
+  }
+}
+
+/** 取末尾 limitTurns 个 turn（含 preamble）；limitTurns<=0 表示全量。 */
+export function sliceTailTurns(raw: SessionEvent[], limitTurns: number): SessionWindow {
+  const events = compactSessionEvents(raw)
+  const totalEvents = events.length
+  const boundaries = turnBoundaryIndexes(events)
+  const totalTurns = boundaries.length
+  if (limitTurns <= 0 || totalTurns <= limitTurns) {
+    return meta(events, false, totalTurns, totalEvents)
+  }
+  const startIndex = boundaries[totalTurns - limitTurns]!
+  const windowEvents = [...preambleBefore(events, startIndex), ...events.slice(startIndex)]
+  return meta(windowEvents, true, totalTurns, totalEvents)
+}
+
+/** 取 beforeSeq 之前的更早 turn 窗口。 */
+export function sliceBeforeTurns(raw: SessionEvent[], beforeSeq: number, limitTurns: number): SessionWindow {
+  const all = compactSessionEvents(raw)
+  const events = all.filter((event) => event.seq < beforeSeq)
+  const totalEvents = all.length
+  const totalTurns = turnBoundaryIndexes(all).length
+  const boundaries = turnBoundaryIndexes(events)
+  if (limitTurns <= 0 || boundaries.length <= limitTurns) {
+    return meta(events, false, totalTurns, totalEvents)
+  }
+  const startIndex = boundaries[boundaries.length - limitTurns]!
+  const windowEvents = [...preambleBefore(events, startIndex), ...events.slice(startIndex)]
+  return meta(windowEvents, startIndex > 0, totalTurns, totalEvents)
+}

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -148,6 +148,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const agentStep = useSessionView((state) => state.agentStep)
   const sessionId = useSessionView((state) => state.sessionId)
   const error = useSessionView((state) => state.error)
+  const hasMoreOlder = useSessionView((state) => state.hasMoreOlder)
+  const loadingOlder = useSessionView((state) => state.loadingOlder)
   const rootRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLElement | null>(null)
   const stickToBottomRef = useRef(true)
@@ -194,11 +196,21 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     const onScroll = () => {
       const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
       stickToBottomRef.current = distance <= NEAR_BOTTOM_PX
+      if (parent.scrollTop <= NEAR_BOTTOM_PX && hasMoreOlder && !loadingOlder) {
+        const beforeHeight = parent.scrollHeight
+        const beforeTop = parent.scrollTop
+        void sessionView.loadOlder().then((loaded) => {
+          if (!loaded) return
+          requestAnimationFrame(() => {
+            parent.scrollTop = beforeTop + (parent.scrollHeight - beforeHeight)
+          })
+        })
+      }
     }
     onScroll()
     parent.addEventListener('scroll', onScroll, { passive: true })
     return () => parent.removeEventListener('scroll', onScroll)
-  }, [sessionId, scrollEpoch, virtualize])
+  }, [sessionId, scrollEpoch, virtualize, hasMoreOlder, loadingOlder, sessionView])
 
   const lastNode = nodes.at(-1)
   // 流式时按 ~96 字符步进 stickKey，避免每个 delta 都触发布局滚动
@@ -219,6 +231,9 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   return (
     <div ref={rootRef} className="mx-auto w-full max-w-[var(--dsw-chat-width)]" data-chat-virtual={virtualize ? '1' : '0'}>
       <StatusRow agentStatus={agentStatus} agentStep={agentStep} />
+      {loadingOlder ? (
+        <div className="mb-3 text-center text-[11px] text-[var(--dsw-label-3)]">加载更早消息…</div>
+      ) : null}
       {virtualize ? (
         <div className="relative w-full" style={{ height: virtualizer.getTotalSize() }}>
           {virtualizer.getVirtualItems().map((item) => {

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -90,7 +90,7 @@ test('inspectCall switches to trajectory with focus', async () => {
   assert.equal(view.get().focusCallId, 'c1')
 })
 
-test('ingest coalesces consecutive chunks and omits them from trajectory', async () => {
+test('ingest coalesces consecutive chunks and skips trajectory on chat view', async () => {
   mockFetch({
     '/api/sessions': () => ({ sessions: [] }),
     '/api/approvals': () => ({ mode: 'auto', pending: [] }),
@@ -109,8 +109,6 @@ test('ingest coalesces consecutive chunks and omits them from trajectory', async
       (view.get().events.find((event) => event.type === 'assistant/chunk') as { text: string }).text,
     'hello',
   )
-  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/chunk'), false)
-  // chunk 路径保持 trajectory 引用，避免隐藏账本随 delta 重绘
   assert.equal(view.get().trajectory, trajBefore)
   const assistant = view.get().nodes.find((node) => node.kind === 'assistant')
   assert.equal(assistant?.kind === 'assistant' && assistant.text, 'hello')
@@ -118,13 +116,16 @@ test('ingest coalesces consecutive chunks and omits them from trajectory', async
 
   view.ingest('s1', { type: 'assistant/message', text: 'hello', seq: 4, ts: 5 })
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
-  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/message'), true)
+  // chat 视图不投影 trajectory
+  assert.equal(view.get().trajectory.length, 0)
 })
 
-test('load compacts historical chunks from host log', async () => {
+test('load fetches tail turns and skips trajectory until ensureTrajectory', async () => {
+  const calls: string[] = []
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input)
-    if (url.match(/\/api\/sessions\/s1$/)) {
+    calls.push(url)
+    if (url.includes('/api/sessions/s1?turns=')) {
       return {
         ok: true,
         status: 200,
@@ -137,6 +138,59 @@ test('load compacts historical chunks from host log', async () => {
             { type: 'assistant/chunk', text: 'b', seq: 3, ts: 4 },
             { type: 'assistant/message', text: 'ab', seq: 4, ts: 5 },
           ],
+          hasMore: false,
+          totalTurns: 1,
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions') && !url.includes('/s1')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.load('s1', { view: 'chat' })
+  assert.equal(calls.some((url) => url.includes('turns=24')), true)
+  assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
+  assert.equal(view.get().trajectory.length, 0)
+  assert.equal(view.get().nodes.some((node) => node.kind === 'assistant' && node.text === 'ab'), true)
+})
+
+test('loadOlder prepends earlier turns', async () => {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/sessions/s1/events?beforeSeq=')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          events: [
+            { type: 'user/message', text: 'old', seq: 1, ts: 1 },
+            { type: 'assistant/message', text: 'old-a', seq: 2, ts: 2 },
+          ],
+          hasMore: false,
+          totalTurns: 2,
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions/s1?turns=')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          events: [
+            { type: 'user/message', text: 'new', seq: 3, ts: 3 },
+            { type: 'assistant/message', text: 'new-a', seq: 4, ts: 4 },
+          ],
+          hasMore: true,
+          totalTurns: 2,
         }),
       } as Response
     }
@@ -151,10 +205,11 @@ test('load compacts historical chunks from host log', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
-  await view.load('s1')
-  assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
-  assert.equal(view.get().trajectory.some((row) => row.type === 'assistant/chunk'), false)
-  assert.equal(view.get().nodes.some((node) => node.kind === 'assistant' && node.text === 'ab'), true)
+  await view.load('s1', { view: 'chat' })
+  assert.equal(view.get().hasMoreOlder, true)
+  await view.loadOlder()
+  assert.equal(view.get().nodes[0]?.kind === 'user' && view.get().nodes[0].text, 'old')
+  assert.equal(view.get().hasMoreOlder, false)
 })
 
 test('deleteSession clears active session when list empty', async () => {

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -27,6 +27,9 @@ export interface SessionListItem {
 export type ConversationView = 'chat' | 'trajectory'
 export type ApprovalMode = 'auto' | 'hold'
 
+/** 与 host DEFAULT_TAIL_TURNS 对齐：首屏只拉最近若干 turn */
+export const SESSION_TAIL_TURNS = 24
+
 export interface SessionViewState {
   sessionId: string | null
   events: SessionEvent[]
@@ -41,6 +44,10 @@ export interface SessionViewState {
   approvalMode: ApprovalMode
   approvals: ApprovalItem[]
   project?: { name: string; path?: string; boundAt: number }
+  /** 是否还有更早的 turn 可懒加载 */
+  hasMoreOlder: boolean
+  loadingOlder: boolean
+  totalTurns: number
   error?: string
 }
 
@@ -55,6 +62,18 @@ const empty: SessionViewState = {
   pending: false,
   approvalMode: 'auto',
   approvals: [],
+  hasMoreOlder: false,
+  loadingOlder: false,
+  totalTurns: 0,
+}
+
+type SessionPayload = {
+  id: string
+  events: SessionEvent[]
+  hasMore?: boolean
+  totalTurns?: number
+  totalEvents?: number
+  project?: { name: string; path?: string; boundAt: number }
 }
 
 export class SessionViewService extends Service {
@@ -76,16 +95,17 @@ export class SessionViewService extends Service {
 
   setView(view: ConversationView) {
     this.replace({ view, focusCallId: view === 'chat' ? undefined : this.value.focusCallId })
+    if (view === 'trajectory') void this.ensureTrajectory()
   }
 
   inspectCall(callId: string) {
     this.replace({ view: 'trajectory', focusCallId: callId })
+    void this.ensureTrajectory()
   }
 
   /** URL → 状态：只由路由层调用，不回写 URL */
   async applyRoute(route: AppRoute) {
     if (route.kind === 'module') {
-      // 其它模块不碰 agent session 投影，切回 Agent 时会话仍在。
       return
     }
     if (route.kind === 'home') {
@@ -100,13 +120,16 @@ export class SessionViewService extends Service {
         pending: false,
         agentStatus: 'idle',
         project: undefined,
+        hasMoreOlder: false,
+        loadingOlder: false,
+        totalTurns: 0,
         error: undefined,
       })
       return
     }
     if (this.value.sessionId !== route.sessionId) {
       try {
-        await this.load(route.sessionId)
+        await this.load(route.sessionId, { view: route.view })
       } catch (error) {
         this.replace({
           error: String(error),
@@ -116,16 +139,19 @@ export class SessionViewService extends Service {
           trajectory: [],
           view: 'chat',
           focusCallId: undefined,
+          hasMoreOlder: false,
+          loadingOlder: false,
+          totalTurns: 0,
         })
         throw error
       }
-    }
-    if (this.value.view !== route.view) {
+    } else if (this.value.view !== route.view) {
       this.replace({
         view: route.view,
         focusCallId: route.view === 'chat' ? undefined : this.value.focusCallId,
       })
     }
+    if (route.view === 'trajectory') await this.ensureTrajectory()
   }
 
   ingest(sessionId: string, event: SessionEvent) {
@@ -139,17 +165,17 @@ export class SessionViewService extends Service {
     }
     this.flushChunkFrame()
     const events = upsertEvent(this.value.sessionId === sessionId ? this.value.events : [], event)
+    const onTraj = this.value.view === 'trajectory'
     this.replace({
       sessionId,
       events,
       nodes: projectNodes(events),
-      trajectory: projectTrajectory(events),
+      ...(onTraj ? { trajectory: projectTrajectory(events) } : {}),
       error: undefined,
     })
     void this.refreshSessions()
   }
 
-  /** chunk 高频：合并进 events/nodes，但 Trajectory 引用保持不变；通知合并到每帧一次。 */
   private ingestChunk(sessionId: string, event: Extract<SessionEvent, { type: 'assistant/chunk' }>) {
     const events = upsertEvent(this.value.sessionId === sessionId ? this.value.events : [], event)
     const chunk = events.at(-1)
@@ -190,7 +216,6 @@ export class SessionViewService extends Service {
   }
 
   setAgentStatus(status: 'idle' | 'running', step?: number) {
-    // pending 由 send()/cancel() 拥有；WS 的 idle 不能提前清掉，否则会像「agent 没响应」
     if (status === 'running') {
       this.replace({ agentStatus: 'running', agentStep: step, pending: true })
       return
@@ -250,8 +275,7 @@ export class SessionViewService extends Service {
     const res = await fetch('/api/sessions', { method: 'POST' })
     const body = (await res.json()) as { id?: string }
     if (!body.id) throw new Error('无法创建 session')
-    await this.load(body.id)
-    this.replace({ view: 'chat', focusCallId: undefined })
+    await this.load(body.id, { view: 'chat' })
     await this.refreshSessions()
     return body.id
   }
@@ -261,27 +285,93 @@ export class SessionViewService extends Service {
     return this.newSession()
   }
 
-  async load(sessionId: string) {
-    const res = await fetch(`/api/sessions/${sessionId}`)
+  async load(sessionId: string, options: { view?: ConversationView } = {}) {
+    const view = options.view ?? this.value.view
+    const turns = view === 'trajectory' ? 'all' : String(SESSION_TAIL_TURNS)
+    const res = await fetch(`/api/sessions/${sessionId}?turns=${encodeURIComponent(turns)}`)
     if (!res.ok) throw new Error(`加载 session 失败：${res.status}`)
-    const body = (await res.json()) as {
-      id: string
-      events: SessionEvent[]
-      project?: { name: string; path?: string; boundAt: number }
-    }
+    const body = (await res.json()) as SessionPayload
     const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+    const onTraj = view === 'trajectory'
     this.replace({
       sessionId: body.id,
       events,
       nodes: projectNodes(events),
-      trajectory: projectTrajectory(events),
+      trajectory: onTraj ? projectTrajectory(events) : [],
       project: body.project,
+      view,
+      focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
       error: undefined,
       pending: false,
       agentStatus: 'idle',
+      hasMoreOlder: Boolean(body.hasMore),
+      loadingOlder: false,
+      totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : 0,
     })
-    await this.refreshSessions()
-    await this.refreshApprovals()
+    void this.refreshSessions()
+    void this.refreshApprovals()
+  }
+
+  /** 上滑加载更早 turn；返回是否真正拉到了数据 */
+  async loadOlder(): Promise<boolean> {
+    const { sessionId, hasMoreOlder, loadingOlder, events } = this.value
+    if (!sessionId || !hasMoreOlder || loadingOlder) return false
+    const beforeSeq = events[0]?.seq
+    if (beforeSeq == null) return false
+    this.replace({ loadingOlder: true })
+    try {
+      const res = await fetch(
+        `/api/sessions/${sessionId}/events?beforeSeq=${beforeSeq}&turns=${SESSION_TAIL_TURNS}`,
+      )
+      if (!res.ok) throw new Error(`加载更早事件失败：${res.status}`)
+      const body = (await res.json()) as SessionPayload
+      const older = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+      if (!older.length) {
+        this.replace({ hasMoreOlder: false, loadingOlder: false })
+        return false
+      }
+      const seen = new Set(events.map((event) => event.seq))
+      const merged = [...older.filter((event) => !seen.has(event.seq)), ...events].sort(
+        (a, b) => a.seq - b.seq,
+      )
+      const onTraj = this.value.view === 'trajectory'
+      this.replace({
+        events: merged,
+        nodes: projectNodes(merged),
+        ...(onTraj ? { trajectory: projectTrajectory(merged) } : {}),
+        hasMoreOlder: Boolean(body.hasMore),
+        loadingOlder: false,
+        totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
+      })
+      return true
+    } catch (error) {
+      this.replace({ loadingOlder: false, error: String(error) })
+      return false
+    }
+  }
+
+  /** 进入 Trajectory 时再拉全量并投影；Chat 路径不碰 trajectory。 */
+  async ensureTrajectory() {
+    const sessionId = this.value.sessionId
+    if (!sessionId) return
+    if (this.value.hasMoreOlder) {
+      const res = await fetch(`/api/sessions/${sessionId}?turns=all`)
+      if (!res.ok) throw new Error(`加载 trajectory 失败：${res.status}`)
+      const body = (await res.json()) as SessionPayload
+      const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+      this.replace({
+        events,
+        nodes: projectNodes(events),
+        trajectory: projectTrajectory(events),
+        hasMoreOlder: false,
+        totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
+        view: 'trajectory',
+      })
+      return
+    }
+    if (this.value.trajectory.length === 0 && this.value.events.length > 0) {
+      this.replace({ trajectory: projectTrajectory(this.value.events), view: 'trajectory' })
+    }
   }
 
   setProjectMeta(project?: { name: string; path?: string; boundAt: number }) {
@@ -298,8 +388,7 @@ export class SessionViewService extends Service {
     const res = await fetch(`/api/sessions/${sessionId}/fork`, { method: 'POST' })
     const body = (await res.json()) as { id?: string; error?: string }
     if (!res.ok || !body.id) throw new Error(body.error || 'fork failed')
-    await this.load(body.id)
-    this.replace({ view: 'chat' })
+    await this.load(body.id, { view: 'chat' })
     return body.id
   }
 
@@ -312,8 +401,7 @@ export class SessionViewService extends Service {
     if (!wasActive) return
     const next = this.value.sessions[0]?.id
     if (next) {
-      await this.load(next)
-      this.replace({ view: 'chat', focusCallId: undefined })
+      await this.load(next, { view: 'chat' })
       return
     }
     this.replace({
@@ -327,6 +415,9 @@ export class SessionViewService extends Service {
       view: 'chat',
       focusCallId: undefined,
       project: undefined,
+      hasMoreOlder: false,
+      loadingOlder: false,
+      totalTurns: 0,
       error: undefined,
     })
   }
@@ -357,14 +448,14 @@ export class SessionViewService extends Service {
       })
       const data = (await res.json()) as { error?: string; sessionId?: string; text?: string }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)
-      if (data.sessionId && data.sessionId !== sessionId) await this.load(data.sessionId)
-      else await this.load(sessionId)
+      if (data.sessionId && data.sessionId !== sessionId) await this.load(data.sessionId, { view: 'chat' })
+      else await this.load(sessionId, { view: this.value.view })
       if (typeof data.text === 'string' && data.text.startsWith('模型调用失败：')) {
         this.replace({ error: data.text })
       }
     } catch (error) {
       try {
-        await this.load(sessionId)
+        await this.load(sessionId, { view: this.value.view })
       } catch {
         /* 加载失败时仍展示下方 error */
       }
@@ -402,7 +493,6 @@ function upsertEvent(events: SessionEvent[], event: SessionEvent) {
   if (event.type === 'assistant/chunk') {
     const last = events.at(-1)
     if (last?.type === 'assistant/chunk') {
-      // 合并连续 delta，保持首条 chunk 的 seq（Chat 流式节点 id 稳定）
       return [
         ...events.slice(0, -1),
         { ...last, text: last.text + event.text, ts: event.ts },
@@ -418,14 +508,12 @@ function upsertEvent(events: SessionEvent[], event: SessionEvent) {
   return [...events, event].sort((a, b) => a.seq - b.seq)
 }
 
-/** 流式 chunk：只补丁最后一条 streaming assistant，避免每 delta 全量 projectNodes。 */
 function patchStreamingNodes(
   nodes: ChatNode[],
   chunk: Extract<SessionEvent, { type: 'assistant/chunk' }>,
 ): ChatNode[] {
   const last = nodes.at(-1)
   if (last?.kind === 'assistant' && last.streaming) {
-    // coalesced chunk.text 已是累计全文
     if (last.text === chunk.text) return nodes
     return [...nodes.slice(0, -1), { ...last, text: chunk.text, streaming: true }]
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
先解决接口过重导致的切换卡顿（**不做 LRU**）。

### Host
- `GET /api/sessions/:id` 默认只返回最近 **24 turns**（`?turns=24`，`turns=all` 全量）
- 服务端 compact chunk，**去掉**客户端不用的 `messages` 字段
- 新增 `GET /api/sessions/:id/events?beforeSeq=&turns=` 拉更早分页

### Client
- Chat 首屏只拉尾部 turn；上滑懒加载更早消息
- **未进入 Trajectory 时不投影 trajectory**；进入该视图再 `turns=all` + 投影

### 测试
全量 vitest 87 passed。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

