### PR TITLE
feat: 工具调用用红绿 diff 展示编辑内容

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -6,6 +6,7 @@ import { bindSessionView, type SessionViewService } from '../../infrastructure/s
 import type { ChatNode } from '../../infrastructure/session-project.ts'
 import { FishLogo } from '../brand.tsx'
 import { MarkdownBody } from './markdown.tsx'
+import { ToolCard } from './tool-card.tsx'
 
 const NEAR_BOTTOM_PX = 96
 const ROW_GAP_PX = 16
@@ -21,53 +22,6 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
     node = node.parentElement
   }
   return null
-}
-
-function ToolRow({
-  node,
-  onInspect,
-}: {
-  node: Extract<ChatNode, { kind: 'tool' }>
-  onInspect: (callId: string) => void
-}) {
-  const [open, setOpen] = useState(false)
-  const summary = node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…'
-  return (
-    <div className="w-full self-stretch">
-      <div className="flex items-center gap-1">
-        <button
-          type="button"
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-black/[0.03]"
-          onClick={() => setOpen((value) => !value)}
-        >
-          <span className="grid size-4 place-items-center text-[10px] text-[var(--dsw-label-3)]">{open ? '▾' : '▸'}</span>
-          <span className="font-medium">{node.name}</span>
-          <span className="text-[var(--dsw-label-3)]">·</span>
-          <span className="min-w-0 flex-1 truncate text-[var(--dsw-label-3)]">{summary}</span>
-          {node.result ? (
-            <span className={node.result.ok ? 'text-[var(--dsw-ok)]' : 'text-[var(--dsw-danger)]'}>
-              {node.result.ok ? 'ok' : 'fail'}
-            </span>
-          ) : (
-            <span className="text-[var(--dsw-label-3)]">running</span>
-          )}
-        </button>
-        <button
-          type="button"
-          className="shrink-0 rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-business)] hover:bg-[var(--dsw-business-soft)]"
-          onClick={() => onInspect(node.callId)}
-        >
-          Trajectory
-        </button>
-      </div>
-      {open ? (
-        <div className="mt-1 space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] p-3 font-mono text-xs">
-          {node.arguments ? <pre className="whitespace-pre-wrap text-[var(--dsw-label-2)]">{node.arguments}</pre> : null}
-          {node.result?.detail ? <pre className="whitespace-pre-wrap">{node.result.detail}</pre> : null}
-        </div>
-      ) : null}
-    </div>
-  )
 }
 
 function NodeView({ node, onInspect }: { node: ChatNode; onInspect: (callId: string) => void }) {
@@ -92,7 +46,7 @@ function NodeView({ node, onInspect }: { node: ChatNode; onInspect: (callId: str
       </div>
     )
   }
-  if (node.kind === 'tool') return <ToolRow node={node} onInspect={onInspect} />
+  if (node.kind === 'tool') return <ToolCard node={node} onInspect={onInspect} />
   return <div className="self-center text-xs text-[var(--dsw-label-3)]">{node.text}</div>
 }
 

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react'
+import type { ChatNode } from '../../infrastructure/session-project.ts'
+import {
+  diffStats,
+  lineDiff,
+  parseToolCall,
+  shouldAutoOpenTool,
+  toolSummary,
+  toolTitle,
+  type DiffLine,
+  type ParsedToolCall,
+} from './tool-format.ts'
+
+function DiffBlock({ lines, path }: { lines: DiffLine[]; path?: string }) {
+  const stats = diffStats(lines)
+  return (
+    <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-white">
+      {path ? (
+        <div className="flex items-center justify-between gap-2 border-b border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-1.5">
+          <span className="min-w-0 truncate font-mono text-[11px] text-[var(--dsw-label-2)]">{path}</span>
+          <span className="shrink-0 font-mono text-[10px] tabular-nums text-[var(--dsw-label-3)]">
+            {stats.removed ? <span className="text-[var(--dsw-danger)]">−{stats.removed}</span> : null}
+            {stats.removed && stats.added ? ' ' : null}
+            {stats.added ? <span className="text-[var(--dsw-ok)]">+{stats.added}</span> : null}
+          </span>
+        </div>
+      ) : null}
+      <pre className="max-h-80 overflow-auto py-1 font-mono text-[11px] leading-5">
+        {lines.map((line, index) => {
+          const prefix = line.type === 'add' ? '+' : line.type === 'remove' ? '−' : ' '
+          const rowClass =
+            line.type === 'add'
+              ? 'bg-[rgba(34,140,90,0.12)] text-[rgb(20,110,70)]'
+              : line.type === 'remove'
+                ? 'bg-[rgba(220,80,80,0.12)] text-[rgb(170,50,50)]'
+                : 'text-[var(--dsw-label-2)]'
+          return (
+            <div key={`${index}-${line.type}`} className={`flex whitespace-pre-wrap break-all px-2 ${rowClass}`}>
+              <span className="w-4 shrink-0 select-none opacity-70">{prefix}</span>
+              <span className="min-w-0 flex-1">{line.text || ' '}</span>
+            </div>
+          )
+        })}
+      </pre>
+    </div>
+  )
+}
+
+function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; rawArguments: string; detail?: string }) {
+  if (parsed.kind === 'str_replace') {
+    const lines = lineDiff(parsed.oldStr, parsed.newStr)
+    return (
+      <div className="space-y-2">
+        <DiffBlock path={parsed.path} lines={lines} />
+        {detail && !detail.startsWith('The file ') ? (
+          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (parsed.kind === 'create') {
+    const lines = lineDiff('', parsed.fileText)
+    return (
+      <div className="space-y-2">
+        <DiffBlock path={parsed.path} lines={lines} />
+        {detail && !detail.startsWith('File created') ? (
+          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (parsed.kind === 'insert') {
+    const lines = lineDiff('', parsed.newStr)
+    return (
+      <div className="space-y-2">
+        <DiffBlock path={`${parsed.path} · after line ${parsed.insertLine}`} lines={lines} />
+        {detail && !detail.startsWith('The file ') ? (
+          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (parsed.kind === 'bash') {
+    return (
+      <div className="space-y-2">
+        <pre className="overflow-x-auto rounded-[10px] border border-[var(--dsw-border)] bg-[#1e1f24] px-3 py-2 font-mono text-[11px] leading-5 text-[#e8eaed]">
+          <span className="text-[#8ab4f8]">$ </span>
+          {parsed.command}
+        </pre>
+        {detail ? (
+          <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--dsw-label)]">
+            {detail}
+          </pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  if (parsed.kind === 'view') {
+    return (
+      <div className="space-y-2">
+        <div className="font-mono text-[11px] text-[var(--dsw-label-3)]">
+          {parsed.path}
+          {parsed.viewRange ? `:${parsed.viewRange[0]}-${parsed.viewRange[1]}` : ''}
+        </div>
+        {detail ? (
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5">
+            {detail}
+          </pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {rawArguments ? (
+        <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-2)]">{rawArguments}</pre>
+      ) : null}
+      {detail ? <pre className="whitespace-pre-wrap font-mono text-[11px]">{detail}</pre> : null}
+    </div>
+  )
+}
+
+export function ToolCard({
+  node,
+  onInspect,
+}: {
+  node: Extract<ChatNode, { kind: 'tool' }>
+  onInspect: (callId: string) => void
+}) {
+  const parsed = useMemo(() => parseToolCall(node.name, node.arguments), [node.name, node.arguments])
+  const [open, setOpen] = useState(() => shouldAutoOpenTool(parsed))
+  const summary = toolSummary(parsed, node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…')
+  const title = toolTitle(parsed, node.name)
+  const previewLines = useMemo(() => {
+    if (parsed.kind !== 'str_replace' || open) return null
+    return lineDiff(parsed.oldStr, parsed.newStr).filter((line) => line.type !== 'equal').slice(0, 4)
+  }, [parsed, open])
+
+  return (
+    <div className="w-full self-stretch">
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-black/[0.03]"
+          onClick={() => setOpen((value) => !value)}
+        >
+          <span className="grid size-4 place-items-center text-[10px] text-[var(--dsw-label-3)]">{open ? '▾' : '▸'}</span>
+          <span className="font-medium text-[var(--dsw-label)]">{title}</span>
+          <span className="text-[var(--dsw-label-3)]">·</span>
+          <span className="min-w-0 flex-1 truncate font-mono text-[12px] text-[var(--dsw-label-3)]">{summary}</span>
+          {node.result ? (
+            <span className={node.result.ok ? 'text-[var(--dsw-ok)]' : 'text-[var(--dsw-danger)]'}>
+              {node.result.ok ? 'ok' : 'fail'}
+            </span>
+          ) : (
+            <span className="text-[var(--dsw-label-3)]">running</span>
+          )}
+        </button>
+        <button
+          type="button"
+          className="shrink-0 rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-business)] hover:bg-[var(--dsw-business-soft)]"
+          onClick={() => onInspect(node.callId)}
+        >
+          Trajectory
+        </button>
+      </div>
+      {!open && previewLines && previewLines.length > 0 ? (
+        <div className="mt-1 px-2">
+          <DiffBlock path={parsed.kind === 'str_replace' ? parsed.path : undefined} lines={previewLines} />
+        </div>
+      ) : null}
+      {open ? (
+        <div className="mt-1 px-2">
+          <ToolBody parsed={parsed} rawArguments={node.arguments} detail={node.result?.detail} />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/plugins/contributors/chat/tool-format.test.ts
+++ b/src/plugins/contributors/chat/tool-format.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { diffStats, lineDiff, parseToolCall, toolSummary } from './tool-format.ts'
+
+test('lineDiff marks removals and additions', () => {
+  const lines = lineDiff('a\nb\nc', 'a\nx\nc')
+  assert.deepEqual(
+    lines.map((line) => [line.type, line.text]),
+    [
+      ['equal', 'a'],
+      ['remove', 'b'],
+      ['add', 'x'],
+      ['equal', 'c'],
+    ],
+  )
+  assert.deepEqual(diffStats(lines), { added: 1, removed: 1 })
+})
+
+test('parseToolCall understands str_replace_editor str_replace', () => {
+  const parsed = parseToolCall(
+    'str_replace_editor',
+    JSON.stringify({
+      command: 'str_replace',
+      path: 'src/a.ts',
+      old_str: 'foo',
+      new_str: 'bar',
+    }),
+  )
+  assert.equal(parsed.kind, 'str_replace')
+  if (parsed.kind !== 'str_replace') return
+  assert.equal(parsed.path, 'src/a.ts')
+  assert.equal(parsed.oldStr, 'foo')
+  assert.equal(parsed.newStr, 'bar')
+  assert.equal(toolSummary(parsed, ''), 'Edited src/a.ts')
+})
+
+test('parseToolCall understands bash command', () => {
+  const parsed = parseToolCall('bash', JSON.stringify({ command: 'ls -la' }))
+  assert.equal(parsed.kind, 'bash')
+  if (parsed.kind !== 'bash') return
+  assert.equal(parsed.command, 'ls -la')
+})
+
+test('parseToolCall create/insert', () => {
+  const created = parseToolCall(
+    'str_replace_editor',
+    JSON.stringify({ command: 'create', path: 'n.ts', file_text: 'hi' }),
+  )
+  assert.equal(created.kind, 'create')
+  const inserted = parseToolCall(
+    'str_replace_editor',
+    JSON.stringify({ command: 'insert', path: 'n.ts', insert_line: 2, new_str: 'x' }),
+  )
+  assert.equal(inserted.kind, 'insert')
+})

--- a/src/plugins/contributors/chat/tool-format.ts
+++ b/src/plugins/contributors/chat/tool-format.ts
@@ -1,0 +1,186 @@
+export type DiffLine = { type: 'add' | 'remove' | 'equal'; text: string }
+
+export type ParsedToolCall =
+  | { kind: 'str_replace'; path: string; oldStr: string; newStr: string }
+  | { kind: 'create'; path: string; fileText: string }
+  | { kind: 'insert'; path: string; insertLine: number; newStr: string }
+  | { kind: 'view'; path: string; viewRange?: [number, number] }
+  | { kind: 'bash'; command: string }
+  | { kind: 'raw'; label: string; raw: string }
+
+const DIFF_LINE_CAP = 400
+
+/** 行级 LCS diff；超大块退化为整段删除 + 整段新增，避免卡 UI。 */
+export function lineDiff(oldText: string, newText: string): DiffLine[] {
+  if (oldText === newText) {
+    return oldText === '' ? [] : oldText.split('\n').map((text) => ({ type: 'equal' as const, text }))
+  }
+  const a = oldText.split('\n')
+  const b = newText.split('\n')
+  if (a.length * b.length > DIFF_LINE_CAP * DIFF_LINE_CAP) {
+    return [
+      ...a.map((text) => ({ type: 'remove' as const, text })),
+      ...b.map((text) => ({ type: 'add' as const, text })),
+    ]
+  }
+
+  const n = a.length
+  const m = b.length
+  const dp: Uint16Array[] = Array.from({ length: n + 1 }, () => new Uint16Array(m + 1))
+  for (let i = n - 1; i >= 0; i -= 1) {
+    for (let j = m - 1; j >= 0; j -= 1) {
+      dp[i]![j] = a[i] === b[j] ? (dp[i + 1]![j + 1]! + 1) : Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!)
+    }
+  }
+
+  const out: DiffLine[] = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ type: 'equal', text: a[i]! })
+      i += 1
+      j += 1
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      out.push({ type: 'remove', text: a[i]! })
+      i += 1
+    } else {
+      out.push({ type: 'add', text: b[j]! })
+      j += 1
+    }
+  }
+  while (i < n) {
+    out.push({ type: 'remove', text: a[i]! })
+    i += 1
+  }
+  while (j < m) {
+    out.push({ type: 'add', text: b[j]! })
+    j += 1
+  }
+  return out
+}
+
+function parseJsonObject(raw: string): Record<string, unknown> | null {
+  const text = raw.trim()
+  if (!text.startsWith('{')) return null
+  try {
+    const value = JSON.parse(text) as unknown
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+    return value as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined
+}
+
+function asInt(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value)) return value
+  if (typeof value === 'string' && /^-?\d+$/.test(value)) return Number(value)
+  return undefined
+}
+
+export function parseToolCall(name: string, argumentsJson: string): ParsedToolCall {
+  const args = parseJsonObject(argumentsJson)
+
+  if (name === 'bash' || name === 'shell' || name === 'run_terminal_cmd') {
+    const command = asString(args?.command) ?? asString(args?.cmd) ?? argumentsJson.trim()
+    return { kind: 'bash', command }
+  }
+
+  if (name === 'str_replace_editor' || name === 'StrReplace' || name === 'str_replace') {
+    const command = asString(args?.command) ?? (name === 'str_replace' || name === 'StrReplace' ? 'str_replace' : undefined)
+    const path = asString(args?.path) ?? asString(args?.file_path) ?? 'unknown'
+    if (command === 'str_replace' || (!command && asString(args?.old_str) != null)) {
+      return {
+        kind: 'str_replace',
+        path,
+        oldStr: asString(args?.old_str) ?? asString(args?.old_string) ?? '',
+        newStr: asString(args?.new_str) ?? asString(args?.new_string) ?? '',
+      }
+    }
+    if (command === 'create') {
+      return { kind: 'create', path, fileText: asString(args?.file_text) ?? '' }
+    }
+    if (command === 'insert') {
+      return {
+        kind: 'insert',
+        path,
+        insertLine: asInt(args?.insert_line) ?? 0,
+        newStr: asString(args?.new_str) ?? '',
+      }
+    }
+    if (command === 'view') {
+      const range = Array.isArray(args?.view_range) ? args.view_range : undefined
+      const start = range ? asInt(range[0]) : undefined
+      const end = range && range.length > 1 ? asInt(range[1]) : start
+      return {
+        kind: 'view',
+        path,
+        viewRange: start != null && end != null ? [start, end] : undefined,
+      }
+    }
+  }
+
+  if (name === 'fs_write' || name === 'Write') {
+    const path = asString(args?.path) ?? asString(args?.file_path) ?? 'unknown'
+    const fileText = asString(args?.contents) ?? asString(args?.content) ?? asString(args?.file_text) ?? ''
+    return { kind: 'create', path, fileText }
+  }
+
+  return { kind: 'raw', label: name, raw: argumentsJson }
+}
+
+export function toolSummary(parsed: ParsedToolCall, fallback: string): string {
+  switch (parsed.kind) {
+    case 'str_replace':
+      return `Edited ${parsed.path}`
+    case 'create':
+      return `Created ${parsed.path}`
+    case 'insert':
+      return `Inserted @${parsed.insertLine} · ${parsed.path}`
+    case 'view':
+      return parsed.viewRange
+        ? `View ${parsed.path}:${parsed.viewRange[0]}-${parsed.viewRange[1]}`
+        : `View ${parsed.path}`
+    case 'bash': {
+      const one = parsed.command.replace(/\s+/g, ' ').trim()
+      return one.length > 72 ? `${one.slice(0, 72)}…` : one || fallback
+    }
+    case 'raw':
+      return fallback
+  }
+}
+
+export function toolTitle(parsed: ParsedToolCall, name: string): string {
+  switch (parsed.kind) {
+    case 'str_replace':
+      return 'Edit'
+    case 'create':
+      return 'Create'
+    case 'insert':
+      return 'Insert'
+    case 'view':
+      return 'View'
+    case 'bash':
+      return 'Bash'
+    case 'raw':
+      return name
+  }
+}
+
+export function shouldAutoOpenTool(parsed: ParsedToolCall): boolean {
+  return parsed.kind === 'str_replace' || parsed.kind === 'create' || parsed.kind === 'insert'
+}
+
+export function diffStats(lines: DiffLine[]): { added: number; removed: number } {
+  let added = 0
+  let removed = 0
+  for (const line of lines) {
+    if (line.type === 'add') added += 1
+    else if (line.type === 'remove') removed += 1
+  }
+  return { added, removed }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
优化聊天里工具调用的展示，尤其是极简模式的 `str_replace_editor`：

- **str_replace**：行级 diff，红色 − / 绿色 +，带路径与 ± 统计
- **create / insert**：按新增行展示
- **bash**：终端风格命令 + 输出块
- 编辑类工具默认展开；不再把原始 JSON 参数直接糊给用户

含 `tool-format` 单测。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

