### PR TITLE
ui: remove cream disk from empty chat hero

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -148,14 +148,6 @@ body {
 .chat-empty-hero-mascot {
   display: grid;
   place-items: center;
-  width: 148px;
-  height: 148px;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at 50% 45%, rgba(243, 239, 230, 0.95), rgba(243, 239, 230, 0.72) 58%, transparent 72%);
-  box-shadow:
-    inset 0 -18px 36px rgba(40, 30, 10, 0.08),
-    0 18px 48px rgba(0, 0, 0, 0.28);
   animation: chat-empty-mascot-float 3.6s ease-in-out infinite;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉空会话欢迎区 mascot 背后的奶油色圆盘，角色直接落在背景上。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

