### PR TITLE
style: UI 切换为夜间模式

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
-<html lang="zh-CN">
+<html lang="zh-CN" class="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>DeepSeek Harness</title>
   </head>

--- a/packages/greeter-ui/src/index.tsx
+++ b/packages/greeter-ui/src/index.tsx
@@ -23,7 +23,7 @@ function HelloCard(_props: SlotProps) {
   }
 
   return (
-    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3">
+    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3">
       <h2 className="text-sm font-medium">Greeting demo</h2>
       <p className="text-xs leading-5 text-[var(--dsw-label-3)]">
         独立包 <code>@hmr/greeter-ui</code> · fetch /api/greet · 随 greeter 热插拔

--- a/src/plugins/contributors/chat/approvals.tsx
+++ b/src/plugins/contributors/chat/approvals.tsx
@@ -100,7 +100,7 @@ export function ApprovalsRail(props: SlotProps) {
                 className={`px-2.5 py-1 ${
                   agentMode === mode
                     ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
-                    : 'hover:bg-black/[0.03]'
+                    : 'hover:bg-[var(--dsw-hover)]'
                 }`}
                 onClick={() => void setMode(mode)}
               >
@@ -118,7 +118,7 @@ export function ApprovalsRail(props: SlotProps) {
               className={`px-2.5 py-1 capitalize ${
                 approvalMode === mode
                   ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
-                  : 'hover:bg-black/[0.03]'
+                  : 'hover:bg-[var(--dsw-hover)]'
               }`}
               onClick={() => void sessionView.setApprovalMode(mode)}
             >

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -89,7 +89,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         {pending ? (
           <>
             <button
-              className="rounded-full border border-[var(--dsw-border)] px-3 py-1.5 text-xs text-[var(--dsw-label-2)] hover:bg-black/5"
+              className="rounded-full border border-[var(--dsw-border)] px-3 py-1.5 text-xs text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)]"
               type="button"
               onClick={() => void sessionView.cancel()}
             >

--- a/src/plugins/contributors/chat/config.tsx
+++ b/src/plugins/contributors/chat/config.tsx
@@ -78,11 +78,11 @@ export function ChatConfig(_props: SlotProps) {
   }
 
   const field =
-    'mt-1 w-full rounded-[12px] border border-[var(--dsw-border)] bg-white px-2 py-2 text-sm text-[var(--dsw-label)] outline-none'
+    'mt-1 w-full rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-2 py-2 text-sm text-[var(--dsw-label)] outline-none'
 
   return (
     <form
-      className="space-y-3 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3"
+      className="space-y-3 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3"
       data-testid="assistant-config"
       onSubmit={onSubmit}
     >

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -62,7 +62,7 @@ function EmptyHero() {
         </span>
         <div className="flex items-center gap-2">
           <h2 className="text-2xl font-semibold tracking-tight">How can I help you?</h2>
-          <span className="rounded-full bg-black/5 px-2 py-0.5 text-[10px] font-semibold tracking-wider text-[var(--dsw-label-3)]">
+          <span className="rounded-full bg-[var(--dsw-hover)] px-2 py-0.5 text-[10px] font-semibold tracking-wider text-[var(--dsw-label-3)]">
             PREVIEW
           </span>
         </div>
@@ -84,7 +84,7 @@ function StatusRow({
   return (
     <div className="mb-4 flex items-center gap-2 text-xs text-[var(--dsw-label-3)]">
       <span
-        className={`size-2 rounded-full ${agentStatus === 'running' ? 'bg-[var(--dsw-ok)]' : 'bg-black/20'}`}
+        className={`size-2 rounded-full ${agentStatus === 'running' ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-hover-strong)]'}`}
         aria-hidden
       />
       <span>{agentStatus === 'running' ? `Running${agentStep != null ? ` · step ${agentStep}` : ''}` : 'Idle'}</span>
@@ -214,7 +214,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
         </div>
       )}
       {error ? (
-        <div className="mt-4 rounded-[12px] bg-red-50 px-3 py-2 text-sm text-[var(--dsw-danger)]">{error}</div>
+        <div className="mt-4 rounded-[12px] bg-[var(--dsw-danger-soft)] px-3 py-2 text-sm text-[var(--dsw-danger)]">{error}</div>
       ) : null}
     </div>
   )

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -17,7 +17,7 @@ import {
 function DiffBlock({ lines, path }: { lines: DiffLine[]; path?: string }) {
   const stats = diffStats(lines)
   return (
-    <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-white">
+    <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)]">
       {path ? (
         <div className="flex items-center justify-between gap-2 border-b border-[var(--dsw-border)] bg-[var(--dsw-tool)] px-3 py-1.5">
           <span className="min-w-0 truncate font-mono text-[11px] text-[var(--dsw-label-2)]">{path}</span>
@@ -186,7 +186,7 @@ export function ToolCard({
       <div className="flex items-center gap-1">
         <button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-black/[0.03]"
+          className="flex min-w-0 flex-1 items-center gap-2 rounded-[12px] px-2 py-1.5 text-left text-[13px] hover:bg-[var(--dsw-hover)]"
           onClick={() => setOpen((value) => !value)}
         >
           <span className="grid size-4 place-items-center text-[10px] text-[var(--dsw-label-3)]">{open ? '▾' : '▸'}</span>

--- a/src/plugins/contributors/clock.tsx
+++ b/src/plugins/contributors/clock.tsx
@@ -16,7 +16,7 @@ function ClockBadge(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const iso = useSnapshot((state: Snapshot) => state.clockIso)
   return (
-    <article className="space-y-1 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3">
+    <article className="space-y-1 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3">
       <h2 className="text-sm font-medium">Heartbeat</h2>
       <time className="font-mono text-sm tracking-wide text-[var(--dsw-label-3)]" dateTime={iso}>
         {formatClock(iso)}

--- a/src/plugins/contributors/notes.tsx
+++ b/src/plugins/contributors/notes.tsx
@@ -36,7 +36,7 @@ function NotesCard(_props: SlotProps) {
   }
 
   return (
-    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3">
+    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3">
       <h2 className="text-sm font-medium">Notes demo</h2>
       <p className="text-xs leading-5 text-[var(--dsw-label-3)]">POST /api/notes — unloads with notes plugin.</p>
       <form className="flex gap-2" onSubmit={onSubmit}>

--- a/src/plugins/contributors/plugin-tree.tsx
+++ b/src/plugins/contributors/plugin-tree.tsx
@@ -12,7 +12,7 @@ function PluginTree(props: SlotProps) {
   return (
     <ul className="m-0 list-none space-y-2 p-0">
       {snap.map((plugin) => (
-        <li className="rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3" key={plugin.id}>
+        <li className="rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3" key={plugin.id}>
           <div className="flex items-start justify-between gap-3">
             <div>
               <h3 className="m-0 text-sm font-medium">{plugin.name}</h3>

--- a/src/plugins/contributors/quotes.tsx
+++ b/src/plugins/contributors/quotes.tsx
@@ -6,7 +6,7 @@ export const inject = ['slots']
 
 function QuotesCard(_props: SlotProps) {
   return (
-    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-white px-3 py-3">
+    <article className="space-y-2 rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3">
       <h2 className="mb-1 text-sm font-medium">Quotes demo</h2>
       <p className="text-sm leading-6 text-[var(--dsw-label-3)]">When enabled, notes pass through notes/filter.</p>
     </article>

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -185,7 +185,7 @@ function Shell(props: SlotProps) {
             <div className="flex items-center gap-0.5">
               <button
                 type="button"
-                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-black/[0.04] hover:text-[var(--dsw-business)]"
+                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
                 title="New Session"
                 aria-label="New Session"
                 onClick={() => {
@@ -196,7 +196,7 @@ function Shell(props: SlotProps) {
               </button>
               <button
                 type="button"
-                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-black/[0.04] hover:text-[var(--dsw-business)] disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--dsw-label-3)]"
+                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--dsw-label-3)]"
                 title="Fork"
                 aria-label="Fork"
                 disabled={!sessionId}
@@ -217,7 +217,7 @@ function Shell(props: SlotProps) {
                 <div
                   key={item.id}
                   className={`group mb-1 flex w-full items-stretch rounded-[12px] ${
-                    active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-black/[0.03]'
+                    active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
                   }`}
                 >
                   <Link
@@ -334,11 +334,11 @@ function Shell(props: SlotProps) {
       </main>
 
       <div
-        className={`fixed inset-0 z-20 flex items-center justify-center bg-black/40 ${settingsOpen ? '' : 'hidden'}`}
+        className={`fixed inset-0 z-20 flex items-center justify-center bg-[var(--dsw-overlay)] ${settingsOpen ? '' : 'hidden'}`}
         onClick={() => setSettingsOpen(false)}
       >
         <div
-          className="flex h-[min(800px,calc(100vh-48px))] w-[min(800px,calc(100vw-48px))] overflow-hidden rounded-[24px] bg-white shadow-2xl"
+          className="flex h-[min(800px,calc(100vh-48px))] w-[min(800px,calc(100vw-48px))] overflow-hidden rounded-[24px] bg-[var(--dsw-surface)] shadow-2xl"
           role="dialog"
           aria-modal="true"
           onClick={(event) => event.stopPropagation()}
@@ -360,7 +360,7 @@ function Shell(props: SlotProps) {
               <h2 className="text-sm font-medium">Plugins & demos</h2>
               <button
                 type="button"
-                className="rounded-full px-2 py-1 text-sm text-[var(--dsw-label-3)] hover:bg-black/5"
+                className="rounded-full px-2 py-1 text-sm text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)]"
                 onClick={() => setSettingsOpen(false)}
               >
                 Close

--- a/src/style.css
+++ b/src/style.css
@@ -1,23 +1,30 @@
 @import "tailwindcss";
 
-/* Lean DSH tokens — mirrored from deepseek-harness ui-theme (light) */
+/* Lean DSH tokens — night / dark theme */
 :root {
-  --dsw-bg: rgb(255, 255, 255);
-  --dsw-sidebar: rgb(249, 250, 251);
-  --dsw-label: rgb(15, 17, 21);
-  --dsw-label-2: rgb(82, 88, 102);
-  --dsw-label-3: rgb(120, 126, 140);
-  --dsw-border: rgba(0, 0, 0, 0.1);
-  --dsw-bubble: rgb(237, 243, 254);
-  --dsw-business: rgb(65, 118, 230);
-  --dsw-business-soft: rgb(237, 243, 254);
-  --dsw-input: rgb(255, 255, 255);
-  --dsw-tool: rgb(249, 250, 251);
-  --dsw-danger: rgb(220, 80, 80);
-  --dsw-ok: rgb(34, 140, 90);
+  color-scheme: dark;
+  --dsw-bg: rgb(16, 17, 20);
+  --dsw-sidebar: rgb(22, 23, 27);
+  --dsw-label: rgb(232, 234, 239);
+  --dsw-label-2: rgb(168, 172, 184);
+  --dsw-label-3: rgb(120, 125, 138);
+  --dsw-border: rgba(255, 255, 255, 0.1);
+  --dsw-bubble: rgb(38, 52, 82);
+  --dsw-business: rgb(96, 148, 245);
+  --dsw-business-soft: rgba(96, 148, 245, 0.18);
+  --dsw-input: rgb(28, 29, 34);
+  --dsw-tool: rgb(28, 29, 34);
+  --dsw-surface: rgb(28, 29, 34);
+  --dsw-danger: rgb(232, 112, 112);
+  --dsw-danger-soft: rgba(232, 112, 112, 0.14);
+  --dsw-ok: rgb(74, 186, 128);
+  --dsw-hover: rgba(255, 255, 255, 0.06);
+  --dsw-hover-strong: rgba(255, 255, 255, 0.1);
+  --dsw-muted-fill: rgba(255, 255, 255, 0.04);
+  --dsw-overlay: rgba(0, 0, 0, 0.55);
   --dsw-radius-bubble: 22px;
   --dsw-radius-card: 12px;
-  --dsw-shadow-lv2: 0 1px 2px rgba(0, 0, 0, 0.04), 0 4px 16px rgba(0, 0, 0, 0.06);
+  --dsw-shadow-lv2: 0 1px 2px rgba(0, 0, 0, 0.35), 0 8px 24px rgba(0, 0, 0, 0.45);
   --dsw-chat-width: 748px;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
     "Microsoft YaHei", sans-serif;
@@ -51,7 +58,7 @@ body {
   height: 1.2rem;
   border: 0;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.12);
+  background: var(--dsw-hover-strong);
   cursor: pointer;
 }
 
@@ -63,7 +70,7 @@ body {
   width: 0.9rem;
   height: 0.9rem;
   border-radius: 999px;
-  background: #fff;
+  background: var(--dsw-label);
   transition: transform 0.16s ease;
 }
 
@@ -95,7 +102,7 @@ body {
 }
 
 .dsw-hero-glow {
-  background: radial-gradient(ellipse at center, rgba(65, 118, 230, 0.16), transparent 70%);
+  background: radial-gradient(ellipse at center, rgba(96, 148, 245, 0.22), transparent 70%);
 }
 
 /* App shell — VS Code-like activity bar + optional side bar */
@@ -191,7 +198,7 @@ body {
   width: 8px;
   height: 8px;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.2);
+  background: var(--dsw-hover-strong);
 }
 
 .app-activity-live.is-live {
@@ -230,7 +237,7 @@ body {
   font-size: 12px;
   line-height: 1.2;
   cursor: pointer;
-  box-shadow: 0 4px 14px rgba(15, 17, 21, 0.06);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
   backdrop-filter: blur(10px);
 }
 
@@ -248,14 +255,14 @@ body {
   border-radius: 999px;
   background: color-mix(in srgb, var(--dsw-bg) 82%, transparent);
   backdrop-filter: blur(10px);
-  box-shadow: 0 4px 14px rgba(15, 17, 21, 0.06);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
 }
 
 .project-chip:hover:not(:disabled) {
   border-color: color-mix(in srgb, var(--dsw-business) 40%, var(--dsw-border));
   background: transparent;
   color: var(--dsw-business);
-  box-shadow: 0 6px 18px rgba(65, 118, 230, 0.12);
+  box-shadow: 0 6px 18px rgba(96, 148, 245, 0.2);
 }
 
 .project-chip:disabled,
@@ -305,9 +312,9 @@ body {
 }
 
 .dock-approval-card {
-  border: 1px solid rgb(253, 230, 138);
+  border: 1px solid rgba(250, 204, 100, 0.35);
   border-radius: 12px;
-  background: rgb(255, 251, 235);
+  background: rgba(250, 204, 100, 0.1);
   padding: 8px 12px;
   font-size: 12px;
   color: var(--dsw-label);
@@ -355,7 +362,7 @@ body {
 }
 
 .project-tree-row:hover {
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--dsw-hover);
 }
 
 .project-tree-row.is-active {
@@ -390,7 +397,7 @@ body {
   flex: 1;
   resize: none;
   border: 0;
-  background: #fff;
+  background: var(--dsw-surface);
   padding: 10px 12px;
   color: var(--dsw-label);
   font-family: var(--font-mono);
@@ -485,7 +492,7 @@ body {
   height: 24px;
   border: 0;
   border-bottom: 1px solid var(--dsw-border);
-  background: rgba(15, 17, 21, 0.03);
+  background: var(--dsw-muted-fill);
   padding: 0 12px;
   color: var(--dsw-label-2);
   font: inherit;
@@ -523,7 +530,7 @@ body {
 .traj-row-wrap {
   display: flex;
   align-items: stretch;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid var(--dsw-border);
 }
 
 .traj-step-fold,
@@ -652,7 +659,7 @@ body {
   gap: 4px;
   max-width: 100%;
   border-radius: 999px;
-  background: rgba(15, 17, 21, 0.06);
+  background: var(--dsw-hover);
   padding: 1px 7px;
   color: var(--dsw-label-2);
   font-weight: 600;
@@ -687,7 +694,7 @@ body {
   border: 1px solid var(--dsw-border);
   border-radius: 12px;
   padding: 10px 12px;
-  background: #fff;
+  background: var(--dsw-surface);
 }
 
 .traj-usage-card-title {
@@ -711,7 +718,7 @@ body {
   gap: 2px;
   border-radius: 8px;
   padding: 8px 10px;
-  background: rgba(15, 17, 21, 0.03);
+  background: var(--dsw-muted-fill);
 }
 
 .traj-usage-stat span {
@@ -746,7 +753,7 @@ body {
   border: 1px solid var(--dsw-border);
   border-radius: 12px;
   padding: 10px 12px;
-  background: #fff;
+  background: var(--dsw-surface);
 }
 
 .traj-io-card-title {
@@ -765,10 +772,10 @@ body {
 }
 
 .traj-io-msg {
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  border: 1px solid var(--dsw-border);
   border-radius: 10px;
   overflow: hidden;
-  background: rgba(15, 17, 21, 0.02);
+  background: var(--dsw-muted-fill);
 }
 
 .traj-io-msg-head {
@@ -776,7 +783,7 @@ body {
   align-items: center;
   gap: 6px;
   padding: 6px 8px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid var(--dsw-border);
   background: rgba(255, 255, 255, 0.7);
 }
 
@@ -790,7 +797,7 @@ body {
 
 .traj-io-role-system {
   color: var(--dsw-label-2);
-  background: rgba(15, 17, 21, 0.06);
+  background: var(--dsw-hover);
 }
 
 .traj-io-role-user {
@@ -828,7 +835,7 @@ body {
 }
 
 .traj-io-msg-tools {
-  border-top: 1px dashed rgba(0, 0, 0, 0.08);
+  border-top: 1px dashed var(--dsw-border);
   color: var(--dsw-label-2);
 }
 
@@ -874,7 +881,7 @@ body {
 
 .traj-tag-system {
   color: var(--dsw-label-2);
-  background: rgba(15, 17, 21, 0.06);
+  background: var(--dsw-hover);
 }
 
 .traj-tag-turn {
@@ -884,7 +891,7 @@ body {
 
 .traj-tag-step {
   color: var(--dsw-label-3);
-  background: rgba(15, 17, 21, 0.04);
+  background: var(--dsw-muted-fill);
 }
 
 .traj-empty {
@@ -961,7 +968,7 @@ body {
 }
 
 .traj-detail-close:hover {
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--dsw-hover);
 }
 
 .traj-detail-body {
@@ -1008,7 +1015,7 @@ body {
   border: 1px solid var(--dsw-border);
   border-radius: 10px;
   padding: 10px;
-  background: #fff;
+  background: var(--dsw-surface);
   color: var(--dsw-label-2);
   font-family: var(--font-mono);
   font-size: 11px;
@@ -1091,7 +1098,7 @@ body {
 .chat-md code {
   border-radius: 4px;
   padding: 0.1em 0.35em;
-  background: rgba(15, 17, 21, 0.06);
+  background: var(--dsw-hover);
   font-family: var(--font-mono);
   font-size: 0.9em;
 }
@@ -1129,7 +1136,7 @@ body {
 }
 
 .chat-md th {
-  background: rgba(15, 17, 21, 0.03);
+  background: var(--dsw-muted-fill);
 }
 
 .chat-md hr {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更
- 将全局 DSH CSS token 切换为夜间色板（深色背景 / 浅色文字 / 半透明边框）
- 新增 `--dsw-surface`、`--dsw-hover`、`--dsw-overlay` 等变量，替换组件里硬编码的 `bg-white` / `hover:bg-black/*`
- `index.html` 设置 `color-scheme: dark`

## 验证
- `npx tsc --noEmit` 通过
- 本地页面截图确认深色 UI

[Dark mode UI](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-mode.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

