### PR TITLE
ui: chat side padding + Copy/Fork on the right

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -131,13 +131,15 @@ function NodeView({
     const streaming = Boolean(node.streaming)
     return (
       <div className="chat-assistant-row">
-        <div className="chat-assistant-body">
-          {node.text ? (
-            <MarkdownBody text={node.text} streaming={streaming} />
-          ) : streaming ? (
-            '…'
-          ) : null}
-          {streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
+        <div className="chat-assistant-main">
+          <div className="chat-assistant-body">
+            {node.text ? (
+              <MarkdownBody text={node.text} streaming={streaming} />
+            ) : streaming ? (
+              '…'
+            ) : null}
+            {streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
+          </div>
         </div>
         {!streaming && node.text.trim() ? <AssistantActions text={node.text} onFork={onFork} /> : null}
       </div>

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -298,10 +298,10 @@ function Shell(props: SlotProps) {
               aria-hidden={view !== 'chat'}
             >
               <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-4 py-4 pb-44 md:px-6">
+                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
                   {props.renderSlot('stage')}
                 </div>
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-4 pb-4 md:px-6">
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-6 pb-4 md:px-8 lg:px-10">
                   <div className="pointer-events-auto space-y-2 bg-transparent">
                     {props.renderSlot('dock')}
                     {props.renderSlot('composer')}

--- a/src/style.css
+++ b/src/style.css
@@ -1168,12 +1168,17 @@ body {
 .chat-assistant-row {
   display: flex;
   width: 100%;
-  flex-direction: column;
+  flex-direction: row;
   align-items: flex-start;
   gap: 6px;
   color: var(--dsw-label);
   font-size: 15px;
   line-height: 1.7;
+}
+
+.chat-assistant-main {
+  min-width: 0;
+  flex: 1;
 }
 
 .chat-assistant-body {
@@ -1183,6 +1188,7 @@ body {
 
 .chat-assistant-actions {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 2px;
   margin-top: 2px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes
1. **聊天区左右留白**：`px-6` / `md:px-8` / `lg:px-10`（消息区与输入框对齐），略松一点但不空
2. **Copy / Fork**：挪到助手消息**右侧**，不再挤在正文下方

## Note
未改消息最大宽度，宽屏仍尽量用满中间栏。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

