### PR TITLE
fix: restore rich sidebar mascot expressions

### DIFF
--- a/src/plugins/contributors/mascot/grok-bot-avatar.tsx
+++ b/src/plugins/contributors/mascot/grok-bot-avatar.tsx
@@ -1,13 +1,18 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { loadGrokBot } from './grok-bot-loader.ts'
-import { attachSharedTicker, detachSharedTicker, quietSidebarMotion } from './grok-bot-scheduler.ts'
+import {
+  applySidebarMood,
+  attachSharedTicker,
+  detachSharedTicker,
+  suppressSidebarTricks,
+} from './grok-bot-scheduler.ts'
 import type { GrokCharacterLike, GrokColor, GrokShape } from './grok-bot-types.ts'
 
 export type GrokBotAvatarProps = {
   shape: GrokShape
   color: GrokColor
   size?: number
-  /** Agent running → thinking; else calm idle (no onboarding thrash) */
+  /** Agent running → thinking; else onboarding expression playlist */
   busy?: boolean
   /** Force-pause (e.g. offscreen). Visibility also auto-pauses. */
   paused?: boolean
@@ -29,7 +34,7 @@ type BotInternal = GrokCharacterLike & {
 
 /**
  * Animated Grok Bot for the session list.
- * Uses a shared ~30fps ticker + hold/idle (no per-bot 60fps / onboarding / tricks).
+ * Shared ~30fps ticker; onboarding cycles rich expressions; hop/spin tricks stay off.
  */
 export const GrokBotAvatar = memo(function GrokBotAvatar({
   shape,
@@ -91,14 +96,13 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
         scheme: 'light',
         loginWrap: true,
         sizePx: size,
-        mode: 'hold',
+        mode: busyRef.current ? 'hold' : 'onboarding',
         state: busyRef.current ? 'thinking' : 'idle',
         followPointer,
         paused: true,
         eyeColor: '#f3efe6',
       }) as BotInternal
-      quietSidebarMotion(bot)
-      if (busyRef.current) bot.setState('thinking', { resetEyes: false })
+      applySidebarMood(bot, busyRef.current)
       attachSharedTicker(bot)
       bot.setPaused(paused || !visible)
       botRef.current = bot
@@ -121,20 +125,15 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
     if (!bot || !ready) return
     bot.setShape(shape)
     bot.setColor(color, 'light')
-    // Shape morph can re-arm tricks — keep them off for sidebar.
-    quietSidebarMotion(bot)
-    if (busy) bot.setState('thinking', { resetEyes: false })
+    // setShape can re-arm tricks — keep them off.
+    suppressSidebarTricks(bot)
+    applySidebarMood(bot, busy)
   }, [shape, color, ready, busy])
 
   useEffect(() => {
-    const bot = botRef.current as BotInternal | null
+    const bot = botRef.current
     if (!bot || !ready) return
-    if (busy) {
-      bot.setMode('hold')
-      bot.setState('thinking', { resetEyes: false })
-    } else {
-      quietSidebarMotion(bot)
-    }
+    applySidebarMood(bot, busy)
   }, [busy, ready])
 
   useEffect(() => {
@@ -160,7 +159,6 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
           overflow: 'visible',
           colorScheme: 'light',
           opacity: ready ? 1 : 0.35,
-          // Promote to own layer so SVG paints don't dirty the whole sidebar
           transform: 'translateZ(0)',
           willChange: 'transform',
         }}

--- a/src/plugins/contributors/mascot/grok-bot-scheduler.ts
+++ b/src/plugins/contributors/mascot/grok-bot-scheduler.ts
@@ -77,21 +77,31 @@ export function detachSharedTicker(bot: object) {
   }
 }
 
-/** Quiet a character: no onboarding mood thrash, no hop/spin tricks. */
-export function quietSidebarMotion(bot: object) {
+/** Keep hop/spin tricks off so expression cycling stays smooth. */
+export function suppressSidebarTricks(bot: object) {
   const raw = bot as {
-    mode?: string
     trickAt?: number
     celebrateAt?: number
     trick?: unknown
     hopAt?: number
-    setMode?: (m: string) => void
-    setState?: (s: string, o?: { resetEyes?: boolean }) => void
   }
-  raw.setMode?.('hold')
-  raw.setState?.('idle', { resetEyes: false })
   raw.trickAt = Number.POSITIVE_INFINITY
   raw.celebrateAt = -1
   raw.trick = null
   raw.hopAt = -1
+}
+
+/** Idle: onboarding mood playlist (curious/happy/playful/…). Busy: thinking. */
+export function applySidebarMood(bot: object, busy: boolean) {
+  const raw = bot as {
+    setMode?: (m: string) => void
+    setState?: (s: string, o?: { resetEyes?: boolean }) => void
+  }
+  suppressSidebarTricks(bot)
+  if (busy) {
+    raw.setMode?.('hold')
+    raw.setState?.('thinking', { resetEyes: false })
+    return
+  }
+  raw.setMode?.('onboarding')
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因
上一版为流畅把侧栏锁成 `hold` + `idle`，表情只剩一张「发呆脸」，看起来像愁眉苦脸。

## 修复
- 恢复 **onboarding** 表情轮换：`curious / happy / playful / excited / listening / proud / laughing / shy`（中间穿插 idle）
- 仍保留共享 ~30fps 时钟
- 仍关掉 hop/spin 特技（卡顿主因），不影响表情丰富度
- busy 时仍切 `thinking`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

