### PR TITLE
Fix: static mascots so chat switch stays smooth

### DIFF
--- a/src/plugins/contributors/mascot/grok-bot-loader.ts
+++ b/src/plugins/contributors/mascot/grok-bot-loader.ts
@@ -1,5 +1,6 @@
-const SCRIPTS = [
-  '/grok-bot/geometry-data.js',
+const GEO_SRC = '/grok-bot/geometry-data.js'
+
+const CHARACTER_SCRIPTS = [
   '/grok-bot/src/math.js',
   '/grok-bot/src/tables.js',
   '/grok-bot/src/pose.js',
@@ -9,7 +10,8 @@ const SCRIPTS = [
   '/grok-bot/src/character.js',
 ] as const
 
-let loadPromise: Promise<void> | null = null
+let geoPromise: Promise<void> | null = null
+let characterPromise: Promise<void> | null = null
 
 function injectScript(src: string): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -40,18 +42,33 @@ function injectScript(src: string): Promise<void> {
   })
 }
 
-/** Load IIFE replica scripts once; exposes `window.GrokCharacter` + `window.GROK_GEO`. */
+/** Geometry + palette only — enough for static session marks (no RAF). */
+export function loadGrokGeo(): Promise<void> {
+  if (typeof window !== 'undefined' && window.GROK_GEO) return Promise.resolve()
+  if (!geoPromise) {
+    geoPromise = injectScript(GEO_SRC).catch((err) => {
+      geoPromise = null
+      throw err
+    })
+  }
+  return geoPromise
+}
+
+/**
+ * Full character runtime (springs / RAF). Prefer not to call this on the
+ * session-switch hot path — static marks via `loadGrokGeo` are enough.
+ */
 export function loadGrokBot(): Promise<void> {
   if (typeof window !== 'undefined' && window.GrokCharacter && window.GROK_GEO) {
     return Promise.resolve()
   }
-  if (!loadPromise) {
-    loadPromise = SCRIPTS.reduce((chain, src) => chain.then(() => injectScript(src)), Promise.resolve()).catch(
-      (err) => {
-        loadPromise = null
+  if (!characterPromise) {
+    characterPromise = loadGrokGeo()
+      .then(() => CHARACTER_SCRIPTS.reduce((chain, src) => chain.then(() => injectScript(src)), Promise.resolve()))
+      .catch((err) => {
+        characterPromise = null
         throw err
-      },
-    )
+      })
   }
-  return loadPromise
+  return characterPromise
 }

--- a/src/plugins/contributors/mascot/sidebar-mascot.tsx
+++ b/src/plugins/contributors/mascot/sidebar-mascot.tsx
@@ -1,73 +1,77 @@
 import { memo, useEffect, useState } from 'react'
-import { GrokBotAvatar } from './grok-bot-avatar.tsx'
-import { loadGrokBot } from './grok-bot-loader.ts'
+import { loadGrokGeo } from './grok-bot-loader.ts'
 import type { GrokColor, GrokShape, SessionMascotIdentity } from './grok-bot-types.ts'
 import { DEFAULT_SESSION_MASCOT } from './session-mascot.ts'
 
 export type SidebarMascotProps = {
   size?: number
+  /** Reserved for future light busy affordance (static pulse). */
   busy?: boolean
   className?: string
   title?: string
   /** Per-chat role; defaults to brand mascot when omitted. */
   identity?: SessionMascotIdentity
-  /** When true, keep RAF paused (inactive session rows). */
-  paused?: boolean
-  followPointer?: boolean
 }
 
-/** Grok Bot study replica — one shape+color role per chat. */
-export const SidebarMascot = memo(function SidebarMascot({
-  size = 44,
-  busy = false,
-  className,
-  title = 'Harness',
-  identity = DEFAULT_SESSION_MASCOT,
-  paused = false,
-  followPointer = false,
-}: SidebarMascotProps) {
-  return (
-    <GrokBotAvatar
-      shape={identity.shape}
-      color={identity.color}
-      size={size}
-      busy={busy}
-      paused={paused}
-      followPointer={followPointer}
-      className={className}
-      title={title}
-    />
-  )
-})
+type MarkPaint = {
+  path: string
+  fill: string
+  viewBox: string
+}
 
-/** Lightweight static silhouette for dense session lists (no RAF). */
+const paintCache = new Map<string, MarkPaint>()
+
+function cacheKey(shape: GrokShape, color: GrokColor) {
+  return `${shape}:${color}`
+}
+
+function paintFromGeo(shape: GrokShape, color: GrokColor): MarkPaint | null {
+  const geo = window.GROK_GEO
+  if (!geo) return null
+  const key = cacheKey(shape, color)
+  const hit = paintCache.get(key)
+  if (hit) return hit
+  const shapeData = geo.shapes[shape]
+  const pal = geo.palette[color] || geo.palette.black
+  if (!shapeData || !pal) return null
+  const vb = geo.viewBox
+  const next: MarkPaint = {
+    path: shapeData.path,
+    fill: pal.light,
+    viewBox: `${vb.minX} ${vb.minY} ${vb.width} ${vb.height}`,
+  }
+  paintCache.set(key, next)
+  return next
+}
+
+/** Lightweight static silhouette — no GrokCharacter / RAF (safe on session switch). */
 export const SessionMascotMark = memo(function SessionMascotMark({
   shape,
   color,
   size = 28,
+  busy = false,
+  className,
   title,
 }: {
   shape: GrokShape
   color: GrokColor
   size?: number
+  busy?: boolean
+  className?: string
   title?: string
 }) {
-  const [path, setPath] = useState<string | null>(null)
-  const [fill, setFill] = useState('#888')
-  const [viewBox, setViewBox] = useState('0 0 229 229')
+  const [paint, setPaint] = useState<MarkPaint | null>(() => paintFromGeo(shape, color))
 
   useEffect(() => {
+    const sync = paintFromGeo(shape, color)
+    if (sync) {
+      setPaint(sync)
+      return
+    }
     let cancelled = false
-    void loadGrokBot().then(() => {
-      if (cancelled || !window.GROK_GEO) return
-      const geo = window.GROK_GEO
-      const shapeData = geo.shapes[shape]
-      const pal = geo.palette[color] || geo.palette.black
-      if (!shapeData) return
-      const vb = geo.viewBox
-      setViewBox(`${vb.minX} ${vb.minY} ${vb.width} ${vb.height}`)
-      setPath(shapeData.path)
-      setFill(pal.light)
+    void loadGrokGeo().then(() => {
+      if (cancelled) return
+      setPaint(paintFromGeo(shape, color))
     })
     return () => {
       cancelled = true
@@ -76,20 +80,48 @@ export const SessionMascotMark = memo(function SessionMascotMark({
 
   return (
     <span
-      className="sidebar-mascot session-mascot-mark"
+      className={`sidebar-mascot session-mascot-mark${busy ? ' is-busy' : ''}${className ? ` ${className}` : ''}`}
       style={{ width: size, height: size, display: 'inline-grid', placeItems: 'center' }}
       title={title}
     >
       <svg
         width={size}
         height={size}
-        viewBox={viewBox}
+        viewBox={paint?.viewBox ?? '0 0 229 229'}
         role="img"
         aria-label={title || `${shape} ${color}`}
         style={{ overflow: 'visible' }}
       >
-        {path ? <path d={path} fill={fill} /> : <circle cx="114" cy="114" r="40" fill={fill} opacity={0.4} />}
+        {paint ? (
+          <path d={paint.path} fill={paint.fill} />
+        ) : (
+          <circle cx="114" cy="114" r="40" fill="#888" opacity={0.4} />
+        )}
       </svg>
     </span>
+  )
+})
+
+/**
+ * Sidebar / activity brand mark.
+ * Static by default — full GrokCharacter RAF was causing chat-switch jank
+ * (multiple animation loops + setShape morph on every session change).
+ */
+export const SidebarMascot = memo(function SidebarMascot({
+  size = 44,
+  busy = false,
+  className,
+  title = 'Harness',
+  identity = DEFAULT_SESSION_MASCOT,
+}: SidebarMascotProps) {
+  return (
+    <SessionMascotMark
+      shape={identity.shape}
+      color={identity.color}
+      size={size}
+      busy={busy}
+      className={className}
+      title={title}
+    />
   )
 })

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -257,21 +257,13 @@ function Shell(props: SlotProps) {
                     to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
                     className="flex min-w-0 flex-1 items-center gap-2.5 px-2.5 py-2 text-left text-sm"
                   >
-                    {active ? (
-                      <SidebarMascot
-                        size={28}
-                        busy={agentBusy}
-                        identity={identity}
-                        title={`${identity.shape} · ${identity.color}`}
-                      />
-                    ) : (
-                      <SessionMascotMark
-                        size={28}
-                        shape={identity.shape}
-                        color={identity.color}
-                        title={`${identity.shape} · ${identity.color}`}
-                      />
-                    )}
+                    <SessionMascotMark
+                      size={28}
+                      shape={identity.shape}
+                      color={identity.color}
+                      busy={active && agentBusy}
+                      title={`${identity.shape} · ${identity.color}`}
+                    />
                     <span className="min-w-0 flex-1">
                       <div className="truncate font-medium">{item.title}</div>
                       <div className="mt-0.5 font-mono text-[10px] opacity-70">

--- a/src/style.css
+++ b/src/style.css
@@ -168,13 +168,27 @@ body {
   border-radius: 8px;
 }
 
-.grok-bot-avatar svg,
-.session-mascot-mark svg {
-  display: block;
+.session-mascot-mark.is-busy svg {
+  animation: session-mascot-pulse 1.1s ease-in-out infinite;
 }
 
-.session-mascot-mark {
-  border-radius: 8px;
+@keyframes session-mascot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.72;
+    transform: scale(0.94);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-mascot-mark.is-busy svg {
+    animation: none;
+    opacity: 0.85;
+  }
 }
 
 .app-activity-brand:hover {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why
每个 chat 挂完整 `GrokCharacter`（RAF + 换形 morph）后，会话切换又会卡：列表里激活行反复 create/destroy，顶栏/Activity 再叠 2 路动画，和聊天切换抢主线程。

## Fix
- 侧栏 / Activity / 会话列表统一用 **静态剪影**（只加载 `geometry-data.js`）
- 切换 session 只改 path/fill，不再跑 `character.js`
- agent busy 用轻量 CSS pulse
- `loadGrokBot()` 仍保留给可选动效，但不走切换热路径

## Test
- `tsc --noEmit`
- `session-mascot.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

