### PR TITLE
fix: keep hydrated markdown; loading for new rows while scrolling

### DIFF
--- a/src/plugins/contributors/chat/markdown.tsx
+++ b/src/plugins/contributors/chat/markdown.tsx
@@ -9,17 +9,14 @@ export const MarkdownBody = memo(function MarkdownBody({
   text,
   className = '',
   streaming = false,
-  /** 快速滚动时用纯文本占位，避免虚表回收后反复 remark 解析导致白屏 */
-  lightweight = false,
 }: {
   text: string
   className?: string
   /** 流式中跳过 remark，避免每帧全量重解析 */
   streaming?: boolean
-  lightweight?: boolean
 }) {
   if (!text) return null
-  if (streaming || lightweight) {
+  if (streaming) {
     return (
       <div className={`chat-md chat-md-stream ${className}`.trim()}>
         <pre className="chat-md-stream-pre">{text}</pre>

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -18,8 +18,8 @@ const ESTIMATE_ROW_PX = 160
 const VIRTUALIZE_AFTER = 12
 /** 加大 overscan：快速上滑时预挂载更多行，减少白屏 */
 const OVERSCAN = 18
-/** 滚动停下多久后恢复完整 Markdown */
-const SCROLL_IDLE_MS = 90
+/** 滚动停下多久后，给尚未 hydrate 的行补上完整渲染 */
+const SCROLL_IDLE_MS = 120
 
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node = el?.parentElement ?? null
@@ -29,6 +29,18 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
     node = node.parentElement
   }
   return null
+}
+
+function RowLoading({ kind }: { kind: ChatNode['kind'] }) {
+  const label =
+    kind === 'user' ? '消息加载中' : kind === 'assistant' ? '回复加载中' : kind === 'tool' ? '工具加载中' : '加载中'
+  return (
+    <div className="chat-row-loading" aria-busy="true" aria-label={label}>
+      <span className="chat-row-loading-dot" />
+      <span className="chat-row-loading-dot" />
+      <span className="chat-row-loading-dot" />
+    </div>
+  )
 }
 
 function AssistantActions({
@@ -91,19 +103,24 @@ function NodeView({
   node,
   onInspect,
   onFork,
-  lightweight,
+  hydrated,
 }: {
   node: ChatNode
   onInspect: (callId: string) => void
   onFork: () => void | Promise<void>
-  lightweight: boolean
+  /** false = 滚动中新进视口，只显示 loading，不动已 hydrate 的 Markdown */
+  hydrated: boolean
 }) {
+  if (!hydrated) {
+    return <RowLoading kind={node.kind} />
+  }
+
   if (node.kind === 'user') {
     return (
       <div className="chat-user-row">
         <div className="chat-user-bubble">
           {node.kindTag === 'inject' ? <div className="chat-user-tag">inject</div> : null}
-          <MarkdownBody text={node.text} lightweight={lightweight} />
+          <MarkdownBody text={node.text} />
         </div>
       </div>
     )
@@ -114,27 +131,17 @@ function NodeView({
       <div className="chat-assistant-row">
         <div className="chat-assistant-body">
           {node.text ? (
-            <MarkdownBody text={node.text} streaming={streaming} lightweight={lightweight && !streaming} />
+            <MarkdownBody text={node.text} streaming={streaming} />
           ) : streaming ? (
             '…'
           ) : null}
           {streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
         </div>
-        {!streaming && !lightweight && node.text.trim() ? (
-          <AssistantActions text={node.text} onFork={onFork} />
-        ) : null}
+        {!streaming && node.text.trim() ? <AssistantActions text={node.text} onFork={onFork} /> : null}
       </div>
     )
   }
   if (node.kind === 'tool') {
-    if (lightweight) {
-      return (
-        <div className="rounded-[12px] border border-[var(--dsw-border)] px-3 py-2 font-mono text-[12px] text-[var(--dsw-label-3)]">
-          {node.name}
-          {node.result ? (node.result.ok ? ' · ok' : ' · err') : ' · …'}
-        </div>
-      )
-    }
     return <ToolCard node={node} onInspect={onInspect} />
   }
   return <div className="self-center text-xs text-[var(--dsw-label-3)]">{node.text}</div>
@@ -199,6 +206,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const stickToBottomRef = useRef(true)
   const scrollIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const prefetchingRef = useRef(false)
+  /** 已完整渲染过的行：滚动中也不降级成原文 / stub */
+  const hydratedRef = useRef(new Set<string>())
   const [scrollEpoch, setScrollEpoch] = useState(0)
   const [isScrolling, setIsScrolling] = useState(false)
 
@@ -217,6 +226,11 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       navigate(`/s/${id}`)
     })
   }, [sessionView, navigate])
+
+  useEffect(() => {
+    hydratedRef.current = new Set()
+    setIsScrolling(false)
+  }, [sessionId])
 
   useLayoutEffect(() => {
     const parent = findScrollParent(rootRef.current)
@@ -305,7 +319,20 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
 
   if (nodes.length === 0 && !pending && !error) return <EmptyHero />
 
-  const lightweight = virtualize && isScrolling
+  const rowHydrated = (node: ChatNode) => {
+    if (hydratedRef.current.has(node.id)) return true
+    // 流式助手：直接展示流式文本，不走 loading
+    if (node.kind === 'assistant' && node.streaming) {
+      hydratedRef.current.add(node.id)
+      return true
+    }
+    // 静止或非虚表：完整渲染，并记下，下次滚动不再拆掉
+    if (!virtualize || !isScrolling) {
+      hydratedRef.current.add(node.id)
+      return true
+    }
+    return false
+  }
 
   return (
     <div ref={rootRef} className="w-full" data-chat-virtual={virtualize ? '1' : '0'}>
@@ -318,11 +345,12 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
           {virtualizer.getVirtualItems().map((item) => {
             const node = nodes[item.index]
             if (!node) return null
+            const hydrated = rowHydrated(node)
             return (
               <div
                 key={item.key}
                 data-index={item.index}
-                ref={isScrolling ? undefined : virtualizer.measureElement}
+                ref={isScrolling && !hydrated ? undefined : virtualizer.measureElement}
                 className="chat-virt-row absolute top-0 left-0 w-full"
                 style={{ transform: `translateY(${item.start}px)` }}
               >
@@ -330,7 +358,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
                   node={node}
                   onInspect={onInspect}
                   onFork={onFork}
-                  lightweight={lightweight}
+                  hydrated={hydrated}
                 />
               </div>
             )
@@ -344,7 +372,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
               node={node}
               onInspect={onInspect}
               onFork={onFork}
-              lightweight={false}
+              hydrated
             />
           ))}
         </div>

--- a/src/style.css
+++ b/src/style.css
@@ -1182,6 +1182,52 @@ body {
   word-break: break-word;
 }
 
+.chat-row-loading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 48px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(242, 241, 237, 0.04);
+}
+
+.chat-row-loading-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--dsw-label-3);
+  opacity: 0.45;
+  animation: chat-row-loading-pulse 0.9s ease-in-out infinite;
+}
+
+.chat-row-loading-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.chat-row-loading-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes chat-row-loading-pulse {
+  0%,
+  100% {
+    opacity: 0.25;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.85;
+    transform: translateY(-2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-row-loading-dot {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
 .chat-md > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fix
滚动时不再把已渲染的 Markdown 拆成原文。

- **已 hydrate 的行**：保持 Markdown / ToolCard，滚动中不降级
- **滚动中新进视口、尚未渲染的行**：只显示 loading 占位，不展示原文
- 停下后再完整渲染，并记入 hydrate 集合

流式助手消息仍直接展示流式文本。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

