### PR TITLE
fix: 清理 TypeScript 编译报错

### DIFF
--- a/host/plugins/core/session-window.test.ts
+++ b/host/plugins/core/session-window.test.ts
@@ -1,15 +1,15 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import type { SessionEvent } from './session-types.ts'
+import type { SessionEvent, SessionEventBody } from './session-types.ts'
 import { compactSessionEvents, sliceBeforeTurns, sliceTailTurns } from './session-window.ts'
 
-function ev(partial: Omit<SessionEvent, 'ts'> & { ts?: number }): SessionEvent {
-  return { ts: partial.ts ?? partial.seq, ...partial } as SessionEvent
+function ev(partial: SessionEventBody & { seq: number; ts?: number }): SessionEvent {
+  return { ...partial, ts: partial.ts ?? partial.seq }
 }
 
 test('compactSessionEvents drops chunks superseded by message', () => {
   const out = compactSessionEvents([
-    ev({ type: 'user/message', text: 'hi', seq: 1 }),
+    ev({ type: 'user/message', text: 'hi', kind: 'wake', seq: 1 }),
     ev({ type: 'assistant/chunk', text: 'a', seq: 2 }),
     ev({ type: 'assistant/chunk', text: 'b', seq: 3 }),
     ev({ type: 'assistant/message', text: 'ab', seq: 4 }),
@@ -26,7 +26,7 @@ test('sliceTailTurns returns only last N user turns with preamble', () => {
     ev({ type: 'system/prompt', text: 'sys', seq: 1 }),
   ]
   for (let turn = 0; turn < 5; turn++) {
-    raw.push(ev({ type: 'user/message', text: `u${turn}`, seq: 10 + turn * 2 }))
+    raw.push(ev({ type: 'user/message', text: `u${turn}`, kind: 'wake', seq: 10 + turn * 2 }))
     raw.push(ev({ type: 'assistant/message', text: `a${turn}`, seq: 11 + turn * 2 }))
   }
   const window = sliceTailTurns(raw, 2)
@@ -44,7 +44,7 @@ test('sliceTailTurns returns only last N user turns with preamble', () => {
 test('sliceBeforeTurns pages older turns', () => {
   const raw: SessionEvent[] = [ev({ type: 'session/open', version: 1, seq: 0 })]
   for (let turn = 0; turn < 6; turn++) {
-    raw.push(ev({ type: 'user/message', text: `u${turn}`, seq: 10 + turn * 2 }))
+    raw.push(ev({ type: 'user/message', text: `u${turn}`, kind: 'wake', seq: 10 + turn * 2 }))
     raw.push(ev({ type: 'assistant/message', text: `a${turn}`, seq: 11 + turn * 2 }))
   }
   const tail = sliceTailTurns(raw, 2)

--- a/host/plugins/core/trajectory-index.test.ts
+++ b/host/plugins/core/trajectory-index.test.ts
@@ -1,16 +1,16 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import type { SessionEvent } from './session-types.ts'
+import type { SessionEvent, SessionEventBody } from './session-types.ts'
 import { buildTrajectoryWindow, findEvent, buildRequestMessages } from './trajectory-index.ts'
 
-function ev(partial: Omit<SessionEvent, 'ts'> & { ts?: number }): SessionEvent {
-  return { ts: partial.ts ?? partial.seq, ...partial } as SessionEvent
+function ev(partial: SessionEventBody & { seq: number; ts?: number }): SessionEvent {
+  return { ...partial, ts: partial.ts ?? partial.seq }
 }
 
 test('trajectory window returns summary rows without full bodies', () => {
   const raw: SessionEvent[] = [ev({ type: 'session/open', version: 1, seq: 0 })]
   for (let i = 0; i < 3; i++) {
-    raw.push(ev({ type: 'user/message', text: `u${i}-${'x'.repeat(200)}`, seq: 10 + i * 2 }))
+    raw.push(ev({ type: 'user/message', text: `u${i}-${'x'.repeat(200)}`, kind: 'wake', seq: 10 + i * 2 }))
     raw.push(
       ev({
         type: 'assistant/message',
@@ -30,7 +30,7 @@ test('findEvent and buildRequestMessages for assistant detail', () => {
   const raw: SessionEvent[] = [
     ev({ type: 'session/open', version: 1, seq: 0 }),
     ev({ type: 'system/prompt', text: 'sys', seq: 1 }),
-    ev({ type: 'user/message', text: 'hi', seq: 2 }),
+    ev({ type: 'user/message', text: 'hi', kind: 'wake', seq: 2 }),
     ev({ type: 'assistant/message', text: 'yo', seq: 3, usage: { inputTokens: 1, outputTokens: 1 } }),
   ]
   const event = findEvent(raw, 3)

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -77,9 +77,9 @@ export class AgentLoop implements AgentRunner {
       if (!chunkBuf) return chunkFlush
       const text = chunkBuf
       chunkBuf = ''
-      chunkFlush = chunkFlush.then(() =>
-        session.append(this.sessionId, { type: 'assistant/chunk', text }),
-      )
+      chunkFlush = chunkFlush.then(async () => {
+        await session.append(this.sessionId, { type: 'assistant/chunk', text })
+      })
       return chunkFlush
     }
 

--- a/host/plugins/orchestration/llm.stream.test.ts
+++ b/host/plugins/orchestration/llm.stream.test.ts
@@ -21,7 +21,7 @@ test('consumeChatCompletionSse yields text deltas and usage', async () => {
       'data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}\n\n',
       'data: [DONE]\n\n',
     ]),
-    { onDelta: (text) => deltas.push(text) },
+    { onDelta: (text) => { deltas.push(text) } },
   )
   assert.deepEqual(deltas, ['你', '好'])
   assert.equal(reply.content, '你好')

--- a/host/plugins/seams/workspace-pick.ts
+++ b/host/plugins/seams/workspace-pick.ts
@@ -97,8 +97,8 @@ async function pickLinux(initial?: string) {
         errors.push(String(err.message))
         continue
       }
-      // zenity cancel → exit 1
-      if (err.code === 1 || err.code === '1') throw new DirectoryPickCancelled()
+      // zenity cancel → exit 1（child_process 上 code 常为 number）
+      if (Number(err.code) === 1) throw new DirectoryPickCancelled()
       throw error
     }
   }

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -362,7 +362,9 @@ test('loadOlder prepends earlier turns', async () => {
   await view.load('s1', { view: 'chat', wait: true })
   assert.equal(view.get().hasMoreOlder, true)
   await view.loadOlder()
-  assert.equal(view.get().nodes[0]?.kind === 'user' && view.get().nodes[0].text, 'old')
+  const first = view.get().nodes[0]
+  assert.equal(first?.kind, 'user')
+  assert.equal(first && first.kind === 'user' ? first.text : undefined, 'old')
   assert.equal(view.get().hasMoreOlder, false)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复 `tsc --noEmit` 报错：

- 测试里 `Omit<SessionEvent, 'ts'>` 打散了判别联合 → 改为 `SessionEventBody & { seq; ts? }`
- `agent-loop` chunkFlush Promise 返回值
- `llm.stream` onDelta 回调返回类型
- `workspace-pick` zenity exit code 比较
- `session-view` 测试里 ChatNode 收窄

`tsc --noEmit` 与全量测试已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

