### PR TITLE
ui: remove sidebar deepseek/HARNESS brand row

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -205,21 +205,7 @@ function Shell(props: SlotProps) {
         }`}
         aria-hidden={activeModule !== 'agent'}
       >
-        <div className="flex shrink-0 items-center gap-2.5 px-4 pt-4 pb-2">
-          <SidebarMascot
-            size={48}
-            busy={agentBusy}
-            identity={activeMascot}
-            title={`${activeMascot.shape} · ${activeMascot.color}`}
-          />
-          <div className="flex items-center gap-2 text-[var(--dsw-label)]">
-            <span className="text-[15px] font-semibold tracking-tight">deepseek</span>
-            <span className="rounded-[6px] border border-[var(--dsw-border)] bg-[var(--dsw-hover)] px-1.5 py-[2px] text-[10px] font-semibold tracking-wider text-[var(--dsw-label-2)]">
-              HARNESS
-            </span>
-          </div>
-        </div>
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3">
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-4">
           <div className="mb-2 flex items-center justify-between gap-2 px-1">
             <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
             <div className="flex items-center gap-0.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉侧栏 Chat 列表上方的 deepseek / HARNESS 品牌行与大号 mascot，列表从顶部直接开始。Activity bar 左上角小图标仍保留。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

