### PR TITLE
style: 项目绑定改为仅图标

### DIFF
--- a/docs/dsh-advantages.md
+++ b/docs/dsh-advantages.md
@@ -24,7 +24,7 @@
 18. **Web：运行中 Steer/inject** — agent 忙时输入仍可用，`kind: 'inject'` 入队，不搬完整 QueueDock。
 19. **Web：React Router（单向）** — `/` · `/s/:id` · `/s/:id/trajectory` · `/workspace`；URL → `applyRoute`；跳转只用 `Link`/`navigate`，无双向 bridge。**单壳常驻**：路由变化不卸载 `AppShell`；Agent/Workspace 与 Chat/Trajectory 用保活叠层（`visibility`，避免 `display:none` 丢掉大 Markdown 布局）；slot props / `renderSlot` 稳定 + Chat/Markdown `memo`，避免切换时重解析。
 20. **Web：Activity Bar 模块切换** — Agent 仅为其中一个视图；切到 Workspace 等其它页不卸载 session 投影，切回 Agent 会话仍在；Settings 挂在 Activity Bar 底部。
-21. **Web：Session 绑定项目** — Agent 顶栏右侧紧凑 **Bind project** chip（不再占大右侧栏）；点选系统目录绑定为 Session cwd。
+21. **Web：Session 绑定项目** — 对话输入上方仅文件夹图标绑定项目（不再占大右侧栏 / 不显示路径文案）；点选系统目录绑定为 Session cwd。
 22. **Agent mode（Standard / Minimal）** — Settings 可选；`minimal` 对齐 dsh：模型侧只暴露 `bash` + `str_replace_editor`；模式写入 `.cordis/chat-config.json`。
 23. **Session host cwd（对齐 dsh）** — Bind project 后 bash / str_replace_editor 以该目录为 cwd。
 24. **配置热插拔（瘦）** — 外部插件只经 `cordis.plugins.json` 加载；主仓源码不 import 具体包名。见 `docs/plugin-packages.md`。

--- a/src/plugins/contributors/chat/project-panel.tsx
+++ b/src/plugins/contributors/chat/project-panel.tsx
@@ -1,7 +1,7 @@
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindProjectView, type ProjectViewService } from '../../infrastructure/project-view.ts'
 
-/** 紧凑项目绑定：输入框上方左侧，与标准/极简胶囊同一行。 */
+/** 紧凑项目绑定：仅文件夹图标，与标准/极简胶囊同一行。 */
 export function SessionProjectPanel(props: SlotProps) {
   const useProjectView = props.useProjectView as ReturnType<typeof bindProjectView>
   const projectView = props.projectView as ProjectViewService
@@ -12,24 +12,25 @@ export function SessionProjectPanel(props: SlotProps) {
 
   if (!sessionId) {
     return (
-      <div className="project-chip project-chip-muted" title="先打开一个 Session">
+      <div className="project-chip project-chip-icon-only project-chip-muted" title="先打开一个 Session" aria-label="先打开一个 Session">
         <FolderGlyph />
-        <span>No session</span>
       </div>
     )
   }
+
+  const label = project?.path ?? '选择本机文件夹并绑定为 Session cwd'
 
   return (
     <div className="project-chip-wrap">
       <button
         type="button"
-        className={`project-chip${project ? '' : ' project-chip-empty'}${busy ? ' is-busy' : ''}`}
+        className={`project-chip project-chip-icon-only${project ? ' is-bound' : ' project-chip-empty'}${busy ? ' is-busy' : ''}`}
         disabled={busy}
-        title={project?.path ?? '选择本机文件夹并绑定为 Session cwd'}
+        title={label}
+        aria-label={project ? `已绑定 ${project.name}` : '绑定项目文件夹'}
         onClick={() => void projectView.openFolderForSession(sessionId).catch(() => undefined)}
       >
         <FolderGlyph />
-        <span className="project-chip-name">{project?.name ?? 'Bind project'}</span>
       </button>
       {error ? <span className="project-chip-error" title={error}>!</span> : null}
     </div>

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -105,8 +105,7 @@ function WorkspaceModule() {
     <div className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center">
       <h1 className="text-xl font-semibold tracking-tight text-[var(--dsw-label)]">Workspace</h1>
       <p className="max-w-md text-sm leading-6 text-[var(--dsw-label-3)]">
-        项目绑定在对话输入上方的 <strong className="font-semibold text-[var(--dsw-label-2)]">Bind project</strong>{' '}
-        胶囊：选目录后作为该 Session 的 cwd。无需单独大面板。
+        项目绑定在对话输入上方的文件夹图标：选目录后作为该 Session 的 cwd。无需单独大面板。
       </p>
     </div>
   )

--- a/src/style.css
+++ b/src/style.css
@@ -210,21 +210,18 @@ body {
   border: 0;
 }
 
-/* Compact project bind chip (dock capsules) */
+/* Compact project bind: icon-only (dock capsules) */
 .project-chip-wrap {
   display: inline-flex;
-  max-width: min(220px, 36vw);
-  flex-shrink: 1;
+  flex-shrink: 0;
   align-items: center;
   gap: 2px;
 }
 
 .project-chip {
   display: inline-flex;
-  min-width: 0;
-  max-width: 100%;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
   border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
   border-radius: 999px;
   background: color-mix(in srgb, var(--dsw-bg) 82%, transparent);
@@ -235,6 +232,12 @@ body {
   cursor: pointer;
   box-shadow: 0 4px 14px rgba(15, 17, 21, 0.06);
   backdrop-filter: blur(10px);
+}
+
+.project-chip-icon-only {
+  width: 32px;
+  height: 32px;
+  padding: 0;
 }
 
 .dock-seg {
@@ -273,17 +276,14 @@ body {
 }
 
 .project-chip-icon {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
 }
 
-.project-chip-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-weight: 550;
+.project-chip.is-bound {
+  color: var(--dsw-business);
+  border-color: color-mix(in srgb, var(--dsw-business) 35%, var(--dsw-border));
 }
 
 .project-chip-error {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更
- 对话输入上方的项目绑定控件去掉「Bind project」/ 项目名文案，只保留文件夹图标按钮
- 路径与绑定说明仍通过 `title` / `aria-label` 展示
- 已绑定态用业务色描边区分；Workspace 说明与 dsh 文档同步更新

## 验证
- `npx tsc --noEmit` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

