### PR TITLE
fix: don't send on Enter during IME composition

### DIFF
--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -79,10 +79,11 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         aria-label="对话输入"
         onChange={(event) => scheduleCanSubmit(event.target.value)}
         onKeyDown={(event) => {
-          if (event.key === 'Enter' && !event.shiftKey) {
-            event.preventDefault()
-            event.currentTarget.form?.requestSubmit()
-          }
+          if (event.key !== 'Enter' || event.shiftKey) return
+          // 中文等 IME 组字确认用的 Enter，不要当成发送
+          if (event.nativeEvent.isComposing || event.keyCode === 229) return
+          event.preventDefault()
+          event.currentTarget.form?.requestSubmit()
         }}
       />
       <div className="flex items-center justify-end gap-2 px-3 pb-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
中文等 IME 组字时，回车用于确认候选字，不应发送消息。

`onKeyDown` 在 `isComposing` / `keyCode === 229` 时跳过发送；组字结束后的 Enter 仍可发送，Shift+Enter 换行不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

