### PR TITLE
perf: 左侧切 session 即时切换（缓存 + 乐观清空）

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -126,6 +126,9 @@ function Shell(props: SlotProps) {
   const view = useSessionView((state) => state.view)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const activeModule = moduleIdFromPath(location.pathname)
+  const appRoute = parseAppPath(location.pathname)
+  // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
+  const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}${view === 'trajectory' ? '/trajectory' : ''}` : '/'
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
@@ -210,7 +213,7 @@ function Shell(props: SlotProps) {
             <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
           ) : (
             sessions.map((item) => {
-              const active = item.id === sessionId
+              const active = item.id === routeSessionId
               return (
                 <div
                   key={item.id}

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -218,6 +218,99 @@ test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () =>
   assert.equal(calls.some((url) => url.includes('/events/4/request')), true)
 })
 
+test('load clears previous chat immediately before network returns', async () => {
+  let release!: (value: unknown) => void
+  const gate = new Promise((resolve) => {
+    release = resolve
+  })
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/sessions/empty?turns=')) {
+      await gate
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 'empty', events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }], hasMore: false, totalTurns: 0 }),
+      } as Response
+    }
+    if (url.includes('/api/sessions/busy?turns=')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 'busy',
+          events: [
+            { type: 'session/open', version: 1, seq: 0, ts: 1 },
+            { type: 'user/message', text: 'hi', seq: 1, ts: 2 },
+            { type: 'assistant/message', text: 'yo', seq: 2, ts: 3 },
+          ],
+          hasMore: false,
+          totalTurns: 1,
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.load('busy', { view: 'chat' })
+  assert.equal(view.get().nodes.length > 0, true)
+
+  const pending = view.load('empty', { view: 'chat' })
+  assert.equal(view.get().sessionId, 'empty')
+  assert.equal(view.get().nodes.length, 0)
+  release(undefined)
+  await pending
+  assert.equal(view.get().sessionId, 'empty')
+})
+
+test('second load of same session hits memory cache without waiting on fetch', async () => {
+  let fetches = 0
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/api/sessions/s1?turns=')) {
+      fetches += 1
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's1',
+          events: [
+            { type: 'session/open', version: 1, seq: 0, ts: 1 },
+            { type: 'user/message', text: 'hi', seq: 1, ts: 2 },
+          ],
+          hasMore: false,
+          totalTurns: 1,
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.load('s1', { view: 'chat' })
+  await view.load('s1', { view: 'chat' })
+  // 首次 + 后台 revalidate；同步路径已用缓存，nodes 立刻可用
+  assert.equal(view.get().nodes.some((node) => node.kind === 'user'), true)
+  assert.equal(fetches >= 1, true)
+})
+
 test('loadOlder prepends earlier turns', async () => {
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input)

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -89,9 +89,43 @@ type TrajectoryPayload = {
   totalTurns?: number
 }
 
+type SessionCacheEntry = {
+  events: SessionEvent[]
+  nodes: ChatNode[]
+  project?: { name: string; path?: string; boundAt: number }
+  hasMoreOlder: boolean
+  totalTurns: number
+}
+
+const SESSION_CACHE_MAX = 16
+
+function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i]!
+    const right = b[i]!
+    if (
+      left.id !== right.id ||
+      left.title !== right.title ||
+      left.eventCount !== right.eventCount ||
+      left.updatedAt !== right.updatedAt ||
+      left.project?.path !== right.project?.path ||
+      left.project?.name !== right.project?.name
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
 export class SessionViewService extends Service {
   private value: SessionViewState = empty
   private listeners = new Set<() => void>()
+  /** 切会话瞬时缓存：避免每次都等网络才卸掉旧 Chat DOM */
+  private cache = new Map<string, SessionCacheEntry>()
+  private cacheOrder: string[] = []
+  private loadGen = 0
 
   constructor(ctx: Context) {
     super(ctx, 'sessionView')
@@ -123,6 +157,8 @@ export class SessionViewService extends Service {
     }
     if (route.kind === 'home') {
       if (!this.value.sessionId && this.value.view === 'chat') return
+      this.stashCurrent()
+      this.loadGen += 1
       this.replace({
         sessionId: null,
         events: [],
@@ -188,6 +224,7 @@ export class SessionViewService extends Service {
       nodes: projectNodes(events),
       error: undefined,
     })
+    this.stashCurrent()
     // Trajectory 索引走独立接口；运行中只做轻量刷新，不塞全文 events
     if (this.value.view === 'trajectory') void this.refreshTrajectoryIndex()
     void this.refreshSessions()
@@ -254,7 +291,10 @@ export class SessionViewService extends Service {
       const res = await fetch('/api/sessions')
       if (!res.ok) return
       const body = (await res.json()) as { sessions?: SessionListItem[] }
-      this.replace({ sessions: Array.isArray(body.sessions) ? body.sessions : [] })
+      const next = Array.isArray(body.sessions) ? body.sessions : []
+      // 列表引用每次都新会打穿 Shell；无变化则跳过
+      if (sessionsEqual(this.value.sessions, next)) return
+      this.replace({ sessions: next })
     } catch {
       /* host 未就绪时忽略 */
     }
@@ -268,10 +308,16 @@ export class SessionViewService extends Service {
         mode?: ApprovalMode
         pending?: ApprovalItem[]
       }
-      this.replace({
-        approvalMode: body.mode === 'hold' ? 'hold' : 'auto',
-        approvals: Array.isArray(body.pending) ? body.pending : [],
-      })
+      const approvalMode = body.mode === 'hold' ? 'hold' : 'auto'
+      const approvals = Array.isArray(body.pending) ? body.pending : []
+      if (
+        this.value.approvalMode === approvalMode &&
+        this.value.approvals.length === approvals.length &&
+        this.value.approvals.every((item, index) => item.id === approvals[index]?.id)
+      ) {
+        return
+      }
+      this.replace({ approvalMode, approvals })
     } catch {
       /* host 未就绪时忽略 */
     }
@@ -304,14 +350,52 @@ export class SessionViewService extends Service {
 
   async load(sessionId: string, options: { view?: ConversationView } = {}) {
     const view = options.view ?? this.value.view
+    if (this.value.sessionId && this.value.sessionId !== sessionId) this.stashCurrent()
+
+    const cached = this.cache.get(sessionId)
+    if (cached) {
+      this.touchCache(sessionId)
+      this.loadGen += 1
+      this.applyCached(sessionId, cached, view)
+      if (view === 'trajectory') void this.ensureTrajectory()
+      // 后台校对，不挡切换
+      void this.revalidate(sessionId, view)
+      return
+    }
+
+    // 立刻清空旧会话 UI —— 切到空 chat 也先卸掉重 Markdown，再等网络
+    const gen = ++this.loadGen
+    this.replace({
+      sessionId,
+      events: [],
+      nodes: [],
+      trajectory: [],
+      project: undefined,
+      view,
+      focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+      error: undefined,
+      pending: false,
+      agentStatus: 'idle',
+      hasMoreOlder: false,
+      loadingOlder: false,
+      trajectoryHasMore: false,
+      trajectoryLoading: false,
+      totalTurns: 0,
+    })
+
     const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
     if (!res.ok) throw new Error(`加载 session 失败：${res.status}`)
+    if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
     const body = (await res.json()) as SessionPayload
+    if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
     const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+    const nodes = projectNodes(events)
+    const hasMoreOlder = Boolean(body.hasMore)
+    const totalTurns = typeof body.totalTurns === 'number' ? body.totalTurns : 0
     this.replace({
       sessionId: body.id,
       events,
-      nodes: projectNodes(events),
+      nodes,
       trajectory: [],
       project: body.project,
       view,
@@ -319,15 +403,113 @@ export class SessionViewService extends Service {
       error: undefined,
       pending: false,
       agentStatus: 'idle',
-      hasMoreOlder: Boolean(body.hasMore),
+      hasMoreOlder,
       loadingOlder: false,
       trajectoryHasMore: false,
       trajectoryLoading: false,
-      totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : 0,
+      totalTurns,
+    })
+    this.putCache(body.id, {
+      events,
+      nodes,
+      project: body.project,
+      hasMoreOlder,
+      totalTurns,
     })
     if (view === 'trajectory') await this.ensureTrajectory()
-    void this.refreshSessions()
-    void this.refreshApprovals()
+  }
+
+  /** 缓存命中后的静默刷新；若用户已切走则丢弃 */
+  private async revalidate(sessionId: string, view: ConversationView) {
+    const gen = this.loadGen
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
+      if (!res.ok) return
+      if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
+      const body = (await res.json()) as SessionPayload
+      if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
+      const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
+      const nodes = projectNodes(events)
+      const hasMoreOlder = Boolean(body.hasMore)
+      const totalTurns = typeof body.totalTurns === 'number' ? body.totalTurns : 0
+      const sameLen = events.length === this.value.events.length
+      const sameTail =
+        sameLen &&
+        events.at(-1)?.seq === this.value.events.at(-1)?.seq &&
+        events.at(-1)?.ts === this.value.events.at(-1)?.ts
+      this.putCache(sessionId, {
+        events,
+        nodes,
+        project: body.project,
+        hasMoreOlder,
+        totalTurns,
+      })
+      if (sameTail && body.project?.path === this.value.project?.path) return
+      this.replace({
+        events,
+        nodes,
+        project: body.project,
+        hasMoreOlder,
+        totalTurns,
+        trajectory: view === 'trajectory' ? this.value.trajectory : [],
+      })
+      if (view === 'trajectory') void this.ensureTrajectory()
+    } catch {
+      /* 静默 */
+    }
+  }
+
+  private applyCached(sessionId: string, cached: SessionCacheEntry, view: ConversationView) {
+    this.replace({
+      sessionId,
+      events: cached.events,
+      nodes: cached.nodes,
+      trajectory: [],
+      project: cached.project,
+      view,
+      focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+      error: undefined,
+      pending: false,
+      agentStatus: 'idle',
+      hasMoreOlder: cached.hasMoreOlder,
+      loadingOlder: false,
+      trajectoryHasMore: false,
+      trajectoryLoading: false,
+      totalTurns: cached.totalTurns,
+    })
+  }
+
+  private stashCurrent() {
+    const id = this.value.sessionId
+    if (!id) return
+    this.putCache(id, {
+      events: this.value.events,
+      nodes: this.value.nodes,
+      project: this.value.project,
+      hasMoreOlder: this.value.hasMoreOlder,
+      totalTurns: this.value.totalTurns,
+    })
+  }
+
+  private putCache(id: string, entry: SessionCacheEntry) {
+    if (this.cache.has(id)) this.cacheOrder = this.cacheOrder.filter((item) => item !== id)
+    this.cache.set(id, entry)
+    this.cacheOrder.push(id)
+    while (this.cacheOrder.length > SESSION_CACHE_MAX) {
+      const evict = this.cacheOrder.shift()
+      if (evict) this.cache.delete(evict)
+    }
+  }
+
+  private touchCache(id: string) {
+    if (!this.cache.has(id)) return
+    this.cacheOrder = this.cacheOrder.filter((item) => item !== id)
+    this.cacheOrder.push(id)
+  }
+
+  private dropCache(id: string) {
+    this.cache.delete(id)
+    this.cacheOrder = this.cacheOrder.filter((item) => item !== id)
   }
 
   /** 上滑加载更早 chat turn；返回是否真正拉到了数据 */
@@ -485,6 +667,7 @@ export class SessionViewService extends Service {
     const res = await fetch(`/api/sessions/${id}`, { method: 'DELETE' })
     const body = (await res.json()) as { ok?: boolean; error?: string }
     if (!res.ok) throw new Error(body.error || `删除失败：${res.status}`)
+    this.dropCache(id)
     const wasActive = this.value.sessionId === id
     await this.refreshSessions()
     if (!wasActive) return
@@ -493,6 +676,7 @@ export class SessionViewService extends Service {
       await this.load(next, { view: 'chat' })
       return
     }
+    this.loadGen += 1
     this.replace({
       sessionId: null,
       events: [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### 原因
左侧切 session（含切到**空对话**）仍卡，主要不是「数据量」，而是：

1. **等网络才换 UI**：`applyRoute → await load(fetch)`，旧 Chat（含重 Markdown DOM）一直挂着，空会话也要等 RTT 才清空 → 体感延迟
2. **侧栏高亮跟 store**：`sessionId` 要等 load 完才变，点击无即时反馈
3. **每次 load 后刷新全量 sessions 列表**：即使列表没变也 `replace`，打穿 Shell

### 修复
- 切走时**立刻**清空/应用内存缓存，网络在后台 revalidate
- 侧栏 active **跟 URL**
- `refreshSessions` 无变化则跳过
- 去掉 load 路径上多余的 sessions/approvals 刷新

### 测试
vitest 92 passed。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

