### PR TITLE
ui: header 图标 + Trajectory usage 靠右

### DIFF
--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -212,7 +212,6 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
           <span>{rows.length} events</span>
           <span className="traj-meta-sep">·</span>
           <span>{groups.length} turns</span>
-          <span className="traj-meta-sep">·</span>
           <span className="traj-meta-usage" title="Sum of assistant/message usage in this session">
             <span className="traj-meta-usage-label">usage</span>
             <UsageInline usage={cumulative} />

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -14,7 +14,7 @@ import {
 import { FishLogo } from './brand.tsx'
 import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
 import { resolveSessionMascot } from './mascot/session-mascot.ts'
-import { LuPanelLeft, LuPanelLeftClose, LuPlus } from 'react-icons/lu'
+import { LuMessageSquare, LuPanelLeft, LuPanelLeftClose, LuPlus, LuWaypoints } from 'react-icons/lu'
 
 export const name = 'shell'
 export const inject = ['slots', 'snapshot', 'sessionView', 'projectView']
@@ -289,27 +289,43 @@ function Shell(props: SlotProps) {
             <NavLink
               to={sessionId ? `/s/${sessionId}` : '/'}
               end
+              title="Chat"
+              aria-label="Chat"
               className={({ isActive }) =>
-                `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
+                `relative grid size-8 place-items-center rounded-[6px] ${
+                  isActive
+                    ? 'text-[var(--dsw-business)]'
+                    : 'text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]'
+                }`
               }
             >
               {({ isActive }) => (
                 <>
-                  Chat
-                  {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                  <LuMessageSquare className="size-4" />
+                  {isActive ? (
+                    <span className="absolute inset-x-1.5 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" />
+                  ) : null}
                 </>
               )}
             </NavLink>
             <NavLink
               to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
+              title="Trajectory"
+              aria-label="Trajectory"
               className={({ isActive }) =>
-                `relative pb-3 pt-3 text-[13px] font-medium ${isActive ? 'text-[var(--dsw-business)]' : 'text-[var(--dsw-label-3)]'}`
+                `relative grid size-8 place-items-center rounded-[6px] ${
+                  isActive
+                    ? 'text-[var(--dsw-business)]'
+                    : 'text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]'
+                }`
               }
             >
               {({ isActive }) => (
                 <>
-                  Trajectory
-                  {isActive ? <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" /> : null}
+                  <LuWaypoints className="size-4" />
+                  {isActive ? (
+                    <span className="absolute inset-x-1.5 bottom-0 h-0.5 rounded-full bg-[var(--dsw-business)]" />
+                  ) : null}
                 </>
               )}
             </NavLink>

--- a/src/style.css
+++ b/src/style.css
@@ -752,6 +752,7 @@ body {
   align-items: center;
   gap: 6px;
   min-width: 0;
+  margin-left: auto;
 }
 
 .traj-meta-usage-label {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 主区 header 的 Chat / Trajectory 改为图标（`LuMessageSquare` / `LuWaypoints`）
- Trajectory 顶栏 cumulative usage 靠最右侧对齐

## Screenshots
[Header tab icons](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fheader-tab-icons.png)
[Trajectory usage right](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftraj-usage-right.png)

## Test plan
- [x] Chat / Trajectory 为图标，hover 有 title
- [x] 激活态底线正确
- [x] Trajectory meta：左侧 events/turns，右侧 usage


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

