### PR TITLE
perf: Trajectory 索引与详情接口拆分懒加载

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -5,6 +5,13 @@ import '../../types.ts'
 import type { ChatMessage } from './chat-types.ts'
 import type { AgentToolMode } from '../registry/tools.ts'
 import { DEFAULT_TAIL_TURNS, sliceBeforeTurns, sliceTailTurns } from '../core/session-window.ts'
+import {
+  DEFAULT_TRAJECTORY_TURNS,
+  buildRequestMessages,
+  buildTrajectoryBefore,
+  buildTrajectoryWindow,
+  findEvent,
+} from '../core/trajectory-index.ts'
 
 export type { ChatMessage }
 
@@ -251,6 +258,56 @@ export function apply(ctx: Context) {
       totalEvents: window.totalEvents,
       oldestSeq: window.oldestSeq,
       newestSeq: window.newestSeq,
+    })
+  })
+  ctx.http.route('GET', '/api/sessions/:id/trajectory', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const beforeSeqRaw = route.query.get('beforeSeq')
+    const turnsRaw = route.query.get('turns')
+    const limitTurns =
+      turnsRaw == null || turnsRaw === ''
+        ? DEFAULT_TRAJECTORY_TURNS
+        : turnsRaw === 'all'
+          ? 0
+          : Math.max(0, Number(turnsRaw) || DEFAULT_TRAJECTORY_TURNS)
+    const window =
+      beforeSeqRaw != null && beforeSeqRaw !== ''
+        ? buildTrajectoryBefore(record.events, Number(beforeSeqRaw), limitTurns || DEFAULT_TRAJECTORY_TURNS)
+        : buildTrajectoryWindow(record.events, limitTurns)
+    route.send(200, {
+      id: record.id,
+      rows: window.rows,
+      hasMore: window.hasMore,
+      totalTurns: window.totalTurns,
+      totalEvents: window.totalEvents,
+      oldestSeq: window.oldestSeq,
+      newestSeq: window.newestSeq,
+    })
+  })
+  ctx.http.route('GET', '/api/sessions/:id/events/:seq', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const seq = Number(route.params.seq)
+    if (!Number.isFinite(seq)) return route.send(400, { error: 'invalid seq' })
+    const event = findEvent(record.events, seq)
+    if (!event) return route.send(404, { error: 'unknown event' })
+    route.send(200, { id: record.id, event })
+  })
+  ctx.http.route('GET', '/api/sessions/:id/events/:seq/request', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const seq = Number(route.params.seq)
+    if (!Number.isFinite(seq)) return route.send(400, { error: 'invalid seq' })
+    const event = findEvent(record.events, seq)
+    if (!event) return route.send(404, { error: 'unknown event' })
+    if (event.type !== 'assistant/message') {
+      return route.send(400, { error: 'request derivation only for assistant/message' })
+    }
+    route.send(200, {
+      id: record.id,
+      seq,
+      messages: buildRequestMessages(record.events, seq),
     })
   })
   ctx.http.route('PUT', '/api/sessions/:id/project', async (route) => {

--- a/host/plugins/core/trajectory-index.test.ts
+++ b/host/plugins/core/trajectory-index.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import type { SessionEvent } from './session-types.ts'
+import { buildTrajectoryWindow, findEvent, buildRequestMessages } from './trajectory-index.ts'
+
+function ev(partial: Omit<SessionEvent, 'ts'> & { ts?: number }): SessionEvent {
+  return { ts: partial.ts ?? partial.seq, ...partial } as SessionEvent
+}
+
+test('trajectory window returns summary rows without full bodies', () => {
+  const raw: SessionEvent[] = [ev({ type: 'session/open', version: 1, seq: 0 })]
+  for (let i = 0; i < 3; i++) {
+    raw.push(ev({ type: 'user/message', text: `u${i}-${'x'.repeat(200)}`, seq: 10 + i * 2 }))
+    raw.push(
+      ev({
+        type: 'assistant/message',
+        text: `a${i}-${'y'.repeat(200)}`,
+        seq: 11 + i * 2,
+        usage: { inputTokens: 1, outputTokens: 2 },
+      }),
+    )
+  }
+  const window = buildTrajectoryWindow(raw, 2)
+  assert.equal(window.hasMore, true)
+  assert.ok(window.rows.every((row) => row.summary.length <= 160))
+  assert.equal(window.rows.some((row) => row.type === 'assistant/message'), true)
+})
+
+test('findEvent and buildRequestMessages for assistant detail', () => {
+  const raw: SessionEvent[] = [
+    ev({ type: 'session/open', version: 1, seq: 0 }),
+    ev({ type: 'system/prompt', text: 'sys', seq: 1 }),
+    ev({ type: 'user/message', text: 'hi', seq: 2 }),
+    ev({ type: 'assistant/message', text: 'yo', seq: 3, usage: { inputTokens: 1, outputTokens: 1 } }),
+  ]
+  const event = findEvent(raw, 3)
+  assert.equal(event?.type, 'assistant/message')
+  const messages = buildRequestMessages(raw, 3)
+  assert.equal(messages[0]?.role, 'system')
+  assert.equal(messages.some((item) => item.role === 'user' && item.content === 'hi'), true)
+})

--- a/host/plugins/core/trajectory-index.ts
+++ b/host/plugins/core/trajectory-index.ts
@@ -1,0 +1,139 @@
+import type { SessionEvent } from './session-types.ts'
+import { compactSessionEvents, sliceBeforeTurns, sliceTailTurns } from './session-window.ts'
+import { deriveMessages } from './sessions.ts'
+import type { LlmMessage } from '../orchestration/llm.ts'
+
+export interface TrajectoryUsage {
+  inputTokens: number
+  outputTokens: number
+  totalTokens?: number
+  cacheReadTokens?: number
+}
+
+/** 列表行：只有摘要，不含全文 body。 */
+export interface TrajectoryRow {
+  id: string
+  seq: number
+  turn: number | null
+  step: number | null
+  depth: 0 | 1 | 2
+  type: SessionEvent['type']
+  summary: string
+  usage?: TrajectoryUsage
+  callId?: string
+}
+
+function assistantSummary(event: Extract<SessionEvent, { type: 'assistant/message' }>): string {
+  const tools = event.tool_calls?.length ?? 0
+  if (event.text.trim()) return event.text.slice(0, 160)
+  if (tools) {
+    const names = event.tool_calls!.map((call) => call.name).join(', ')
+    return `→ ${tools} tool call${tools > 1 ? 's' : ''}: ${names}`
+  }
+  return '(empty assistant message)'
+}
+
+export function projectTrajectoryRows(events: SessionEvent[]): TrajectoryRow[] {
+  let turn: number | null = null
+  let step: number | null = null
+  let inStep = false
+  const rows: TrajectoryRow[] = []
+  for (const event of events) {
+    if (event.type === 'turn/start') {
+      turn = event.turn
+      step = null
+      inStep = false
+    }
+    if (event.type === 'session/open' || event.type === 'assistant/chunk') continue
+    if (event.type === 'step/start') {
+      step = event.step
+      inStep = true
+    }
+
+    let summary: string = event.type
+    let callId: string | undefined
+    let usage: TrajectoryUsage | undefined
+    if (event.type === 'assistant/message') {
+      summary = assistantSummary(event)
+      usage = event.usage
+    } else if (event.type === 'user/message' || event.type === 'system/prompt') {
+      summary = event.text.slice(0, 160)
+    } else if (event.type === 'tool/call') {
+      callId = event.id
+      summary = `${event.name}(${event.arguments.slice(0, 80)})`
+    } else if (event.type === 'tool/result') {
+      callId = event.id
+      summary = `${event.name} → ${event.ok ? 'ok' : 'fail'}: ${event.detail.slice(0, 80)}`
+    } else if (event.type === 'turn/end') {
+      summary = `end · ${event.reason}`
+    } else if (event.type === 'step/start' || event.type === 'step/end') {
+      summary = `step ${event.step}`
+    }
+
+    const depth: 0 | 1 | 2 =
+      event.type === 'step/start' || event.type === 'step/end'
+        ? 1
+        : inStep && event.type !== 'turn/end'
+          ? 2
+          : 0
+
+    rows.push({
+      id: `tr-${event.seq}`,
+      seq: event.seq,
+      turn,
+      step: event.type === 'step/start' || event.type === 'step/end' || inStep ? step : null,
+      depth,
+      type: event.type,
+      summary,
+      usage,
+      callId,
+    })
+
+    if (event.type === 'step/end') {
+      inStep = false
+      step = null
+    }
+    if (event.type === 'turn/end') {
+      turn = null
+      step = null
+      inStep = false
+    }
+  }
+  return rows
+}
+
+export const DEFAULT_TRAJECTORY_TURNS = 48
+
+export function buildTrajectoryWindow(raw: SessionEvent[], limitTurns: number) {
+  const window = sliceTailTurns(raw, limitTurns)
+  return {
+    rows: projectTrajectoryRows(window.events),
+    hasMore: window.hasMore,
+    totalTurns: window.totalTurns,
+    totalEvents: window.totalEvents,
+    oldestSeq: window.oldestSeq,
+    newestSeq: window.newestSeq,
+  }
+}
+
+export function buildTrajectoryBefore(raw: SessionEvent[], beforeSeq: number, limitTurns: number) {
+  const window = sliceBeforeTurns(raw, beforeSeq, limitTurns)
+  return {
+    rows: projectTrajectoryRows(window.events),
+    hasMore: window.hasMore,
+    totalTurns: window.totalTurns,
+    totalEvents: window.totalEvents,
+    oldestSeq: window.oldestSeq,
+    newestSeq: window.newestSeq,
+  }
+}
+
+/** 单条事件详情（已 compact 视图：chunk 仍原样返回若仍在盘上）。 */
+export function findEvent(raw: SessionEvent[], seq: number): SessionEvent | undefined {
+  return compactSessionEvents(raw).find((event) => event.seq === seq) ?? raw.find((event) => event.seq === seq)
+}
+
+export function buildRequestMessages(raw: SessionEvent[], assistantSeq: number): LlmMessage[] {
+  const events = compactSessionEvents(raw).filter((event) => event.seq < assistantSeq)
+  return deriveMessages(events)
+}

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -3,7 +3,6 @@ import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
   formatTrajectoryUsage,
-  projectRequestMessages,
   sumTrajectoryRowUsage,
   type DerivedMessage,
   type SessionEvent,
@@ -122,19 +121,20 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
   const rows = useSessionView((state) => state.trajectory)
   const focusCallId = useSessionView((state) => state.focusCallId)
   const sessionId = useSessionView((state) => state.sessionId)
+  const trajectoryHasMore = useSessionView((state) => state.trajectoryHasMore)
+  const trajectoryLoading = useSessionView((state) => state.trajectoryLoading)
   const [selectedSeq, setSelectedSeq] = useState<number | null>(null)
+  const [detailEvent, setDetailEvent] = useState<SessionEvent | null>(null)
+  const [detailRequest, setDetailRequest] = useState<DerivedMessage[] | null>(null)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState<string | undefined>()
   /** turn key → collapsed */
   const [collapsedTurns, setCollapsedTurns] = useState<Record<string, boolean>>({})
   /** `${turn}:${step}` → collapsed */
   const [collapsedSteps, setCollapsedSteps] = useState<Record<string, boolean>>({})
 
   const groups = useMemo(() => groupByTurn(rows), [rows])
-  // 不要订阅 events：chunk 流式时 events 每帧变，会拖垮隐藏的 Trajectory 与输入框
   const cumulative = useMemo(() => sumTrajectoryRowUsage(rows), [rows])
-  const selected = useMemo(() => {
-    if (selectedSeq == null) return undefined
-    return sessionView.get().events.find((event) => event.seq === selectedSeq)
-  }, [selectedSeq, rows, sessionView])
 
   useEffect(() => {
     if (!focusCallId) return
@@ -144,8 +144,39 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
   }, [focusCallId, rows])
 
   useEffect(() => {
-    if (selectedSeq == null) return
-    if (!sessionView.get().events.some((event) => event.seq === selectedSeq)) setSelectedSeq(null)
+    if (selectedSeq == null) {
+      setDetailEvent(null)
+      setDetailRequest(null)
+      setDetailError(undefined)
+      return
+    }
+    if (!rows.some((row) => row.seq === selectedSeq)) {
+      setSelectedSeq(null)
+      return
+    }
+    let cancelled = false
+    setDetailLoading(true)
+    setDetailError(undefined)
+    setDetailEvent(null)
+    setDetailRequest(null)
+    void (async () => {
+      try {
+        const event = await sessionView.fetchEventDetail(selectedSeq)
+        if (cancelled) return
+        setDetailEvent(event)
+        if (event?.type === 'assistant/message') {
+          const request = await sessionView.fetchEventRequest(selectedSeq)
+          if (!cancelled) setDetailRequest(request)
+        }
+      } catch (error) {
+        if (!cancelled) setDetailError(String(error))
+      } finally {
+        if (!cancelled) setDetailLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
   }, [selectedSeq, rows, sessionView])
 
   if (!sessionId) {
@@ -153,6 +184,14 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
       <div className="traj-empty">
         <p className="traj-empty-title">No session</p>
         <p className="traj-empty-body">Open or create a session to inspect its append-only event ledger.</p>
+      </div>
+    )
+  }
+
+  if (!rows.length && trajectoryLoading) {
+    return (
+      <div className="traj-empty">
+        <p className="traj-empty-title">Loading trajectory…</p>
       </div>
     )
   }
@@ -167,7 +206,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
   }
 
   return (
-    <div className={`traj-root${selected ? ' traj-root-split' : ''}`}>
+    <div className={`traj-root${selectedSeq != null ? ' traj-root-split' : ''}`}>
       <div className="traj-pane">
         <div className="traj-meta">
           <span>{rows.length} events</span>
@@ -179,6 +218,19 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
             <UsageInline usage={cumulative} />
           </span>
         </div>
+
+        {trajectoryHasMore ? (
+          <div className="traj-meta">
+            <button
+              type="button"
+              className="traj-detail-close"
+              disabled={trajectoryLoading}
+              onClick={() => void sessionView.loadOlderTrajectory()}
+            >
+              {trajectoryLoading ? 'Loading…' : 'Load earlier turns'}
+            </button>
+          </div>
+        ) : null}
 
         <div className="traj-head" role="row">
           <span className="traj-col-seq">#</span>
@@ -266,18 +318,22 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
         </div>
       </div>
 
-      {selected ? (
+      {selectedSeq != null ? (
         <aside className="traj-detail" aria-label="Event detail">
           <div className="traj-detail-head">
             <div>
-              <div className="traj-detail-title">#{selected.seq}</div>
-              <div className="traj-detail-type">{selected.type}</div>
+              <div className="traj-detail-title">#{selectedSeq}</div>
+              <div className="traj-detail-type">{detailEvent?.type ?? (detailLoading ? 'loading…' : '—')}</div>
             </div>
             <button type="button" className="traj-detail-close" onClick={() => setSelectedSeq(null)}>
               Close
             </button>
           </div>
-          <EventDetailBody event={selected} events={sessionView.get().events} />
+          {detailLoading ? <div className="traj-detail-body">Loading detail…</div> : null}
+          {detailError ? <div className="traj-detail-body">{detailError}</div> : null}
+          {!detailLoading && detailEvent ? (
+            <EventDetailBody event={detailEvent} request={detailRequest ?? undefined} />
+          ) : null}
         </aside>
       ) : null}
     </div>
@@ -308,11 +364,15 @@ function filterCollapsedSteps(
   return out
 }
 
-function EventDetailBody({ event, events }: { event: SessionEvent; events: SessionEvent[] }) {
-  const fields = detailFields(event, events)
+function EventDetailBody({
+  event,
+  request,
+}: {
+  event: SessionEvent
+  request?: DerivedMessage[]
+}) {
+  const fields = detailFields(event, request)
   const usage = event.type === 'assistant/message' ? event.usage : undefined
-  const request =
-    event.type === 'assistant/message' ? projectRequestMessages(events, event.seq) : undefined
   return (
     <div className="traj-detail-body">
       <dl className="traj-detail-meta">
@@ -385,7 +445,10 @@ function ResponsePanel({ event }: { event: Extract<SessionEvent, { type: 'assist
   )
 }
 
-function detailFields(event: SessionEvent, events: SessionEvent[]): Array<{ label: string; value: string }> {
+function detailFields(
+  event: SessionEvent,
+  request?: DerivedMessage[],
+): Array<{ label: string; value: string }> {
   if (event.type === 'user/message' || event.type === 'assistant/chunk' || event.type === 'system/prompt') {
     return [
       ...(event.type === 'user/message' && event.kind ? [{ label: 'kind', value: event.kind }] : []),
@@ -395,8 +458,7 @@ function detailFields(event: SessionEvent, events: SessionEvent[]): Array<{ labe
   if (event.type === 'assistant/message') {
     const rows = [{ label: 'text', value: `${event.text.length} chars` }]
     if (event.tool_calls?.length) rows.push({ label: 'tool_calls', value: String(event.tool_calls.length) })
-    const requestCount = projectRequestMessages(events, event.seq).length
-    rows.push({ label: 'request', value: `${requestCount} messages (derived)` })
+    if (request) rows.push({ label: 'request', value: `${request.length} messages (derived)` })
     return rows
   }
   if (event.type === 'tool/call') {

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -125,6 +125,18 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input)
     calls.push(url)
+    if (url.includes('/api/sessions/s1/trajectory')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          rows: [{ id: 'tr-4', seq: 4, turn: 0, step: null, depth: 0, type: 'assistant/message', summary: 'ab' }],
+          hasMore: false,
+          totalTurns: 1,
+        }),
+      } as Response
+    }
     if (url.includes('/api/sessions/s1?turns=')) {
       return {
         ok: true,
@@ -159,6 +171,51 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
   assert.equal(view.get().trajectory.length, 0)
   assert.equal(view.get().nodes.some((node) => node.kind === 'assistant' && node.text === 'ab'), true)
+  await view.ensureTrajectory()
+  assert.equal(calls.some((url) => url.includes('/trajectory?turns=')), true)
+  assert.equal(view.get().trajectory.length, 1)
+  assert.equal(calls.some((url) => url.includes('turns=all')), false)
+})
+
+test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () => {
+  const calls: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    calls.push(url)
+    if (url.endsWith('/api/sessions/s1/events/4/request')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 's1', seq: 4, messages: [{ role: 'user', content: 'hi' }] }),
+      } as Response
+    }
+    if (url.endsWith('/api/sessions/s1/events/4')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          event: { type: 'assistant/message', text: 'ab', seq: 4, ts: 5 },
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  const event = await view.fetchEventDetail(4)
+  assert.equal(event?.type, 'assistant/message')
+  const request = await view.fetchEventRequest(4)
+  assert.equal(request[0]?.content, 'hi')
+  assert.equal(calls.some((url) => url.includes('/events/4/request')), true)
 })
 
 test('loadOlder prepends earlier turns', async () => {

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -3,8 +3,8 @@ import { Service, type Context } from 'cordis'
 import {
   compactSessionEvents,
   projectNodes,
-  projectTrajectory,
   type ChatNode,
+  type DerivedMessage,
   type SessionEvent,
   type TrajectoryRow,
 } from './session-project.ts'
@@ -27,8 +27,9 @@ export interface SessionListItem {
 export type ConversationView = 'chat' | 'trajectory'
 export type ApprovalMode = 'auto' | 'hold'
 
-/** 与 host DEFAULT_TAIL_TURNS 对齐：首屏只拉最近若干 turn */
+/** 与 host DEFAULT_TAIL_TURNS / DEFAULT_TRAJECTORY_TURNS 对齐 */
 export const SESSION_TAIL_TURNS = 24
+export const TRAJECTORY_TAIL_TURNS = 48
 
 export interface SessionViewState {
   sessionId: string | null
@@ -44,9 +45,12 @@ export interface SessionViewState {
   approvalMode: ApprovalMode
   approvals: ApprovalItem[]
   project?: { name: string; path?: string; boundAt: number }
-  /** 是否还有更早的 turn 可懒加载 */
+  /** Chat 是否还有更早 turn */
   hasMoreOlder: boolean
   loadingOlder: boolean
+  /** Trajectory 索引是否还有更早 turn */
+  trajectoryHasMore: boolean
+  trajectoryLoading: boolean
   totalTurns: number
   error?: string
 }
@@ -64,6 +68,8 @@ const empty: SessionViewState = {
   approvals: [],
   hasMoreOlder: false,
   loadingOlder: false,
+  trajectoryHasMore: false,
+  trajectoryLoading: false,
   totalTurns: 0,
 }
 
@@ -74,6 +80,13 @@ type SessionPayload = {
   totalTurns?: number
   totalEvents?: number
   project?: { name: string; path?: string; boundAt: number }
+}
+
+type TrajectoryPayload = {
+  id: string
+  rows?: TrajectoryRow[]
+  hasMore?: boolean
+  totalTurns?: number
 }
 
 export class SessionViewService extends Service {
@@ -122,6 +135,8 @@ export class SessionViewService extends Service {
         project: undefined,
         hasMoreOlder: false,
         loadingOlder: false,
+        trajectoryHasMore: false,
+        trajectoryLoading: false,
         totalTurns: 0,
         error: undefined,
       })
@@ -141,6 +156,8 @@ export class SessionViewService extends Service {
           focusCallId: undefined,
           hasMoreOlder: false,
           loadingOlder: false,
+          trajectoryHasMore: false,
+          trajectoryLoading: false,
           totalTurns: 0,
         })
         throw error
@@ -165,14 +182,14 @@ export class SessionViewService extends Service {
     }
     this.flushChunkFrame()
     const events = upsertEvent(this.value.sessionId === sessionId ? this.value.events : [], event)
-    const onTraj = this.value.view === 'trajectory'
     this.replace({
       sessionId,
       events,
       nodes: projectNodes(events),
-      ...(onTraj ? { trajectory: projectTrajectory(events) } : {}),
       error: undefined,
     })
+    // Trajectory 索引走独立接口；运行中只做轻量刷新，不塞全文 events
+    if (this.value.view === 'trajectory') void this.refreshTrajectoryIndex()
     void this.refreshSessions()
   }
 
@@ -287,17 +304,15 @@ export class SessionViewService extends Service {
 
   async load(sessionId: string, options: { view?: ConversationView } = {}) {
     const view = options.view ?? this.value.view
-    const turns = view === 'trajectory' ? 'all' : String(SESSION_TAIL_TURNS)
-    const res = await fetch(`/api/sessions/${sessionId}?turns=${encodeURIComponent(turns)}`)
+    const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
     if (!res.ok) throw new Error(`加载 session 失败：${res.status}`)
     const body = (await res.json()) as SessionPayload
     const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
-    const onTraj = view === 'trajectory'
     this.replace({
       sessionId: body.id,
       events,
       nodes: projectNodes(events),
-      trajectory: onTraj ? projectTrajectory(events) : [],
+      trajectory: [],
       project: body.project,
       view,
       focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
@@ -306,13 +321,16 @@ export class SessionViewService extends Service {
       agentStatus: 'idle',
       hasMoreOlder: Boolean(body.hasMore),
       loadingOlder: false,
+      trajectoryHasMore: false,
+      trajectoryLoading: false,
       totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : 0,
     })
+    if (view === 'trajectory') await this.ensureTrajectory()
     void this.refreshSessions()
     void this.refreshApprovals()
   }
 
-  /** 上滑加载更早 turn；返回是否真正拉到了数据 */
+  /** 上滑加载更早 chat turn；返回是否真正拉到了数据 */
   async loadOlder(): Promise<boolean> {
     const { sessionId, hasMoreOlder, loadingOlder, events } = this.value
     if (!sessionId || !hasMoreOlder || loadingOlder) return false
@@ -334,11 +352,9 @@ export class SessionViewService extends Service {
       const merged = [...older.filter((event) => !seen.has(event.seq)), ...events].sort(
         (a, b) => a.seq - b.seq,
       )
-      const onTraj = this.value.view === 'trajectory'
       this.replace({
         events: merged,
         nodes: projectNodes(merged),
-        ...(onTraj ? { trajectory: projectTrajectory(merged) } : {}),
         hasMoreOlder: Boolean(body.hasMore),
         loadingOlder: false,
         totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
@@ -350,28 +366,101 @@ export class SessionViewService extends Service {
     }
   }
 
-  /** 进入 Trajectory 时再拉全量并投影；Chat 路径不碰 trajectory。 */
+  /** 进入 Trajectory：只拉轻量 rows 索引，不拉全文 events。 */
   async ensureTrajectory() {
     const sessionId = this.value.sessionId
     if (!sessionId) return
-    if (this.value.hasMoreOlder) {
-      const res = await fetch(`/api/sessions/${sessionId}?turns=all`)
+    if (this.value.trajectoryLoading) return
+    this.replace({ trajectoryLoading: true, view: 'trajectory' })
+    try {
+      const res = await fetch(
+        `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,
+      )
       if (!res.ok) throw new Error(`加载 trajectory 失败：${res.status}`)
-      const body = (await res.json()) as SessionPayload
-      const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+      const body = (await res.json()) as TrajectoryPayload
       this.replace({
-        events,
-        nodes: projectNodes(events),
-        trajectory: projectTrajectory(events),
-        hasMoreOlder: false,
+        trajectory: Array.isArray(body.rows) ? body.rows : [],
+        trajectoryHasMore: Boolean(body.hasMore),
+        trajectoryLoading: false,
         totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
         view: 'trajectory',
       })
-      return
+    } catch (error) {
+      this.replace({ trajectoryLoading: false, error: String(error) })
     }
-    if (this.value.trajectory.length === 0 && this.value.events.length > 0) {
-      this.replace({ trajectory: projectTrajectory(this.value.events), view: 'trajectory' })
+  }
+
+  async refreshTrajectoryIndex() {
+    const sessionId = this.value.sessionId
+    if (!sessionId || this.value.view !== 'trajectory') return
+    try {
+      const res = await fetch(
+        `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,
+      )
+      if (!res.ok) return
+      const body = (await res.json()) as TrajectoryPayload
+      this.replace({
+        trajectory: Array.isArray(body.rows) ? body.rows : [],
+        trajectoryHasMore: Boolean(body.hasMore),
+        totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
+      })
+    } catch {
+      /* ignore */
     }
+  }
+
+  async loadOlderTrajectory(): Promise<boolean> {
+    const { sessionId, trajectoryHasMore, trajectoryLoading, trajectory } = this.value
+    if (!sessionId || !trajectoryHasMore || trajectoryLoading) return false
+    const beforeSeq = trajectory[0]?.seq
+    if (beforeSeq == null) return false
+    this.replace({ trajectoryLoading: true })
+    try {
+      const res = await fetch(
+        `/api/sessions/${sessionId}/trajectory?beforeSeq=${beforeSeq}&turns=${TRAJECTORY_TAIL_TURNS}`,
+      )
+      if (!res.ok) throw new Error(`加载更早 trajectory 失败：${res.status}`)
+      const body = (await res.json()) as TrajectoryPayload
+      const older = Array.isArray(body.rows) ? body.rows : []
+      if (!older.length) {
+        this.replace({ trajectoryHasMore: false, trajectoryLoading: false })
+        return false
+      }
+      const seen = new Set(trajectory.map((row) => row.seq))
+      const merged = [...older.filter((row) => !seen.has(row.seq)), ...trajectory].sort(
+        (a, b) => a.seq - b.seq,
+      )
+      this.replace({
+        trajectory: merged,
+        trajectoryHasMore: Boolean(body.hasMore),
+        trajectoryLoading: false,
+        totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
+      })
+      return true
+    } catch (error) {
+      this.replace({ trajectoryLoading: false, error: String(error) })
+      return false
+    }
+  }
+
+  /** 详情懒加载：单条事件全文 */
+  async fetchEventDetail(seq: number): Promise<SessionEvent | null> {
+    const sessionId = this.value.sessionId
+    if (!sessionId) return null
+    const res = await fetch(`/api/sessions/${sessionId}/events/${seq}`)
+    if (!res.ok) throw new Error(`加载事件失败：${res.status}`)
+    const body = (await res.json()) as { event?: SessionEvent }
+    return body.event ?? null
+  }
+
+  /** 详情懒加载：assistant/message 的 derived request */
+  async fetchEventRequest(seq: number): Promise<DerivedMessage[]> {
+    const sessionId = this.value.sessionId
+    if (!sessionId) return []
+    const res = await fetch(`/api/sessions/${sessionId}/events/${seq}/request`)
+    if (!res.ok) throw new Error(`加载 request 失败：${res.status}`)
+    const body = (await res.json()) as { messages?: DerivedMessage[] }
+    return Array.isArray(body.messages) ? body.messages : []
   }
 
   setProjectMeta(project?: { name: string; path?: string; boundAt: number }) {
@@ -417,6 +506,8 @@ export class SessionViewService extends Service {
       project: undefined,
       hasMoreOlder: false,
       loadingOlder: false,
+      trajectoryHasMore: false,
+      trajectoryLoading: false,
       totalTurns: 0,
       error: undefined,
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Trajectory 详情按需懒加载，接口拆细。

### 新接口
- `GET /api/sessions/:id/trajectory?turns=48` — 只返回摘要 rows（无全文）
- `GET .../trajectory?beforeSeq=` — 更早索引分页
- `GET /api/sessions/:id/events/:seq` — 单条事件全文
- `GET /api/sessions/:id/events/:seq/request` — assistant 的 derived request

### 客户端
- 进入 Trajectory **不再** `turns=all`
- 点某一行才拉 event / request 详情
- 列表可「Load earlier turns」

### 测试
全量 vitest 90 passed。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

