### PR TITLE
ui: Chat 主栏全宽（去掉右侧留白）

### DIFF
--- a/src/plugins/contributors/chat/approvals.tsx
+++ b/src/plugins/contributors/chat/approvals.tsx
@@ -47,7 +47,7 @@ export function ApprovalsRail(props: SlotProps) {
   }
 
   return (
-    <div className="mx-auto w-full max-w-[calc(var(--dsw-chat-width)+32px)] space-y-2">
+    <div className="w-full space-y-2">
       <div className="dock-capsules" role="toolbar" aria-label="Session controls">
         <SessionProjectPanel {...props} />
         <div className="dock-mode-pills" role="group" aria-label="Agent mode">

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -66,7 +66,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
   return (
     <form
-      className="mx-auto w-full max-w-[calc(var(--dsw-chat-width)+32px)] border border-[var(--dsw-border)] bg-[var(--dsw-input)]"
+      className="w-full border border-[var(--dsw-border)] bg-[var(--dsw-input)]"
       style={{ borderRadius: 'var(--dsw-radius-bubble)', boxShadow: 'var(--dsw-shadow-lv2)' }}
       onSubmit={onSubmit}
     >

--- a/src/plugins/contributors/chat/config-banner.tsx
+++ b/src/plugins/contributors/chat/config-banner.tsx
@@ -28,7 +28,7 @@ export function ChatConfigBanner(_props: SlotProps) {
 
   return (
     <div
-      className="mx-auto w-full max-w-[calc(var(--dsw-chat-width)+32px)] border border-[var(--dsw-border)] bg-[var(--dsw-input)] px-4 py-2 text-xs text-[var(--dsw-label-2)]"
+      className="w-full border border-[var(--dsw-border)] bg-[var(--dsw-input)] px-4 py-2 text-xs text-[var(--dsw-label-2)]"
       style={{ borderRadius: 'var(--dsw-radius-bubble)' }}
       role="status"
     >

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -33,7 +33,7 @@ function ToolRow({
   const [open, setOpen] = useState(false)
   const summary = node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…'
   return (
-    <div className="w-full max-w-[var(--dsw-chat-width)] self-stretch">
+    <div className="w-full self-stretch">
       <div className="flex items-center gap-1">
         <button
           type="button"
@@ -86,7 +86,7 @@ function NodeView({ node, onInspect }: { node: ChatNode; onInspect: (callId: str
   }
   if (node.kind === 'assistant') {
     return (
-      <div className="w-full max-w-[var(--dsw-chat-width)] self-start text-[15px] leading-7 text-[var(--dsw-label)]">
+      <div className="w-full self-start text-[15px] leading-7 text-[var(--dsw-label)]">
         {node.text ? <MarkdownBody text={node.text} streaming={Boolean(node.streaming)} /> : node.streaming ? '…' : null}
         {node.streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
       </div>
@@ -113,7 +113,7 @@ function EmptyHero() {
           </span>
         </div>
         <p className="max-w-md text-sm text-[var(--dsw-label-3)]">
-          对话由 append-only session 投影。右侧 Project 可为本 Session 打开本地文件夹并编辑文件。
+          对话由 append-only session 投影。输入框上方可绑定本机文件夹作为 Session cwd。
         </p>
       </div>
     </div>
@@ -229,7 +229,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   if (nodes.length === 0 && !pending && !error) return <EmptyHero />
 
   return (
-    <div ref={rootRef} className="mx-auto w-full max-w-[var(--dsw-chat-width)]" data-chat-virtual={virtualize ? '1' : '0'}>
+    <div ref={rootRef} className="w-full" data-chat-virtual={virtualize ? '1' : '0'}>
       <StatusRow agentStatus={agentStatus} agentStep={agentStep} />
       {loadingOlder ? (
         <div className="mb-3 text-center text-[11px] text-[var(--dsw-label-3)]">加载更早消息…</div>

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -299,7 +299,7 @@ function Shell(props: SlotProps) {
               }`}
               aria-hidden={view !== 'chat'}
             >
-              <div className="mx-auto flex min-h-0 w-full max-w-[calc(var(--dsw-chat-width)+32px)] flex-1 flex-col overflow-hidden px-4 pb-4">
+              <div className="flex min-h-0 w-full flex-1 flex-col overflow-hidden px-4 pb-4 md:px-6">
                 <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain py-4">
                   {props.renderSlot('stage')}
                 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat 主栏改为铺满可用宽度，去掉居中 `max-width` 造成的右侧大块留白。

- stage / dock / composer 全宽
- 用户气泡仍保留 `max-w` 以便阅读
- 左侧 Sessions 列表保留（活动栏旁）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

