### PR TITLE
Persist per-session shape/color on the server

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -190,7 +190,11 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/sessions', async (route) => {
     const record = await ctx.sessions.create()
-    route.send(201, { id: record.id, version: record.version })
+    route.send(201, {
+      id: record.id,
+      version: record.version,
+      ...(record.mascot ? { mascot: record.mascot } : {}),
+    })
   })
   ctx.http.route('GET', '/api/sessions', async (route) => {
     const items = await ctx.sessions.listSummaries()
@@ -202,6 +206,7 @@ export function apply(ctx: Context) {
         title: item.title,
         updatedAt: item.updatedAt,
         ...(item.project ? { project: item.project } : {}),
+        ...(item.mascot ? { mascot: item.mascot } : {}),
       })),
     })
   })
@@ -226,6 +231,7 @@ export function apply(ctx: Context) {
       oldestSeq: window.oldestSeq,
       newestSeq: window.newestSeq,
       ...(record.project ? { project: record.project } : {}),
+      ...(record.mascot ? { mascot: record.mascot } : {}),
     })
   })
   ctx.http.route('GET', '/api/sessions/:id/events', async (route) => {
@@ -332,7 +338,12 @@ export function apply(ctx: Context) {
   ctx.http.route('POST', '/api/sessions/:id/fork', async (route) => {
     try {
       const child = await ctx.sessions.fork(route.params.id)
-      route.send(201, { id: child.id, version: child.version, parentId: route.params.id })
+      route.send(201, {
+        id: child.id,
+        version: child.version,
+        parentId: route.params.id,
+        ...(child.mascot ? { mascot: child.mascot } : {}),
+      })
     } catch (error) {
       route.send(400, { error: String(error) })
     }

--- a/host/plugins/core/session-mascot.test.ts
+++ b/host/plugins/core/session-mascot.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { Context } from 'cordis'
+import '../../types.ts'
+import * as sessionStore from '../storage/session-store.ts'
+import * as sessions from './sessions.ts'
+import { SESSION_FORMAT_VERSION } from './sessions.ts'
+import { mascotFromSessionId } from './session-mascot.ts'
+
+test('create persists mascot on the session record', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create()
+  assert.ok(record.mascot)
+  assert.equal(typeof record.mascot!.shape, 'string')
+  assert.equal(typeof record.mascot!.color, 'string')
+
+  const again = await ctx.sessions.require(record.id)
+  assert.deepEqual(again.mascot, record.mascot)
+
+  const listed = await ctx.sessions.listSummaries()
+  const item = listed.find((row) => row.id === record.id)
+  assert.deepEqual(item?.mascot, record.mascot)
+})
+
+test('legacy sessions get a stable backfilled mascot', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const bare = {
+    id: crypto.randomUUID(),
+    version: SESSION_FORMAT_VERSION,
+    events: [{ type: 'session/open' as const, version: SESSION_FORMAT_VERSION, seq: 0, ts: Date.now() }],
+  }
+  await ctx.sessionStore.save(bare)
+  const expected = mascotFromSessionId(bare.id)
+  const listed = await ctx.sessions.listSummaries()
+  const item = listed.find((row) => row.id === bare.id)
+  assert.deepEqual(item?.mascot, expected)
+  const loaded = await ctx.sessions.require(bare.id)
+  assert.deepEqual(loaded.mascot, expected)
+})
+
+test('fork assigns a persisted mascot', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const parent = await ctx.sessions.create()
+  const child = await ctx.sessions.fork(parent.id)
+  assert.ok(child.mascot)
+  const loaded = await ctx.sessions.require(child.id)
+  assert.deepEqual(loaded.mascot, child.mascot)
+})

--- a/host/plugins/core/session-mascot.ts
+++ b/host/plugins/core/session-mascot.ts
@@ -1,0 +1,103 @@
+/** Shared session mascot identity — keep frontend mirror in sync. */
+
+export const GROK_SHAPES = [
+  'blob',
+  'pebble',
+  'bean',
+  'egg',
+  'squircle',
+  'tablet',
+  'capsule',
+  'cylinder',
+  'hex',
+  'gem',
+  'crystal',
+  'wedge',
+  'shield',
+  'dome',
+  'arch',
+  'cloud',
+  'teardrop',
+  'leaf',
+] as const
+
+export const GROK_COLORS = [
+  'black',
+  'brown',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'cyan',
+  'blue',
+  'violet',
+  'magenta',
+  'gray',
+] as const
+
+export type GrokShape = (typeof GROK_SHAPES)[number]
+export type GrokColor = (typeof GROK_COLORS)[number]
+
+export type SessionMascot = {
+  shape: GrokShape
+  color: GrokColor
+}
+
+export function isSessionMascot(value: unknown): value is SessionMascot {
+  if (!value || typeof value !== 'object') return false
+  const v = value as { shape?: unknown; color?: unknown }
+  return (
+    typeof v.shape === 'string' &&
+    typeof v.color === 'string' &&
+    (GROK_SHAPES as readonly string[]).includes(v.shape) &&
+    (GROK_COLORS as readonly string[]).includes(v.color)
+  )
+}
+
+export function parseSessionMascot(raw: string | null | undefined): SessionMascot | undefined {
+  if (!raw) return undefined
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    return isSessionMascot(parsed) ? parsed : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export function hashSessionId(id: string): number {
+  let h = 2166136261
+  for (let i = 0; i < id.length; i += 1) {
+    h ^= id.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+/** Stable fallback from id alone — never changes for a given session id. */
+export function mascotFromSessionId(id: string): SessionMascot {
+  const seed = hashSessionId(id)
+  const shape = GROK_SHAPES[seed % GROK_SHAPES.length]!
+  const color = GROK_COLORS[Math.floor(seed / GROK_SHAPES.length) % GROK_COLORS.length]!
+  return { shape, color }
+}
+
+function comboKey(shape: GrokShape, color: GrokColor) {
+  return `${shape}:${color}`
+}
+
+/** Prefer unused combos at create time; still seeded by session id. */
+export function pickSessionMascot(sessionId: string, used: Iterable<SessionMascot>): SessionMascot {
+  const usedKeys = new Set([...used].map((m) => comboKey(m.shape, m.color)))
+  const seed = hashSessionId(sessionId)
+  const shapeCount = GROK_SHAPES.length
+  const colorCount = GROK_COLORS.length
+  const total = shapeCount * colorCount
+
+  for (let i = 0; i < total; i += 1) {
+    const n = (seed + i) % total
+    const shape = GROK_SHAPES[n % shapeCount]!
+    const color = GROK_COLORS[Math.floor(n / shapeCount) % colorCount]!
+    if (!usedKeys.has(comboKey(shape, color))) return { shape, color }
+  }
+  return mascotFromSessionId(sessionId)
+}

--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -38,11 +38,18 @@ export interface SessionProject {
   boundAt: number
 }
 
+/** Per-chat Grok shape+color role — assigned once at create and persisted. */
+export interface SessionMascot {
+  shape: string
+  color: string
+}
+
 export interface SessionRecord {
   id: string
   version: number
   events: SessionEvent[]
   project?: SessionProject
+  mascot?: SessionMascot
 }
 
 /** 侧栏列表用：不必加载整段 events。 */
@@ -53,6 +60,7 @@ export interface SessionSummary {
   title: string
   updatedAt: number
   project?: SessionProject
+  mascot?: SessionMascot
 }
 
 export interface SessionStore {

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -7,11 +7,18 @@ import {
   SESSION_FORMAT_VERSION,
   type SessionEvent,
   type SessionEventBody,
+  type SessionMascot,
   type SessionProject,
   type SessionRecord,
 } from './session-types.ts'
+import {
+  isSessionMascot,
+  mascotFromSessionId,
+  pickSessionMascot,
+  type SessionMascot as AssignedMascot,
+} from './session-mascot.ts'
 
-export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord }
+export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord, SessionMascot }
 export { SESSION_FORMAT_VERSION }
 
 export function deriveMessages(events: SessionEvent[]): LlmMessage[] {
@@ -52,10 +59,13 @@ export class SessionsService extends Service {
   }
 
   async create(id: string = crypto.randomUUID()) {
+    const used = await this.collectUsedMascots()
+    const mascot = pickSessionMascot(id, used)
     const record: SessionRecord = {
       id,
       version: SESSION_FORMAT_VERSION,
       events: [{ type: 'session/open', version: SESSION_FORMAT_VERSION, seq: 0, ts: Date.now() }],
+      mascot,
     }
     await this.persist(record)
     return record
@@ -104,11 +114,14 @@ export class SessionsService extends Service {
 
   async fork(sourceId: string, childId: string = crypto.randomUUID()) {
     const source = await this.require(sourceId)
+    const used = await this.collectUsedMascots()
+    const mascot = pickSessionMascot(childId, used)
     const record: SessionRecord = {
       id: childId,
       version: source.version,
       events: source.events.map((event) => ({ ...event })),
       ...(source.project ? { project: { ...source.project } } : {}),
+      mascot,
     }
     await this.persist(record)
     return record
@@ -130,8 +143,32 @@ export class SessionsService extends Service {
     return this.ctx.sessionStore.list()
   }
 
-  listSummaries() {
-    return this.ctx.sessionStore.listSummaries()
+  async listSummaries() {
+    const items = await this.ctx.sessionStore.listSummaries()
+    const out = []
+    for (const item of items) {
+      if (item.mascot && isSessionMascot(item.mascot)) {
+        out.push(item)
+        continue
+      }
+      // Legacy sessions: pin a stable mascot once and persist.
+      const record = await this.require(item.id)
+      if (!record.mascot || !isSessionMascot(record.mascot)) {
+        record.mascot = mascotFromSessionId(record.id)
+        await this.persist(record)
+      }
+      out.push({ ...item, mascot: record.mascot })
+    }
+    return out
+  }
+
+  private async collectUsedMascots(): Promise<AssignedMascot[]> {
+    const items = await this.ctx.sessionStore.listSummaries()
+    const used: AssignedMascot[] = []
+    for (const item of items) {
+      if (item.mascot && isSessionMascot(item.mascot)) used.push(item.mascot)
+    }
+    return used
   }
 
   async delete(id: string) {

--- a/host/plugins/storage/session-store.ts
+++ b/host/plugins/storage/session-store.ts
@@ -26,6 +26,7 @@ function toSummary(record: SessionRecord): SessionSummary {
     title: deriveTitle(record.events, record.id),
     updatedAt: record.events.at(-1)?.ts ?? 0,
     ...(record.project ? { project: record.project } : {}),
+    ...(record.mascot ? { mascot: record.mascot } : {}),
   }
 }
 

--- a/host/plugins/storage/sqlite-session-store.ts
+++ b/host/plugins/storage/sqlite-session-store.ts
@@ -4,11 +4,13 @@ import { createRequire } from 'node:module'
 import {
   SESSION_FORMAT_VERSION,
   type SessionEvent,
+  type SessionMascot,
   type SessionProject,
   type SessionRecord,
   type SessionStore,
   type SessionSummary,
 } from '../core/session-types.ts'
+import { isSessionMascot, parseSessionMascot } from '../core/session-mascot.ts'
 
 type DatabaseSync = import('node:sqlite').DatabaseSync
 
@@ -18,6 +20,7 @@ type SessionRow = {
   id: string
   version: number
   project_json: string | null
+  mascot_json: string | null
   event_count: number
   title: string
   updated_at: number
@@ -38,6 +41,11 @@ function parseProject(raw: string | null): SessionProject | undefined {
   } catch {
     return undefined
   }
+}
+
+function parseMascot(raw: string | null): SessionMascot | undefined {
+  const parsed = parseSessionMascot(raw)
+  return parsed && isSessionMascot(parsed) ? parsed : undefined
 }
 
 /** SQLite session store：事件分行增量写入，避免整包 JSON 反复落盘。 */
@@ -72,13 +80,18 @@ export class SqliteSessionStore implements SessionStore {
       );
       CREATE INDEX IF NOT EXISTS events_session_seq ON events(session_id, seq);
     `)
+    try {
+      this.db.exec('ALTER TABLE sessions ADD COLUMN mascot_json TEXT')
+    } catch {
+      /* column already exists */
+    }
     return this
   }
 
   async load(id: string): Promise<SessionRecord | undefined> {
-    const row = this.db.prepare('SELECT id, version, project_json FROM sessions WHERE id = ?').get(id) as
-      | Pick<SessionRow, 'id' | 'version' | 'project_json'>
-      | undefined
+    const row = this.db
+      .prepare('SELECT id, version, project_json, mascot_json FROM sessions WHERE id = ?')
+      .get(id) as Pick<SessionRow, 'id' | 'version' | 'project_json' | 'mascot_json'> | undefined
     if (!row) return undefined
     if (row.version !== SESSION_FORMAT_VERSION) {
       throw new Error(`unsupported session version ${row.version}`)
@@ -88,11 +101,13 @@ export class SqliteSessionStore implements SessionStore {
       .all(id) as Array<{ event_json: string }>
     const events = eventRows.map((item) => JSON.parse(item.event_json) as SessionEvent)
     const project = parseProject(row.project_json)
+    const mascot = parseMascot(row.mascot_json)
     return {
       id: row.id,
       version: row.version,
       events,
       ...(project ? { project } : {}),
+      ...(mascot ? { mascot } : {}),
     }
   }
 
@@ -103,17 +118,19 @@ export class SqliteSessionStore implements SessionStore {
     const title = deriveTitle(record.events, record.id)
     const updatedAt = record.events.at(-1)?.ts ?? Date.now()
     const projectJson = record.project ? JSON.stringify(record.project) : null
+    const mascotJson = record.mascot ? JSON.stringify(record.mascot) : null
     const eventCount = record.events.length
 
     const insertEvent = this.db.prepare(
       'INSERT INTO events (session_id, seq, ts, type, event_json) VALUES (?, ?, ?, ?, ?)',
     )
     const upsertSession = this.db.prepare(`
-      INSERT INTO sessions (id, version, project_json, event_count, title, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (id, version, project_json, mascot_json, event_count, title, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         version = excluded.version,
         project_json = excluded.project_json,
+        mascot_json = excluded.mascot_json,
         event_count = excluded.event_count,
         title = excluded.title,
         updated_at = excluded.updated_at
@@ -140,7 +157,7 @@ export class SqliteSessionStore implements SessionStore {
 
     this.db.exec('BEGIN IMMEDIATE')
     try {
-      upsertSession.run(record.id, record.version, projectJson, eventCount, title, updatedAt)
+      upsertSession.run(record.id, record.version, projectJson, mascotJson, eventCount, title, updatedAt)
 
       if (storedCount === 0) {
         if (eventCount > 0) replaceAll()
@@ -182,11 +199,12 @@ export class SqliteSessionStore implements SessionStore {
   async listSummaries(): Promise<SessionSummary[]> {
     const rows = this.db
       .prepare(
-        'SELECT id, version, project_json, event_count, title, updated_at FROM sessions ORDER BY updated_at DESC',
+        'SELECT id, version, project_json, mascot_json, event_count, title, updated_at FROM sessions ORDER BY updated_at DESC',
       )
       .all() as SessionRow[]
     return rows.map((row) => {
       const project = parseProject(row.project_json)
+      const mascot = parseMascot(row.mascot_json)
       return {
         id: row.id,
         version: row.version,
@@ -194,6 +212,7 @@ export class SqliteSessionStore implements SessionStore {
         title: row.title || row.id.slice(0, 8),
         updatedAt: row.updated_at,
         ...(project ? { project } : {}),
+        ...(mascot ? { mascot } : {}),
       }
     })
   }

--- a/src/plugins/contributors/mascot/session-mascot.test.ts
+++ b/src/plugins/contributors/mascot/session-mascot.test.ts
@@ -1,41 +1,19 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import {
-  assignSessionMascot,
-  getOrAssignSessionMascot,
-  peekSessionMascot,
-  releaseSessionMascot,
-} from './session-mascot.ts'
+import { describe, expect, it } from 'vitest'
+import { mascotFromSessionId, resolveSessionMascot } from './session-mascot.ts'
 import { GROK_COLORS, GROK_SHAPES } from './grok-bot-types.ts'
 
-const KEY = 'dsh.session-mascots.v1'
-
-afterEach(() => {
-  localStorage.removeItem(KEY)
-})
-
-describe('session mascot assignment', () => {
-  it('assigns a stable shape+color per session id', () => {
-    const a = assignSessionMascot('sess-a')
+describe('session mascot persistence helpers', () => {
+  it('derives a stable shape+color from session id', () => {
+    const a = mascotFromSessionId('sess-a')
+    const b = mascotFromSessionId('sess-a')
+    expect(a).toEqual(b)
     expect(GROK_SHAPES).toContain(a.shape)
     expect(GROK_COLORS).toContain(a.color)
-    expect(getOrAssignSessionMascot('sess-a')).toEqual(a)
-    expect(peekSessionMascot('sess-a')).toEqual(a)
   })
 
-  it('prefers unused combos across chats', () => {
-    const seen = new Set<string>()
-    for (let i = 0; i < 20; i += 1) {
-      const id = `sess-${i}`
-      const m = assignSessionMascot(id)
-      const key = `${m.shape}:${m.color}`
-      expect(seen.has(key)).toBe(false)
-      seen.add(key)
-    }
-  })
-
-  it('releases identity on delete', () => {
-    assignSessionMascot('gone')
-    releaseSessionMascot('gone')
-    expect(peekSessionMascot('gone')).toBeNull()
+  it('prefers server-persisted mascot over hash fallback', () => {
+    const server = { shape: 'cloud' as const, color: 'orange' as const }
+    expect(resolveSessionMascot('sess-a', server)).toEqual(server)
+    expect(resolveSessionMascot('sess-a')).toEqual(mascotFromSessionId('sess-a'))
   })
 })

--- a/src/plugins/contributors/mascot/session-mascot.ts
+++ b/src/plugins/contributors/mascot/session-mascot.ts
@@ -6,9 +6,13 @@ import {
   type SessionMascotIdentity,
 } from './grok-bot-types.ts'
 
-const STORAGE_KEY = 'dsh.session-mascots.v1'
+export type { SessionMascotIdentity }
 
-type Store = Record<string, SessionMascotIdentity>
+/** Stable default when no session is selected. */
+export const DEFAULT_SESSION_MASCOT: SessionMascotIdentity = {
+  shape: 'blob',
+  color: 'cyan',
+}
 
 function isShape(v: unknown): v is GrokShape {
   return typeof v === 'string' && (GROK_SHAPES as readonly string[]).includes(v)
@@ -18,115 +22,30 @@ function isColor(v: unknown): v is GrokColor {
   return typeof v === 'string' && (GROK_COLORS as readonly string[]).includes(v)
 }
 
-function readStore(): Store {
-  if (typeof localStorage === 'undefined') return {}
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return {}
-    const parsed = JSON.parse(raw) as Record<string, { shape?: unknown; color?: unknown }>
-    const out: Store = {}
-    for (const [id, value] of Object.entries(parsed)) {
-      if (isShape(value?.shape) && isColor(value?.color)) {
-        out[id] = { shape: value.shape, color: value.color }
-      }
-    }
-    return out
-  } catch {
-    return {}
-  }
+export function isSessionMascotIdentity(value: unknown): value is SessionMascotIdentity {
+  if (!value || typeof value !== 'object') return false
+  const v = value as { shape?: unknown; color?: unknown }
+  return isShape(v.shape) && isColor(v.color)
 }
 
-function writeStore(store: Store) {
-  if (typeof localStorage === 'undefined') return
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(store))
-  } catch {
-    /* quota / private mode */
-  }
-}
-
-function hashId(id: string): number {
+/** Keep in sync with host/plugins/core/session-mascot.ts `mascotFromSessionId`. */
+export function mascotFromSessionId(id: string): SessionMascotIdentity {
   let h = 2166136261
   for (let i = 0; i < id.length; i += 1) {
     h ^= id.charCodeAt(i)
     h = Math.imul(h, 16777619)
   }
-  return h >>> 0
-}
-
-function comboKey(shape: GrokShape, color: GrokColor) {
-  return `${shape}:${color}`
-}
-
-function pickFresh(used: Set<string>, seed: number): SessionMascotIdentity {
-  const shapeCount = GROK_SHAPES.length
-  const colorCount = GROK_COLORS.length
-  const total = shapeCount * colorCount
-
-  for (let i = 0; i < total; i += 1) {
-    const n = (seed + i) % total
-    const shape = GROK_SHAPES[n % shapeCount]!
-    const color = GROK_COLORS[Math.floor(n / shapeCount) % colorCount]!
-    const key = comboKey(shape, color)
-    if (!used.has(key)) return { shape, color }
-  }
-
-  // All combos taken — still deterministic per seed.
-  const shape = GROK_SHAPES[seed % shapeCount]!
-  const color = GROK_COLORS[Math.floor(seed / shapeCount) % colorCount]!
+  const seed = h >>> 0
+  const shape = GROK_SHAPES[seed % GROK_SHAPES.length]!
+  const color = GROK_COLORS[Math.floor(seed / GROK_SHAPES.length) % GROK_COLORS.length]!
   return { shape, color }
 }
 
-/** Stable default when no session is selected. */
-export const DEFAULT_SESSION_MASCOT: SessionMascotIdentity = {
-  shape: 'blob',
-  color: 'cyan',
-}
-
-/** Read identity without creating one. */
-export function peekSessionMascot(sessionId: string): SessionMascotIdentity | null {
-  const store = readStore()
-  return store[sessionId] ?? null
-}
-
-/**
- * Ensure a session has a shape+color role.
- * Prefers unused combinations among already-assigned chats so the sidebar stays distinct.
- */
-export function getOrAssignSessionMascot(sessionId: string): SessionMascotIdentity {
-  const store = readStore()
-  const existing = store[sessionId]
-  if (existing) return existing
-
-  const used = new Set<string>()
-  for (const [id, value] of Object.entries(store)) {
-    if (id === sessionId) continue
-    used.add(comboKey(value.shape, value.color))
-  }
-
-  const next = pickFresh(used, hashId(sessionId))
-  store[sessionId] = next
-  writeStore(store)
-  return next
-}
-
-/** Assign (or reaffirm) identity right after creating a chat. */
-export function assignSessionMascot(sessionId: string): SessionMascotIdentity {
-  return getOrAssignSessionMascot(sessionId)
-}
-
-export function releaseSessionMascot(sessionId: string) {
-  const store = readStore()
-  if (!(sessionId in store)) return
-  delete store[sessionId]
-  writeStore(store)
-}
-
-/** Backfill identities for a session list (idempotent). */
-export function ensureSessionMascots(sessionIds: string[]): Record<string, SessionMascotIdentity> {
-  const out: Record<string, SessionMascotIdentity> = {}
-  for (const id of sessionIds) {
-    out[id] = getOrAssignSessionMascot(id)
-  }
-  return out
+/** Prefer server-persisted mascot; otherwise stable hash fallback (never random). */
+export function resolveSessionMascot(
+  sessionId: string,
+  mascot?: SessionMascotIdentity | { shape: string; color: string } | null,
+): SessionMascotIdentity {
+  if (isSessionMascotIdentity(mascot)) return mascot
+  return mascotFromSessionId(sessionId)
 }

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -13,12 +13,7 @@ import {
 } from '../infrastructure/app-modules.ts'
 import { FishLogo } from './brand.tsx'
 import { SessionMascotMark, SidebarMascot } from './mascot/sidebar-mascot.tsx'
-import {
-  assignSessionMascot,
-  DEFAULT_SESSION_MASCOT,
-  ensureSessionMascots,
-  releaseSessionMascot,
-} from './mascot/session-mascot.ts'
+import { DEFAULT_SESSION_MASCOT, resolveSessionMascot } from './mascot/session-mascot.ts'
 import type { SessionMascotIdentity } from './mascot/grok-bot-types.ts'
 import { LuPlus } from 'react-icons/lu'
 
@@ -142,16 +137,18 @@ function Shell(props: SlotProps) {
   const view = useSessionView((state) => state.view)
   const agentBusy = useSessionView((state) => state.agentStatus === 'running')
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const [mascotMap, setMascotMap] = useState<Record<string, SessionMascotIdentity>>({})
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}${view === 'trajectory' ? '/trajectory' : ''}` : '/'
-  const activeMascot =
-    (routeSessionId && mascotMap[routeSessionId]) ||
-    (sessionId && mascotMap[sessionId]) ||
-    DEFAULT_SESSION_MASCOT
+  const activeSession =
+    sessions.find((item) => item.id === routeSessionId) || sessions.find((item) => item.id === sessionId)
+  const activeMascot = activeSession
+    ? resolveSessionMascot(activeSession.id, activeSession.mascot)
+    : routeSessionId
+      ? resolveSessionMascot(routeSessionId)
+      : DEFAULT_SESSION_MASCOT
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -164,10 +161,6 @@ function Shell(props: SlotProps) {
   useEffect(() => {
     void sessionView.refreshSessions()
   }, [sessionView])
-
-  useEffect(() => {
-    setMascotMap(ensureSessionMascots(sessions.map((item) => item.id)))
-  }, [sessions])
 
   useEffect(() => {
     void projectView.attachSession(sessionId, project)
@@ -215,11 +208,7 @@ function Shell(props: SlotProps) {
                 title="New Session"
                 aria-label="New Session"
                 onClick={() => {
-                  void sessionView.newSession().then((id) => {
-                    const identity = assignSessionMascot(id)
-                    setMascotMap((prev) => ({ ...prev, [id]: identity }))
-                    navigate(`/s/${id}`)
-                  })
+                  void sessionView.newSession().then((id) => navigate(`/s/${id}`))
                 }}
               >
                 <LuPlus className="size-3.5" />
@@ -231,7 +220,7 @@ function Shell(props: SlotProps) {
           ) : (
             sessions.map((item) => {
               const active = item.id === routeSessionId
-              const identity = mascotMap[item.id] ?? DEFAULT_SESSION_MASCOT
+              const identity = resolveSessionMascot(item.id, item.mascot)
               return (
                 <div
                   key={item.id}
@@ -268,12 +257,6 @@ function Shell(props: SlotProps) {
                       event.stopPropagation()
                       if (!window.confirm(`Delete session “${item.title}”?`)) return
                       const wasActive = item.id === sessionId
-                      releaseSessionMascot(item.id)
-                      setMascotMap((prev) => {
-                        const next = { ...prev }
-                        delete next[item.id]
-                        return next
-                      })
                       void sessionView.deleteSession(item.id).then(() => {
                         if (!wasActive) return
                         const next = sessionView.get().sessionId

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -22,6 +22,7 @@ export interface SessionListItem {
   eventCount: number
   updatedAt: number
   project?: { name: string; path?: string; boundAt: number }
+  mascot?: { shape: string; color: string }
 }
 
 export type ConversationView = 'chat' | 'trajectory'
@@ -111,7 +112,9 @@ function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
       left.eventCount !== right.eventCount ||
       left.updatedAt !== right.updatedAt ||
       left.project?.path !== right.project?.path ||
-      left.project?.name !== right.project?.name
+      left.project?.name !== right.project?.name ||
+      left.mascot?.shape !== right.mascot?.shape ||
+      left.mascot?.color !== right.mascot?.color
     ) {
       return false
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
每个 session 的 shape/color 之前只写在浏览器 `localStorage`，刷新/清缓存/按「当前已占用组合」重算时会变。

## Fix
- 创建 session 时分配一次 mascot，写入 session 记录（sqlite `mascot_json`）
- `GET /api/sessions` / create / get 返回 `mascot`
- 旧 session 首次列表时用 **稳定 hash(sessionId)** 回填并落盘，之后不再变
- 前端以服务端字段为准，去掉 localStorage 分配

## Test
- `host/plugins/core/session-mascot.test.ts`
- `src/plugins/contributors/mascot/session-mascot.test.ts`
- existing `sessions.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

