### PR TITLE
perf: smooth chat-sidebar mascot animation

### DIFF
--- a/src/plugins/contributors/mascot/grok-bot-avatar.tsx
+++ b/src/plugins/contributors/mascot/grok-bot-avatar.tsx
@@ -1,12 +1,13 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { loadGrokBot } from './grok-bot-loader.ts'
+import { attachSharedTicker, detachSharedTicker, quietSidebarMotion } from './grok-bot-scheduler.ts'
 import type { GrokCharacterLike, GrokColor, GrokShape } from './grok-bot-types.ts'
 
 export type GrokBotAvatarProps = {
   shape: GrokShape
   color: GrokColor
   size?: number
-  /** Agent running → thinking; else onboarding idle cycle */
+  /** Agent running → thinking; else calm idle (no onboarding thrash) */
   busy?: boolean
   /** Force-pause (e.g. offscreen). Visibility also auto-pauses. */
   paused?: boolean
@@ -20,40 +21,15 @@ type BotInternal = GrokCharacterLike & {
   last: number
   _raf: number
   _tick: (now: number) => void
-}
-
-/** Stop empty RAF while paused — vendored setPaused still schedules frames. */
-function patchPauseStopsRaf(bot: GrokCharacterLike) {
-  const raw = bot as BotInternal
-  if ((raw as { __pausePatched?: boolean }).__pausePatched) return
-  const tick = raw._tick.bind(raw)
-  raw._tick = (now: number) => {
-    if (raw.paused) {
-      raw._raf = 0
-      return
-    }
-    tick(now)
-  }
-  const setPaused = raw.setPaused.bind(raw)
-  raw.setPaused = (v: boolean) => {
-    setPaused(v)
-    if (raw.paused) {
-      if (raw._raf) cancelAnimationFrame(raw._raf)
-      raw._raf = 0
-      return
-    }
-    if (!raw._raf) {
-      raw.last = performance.now()
-      raw._raf = requestAnimationFrame((t) => raw._tick(t))
-    }
-  }
-  ;(raw as { __pausePatched?: boolean }).__pausePatched = true
+  trickAt?: number
+  celebrateAt?: number
+  trick?: unknown
+  hopAt?: number
 }
 
 /**
- * Animated Grok Bot character.
- * Stable across session switches (shape/color set in place).
- * Off-screen / paused instances cancel RAF so chat swaps stay smooth.
+ * Animated Grok Bot for the session list.
+ * Uses a shared ~30fps ticker + hold/idle (no per-bot 60fps / onboarding / tricks).
  */
 export const GrokBotAvatar = memo(function GrokBotAvatar({
   shape,
@@ -80,12 +56,22 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
   useEffect(() => {
     const el = wrapRef.current
     if (!el || typeof IntersectionObserver === 'undefined') return
+    let root: Element | null = null
+    let node: HTMLElement | null = el.parentElement
+    while (node) {
+      const { overflowY } = getComputedStyle(node)
+      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+        root = node
+        break
+      }
+      node = node.parentElement
+    }
     const io = new IntersectionObserver(
       (entries) => {
         const entry = entries[0]
         setVisible(Boolean(entry?.isIntersecting))
       },
-      { root: null, threshold: 0.01 },
+      { root, rootMargin: '32px 0px', threshold: 0.01 },
     )
     io.observe(el)
     return () => io.disconnect()
@@ -95,27 +81,36 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
     let cancelled = false
     void loadGrokBot().then(() => {
       if (cancelled || !svgRef.current || !window.GrokCharacter) return
-      botRef.current?.destroy()
+      if (botRef.current) {
+        detachSharedTicker(botRef.current)
+        botRef.current.destroy()
+      }
       const bot = new window.GrokCharacter(svgRef.current, {
         shape: shapeRef.current,
         color: colorRef.current,
         scheme: 'light',
         loginWrap: true,
         sizePx: size,
-        mode: busyRef.current ? 'hold' : 'onboarding',
+        mode: 'hold',
         state: busyRef.current ? 'thinking' : 'idle',
         followPointer,
-        paused: paused || !visible,
+        paused: true,
         eyeColor: '#f3efe6',
-      })
-      patchPauseStopsRaf(bot)
+      }) as BotInternal
+      quietSidebarMotion(bot)
+      if (busyRef.current) bot.setState('thinking', { resetEyes: false })
+      attachSharedTicker(bot)
+      bot.setPaused(paused || !visible)
       botRef.current = bot
       setReady(true)
     })
     return () => {
       cancelled = true
-      botRef.current?.destroy()
-      botRef.current = null
+      if (botRef.current) {
+        detachSharedTicker(botRef.current)
+        botRef.current.destroy()
+        botRef.current = null
+      }
     }
     // Recreate only when size / pointer policy changes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -126,16 +121,19 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
     if (!bot || !ready) return
     bot.setShape(shape)
     bot.setColor(color, 'light')
-  }, [shape, color, ready])
+    // Shape morph can re-arm tricks — keep them off for sidebar.
+    quietSidebarMotion(bot)
+    if (busy) bot.setState('thinking', { resetEyes: false })
+  }, [shape, color, ready, busy])
 
   useEffect(() => {
-    const bot = botRef.current
+    const bot = botRef.current as BotInternal | null
     if (!bot || !ready) return
     if (busy) {
       bot.setMode('hold')
       bot.setState('thinking', { resetEyes: false })
     } else {
-      bot.setMode('onboarding')
+      quietSidebarMotion(bot)
     }
   }, [busy, ready])
 
@@ -162,6 +160,9 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
           overflow: 'visible',
           colorScheme: 'light',
           opacity: ready ? 1 : 0.35,
+          // Promote to own layer so SVG paints don't dirty the whole sidebar
+          transform: 'translateZ(0)',
+          willChange: 'transform',
         }}
       />
     </span>

--- a/src/plugins/contributors/mascot/grok-bot-scheduler.ts
+++ b/src/plugins/contributors/mascot/grok-bot-scheduler.ts
@@ -1,0 +1,97 @@
+type Tickable = {
+  paused: boolean
+  last: number
+  _raf: number
+  _tick: (now: number) => void
+  __shared?: boolean
+}
+
+const bots = new Set<Tickable>()
+let rafId = 0
+let lastDrive = 0
+
+/** Sidebar bots share one clock (~30fps) instead of N×60 RAF loops. */
+const FRAME_MS = 1000 / 30
+
+function drive(now: number) {
+  rafId = requestAnimationFrame(drive)
+  if (now - lastDrive < FRAME_MS) return
+  lastDrive = now
+  for (const bot of bots) {
+    if (bot.paused) continue
+    bot._tick(now)
+  }
+  if (bots.size === 0 && rafId) {
+    cancelAnimationFrame(rafId)
+    rafId = 0
+  }
+}
+
+function ensureLoop() {
+  if (!rafId) {
+    lastDrive = 0
+    rafId = requestAnimationFrame(drive)
+  }
+}
+
+/**
+ * Detach a GrokCharacter from its private RAF and register on the shared ticker.
+ * Safe to call once per instance after construction.
+ */
+export function attachSharedTicker(bot: object) {
+  const raw = bot as Tickable
+  if (raw.__shared) return
+  if (raw._raf) {
+    cancelAnimationFrame(raw._raf)
+    raw._raf = 0
+  }
+
+  const inner = raw._tick.bind(raw)
+  raw._tick = (now: number) => {
+    // Inner tick normally schedules the next frame at the end — neutralize that.
+    const prevRaf = raw._raf
+    inner(now)
+    if (raw._raf && raw._raf !== prevRaf) {
+      cancelAnimationFrame(raw._raf)
+      raw._raf = 0
+    }
+  }
+
+  raw.__shared = true
+  bots.add(raw)
+  ensureLoop()
+}
+
+export function detachSharedTicker(bot: object) {
+  const raw = bot as Tickable
+  if (!raw.__shared) return
+  bots.delete(raw)
+  raw.__shared = false
+  if (raw._raf) {
+    cancelAnimationFrame(raw._raf)
+    raw._raf = 0
+  }
+  if (bots.size === 0 && rafId) {
+    cancelAnimationFrame(rafId)
+    rafId = 0
+  }
+}
+
+/** Quiet a character: no onboarding mood thrash, no hop/spin tricks. */
+export function quietSidebarMotion(bot: object) {
+  const raw = bot as {
+    mode?: string
+    trickAt?: number
+    celebrateAt?: number
+    trick?: unknown
+    hopAt?: number
+    setMode?: (m: string) => void
+    setState?: (s: string, o?: { resetEyes?: boolean }) => void
+  }
+  raw.setMode?.('hold')
+  raw.setState?.('idle', { resetEyes: false })
+  raw.trickAt = Number.POSITIVE_INFINITY
+  raw.celebrateAt = -1
+  raw.trick = null
+  raw.hopAt = -1
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why 不流畅
侧栏每个 session 各自跑一整套 `GrokCharacter`：
- N 路独立 **60fps RAF**
- **onboarding** 不停换表情（重 morph）
- 还不时 hop / spin 特技

主线程被这堆动画挤占，看起来就一卡一卡。

## Fix
- **共享一只时钟**，侧栏统一 ~30fps
- 只用 `hold` + `idle`/`thinking`，关掉 onboarding 轮换与特技
- 不可见实例仍 pause；Observer 跟侧栏滚动容器

shape/color 持久化不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

