### PR TITLE
style: 去掉侧边栏 + 旁的 Fork 图标

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -12,7 +12,7 @@ import {
   type AppModuleId,
 } from '../infrastructure/app-modules.ts'
 import { BrandWordmark, FishLogo } from './brand.tsx'
-import { LuGitFork, LuPlus } from 'react-icons/lu'
+import { LuPlus } from 'react-icons/lu'
 
 export const name = 'shell'
 export const inject = ['slots', 'snapshot', 'sessionView', 'projectView']
@@ -193,18 +193,6 @@ function Shell(props: SlotProps) {
                 }}
               >
                 <LuPlus className="size-3.5" />
-              </button>
-              <button
-                type="button"
-                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-[var(--dsw-label-3)]"
-                title="Fork"
-                aria-label="Fork"
-                disabled={!sessionId}
-                onClick={() => {
-                  void sessionView.forkCurrent().then((id) => navigate(`/s/${id}`))
-                }}
-              >
-                <LuGitFork className="size-3.5" />
               </button>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更
删除左侧 Chat 列表标题旁「+」右侧的 Fork 按钮。回复下方的 Fork 操作保留。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

