### PR TITLE
Animate session mascots; remove activity-bar character

### DIFF
--- a/src/plugins/contributors/mascot/grok-bot-avatar.tsx
+++ b/src/plugins/contributors/mascot/grok-bot-avatar.tsx
@@ -8,16 +8,52 @@ export type GrokBotAvatarProps = {
   size?: number
   /** Agent running → thinking; else onboarding idle cycle */
   busy?: boolean
-  /** Pause RAF work (still paints once). Prefer for inactive list rows. */
+  /** Force-pause (e.g. offscreen). Visibility also auto-pauses. */
   paused?: boolean
   followPointer?: boolean
   className?: string
   title?: string
 }
 
+type BotInternal = GrokCharacterLike & {
+  paused: boolean
+  last: number
+  _raf: number
+  _tick: (now: number) => void
+}
+
+/** Stop empty RAF while paused — vendored setPaused still schedules frames. */
+function patchPauseStopsRaf(bot: GrokCharacterLike) {
+  const raw = bot as BotInternal
+  if ((raw as { __pausePatched?: boolean }).__pausePatched) return
+  const tick = raw._tick.bind(raw)
+  raw._tick = (now: number) => {
+    if (raw.paused) {
+      raw._raf = 0
+      return
+    }
+    tick(now)
+  }
+  const setPaused = raw.setPaused.bind(raw)
+  raw.setPaused = (v: boolean) => {
+    setPaused(v)
+    if (raw.paused) {
+      if (raw._raf) cancelAnimationFrame(raw._raf)
+      raw._raf = 0
+      return
+    }
+    if (!raw._raf) {
+      raw.last = performance.now()
+      raw._raf = requestAnimationFrame((t) => raw._tick(t))
+    }
+  }
+  ;(raw as { __pausePatched?: boolean }).__pausePatched = true
+}
+
 /**
- * Animated Grok Bot character (vendored study replica).
- * One instance owns one SVG + RAF loop; call destroy on unmount.
+ * Animated Grok Bot character.
+ * Stable across session switches (shape/color set in place).
+ * Off-screen / paused instances cancel RAF so chat swaps stay smooth.
  */
 export const GrokBotAvatar = memo(function GrokBotAvatar({
   shape,
@@ -29,27 +65,51 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
   className,
   title = 'Session mascot',
 }: GrokBotAvatarProps) {
+  const wrapRef = useRef<HTMLSpanElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
   const botRef = useRef<GrokCharacterLike | null>(null)
   const [ready, setReady] = useState(false)
+  const [visible, setVisible] = useState(true)
+  const shapeRef = useRef(shape)
+  const colorRef = useRef(color)
+  const busyRef = useRef(busy)
+  shapeRef.current = shape
+  colorRef.current = color
+  busyRef.current = busy
+
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el || typeof IntersectionObserver === 'undefined') return
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        setVisible(Boolean(entry?.isIntersecting))
+      },
+      { root: null, threshold: 0.01 },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
 
   useEffect(() => {
     let cancelled = false
     void loadGrokBot().then(() => {
       if (cancelled || !svgRef.current || !window.GrokCharacter) return
       botRef.current?.destroy()
-      botRef.current = new window.GrokCharacter(svgRef.current, {
-        shape,
-        color,
+      const bot = new window.GrokCharacter(svgRef.current, {
+        shape: shapeRef.current,
+        color: colorRef.current,
         scheme: 'light',
         loginWrap: true,
         sizePx: size,
-        mode: busy ? 'hold' : 'onboarding',
-        state: busy ? 'thinking' : 'idle',
+        mode: busyRef.current ? 'hold' : 'onboarding',
+        state: busyRef.current ? 'thinking' : 'idle',
         followPointer,
-        paused,
+        paused: paused || !visible,
         eyeColor: '#f3efe6',
       })
+      patchPauseStopsRaf(bot)
+      botRef.current = bot
       setReady(true)
     })
     return () => {
@@ -57,7 +117,7 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
       botRef.current?.destroy()
       botRef.current = null
     }
-    // Recreate only when size / pointer policy changes; shape/color/busy update below.
+    // Recreate only when size / pointer policy changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [size, followPointer])
 
@@ -80,11 +140,12 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
   }, [busy, ready])
 
   useEffect(() => {
-    botRef.current?.setPaused(paused)
-  }, [paused, ready])
+    botRef.current?.setPaused(paused || !visible)
+  }, [paused, visible, ready])
 
   return (
     <span
+      ref={wrapRef}
       className={`sidebar-mascot grok-bot-avatar${className ? ` ${className}` : ''}`}
       style={{ width: size, height: size, display: 'inline-grid', placeItems: 'center' }}
       title={title}

--- a/src/plugins/contributors/mascot/sidebar-mascot.tsx
+++ b/src/plugins/contributors/mascot/sidebar-mascot.tsx
@@ -1,125 +1,37 @@
-import { memo, useEffect, useState } from 'react'
-import { loadGrokGeo } from './grok-bot-loader.ts'
-import type { GrokColor, GrokShape, SessionMascotIdentity } from './grok-bot-types.ts'
+import { memo } from 'react'
+import { GrokBotAvatar } from './grok-bot-avatar.tsx'
+import type { SessionMascotIdentity } from './grok-bot-types.ts'
 import { DEFAULT_SESSION_MASCOT } from './session-mascot.ts'
 
 export type SidebarMascotProps = {
   size?: number
-  /** Reserved for future light busy affordance (static pulse). */
   busy?: boolean
   className?: string
   title?: string
   /** Per-chat role; defaults to brand mascot when omitted. */
   identity?: SessionMascotIdentity
+  paused?: boolean
+  followPointer?: boolean
 }
 
-type MarkPaint = {
-  path: string
-  fill: string
-  viewBox: string
-}
-
-const paintCache = new Map<string, MarkPaint>()
-
-function cacheKey(shape: GrokShape, color: GrokColor) {
-  return `${shape}:${color}`
-}
-
-function paintFromGeo(shape: GrokShape, color: GrokColor): MarkPaint | null {
-  const geo = window.GROK_GEO
-  if (!geo) return null
-  const key = cacheKey(shape, color)
-  const hit = paintCache.get(key)
-  if (hit) return hit
-  const shapeData = geo.shapes[shape]
-  const pal = geo.palette[color] || geo.palette.black
-  if (!shapeData || !pal) return null
-  const vb = geo.viewBox
-  const next: MarkPaint = {
-    path: shapeData.path,
-    fill: pal.light,
-    viewBox: `${vb.minX} ${vb.minY} ${vb.width} ${vb.height}`,
-  }
-  paintCache.set(key, next)
-  return next
-}
-
-/** Lightweight static silhouette — no GrokCharacter / RAF (safe on session switch). */
-export const SessionMascotMark = memo(function SessionMascotMark({
-  shape,
-  color,
-  size = 28,
-  busy = false,
-  className,
-  title,
-}: {
-  shape: GrokShape
-  color: GrokColor
-  size?: number
-  busy?: boolean
-  className?: string
-  title?: string
-}) {
-  const [paint, setPaint] = useState<MarkPaint | null>(() => paintFromGeo(shape, color))
-
-  useEffect(() => {
-    const sync = paintFromGeo(shape, color)
-    if (sync) {
-      setPaint(sync)
-      return
-    }
-    let cancelled = false
-    void loadGrokGeo().then(() => {
-      if (cancelled) return
-      setPaint(paintFromGeo(shape, color))
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [shape, color])
-
-  return (
-    <span
-      className={`sidebar-mascot session-mascot-mark${busy ? ' is-busy' : ''}${className ? ` ${className}` : ''}`}
-      style={{ width: size, height: size, display: 'inline-grid', placeItems: 'center' }}
-      title={title}
-    >
-      <svg
-        width={size}
-        height={size}
-        viewBox={paint?.viewBox ?? '0 0 229 229'}
-        role="img"
-        aria-label={title || `${shape} ${color}`}
-        style={{ overflow: 'visible' }}
-      >
-        {paint ? (
-          <path d={paint.path} fill={paint.fill} />
-        ) : (
-          <circle cx="114" cy="114" r="40" fill="#888" opacity={0.4} />
-        )}
-      </svg>
-    </span>
-  )
-})
-
-/**
- * Sidebar / activity brand mark.
- * Static by default — full GrokCharacter RAF was causing chat-switch jank
- * (multiple animation loops + setShape morph on every session change).
- */
+/** Animated per-session Grok role (stable instance; off-screen pauses RAF). */
 export const SidebarMascot = memo(function SidebarMascot({
   size = 44,
   busy = false,
   className,
   title = 'Harness',
   identity = DEFAULT_SESSION_MASCOT,
+  paused = false,
+  followPointer = false,
 }: SidebarMascotProps) {
   return (
-    <SessionMascotMark
+    <GrokBotAvatar
       shape={identity.shape}
       color={identity.color}
       size={size}
       busy={busy}
+      paused={paused}
+      followPointer={followPointer}
       className={className}
       title={title}
     />

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -12,9 +12,8 @@ import {
   type AppModuleId,
 } from '../infrastructure/app-modules.ts'
 import { FishLogo } from './brand.tsx'
-import { SessionMascotMark, SidebarMascot } from './mascot/sidebar-mascot.tsx'
-import { DEFAULT_SESSION_MASCOT, resolveSessionMascot } from './mascot/session-mascot.ts'
-import type { SessionMascotIdentity } from './mascot/grok-bot-types.ts'
+import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
+import { resolveSessionMascot } from './mascot/session-mascot.ts'
 import { LuPlus } from 'react-icons/lu'
 
 export const name = 'shell'
@@ -44,27 +43,15 @@ function ModuleRail({
   active,
   agentHref,
   live,
-  busy,
-  identity,
   onSettings,
 }: {
   active: AppModuleId
   agentHref: string
   live: boolean
-  busy: boolean
-  identity: SessionMascotIdentity
   onSettings: () => void
 }) {
   return (
     <nav className="app-activity-bar" aria-label="Activity bar">
-      <Link to={agentHref} className="app-activity-brand" title="HARNESS" aria-label="Home">
-        <SidebarMascot
-          size={34}
-          busy={busy}
-          identity={identity}
-          title={`${identity.shape} · ${identity.color}`}
-        />
-      </Link>
       <div className="app-activity-list">
         {APP_MODULES.map((module) => {
           const to = module.id === 'agent' ? agentHref : module.path
@@ -142,13 +129,6 @@ function Shell(props: SlotProps) {
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}${view === 'trajectory' ? '/trajectory' : ''}` : '/'
-  const activeSession =
-    sessions.find((item) => item.id === routeSessionId) || sessions.find((item) => item.id === sessionId)
-  const activeMascot = activeSession
-    ? resolveSessionMascot(activeSession.id, activeSession.mascot)
-    : routeSessionId
-      ? resolveSessionMascot(routeSessionId)
-      : DEFAULT_SESSION_MASCOT
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -186,8 +166,6 @@ function Shell(props: SlotProps) {
         active={activeModule}
         agentHref={agentHref}
         live={live}
-        busy={agentBusy}
-        identity={activeMascot}
         onSettings={() => setSettingsOpen(true)}
       />
 
@@ -232,10 +210,9 @@ function Shell(props: SlotProps) {
                     to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
                     className="flex min-w-0 flex-1 items-center gap-2.5 px-2.5 py-2 text-left text-sm"
                   >
-                    <SessionMascotMark
+                    <SidebarMascot
                       size={28}
-                      shape={identity.shape}
-                      color={identity.color}
+                      identity={identity}
                       busy={active && agentBusy}
                       title={`${identity.shape} · ${identity.color}`}
                     />

--- a/src/style.css
+++ b/src/style.css
@@ -201,7 +201,7 @@ body {
   flex-direction: column;
   align-items: stretch;
   gap: 2px;
-  padding-top: 4px;
+  padding-top: 10px;
 }
 
 .app-activity-footer {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
1. **去掉最左侧 Activity bar 顶部小人物**（Chat 图标上方不再有品牌 mascot）
2. **会话列表恢复动画角色**：每个 session 用 `GrokCharacter` 动起来，不再用静态剪影
3. **性能**：实例按 session 稳定挂载；滚出视口的取消 RAF，避免切换卡顿
4. Activity list 顶部补一点 padding

## Note
shape/color 仍由服务端持久化，刷新不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

