### PR TITLE
perf: 快速上滑时聊天 UI 不再白屏等待

### DIFF
--- a/src/plugins/contributors/chat/markdown.tsx
+++ b/src/plugins/contributors/chat/markdown.tsx
@@ -9,14 +9,17 @@ export const MarkdownBody = memo(function MarkdownBody({
   text,
   className = '',
   streaming = false,
+  /** 快速滚动时用纯文本占位，避免虚表回收后反复 remark 解析导致白屏 */
+  lightweight = false,
 }: {
   text: string
   className?: string
   /** 流式中跳过 remark，避免每帧全量重解析 */
   streaming?: boolean
+  lightweight?: boolean
 }) {
   if (!text) return null
-  if (streaming) {
+  if (streaming || lightweight) {
     return (
       <div className={`chat-md chat-md-stream ${className}`.trim()}>
         <pre className="chat-md-stream-pre">{text}</pre>

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -10,10 +10,16 @@ import { MarkdownBody } from './markdown.tsx'
 import { ToolCard } from './tool-card.tsx'
 
 const NEAR_BOTTOM_PX = 96
+/** 提早预取更早消息，避免滑到顶才开始请求 */
+const PREFETCH_OLDER_PX = 720
 const ROW_GAP_PX = 16
 const ESTIMATE_ROW_PX = 160
 /** 消息很少时全量渲染更简单，也避免虚表测量抖动 */
 const VIRTUALIZE_AFTER = 12
+/** 加大 overscan：快速上滑时预挂载更多行，减少白屏 */
+const OVERSCAN = 18
+/** 滚动停下多久后恢复完整 Markdown */
+const SCROLL_IDLE_MS = 90
 
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node = el?.parentElement ?? null
@@ -85,17 +91,19 @@ function NodeView({
   node,
   onInspect,
   onFork,
+  lightweight,
 }: {
   node: ChatNode
   onInspect: (callId: string) => void
   onFork: () => void | Promise<void>
+  lightweight: boolean
 }) {
   if (node.kind === 'user') {
     return (
       <div className="chat-user-row">
         <div className="chat-user-bubble">
           {node.kindTag === 'inject' ? <div className="chat-user-tag">inject</div> : null}
-          <MarkdownBody text={node.text} />
+          <MarkdownBody text={node.text} lightweight={lightweight} />
         </div>
       </div>
     )
@@ -105,14 +113,30 @@ function NodeView({
     return (
       <div className="chat-assistant-row">
         <div className="chat-assistant-body">
-          {node.text ? <MarkdownBody text={node.text} streaming={streaming} /> : streaming ? '…' : null}
+          {node.text ? (
+            <MarkdownBody text={node.text} streaming={streaming} lightweight={lightweight && !streaming} />
+          ) : streaming ? (
+            '…'
+          ) : null}
           {streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
         </div>
-        {!streaming && node.text.trim() ? <AssistantActions text={node.text} onFork={onFork} /> : null}
+        {!streaming && !lightweight && node.text.trim() ? (
+          <AssistantActions text={node.text} onFork={onFork} />
+        ) : null}
       </div>
     )
   }
-  if (node.kind === 'tool') return <ToolCard node={node} onInspect={onInspect} />
+  if (node.kind === 'tool') {
+    if (lightweight) {
+      return (
+        <div className="rounded-[12px] border border-[var(--dsw-border)] px-3 py-2 font-mono text-[12px] text-[var(--dsw-label-3)]">
+          {node.name}
+          {node.result ? (node.result.ok ? ' · ok' : ' · err') : ' · …'}
+        </div>
+      )
+    }
+    return <ToolCard node={node} onInspect={onInspect} />
+  }
   return <div className="self-center text-xs text-[var(--dsw-label-3)]">{node.text}</div>
 }
 
@@ -173,7 +197,10 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const rootRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLElement | null>(null)
   const stickToBottomRef = useRef(true)
+  const scrollIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const prefetchingRef = useRef(false)
   const [scrollEpoch, setScrollEpoch] = useState(0)
+  const [isScrolling, setIsScrolling] = useState(false)
 
   const virtualize = nodes.length >= VIRTUALIZE_AFTER
 
@@ -203,7 +230,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     count: virtualize ? nodes.length : 0,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ESTIMATE_ROW_PX,
-    overscan: 4,
+    overscan: OVERSCAN,
     gap: ROW_GAP_PX,
     getItemKey: (index) => nodes[index]?.id ?? index,
   })
@@ -219,23 +246,47 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   useEffect(() => {
     const parent = scrollRef.current
     if (!parent) return
-    const onScroll = () => {
-      const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
-      stickToBottomRef.current = distance <= NEAR_BOTTOM_PX
-      if (parent.scrollTop <= NEAR_BOTTOM_PX && hasMoreOlder && !loadingOlder) {
-        const beforeHeight = parent.scrollHeight
-        const beforeTop = parent.scrollTop
-        void sessionView.loadOlder().then((loaded) => {
+
+    const markScrolling = () => {
+      setIsScrolling(true)
+      if (scrollIdleTimer.current != null) clearTimeout(scrollIdleTimer.current)
+      scrollIdleTimer.current = setTimeout(() => {
+        scrollIdleTimer.current = null
+        setIsScrolling(false)
+      }, SCROLL_IDLE_MS)
+    }
+
+    const maybePrefetchOlder = () => {
+      if (!hasMoreOlder || loadingOlder || prefetchingRef.current) return
+      if (parent.scrollTop > PREFETCH_OLDER_PX) return
+      const beforeHeight = parent.scrollHeight
+      const beforeTop = parent.scrollTop
+      prefetchingRef.current = true
+      void sessionView
+        .loadOlder()
+        .then((loaded) => {
           if (!loaded) return
           requestAnimationFrame(() => {
             parent.scrollTop = beforeTop + (parent.scrollHeight - beforeHeight)
           })
         })
-      }
+        .finally(() => {
+          prefetchingRef.current = false
+        })
+    }
+
+    const onScroll = () => {
+      markScrolling()
+      const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
+      stickToBottomRef.current = distance <= NEAR_BOTTOM_PX
+      maybePrefetchOlder()
     }
     onScroll()
     parent.addEventListener('scroll', onScroll, { passive: true })
-    return () => parent.removeEventListener('scroll', onScroll)
+    return () => {
+      parent.removeEventListener('scroll', onScroll)
+      if (scrollIdleTimer.current != null) clearTimeout(scrollIdleTimer.current)
+    }
   }, [sessionId, scrollEpoch, virtualize, hasMoreOlder, loadingOlder, sessionView])
 
   const lastNode = nodes.at(-1)
@@ -254,6 +305,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
 
   if (nodes.length === 0 && !pending && !error) return <EmptyHero />
 
+  const lightweight = virtualize && isScrolling
+
   return (
     <div ref={rootRef} className="w-full" data-chat-virtual={virtualize ? '1' : '0'}>
       <StatusRow agentStatus={agentStatus} agentStep={agentStep} />
@@ -269,11 +322,16 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
               <div
                 key={item.key}
                 data-index={item.index}
-                ref={virtualizer.measureElement}
-                className="absolute top-0 left-0 w-full"
+                ref={isScrolling ? undefined : virtualizer.measureElement}
+                className="chat-virt-row absolute top-0 left-0 w-full"
                 style={{ transform: `translateY(${item.start}px)` }}
               >
-                <NodeViewMemo node={node} onInspect={onInspect} onFork={onFork} />
+                <NodeViewMemo
+                  node={node}
+                  onInspect={onInspect}
+                  onFork={onFork}
+                  lightweight={lightweight}
+                />
               </div>
             )
           })}
@@ -281,7 +339,13 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       ) : (
         <div className="flex flex-col gap-4">
           {nodes.map((node) => (
-            <NodeViewMemo key={node.id} node={node} onInspect={onInspect} onFork={onFork} />
+            <NodeViewMemo
+              key={node.id}
+              node={node}
+              onInspect={onInspect}
+              onFork={onFork}
+              lightweight={false}
+            />
           ))}
         </div>
       )}

--- a/src/style.css
+++ b/src/style.css
@@ -1114,6 +1114,12 @@ body {
   color: var(--dsw-ok);
 }
 
+/* Virtualized chat rows — hint browser to skip offscreen paint work */
+.chat-virt-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 160px;
+}
+
 /* Chat Markdown */
 .chat-md {
   max-width: 100%;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
快速上滑时虚表行来不及挂载/Markdown 解析，UI 会白一会儿（约 1s）。

## 改动
- overscan `4 → 18`，预挂载更多行
- 滚动中：纯文本占位 + 跳过 `measureElement` / ToolCard；停下 90ms 后再完整 Markdown
- 距顶部 `720px` 就开始 `loadOlder` 预取
- `content-visibility: auto` 辅助离屏跳过绘制

## 验证
- `tsc --noEmit` / chat vitest 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

