### PR TITLE
ui: 绑定后去掉 cwd 与解绑叉

### DIFF
--- a/src/plugins/contributors/chat/project-panel.tsx
+++ b/src/plugins/contributors/chat/project-panel.tsx
@@ -30,20 +30,7 @@ export function SessionProjectPanel(props: SlotProps) {
       >
         <FolderGlyph />
         <span className="project-chip-name">{project?.name ?? 'Bind project'}</span>
-        {project ? <span className="project-chip-hint">cwd</span> : null}
       </button>
-      {project ? (
-        <button
-          type="button"
-          className="project-chip-unbind"
-          disabled={busy}
-          title="Unbind workspace"
-          aria-label="Unbind workspace"
-          onClick={() => void projectView.unbindFolder()}
-        >
-          ×
-        </button>
-      ) : null}
       {error ? <span className="project-chip-error" title={error}>!</span> : null}
     </div>
   )

--- a/src/style.css
+++ b/src/style.css
@@ -286,37 +286,6 @@ body {
   font-weight: 550;
 }
 
-.project-chip-hint {
-  flex-shrink: 0;
-  border-radius: 999px;
-  background: transparent;
-  padding: 1px 6px;
-  color: var(--dsw-label-3);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.project-chip-unbind {
-  display: grid;
-  width: 22px;
-  height: 22px;
-  place-items: center;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--dsw-label-3);
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.project-chip-unbind:hover:not(:disabled) {
-  background: transparent;
-  color: var(--dsw-danger);
-}
-
 .project-chip-error {
   color: var(--dsw-danger);
   font-size: 12px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
绑定文件夹后，项目胶囊只保留文件夹图标 + 名称，去掉 `cwd` 标签和右侧 `×` 解绑按钮。仍可点击胶囊重新选目录。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

