### PR TITLE
fix: 切空会话也不等网络

### DIFF
--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -166,7 +166,7 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
-  await view.load('s1', { view: 'chat' })
+  await view.load('s1', { view: 'chat', wait: true })
   assert.equal(calls.some((url) => url.includes('turns=24')), true)
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
   assert.equal(view.get().trajectory.length, 0)
@@ -218,14 +218,16 @@ test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () =>
   assert.equal(calls.some((url) => url.includes('/events/4/request')), true)
 })
 
-test('load clears previous chat immediately before network returns', async () => {
+test('load clears previous chat immediately and does not wait on network', async () => {
   let release!: (value: unknown) => void
   const gate = new Promise((resolve) => {
     release = resolve
   })
+  let emptyFetchStarted = false
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input)
     if (url.includes('/api/sessions/empty?turns=')) {
+      emptyFetchStarted = true
       await gate
       return {
         ok: true,
@@ -261,14 +263,16 @@ test('load clears previous chat immediately before network returns', async () =>
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
-  await view.load('busy', { view: 'chat' })
+  await view.load('busy', { view: 'chat', wait: true })
   assert.equal(view.get().nodes.length > 0, true)
 
-  const pending = view.load('empty', { view: 'chat' })
+  // 切到空会话：load 在网络返回前就 resolve；UI 已清空
+  await view.load('empty', { view: 'chat' })
   assert.equal(view.get().sessionId, 'empty')
   assert.equal(view.get().nodes.length, 0)
+  assert.equal(emptyFetchStarted, true)
   release(undefined)
-  await pending
+  await new Promise((r) => setTimeout(r, 0))
   assert.equal(view.get().sessionId, 'empty')
 })
 
@@ -304,7 +308,7 @@ test('second load of same session hits memory cache without waiting on fetch', a
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
-  await view.load('s1', { view: 'chat' })
+  await view.load('s1', { view: 'chat', wait: true })
   await view.load('s1', { view: 'chat' })
   // 首次 + 后台 revalidate；同步路径已用缓存，nodes 立刻可用
   assert.equal(view.get().nodes.some((node) => node.kind === 'user'), true)
@@ -355,7 +359,7 @@ test('loadOlder prepends earlier turns', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
-  await view.load('s1', { view: 'chat' })
+  await view.load('s1', { view: 'chat', wait: true })
   assert.equal(view.get().hasMoreOlder, true)
   await view.loadOlder()
   assert.equal(view.get().nodes[0]?.kind === 'user' && view.get().nodes[0].text, 'old')

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -348,84 +348,102 @@ export class SessionViewService extends Service {
     return this.newSession()
   }
 
-  async load(sessionId: string, options: { view?: ConversationView } = {}) {
+  async load(sessionId: string, options: { view?: ConversationView; wait?: boolean } = {}) {
     const view = options.view ?? this.value.view
-    if (this.value.sessionId && this.value.sessionId !== sessionId) this.stashCurrent()
+    const wait = options.wait === true
+    const switching = Boolean(this.value.sessionId && this.value.sessionId !== sessionId)
+    if (switching) this.stashCurrent()
 
     const cached = this.cache.get(sessionId)
-    if (cached) {
-      this.touchCache(sessionId)
-      this.loadGen += 1
-      this.applyCached(sessionId, cached, view)
-      if (view === 'trajectory') void this.ensureTrajectory()
-      // 后台校对，不挡切换
-      void this.revalidate(sessionId, view)
-      return
+    const needSwap = this.value.sessionId !== sessionId
+
+    // 路由切换（含空会话 / 冷启动）：立刻换壳，网络只后台校对，绝不 await
+    if (!wait) {
+      if (cached) {
+        this.touchCache(sessionId)
+        this.loadGen += 1
+        this.applyCached(sessionId, cached, view)
+        if (view === 'trajectory') void this.ensureTrajectory()
+        void this.revalidate(sessionId, view)
+        return
+      }
+      if (needSwap) {
+        this.loadGen += 1
+        this.replace({
+          sessionId,
+          events: [],
+          nodes: [],
+          trajectory: [],
+          project: undefined,
+          view,
+          focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+          error: undefined,
+          pending: false,
+          agentStatus: 'idle',
+          hasMoreOlder: false,
+          loadingOlder: false,
+          trajectoryHasMore: false,
+          trajectoryLoading: false,
+          totalTurns: 0,
+        })
+        if (view === 'trajectory') void this.ensureTrajectory()
+        void this.revalidate(sessionId, view)
+        return
+      }
     }
 
-    // 立刻清空旧会话 UI —— 切到空 chat 也先卸掉重 Markdown，再等网络
-    const gen = ++this.loadGen
-    this.replace({
-      sessionId,
-      events: [],
-      nodes: [],
-      trajectory: [],
-      project: undefined,
-      view,
-      focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
-      error: undefined,
-      pending: false,
-      agentStatus: 'idle',
-      hasMoreOlder: false,
-      loadingOlder: false,
-      trajectoryHasMore: false,
-      trajectoryLoading: false,
-      totalTurns: 0,
-    })
-
-    const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
-    if (!res.ok) throw new Error(`加载 session 失败：${res.status}`)
-    if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
-    const body = (await res.json()) as SessionPayload
-    if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
-    const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
-    const nodes = projectNodes(events)
-    const hasMoreOlder = Boolean(body.hasMore)
-    const totalTurns = typeof body.totalTurns === 'number' ? body.totalTurns : 0
-    this.replace({
-      sessionId: body.id,
-      events,
-      nodes,
-      trajectory: [],
-      project: body.project,
-      view,
-      focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
-      error: undefined,
-      pending: false,
-      agentStatus: 'idle',
-      hasMoreOlder,
-      loadingOlder: false,
-      trajectoryHasMore: false,
-      trajectoryLoading: false,
-      totalTurns,
-    })
-    this.putCache(body.id, {
-      events,
-      nodes,
-      project: body.project,
-      hasMoreOlder,
-      totalTurns,
-    })
+    // wait：发送后等同会话刷新，必须等网络；切会话时也先乐观换壳再 await
+    this.loadGen += 1
+    if (needSwap) {
+      if (cached) {
+        this.touchCache(sessionId)
+        this.applyCached(sessionId, cached, view)
+      } else {
+        this.replace({
+          sessionId,
+          events: [],
+          nodes: [],
+          trajectory: [],
+          project: undefined,
+          view,
+          focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+          error: undefined,
+          pending: false,
+          agentStatus: 'idle',
+          hasMoreOlder: false,
+          loadingOlder: false,
+          trajectoryHasMore: false,
+          trajectoryLoading: false,
+          totalTurns: 0,
+        })
+      }
+    }
+    await this.revalidate(sessionId, view)
     if (view === 'trajectory') await this.ensureTrajectory()
   }
 
-  /** 缓存命中后的静默刷新；若用户已切走则丢弃 */
+  /** 静默拉取并套用；若用户已切走则丢弃 */
   private async revalidate(sessionId: string, view: ConversationView) {
     const gen = this.loadGen
     try {
       const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
-      if (!res.ok) return
       if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
+      if (!res.ok) {
+        if (res.status === 404) {
+          this.replace({
+            error: `加载 session 失败：${res.status}`,
+            sessionId: null,
+            events: [],
+            nodes: [],
+            trajectory: [],
+            view: 'chat',
+            focusCallId: undefined,
+            hasMoreOlder: false,
+            totalTurns: 0,
+          })
+        }
+        return
+      }
       const body = (await res.json()) as SessionPayload
       if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
       const events = compactSessionEvents(Array.isArray(body.events) ? body.events : [])
@@ -444,14 +462,18 @@ export class SessionViewService extends Service {
         hasMoreOlder,
         totalTurns,
       })
-      if (sameTail && body.project?.path === this.value.project?.path) return
+      if (sameTail && body.project?.path === this.value.project?.path && this.value.totalTurns === totalTurns) {
+        return
+      }
       this.replace({
+        sessionId: body.id,
         events,
         nodes,
         project: body.project,
         hasMoreOlder,
         totalTurns,
         trajectory: view === 'trajectory' ? this.value.trajectory : [],
+        error: undefined,
       })
       if (view === 'trajectory') void this.ensureTrajectory()
     } catch {
@@ -723,14 +745,17 @@ export class SessionViewService extends Service {
       })
       const data = (await res.json()) as { error?: string; sessionId?: string; text?: string }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)
-      if (data.sessionId && data.sessionId !== sessionId) await this.load(data.sessionId, { view: 'chat' })
-      else await this.load(sessionId, { view: this.value.view })
+      if (data.sessionId && data.sessionId !== sessionId) {
+        await this.load(data.sessionId, { view: 'chat', wait: true })
+      } else {
+        await this.load(sessionId, { view: this.value.view, wait: true })
+      }
       if (typeof data.text === 'string' && data.text.startsWith('模型调用失败：')) {
         this.replace({ error: data.text })
       }
     } catch (error) {
       try {
-        await this.load(sessionId, { view: this.value.view })
+        await this.load(sessionId, { view: this.value.view, wait: true })
       } catch {
         /* 加载失败时仍展示下方 error */
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏切换（含空会话）不再 `await fetch`：立刻换空壳 / 缓存，后台 `revalidate`。只有发送后等场景用 `wait: true` 才等网络。

测试已覆盖「切到 empty 时 load 在网络返回前就 resolve」。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

