### PR TITLE
feat: 美化 bash/工具结果的 JSON 展示

### DIFF
--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -2,12 +2,15 @@ import { useMemo, useState } from 'react'
 import type { ChatNode } from '../../infrastructure/session-project.ts'
 import {
   diffStats,
+  formatToolDetail,
   lineDiff,
   parseToolCall,
+  prettyJsonString,
   shouldAutoOpenTool,
   toolSummary,
   toolTitle,
   type DiffLine,
+  type FormattedDetail,
   type ParsedToolCall,
 } from './tool-format.ts'
 
@@ -46,14 +49,57 @@ function DiffBlock({ lines, path }: { lines: DiffLine[]; path?: string }) {
   )
 }
 
+function DetailView({ detail }: { detail: FormattedDetail }) {
+  if (detail.kind === 'bash') {
+    const hasOut = Boolean(detail.stdout)
+    const hasErr = Boolean(detail.stderr)
+    return (
+      <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-[#1e1f24]">
+        <div className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-1.5">
+          <span className="font-mono text-[10px] tracking-wide text-white/45 uppercase">output</span>
+          <span
+            className={`font-mono text-[10px] tabular-nums ${
+              detail.code === 0 || detail.code == null ? 'text-[#7dcea0]' : 'text-[#f1948a]'
+            }`}
+          >
+            exit {detail.code ?? '—'}
+          </span>
+        </div>
+        <pre className="max-h-72 overflow-auto px-3 py-2 font-mono text-[11px] leading-5 text-[#e8eaed]">
+          {hasOut ? <span className="whitespace-pre-wrap">{detail.stdout.replace(/\n$/, '')}</span> : null}
+          {hasOut && hasErr ? '\n\n' : null}
+          {hasErr ? <span className="whitespace-pre-wrap text-[#f5b7b1]">{detail.stderr.replace(/\n$/, '')}</span> : null}
+          {!hasOut && !hasErr ? <span className="text-white/35">(empty)</span> : null}
+        </pre>
+      </div>
+    )
+  }
+
+  if (detail.kind === 'json') {
+    return (
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--dsw-label-2)]">
+        {detail.text}
+      </pre>
+    )
+  }
+
+  return (
+    <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--dsw-label)]">
+      {detail.text}
+    </pre>
+  )
+}
+
 function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; rawArguments: string; detail?: string }) {
+  const formatted = formatToolDetail(detail, parsed.kind)
+
   if (parsed.kind === 'str_replace') {
     const lines = lineDiff(parsed.oldStr, parsed.newStr)
     return (
       <div className="space-y-2">
         <DiffBlock path={parsed.path} lines={lines} />
-        {detail && !detail.startsWith('The file ') ? (
-          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        {formatted && formatted.kind === 'text' && !formatted.text.startsWith('The file ') ? (
+          <DetailView detail={formatted} />
         ) : null}
       </div>
     )
@@ -64,8 +110,8 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
     return (
       <div className="space-y-2">
         <DiffBlock path={parsed.path} lines={lines} />
-        {detail && !detail.startsWith('File created') ? (
-          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        {formatted && formatted.kind === 'text' && !formatted.text.startsWith('File created') ? (
+          <DetailView detail={formatted} />
         ) : null}
       </div>
     )
@@ -76,8 +122,8 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
     return (
       <div className="space-y-2">
         <DiffBlock path={`${parsed.path} · after line ${parsed.insertLine}`} lines={lines} />
-        {detail && !detail.startsWith('The file ') ? (
-          <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-3)]">{detail}</pre>
+        {formatted && formatted.kind === 'text' && !formatted.text.startsWith('The file ') ? (
+          <DetailView detail={formatted} />
         ) : null}
       </div>
     )
@@ -90,11 +136,7 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
           <span className="text-[#8ab4f8]">$ </span>
           {parsed.command}
         </pre>
-        {detail ? (
-          <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--dsw-label)]">
-            {detail}
-          </pre>
-        ) : null}
+        {formatted ? <DetailView detail={formatted} /> : null}
       </div>
     )
   }
@@ -106,11 +148,7 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
           {parsed.path}
           {parsed.viewRange ? `:${parsed.viewRange[0]}-${parsed.viewRange[1]}` : ''}
         </div>
-        {detail ? (
-          <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5">
-            {detail}
-          </pre>
-        ) : null}
+        {formatted ? <DetailView detail={formatted} /> : null}
       </div>
     )
   }
@@ -118,9 +156,11 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
   return (
     <div className="space-y-2">
       {rawArguments ? (
-        <pre className="whitespace-pre-wrap font-mono text-[11px] text-[var(--dsw-label-2)]">{rawArguments}</pre>
+        <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-2 font-mono text-[11px] leading-5 text-[var(--dsw-label-2)]">
+          {prettyJsonString(rawArguments)}
+        </pre>
       ) : null}
-      {detail ? <pre className="whitespace-pre-wrap font-mono text-[11px]">{detail}</pre> : null}
+      {formatted ? <DetailView detail={formatted} /> : null}
     </div>
   )
 }

--- a/src/plugins/contributors/chat/tool-format.test.ts
+++ b/src/plugins/contributors/chat/tool-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { diffStats, lineDiff, parseToolCall, toolSummary } from './tool-format.ts'
+import { diffStats, formatToolDetail, lineDiff, parseToolCall, prettyJsonString, toolSummary } from './tool-format.ts'
 
 test('lineDiff marks removals and additions', () => {
   const lines = lineDiff('a\nb\nc', 'a\nx\nc')
@@ -52,4 +52,28 @@ test('parseToolCall create/insert', () => {
     JSON.stringify({ command: 'insert', path: 'n.ts', insert_line: 2, new_str: 'x' }),
   )
   assert.equal(inserted.kind, 'insert')
+})
+
+test('formatToolDetail unwraps bash stdout/stderr json', () => {
+  const formatted = formatToolDetail(
+    JSON.stringify({ code: 0, stdout: 'hello\nworld\n', stderr: '' }),
+    'bash',
+  )
+  assert.equal(formatted?.kind, 'bash')
+  if (formatted?.kind !== 'bash') return
+  assert.equal(formatted.code, 0)
+  assert.equal(formatted.stdout, 'hello\nworld\n')
+  assert.equal(formatted.stderr, '')
+})
+
+test('formatToolDetail pretty-prints generic json objects', () => {
+  const formatted = formatToolDetail('{"a":1,"b":[2,3]}')
+  assert.equal(formatted?.kind, 'json')
+  if (formatted?.kind !== 'json') return
+  assert.match(formatted.text, /\n/)
+  assert.match(formatted.text, /"a": 1/)
+})
+
+test('prettyJsonString indents objects', () => {
+  assert.match(prettyJsonString('{"x":1}'), /"x": 1/)
 })

--- a/src/plugins/contributors/chat/tool-format.ts
+++ b/src/plugins/contributors/chat/tool-format.ts
@@ -72,6 +72,66 @@ function parseJsonObject(raw: string): Record<string, unknown> | null {
   }
 }
 
+function parseJsonValue(raw: string): unknown | undefined {
+  const text = raw.trim()
+  if (!text || (text[0] !== '{' && text[0] !== '[' && text[0] !== '"' && text !== 'true' && text !== 'false' && text !== 'null' && !/^-?\d/.test(text))) {
+    return undefined
+  }
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+/** 把工具结果里的 JSON 变得可读；bash 特判 stdout/stderr。 */
+export type FormattedDetail =
+  | { kind: 'bash'; code: number | null; stdout: string; stderr: string }
+  | { kind: 'text'; text: string }
+  | { kind: 'json'; text: string }
+
+export function formatToolDetail(detail: string | undefined, toolKind?: ParsedToolCall['kind']): FormattedDetail | null {
+  if (detail == null || detail === '') return null
+  const trimmed = detail.trim()
+
+  if (toolKind === 'bash' || trimmed.startsWith('{')) {
+    const obj = parseJsonObject(trimmed)
+    if (obj && ('stdout' in obj || 'stderr' in obj || 'code' in obj)) {
+      const codeRaw = obj.code
+      const code =
+        typeof codeRaw === 'number'
+          ? codeRaw
+          : codeRaw === null
+            ? null
+            : typeof codeRaw === 'string' && /^-?\d+$/.test(codeRaw)
+              ? Number(codeRaw)
+              : null
+      return {
+        kind: 'bash',
+        code,
+        stdout: typeof obj.stdout === 'string' ? obj.stdout : obj.stdout != null ? String(obj.stdout) : '',
+        stderr: typeof obj.stderr === 'string' ? obj.stderr : obj.stderr != null ? String(obj.stderr) : '',
+      }
+    }
+  }
+
+  const parsed = parseJsonValue(trimmed)
+  if (parsed !== undefined && (typeof parsed === 'object' || Array.isArray(parsed))) {
+    return { kind: 'json', text: JSON.stringify(parsed, null, 2) }
+  }
+  return { kind: 'text', text: detail }
+}
+
+export function prettyJsonString(raw: string): string {
+  const parsed = parseJsonValue(raw)
+  if (parsed === undefined) return raw
+  try {
+    return JSON.stringify(parsed, null, 2)
+  } catch {
+    return raw
+  }
+}
+
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
美化工具结果里的原始 JSON：

- **bash**：解析 `{code, stdout, stderr}`，暗色 output 面板展示纯文本，并显示 `exit N`
- **其它工具**：对象/数组结果自动 `JSON.stringify(..., null, 2)` 缩进
- 通用 raw arguments 同样 pretty-print

含单测；截图验证中。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

