### PR TITLE
feat: session 持久化改用 SQLite

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -193,28 +193,17 @@ export function apply(ctx: Context) {
     route.send(201, { id: record.id, version: record.version })
   })
   ctx.http.route('GET', '/api/sessions', async (route) => {
-    const ids = await ctx.sessions.list()
-    const items = []
-    for (const id of ids) {
-      const record = await ctx.sessions.get(id)
-      if (!record) continue
-      const users = record.events.filter((event) => event.type === 'user/message')
-      const lastUser = users.at(-1)
-      const title =
-        lastUser && 'text' in lastUser && typeof lastUser.text === 'string'
-          ? lastUser.text.slice(0, 48) || id.slice(0, 8)
-          : id.slice(0, 8)
-      items.push({
-        id,
-        version: record.version,
-        eventCount: record.events.length,
-        title,
-        updatedAt: record.events.at(-1)?.ts ?? 0,
-        ...(record.project ? { project: record.project } : {}),
-      })
-    }
-    items.sort((a, b) => b.updatedAt - a.updatedAt)
-    route.send(200, { sessions: items })
+    const items = await ctx.sessions.listSummaries()
+    route.send(200, {
+      sessions: items.map((item) => ({
+        id: item.id,
+        version: item.version,
+        eventCount: item.eventCount,
+        title: item.title,
+        updatedAt: item.updatedAt,
+        ...(item.project ? { project: item.project } : {}),
+      })),
+    })
   })
   ctx.http.route('GET', '/api/sessions/:id', async (route) => {
     const record = await ctx.sessions.get(route.params.id)

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -45,9 +45,20 @@ export interface SessionRecord {
   project?: SessionProject
 }
 
+/** 侧栏列表用：不必加载整段 events。 */
+export interface SessionSummary {
+  id: string
+  version: number
+  eventCount: number
+  title: string
+  updatedAt: number
+  project?: SessionProject
+}
+
 export interface SessionStore {
   load(id: string): Promise<SessionRecord | undefined>
   save(record: SessionRecord): Promise<void>
   list(): Promise<string[]>
+  listSummaries(): Promise<SessionSummary[]>
   delete(id: string): Promise<boolean>
 }

--- a/host/plugins/core/sessions.test.ts
+++ b/host/plugins/core/sessions.test.ts
@@ -64,6 +64,47 @@ test('json session store round-trips versioned records', async () => {
   assert.equal(loaded?.events.some((item) => item.type === 'user/message'), true)
 })
 
+test('sqlite session store round-trips and listSummaries skips full reload', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'cordis-sqlite-'))
+  const path = join(dir, 'sessions.sqlite')
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'sqlite', path, dir: join(dir, 'json') })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create('sql1')
+  await ctx.sessions.append('sql1', { type: 'user/message', text: 'sqlite hi', kind: 'wake' })
+  await ctx.sessions.append('sql1', { type: 'assistant/message', text: 'ok' })
+  await ctx.sessions.append('sql1', { type: 'turn/end', turn: 1, reason: 'complete' })
+  const summaries = await ctx.sessions.listSummaries()
+  assert.equal(summaries[0]?.id, 'sql1')
+  assert.equal(summaries[0]?.title, 'sqlite hi')
+  assert.equal(summaries[0]?.eventCount, 4)
+
+  const ctx2 = new Context()
+  await ctx2.plugin(sessionStore, { driver: 'sqlite', path, dir: join(dir, 'json') })
+  await ctx2.plugin(sessions)
+  const loaded = await ctx2.sessions.get('sql1')
+  assert.equal(loaded?.id, record.id)
+  assert.equal(loaded?.events.length, 4)
+  assert.equal(loaded?.events.some((item) => item.type === 'assistant/message' && item.text === 'ok'), true)
+})
+
+test('sqlite migrates legacy json sessions once', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'cordis-migrate-'))
+  const jsonDir = join(dir, 'sessions')
+  const path = join(dir, 'sessions.sqlite')
+  const ctxJson = new Context()
+  await ctxJson.plugin(sessionStore, { driver: 'json', dir: jsonDir })
+  await ctxJson.plugin(sessions)
+  await ctxJson.sessions.create('legacy1')
+  await ctxJson.sessions.append('legacy1', { type: 'user/message', text: 'from json', kind: 'wake' })
+
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'sqlite', path, dir: jsonDir })
+  await ctx.plugin(sessions)
+  const loaded = await ctx.sessions.get('legacy1')
+  assert.equal(loaded?.events.some((item) => item.type === 'user/message' && item.text === 'from json'), true)
+})
+
 test('fork copies the append-only log into a child session', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'memory' })

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -130,6 +130,10 @@ export class SessionsService extends Service {
     return this.ctx.sessionStore.list()
   }
 
+  listSummaries() {
+    return this.ctx.sessionStore.listSummaries()
+  }
+
   async delete(id: string) {
     this.clearPersistTimer(id)
     this.cache.delete(id)

--- a/host/plugins/storage/session-store.ts
+++ b/host/plugins/storage/session-store.ts
@@ -2,7 +2,32 @@ import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
-import { SESSION_FORMAT_VERSION, type SessionRecord, type SessionStore } from '../core/session-types.ts'
+import {
+  SESSION_FORMAT_VERSION,
+  type SessionEvent,
+  type SessionRecord,
+  type SessionStore,
+  type SessionSummary,
+} from '../core/session-types.ts'
+
+function deriveTitle(events: SessionEvent[], fallbackId: string): string {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i]
+    if (event?.type === 'user/message' && event.text.trim()) return event.text.slice(0, 48)
+  }
+  return fallbackId.slice(0, 8)
+}
+
+function toSummary(record: SessionRecord): SessionSummary {
+  return {
+    id: record.id,
+    version: record.version,
+    eventCount: record.events.length,
+    title: deriveTitle(record.events, record.id),
+    updatedAt: record.events.at(-1)?.ts ?? 0,
+    ...(record.project ? { project: record.project } : {}),
+  }
+}
 
 export class MemorySessionStore implements SessionStore {
   private records = new Map<string, SessionRecord>()
@@ -17,6 +42,10 @@ export class MemorySessionStore implements SessionStore {
 
   async list() {
     return [...this.records.keys()]
+  }
+
+  async listSummaries() {
+    return [...this.records.values()].map(toSummary).sort((a, b) => b.updatedAt - a.updatedAt)
   }
 
   async delete(id: string) {
@@ -60,6 +89,16 @@ export class JsonSessionStore implements SessionStore {
     }
   }
 
+  async listSummaries() {
+    const ids = await this.list()
+    const items: SessionSummary[] = []
+    for (const id of ids) {
+      const record = await this.load(id)
+      if (record) items.push(toSummary(record))
+    }
+    return items.sort((a, b) => b.updatedAt - a.updatedAt)
+  }
+
   async delete(id: string) {
     try {
       await unlink(this.file(id))
@@ -91,6 +130,10 @@ export class SessionStoreService extends Service implements SessionStore {
     return this.inner.list()
   }
 
+  listSummaries() {
+    return this.inner.listSummaries()
+  }
+
   delete(id: string) {
     return this.inner.delete(id)
   }
@@ -99,11 +142,25 @@ export class SessionStoreService extends Service implements SessionStore {
 export const name = 'session-store'
 export const inject = [] as const
 
-export function apply(ctx: Context, config: { driver?: 'memory' | 'json'; dir?: string } = {}) {
-  const driver = config.driver ?? (process.env.CORDIS_SESSION_STORE === 'memory' ? 'memory' : 'json')
-  const inner =
-    driver === 'memory'
-      ? new MemorySessionStore()
-      : new JsonSessionStore(config.dir ?? join(process.cwd(), '.cordis', 'sessions'))
+export type SessionStoreDriver = 'memory' | 'json' | 'sqlite'
+
+export async function apply(
+  ctx: Context,
+  config: { driver?: SessionStoreDriver; dir?: string; path?: string } = {},
+) {
+  const envDriver = process.env.CORDIS_SESSION_STORE as SessionStoreDriver | undefined
+  const driver = config.driver ?? (envDriver === 'memory' || envDriver === 'json' || envDriver === 'sqlite' ? envDriver : 'sqlite')
+  const jsonDir = config.dir ?? join(process.cwd(), '.cordis', 'sessions')
+  const sqlitePath = config.path ?? join(process.cwd(), '.cordis', 'sessions.sqlite')
+
+  let inner: SessionStore
+  if (driver === 'memory') {
+    inner = new MemorySessionStore()
+  } else if (driver === 'json') {
+    inner = new JsonSessionStore(jsonDir)
+  } else {
+    const { ensureSqliteSessionStore } = await import('./sqlite-session-store.ts')
+    inner = await ensureSqliteSessionStore(sqlitePath, jsonDir)
+  }
   new SessionStoreService(ctx, inner)
 }

--- a/host/plugins/storage/sqlite-session-store.ts
+++ b/host/plugins/storage/sqlite-session-store.ts
@@ -1,0 +1,259 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import {
+  SESSION_FORMAT_VERSION,
+  type SessionEvent,
+  type SessionProject,
+  type SessionRecord,
+  type SessionStore,
+  type SessionSummary,
+} from '../core/session-types.ts'
+
+type DatabaseSync = import('node:sqlite').DatabaseSync
+
+const require = createRequire(import.meta.url)
+
+type SessionRow = {
+  id: string
+  version: number
+  project_json: string | null
+  event_count: number
+  title: string
+  updated_at: number
+}
+
+function deriveTitle(events: SessionEvent[], fallbackId: string): string {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const event = events[i]
+    if (event?.type === 'user/message' && event.text.trim()) return event.text.slice(0, 48)
+  }
+  return fallbackId.slice(0, 8)
+}
+
+function parseProject(raw: string | null): SessionProject | undefined {
+  if (!raw) return undefined
+  try {
+    return JSON.parse(raw) as SessionProject
+  } catch {
+    return undefined
+  }
+}
+
+/** SQLite session store：事件分行增量写入，避免整包 JSON 反复落盘。 */
+export class SqliteSessionStore implements SessionStore {
+  private db!: DatabaseSync
+
+  constructor(private path: string) {}
+
+  /** 懒打开，便于 apply() 里先 mkdir 再 init。 */
+  open() {
+    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
+    this.db = new DatabaseSync(this.path)
+    this.db.exec('PRAGMA journal_mode = WAL')
+    this.db.exec('PRAGMA synchronous = NORMAL')
+    this.db.exec('PRAGMA foreign_keys = ON')
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        project_json TEXT,
+        event_count INTEGER NOT NULL DEFAULT 0,
+        title TEXT NOT NULL DEFAULT '',
+        updated_at INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS events (
+        session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        ts INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        event_json TEXT NOT NULL,
+        PRIMARY KEY (session_id, seq)
+      );
+      CREATE INDEX IF NOT EXISTS events_session_seq ON events(session_id, seq);
+    `)
+    return this
+  }
+
+  async load(id: string): Promise<SessionRecord | undefined> {
+    const row = this.db.prepare('SELECT id, version, project_json FROM sessions WHERE id = ?').get(id) as
+      | Pick<SessionRow, 'id' | 'version' | 'project_json'>
+      | undefined
+    if (!row) return undefined
+    if (row.version !== SESSION_FORMAT_VERSION) {
+      throw new Error(`unsupported session version ${row.version}`)
+    }
+    const eventRows = this.db
+      .prepare('SELECT event_json FROM events WHERE session_id = ? ORDER BY seq ASC')
+      .all(id) as Array<{ event_json: string }>
+    const events = eventRows.map((item) => JSON.parse(item.event_json) as SessionEvent)
+    const project = parseProject(row.project_json)
+    return {
+      id: row.id,
+      version: row.version,
+      events,
+      ...(project ? { project } : {}),
+    }
+  }
+
+  async save(record: SessionRecord): Promise<void> {
+    if (record.version !== SESSION_FORMAT_VERSION) {
+      throw new Error(`unsupported session version ${record.version}`)
+    }
+    const title = deriveTitle(record.events, record.id)
+    const updatedAt = record.events.at(-1)?.ts ?? Date.now()
+    const projectJson = record.project ? JSON.stringify(record.project) : null
+    const eventCount = record.events.length
+
+    const insertEvent = this.db.prepare(
+      'INSERT INTO events (session_id, seq, ts, type, event_json) VALUES (?, ?, ?, ?, ?)',
+    )
+    const upsertSession = this.db.prepare(`
+      INSERT INTO sessions (id, version, project_json, event_count, title, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        version = excluded.version,
+        project_json = excluded.project_json,
+        event_count = excluded.event_count,
+        title = excluded.title,
+        updated_at = excluded.updated_at
+    `)
+
+    const existing = this.db.prepare('SELECT event_count FROM sessions WHERE id = ?').get(record.id) as
+      | { event_count: number }
+      | undefined
+    const storedCount = existing?.event_count ?? 0
+
+    const replaceAll = () => {
+      this.db.prepare('DELETE FROM events WHERE session_id = ?').run(record.id)
+      for (const event of record.events) {
+        insertEvent.run(record.id, event.seq, event.ts, event.type, JSON.stringify(event))
+      }
+    }
+
+    const appendTail = (from: number) => {
+      for (let i = from; i < record.events.length; i += 1) {
+        const event = record.events[i]!
+        insertEvent.run(record.id, event.seq, event.ts, event.type, JSON.stringify(event))
+      }
+    }
+
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      upsertSession.run(record.id, record.version, projectJson, eventCount, title, updatedAt)
+
+      if (storedCount === 0) {
+        if (eventCount > 0) replaceAll()
+      } else if (eventCount < storedCount) {
+        replaceAll()
+      } else if (eventCount === storedCount) {
+        const last = this.db
+          .prepare('SELECT seq FROM events WHERE session_id = ? ORDER BY seq DESC LIMIT 1')
+          .get(record.id) as { seq: number } | undefined
+        const expected = record.events.at(-1)?.seq
+        if (last && expected != null && last.seq !== expected) replaceAll()
+      } else {
+        const last = this.db
+          .prepare('SELECT seq FROM events WHERE session_id = ? ORDER BY seq DESC LIMIT 1')
+          .get(record.id) as { seq: number } | undefined
+        const prev = record.events[storedCount - 1]
+        if (!last || !prev || last.seq !== prev.seq) {
+          replaceAll()
+        } else {
+          appendTail(storedCount)
+        }
+      }
+      this.db.exec('COMMIT')
+    } catch (error) {
+      try {
+        this.db.exec('ROLLBACK')
+      } catch {
+        /* ignore */
+      }
+      throw error
+    }
+  }
+
+  async list(): Promise<string[]> {
+    const rows = this.db.prepare('SELECT id FROM sessions ORDER BY updated_at DESC').all() as Array<{ id: string }>
+    return rows.map((row) => row.id)
+  }
+
+  async listSummaries(): Promise<SessionSummary[]> {
+    const rows = this.db
+      .prepare(
+        'SELECT id, version, project_json, event_count, title, updated_at FROM sessions ORDER BY updated_at DESC',
+      )
+      .all() as SessionRow[]
+    return rows.map((row) => {
+      const project = parseProject(row.project_json)
+      return {
+        id: row.id,
+        version: row.version,
+        eventCount: row.event_count,
+        title: row.title || row.id.slice(0, 8),
+        updatedAt: row.updated_at,
+        ...(project ? { project } : {}),
+      }
+    })
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = this.db.prepare('DELETE FROM sessions WHERE id = ?').run(id)
+    return Number(result.changes) > 0
+  }
+
+  close() {
+    this.db.close()
+  }
+}
+
+/** 若 sqlite 为空且遗留 json 目录有数据，一次性导入。 */
+export async function migrateJsonSessionsIfNeeded(store: SqliteSessionStore, jsonDir: string) {
+  const summaries = await store.listSummaries()
+  if (summaries.length > 0) return { migrated: 0, skipped: true as const }
+
+  const marker = join(jsonDir, '.migrated-to-sqlite')
+  try {
+    await readFile(marker, 'utf8')
+    return { migrated: 0, skipped: true as const }
+  } catch {
+    /* no marker */
+  }
+
+  let names: string[] = []
+  try {
+    names = (await readdir(jsonDir)).filter((name) => name.endsWith('.json'))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { migrated: 0, skipped: true as const }
+    throw error
+  }
+
+  let migrated = 0
+  for (const name of names) {
+    const id = name.slice(0, -5)
+    try {
+      const raw = await readFile(join(jsonDir, name), 'utf8')
+      const record = JSON.parse(raw) as SessionRecord
+      if (record.version !== SESSION_FORMAT_VERSION || record.id !== id) continue
+      await store.save(record)
+      migrated += 1
+    } catch {
+      /* skip corrupt */
+    }
+  }
+
+  await mkdir(jsonDir, { recursive: true })
+  await writeFile(marker, `${new Date().toISOString()}\nmigrated=${migrated}\n`, 'utf8')
+  return { migrated, skipped: false as const }
+}
+
+export async function ensureSqliteSessionStore(path: string, jsonDir: string) {
+  await mkdir(dirname(path), { recursive: true })
+  const store = new SqliteSessionStore(path).open()
+  const result = await migrateJsonSessionsIfNeeded(store, jsonDir)
+  if (result.migrated > 0) {
+    console.info(`[session-store] migrated ${result.migrated} json session(s) → sqlite`)
+  }
+  return store
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
   },
   test: {
     environment: 'jsdom',
+    environmentMatchGlobs: [['host/**', 'node']],
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
后端 session 持久化从整文件 JSON 改为 SQLite（Node 内置 `node:sqlite`）：

- 默认 driver：`sqlite` → `.cordis/sessions.sqlite`
- 事件分行存储；append-only 热路径只增量 INSERT，不再每次重写整包
- 侧栏 `GET /api/sessions` 走 `listSummaries`，不再为列表加载全部 events
- 首次启动若 sqlite 为空，自动把 `.cordis/sessions/*.json` 迁入一次
- 仍可用 `CORDIS_SESSION_STORE=json|memory` 或 plugin config 回退

重启 host 后生效。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

