### PR TITLE
feat: 输入 / 唤起工具选择（极简可临时加工具）

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -110,6 +110,7 @@ export class ChatService extends Service {
       configured: Boolean(this.config.apiKey),
       hint: hint(this.config.apiKey),
       tools: this.ctx.tools.names(),
+      toolCatalog: this.ctx.tools.catalog(),
     }
   }
 
@@ -356,16 +357,24 @@ export function apply(ctx: Context) {
     route.send(200, { ok: true, id })
   })
   ctx.http.route('POST', '/api/sessions/:id/messages', async (route) => {
-    const payload = (await route.json()) as { text?: string; kind?: 'wake' | 'inject' }
+    const payload = (await route.json()) as {
+      text?: string
+      kind?: 'wake' | 'inject'
+      extraTools?: string[]
+    }
     const agent = await ctx.agents.create(route.params.id)
     // re-sync in-memory LLM without rewriting disk
     chat.patch({}, { persist: false })
+    const extraTools = Array.isArray(payload.extraTools)
+      ? [...new Set(payload.extraTools.map((name) => String(name).trim()).filter(Boolean))]
+      : []
+    const sendOpts = extraTools.length ? { extraTools } : undefined
     if (payload.kind === 'inject') {
-      agent.inject(payload.text ?? '')
+      agent.inject(payload.text ?? '', sendOpts)
       return route.send(200, { sessionId: agent.sessionId, queued: true })
     }
     try {
-      const turn = await agent.send(payload.text ?? '')
+      const turn = await agent.send(payload.text ?? '', sendOpts)
       route.send(200, { sessionId: agent.sessionId, text: turn.text, steps: turn.steps })
     } catch (error) {
       route.send(500, { error: String(error) })

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -3,6 +3,7 @@ import '../../types.ts'
 import type { AssistantReply, ChatOptions, LlmClient, LlmConfig, LlmMessage } from './llm.ts'
 import type { InboxKind } from '../core/session-types.ts'
 import { runWithSession } from '../core/session-scope.ts'
+import { runWithExtraTools } from '../registry/tools.ts'
 
 export interface AgentTurn {
   text: string
@@ -12,6 +13,8 @@ export interface AgentTurn {
 export interface ClaimedInput {
   kind: InboxKind
   text: string
+  /** slash 为本回合临时放开的额外工具（极简模式） */
+  extraTools?: string[]
 }
 
 export interface PreStepReq {
@@ -36,7 +39,10 @@ export class AgentLoop implements AgentRunner {
   ) {}
 
   async run(claimed: ClaimedInput[]): Promise<AgentTurn> {
-    return runWithSession(this.sessionId, () => this.runInSession(claimed))
+    const extras = [
+      ...new Set(claimed.flatMap((item) => item.extraTools ?? []).map((name) => name.trim()).filter(Boolean)),
+    ]
+    return runWithSession(this.sessionId, () => runWithExtraTools(extras, () => this.runInSession(claimed)))
   }
 
   private async runInSession(claimed: ClaimedInput[]): Promise<AgentTurn> {

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -5,10 +5,14 @@ import type { AgentTurn, ClaimedInput } from './agent-loop.ts'
 
 export type { AgentTurn, LlmConfig }
 
+export interface AgentSendOptions {
+  extraTools?: string[]
+}
+
 export interface AgentHandle {
   sessionId: string
-  send(text: string): Promise<AgentTurn>
-  inject(text: string): void
+  send(text: string, opts?: AgentSendOptions): Promise<AgentTurn>
+  inject(text: string, opts?: AgentSendOptions): void
   cancel(): void
   dispose(): void
 }
@@ -56,10 +60,15 @@ export class AgentsService extends Service {
 
     const handle: AgentHandle = {
       sessionId: id,
-      send: async (text: string) => {
+      send: async (text: string, opts?: AgentSendOptions) => {
         const trimmed = text.trim()
         if (!trimmed) return { text: '请先输入内容。', steps: [] }
-        live.inbox.push({ kind: 'wake', text: trimmed })
+        const extraTools = sanitizeExtraTools(opts?.extraTools)
+        live.inbox.push({
+          kind: 'wake',
+          text: trimmed,
+          ...(extraTools.length ? { extraTools } : {}),
+        })
         if (live.running) await live.running
         let result: AgentTurn = { text: '', steps: [] }
         live.abort = new AbortController()
@@ -73,9 +82,15 @@ export class AgentsService extends Service {
           live.running = undefined
         }
       },
-      inject: (text: string) => {
+      inject: (text: string, opts?: AgentSendOptions) => {
         const trimmed = text.trim()
-        if (trimmed) live.inbox.push({ kind: 'inject', text: trimmed })
+        if (!trimmed) return
+        const extraTools = sanitizeExtraTools(opts?.extraTools)
+        live.inbox.push({
+          kind: 'inject',
+          text: trimmed,
+          ...(extraTools.length ? { extraTools } : {}),
+        })
       },
       cancel: () => live.abort.abort(),
       dispose: () => {
@@ -99,6 +114,11 @@ export class AgentsService extends Service {
     const agent = await this.create()
     return agent.send(last)
   }
+}
+
+function sanitizeExtraTools(names: string[] | undefined): string[] {
+  if (!Array.isArray(names) || !names.length) return []
+  return [...new Set(names.map((name) => String(name).trim()).filter(Boolean))]
 }
 
 function claim(inbox: ClaimedInput[]): ClaimedInput[] | undefined {

--- a/host/plugins/registry/tools.test.ts
+++ b/host/plugins/registry/tools.test.ts
@@ -73,3 +73,27 @@ test('minimal mode only exposes bash and str_replace_editor', async () => {
   assert.equal(await ctx.tools.invoke('bash'), 'bash')
   await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in minimal mode/)
 })
+
+test('catalog lists all tools; extraTools temporarily unlocks minimal', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  for (const name of ['bash', 'str_replace_editor', 'fs_read']) {
+    ctx.tools.register({
+      name,
+      description: `${name} desc`,
+      parameters: { type: 'object', properties: {} },
+      execute: () => name,
+    })
+  }
+  ctx.tools.setMode('minimal')
+  assert.deepEqual(
+    ctx.tools.catalog().map((item) => item.name),
+    ['bash', 'fs_read', 'str_replace_editor'],
+  )
+  await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in minimal mode/)
+  await tools.runWithExtraTools(['fs_read'], async () => {
+    assert.deepEqual(ctx.tools.names().sort(), ['bash', 'fs_read', 'str_replace_editor'])
+    assert.equal(await ctx.tools.invoke('fs_read'), 'fs_read')
+  })
+  await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in minimal mode/)
+})

--- a/host/plugins/registry/tools.ts
+++ b/host/plugins/registry/tools.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
 
@@ -6,6 +7,11 @@ export interface ToolSpec {
   description: string
   parameters: Record<string, unknown>
   execute: (args: Record<string, unknown>, signal: AbortSignal) => unknown | Promise<unknown>
+}
+
+export interface ToolCatalogItem {
+  name: string
+  description: string
 }
 
 export interface ToolRequest {
@@ -20,6 +26,14 @@ export type ToolGuard = (req: ToolRequest) => ToolRequest | Promise<ToolRequest>
 export type AgentToolMode = 'standard' | 'minimal'
 
 export const MINIMAL_TOOL_NAMES = ['bash', 'str_replace_editor'] as const
+
+/** 本回合 slash 选中的额外工具（极简模式下临时放开）。 */
+const extraToolsStorage = new AsyncLocalStorage<ReadonlySet<string>>()
+
+export function runWithExtraTools<T>(names: readonly string[], fn: () => T): T {
+  const cleaned = [...new Set(names.map((n) => n.trim()).filter(Boolean))]
+  return extraToolsStorage.run(new Set(cleaned), fn)
+}
 
 export class ToolsService extends Service {
   private tools = new Map<string, ToolSpec>()
@@ -43,7 +57,8 @@ export class ToolsService extends Service {
 
   private visible(name: string) {
     if (this.mode === 'standard') return true
-    return (MINIMAL_TOOL_NAMES as readonly string[]).includes(name)
+    if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return true
+    return extraToolsStorage.getStore()?.has(name) ?? false
   }
 
   register(spec: ToolSpec) {
@@ -65,6 +80,13 @@ export class ToolsService extends Service {
         this.guards = this.guards.filter((item) => item !== fn)
       }
     }, 'tools.guard')
+  }
+
+  /** 全量目录（不受 mode 过滤），供 slash 菜单。 */
+  catalog(): ToolCatalogItem[] {
+    return [...this.tools.values()]
+      .map((tool) => ({ name: tool.name, description: tool.description }))
+      .sort((a, b) => a.name.localeCompare(b.name))
   }
 
   schemas() {

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, type FormEvent } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
@@ -6,11 +6,33 @@ import { bindSessionView, type SessionViewService } from '../../infrastructure/s
 /** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
 const INPUT_DEBOUNCE_MS = 120
 
+type ToolCatalogItem = { name: string; description: string }
+
+type SlashState = {
+  open: boolean
+  query: string
+  start: number
+  end: number
+}
+
+function readSlashAtCursor(value: string, cursor: number): SlashState | null {
+  const before = value.slice(0, cursor)
+  const match = /(?:^|\s)\/([^\s/]*)$/.exec(before)
+  if (!match) return null
+  const token = match[1] ?? ''
+  const start = before.length - token.length - 1
+  return { open: true, query: token, start, end: cursor }
+}
+
 export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const canSubmitRef = useRef(false)
   const [canSubmit, setCanSubmit] = useState(false)
+  const [catalog, setCatalog] = useState<ToolCatalogItem[]>([])
+  const [picked, setPicked] = useState<string[]>([])
+  const [slash, setSlash] = useState<SlashState | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
   const sessionView = props.sessionView as SessionViewService
@@ -24,10 +46,46 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     [],
   )
 
-  function scheduleCanSubmit(value: string) {
-    const next = Boolean(value.trim())
+  useEffect(() => {
+    let cancelled = false
+    void fetch('/api/chat/config')
+      .then((res) => res.json())
+      .then((data: { toolCatalog?: ToolCatalogItem[] }) => {
+        if (cancelled) return
+        const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
+        setCatalog(items.filter((item) => item?.name))
+      })
+      .catch(() => {
+        /* ignore */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const filtered = useMemo(() => {
+    if (!slash?.open) return []
+    const q = slash.query.trim().toLowerCase()
+    const base = catalog.filter((item) => !picked.includes(item.name))
+    if (!q) return base.slice(0, 12)
+    return base.filter((item) => item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q)).slice(0, 12)
+  }, [catalog, picked, slash])
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [slash?.query, slash?.open, filtered.length])
+
+  function scheduleCanSubmit(value: string, tools: string[] = picked) {
+    const next = Boolean(value.trim()) || tools.length > 0
     if (debounceRef.current != null) clearTimeout(debounceRef.current)
-    if (next === canSubmitRef.current) return
+    if (next === canSubmitRef.current) {
+      // still flush quickly when already true after pick
+      if (next) {
+        canSubmitRef.current = true
+        setCanSubmit(true)
+      }
+      return
+    }
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null
       canSubmitRef.current = next
@@ -44,19 +102,68 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     if (el) el.value = ''
     canSubmitRef.current = false
     setCanSubmit(false)
+    setSlash(null)
+    setPicked([])
   }
+
+  const syncSlashFromTextarea = useCallback(() => {
+    const el = textareaRef.current
+    if (!el) return
+    const next = readSlashAtCursor(el.value, el.selectionStart ?? el.value.length)
+    setSlash(next)
+    if (next?.open && catalog.length === 0) {
+      void fetch('/api/chat/config')
+        .then((res) => res.json())
+        .then((data: { toolCatalog?: ToolCatalogItem[] }) => {
+          const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
+          setCatalog(items.filter((item) => item?.name))
+        })
+        .catch(() => {
+          /* ignore */
+        })
+    }
+  }, [catalog.length])
+
+  const pickTool = useCallback((name: string, slashState: SlashState | null = slash) => {
+    const el = textareaRef.current
+    setPicked((prev) => {
+      const nextTools = prev.includes(name) ? prev : [...prev, name]
+      if (el && slashState) {
+        const before = el.value.slice(0, slashState.start)
+        const after = el.value.slice(slashState.end)
+        el.value = `${before}${after}`.replace(/\s{2,}/g, ' ')
+        const caret = Math.min(before.length, el.value.length)
+        el.focus()
+        el.setSelectionRange(caret, caret)
+        scheduleCanSubmit(el.value, nextTools)
+      } else {
+        scheduleCanSubmit(el?.value ?? '', nextTools)
+      }
+      return nextTools
+    })
+    setSlash(null)
+  }, [slash, picked])
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
+    if (slash?.open && filtered.length) {
+      const item = filtered[activeIndex] ?? filtered[0]
+      if (item) pickTool(item.name)
+      return
+    }
     if (debounceRef.current != null) {
       clearTimeout(debounceRef.current)
       debounceRef.current = null
     }
     const content = (textareaRef.current?.value ?? '').trim()
-    if (!content) return
+    if (!content && !picked.length) return
+    const tools = [...picked]
+    const text =
+      content ||
+      (tools.length ? `请使用工具：${tools.join(', ')}` : '')
     clearInput()
     try {
-      await sessionView.send(content, pending ? 'inject' : 'wake')
+      await sessionView.send(text, pending ? 'inject' : 'wake', tools)
       const id = sessionView.get().sessionId
       if (id && !location.pathname.startsWith(`/s/${id}`)) navigate(`/s/${id}`)
     } catch {
@@ -64,27 +171,111 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
   }
 
+  function onKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (slash?.open && filtered.length) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActiveIndex((i) => (i + 1) % filtered.length)
+        return
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActiveIndex((i) => (i - 1 + filtered.length) % filtered.length)
+        return
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setSlash(null)
+        return
+      }
+      if (event.key === 'Enter' && !event.shiftKey) {
+        if (event.nativeEvent.isComposing || event.keyCode === 229) return
+        event.preventDefault()
+        const item = filtered[activeIndex] ?? filtered[0]
+        if (item) pickTool(item.name)
+        return
+      }
+      if (event.key === 'Tab') {
+        event.preventDefault()
+        const item = filtered[activeIndex] ?? filtered[0]
+        if (item) pickTool(item.name)
+        return
+      }
+    }
+
+    if (event.key !== 'Enter' || event.shiftKey) return
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return
+    event.preventDefault()
+    event.currentTarget.form?.requestSubmit()
+  }
+
   return (
     <form
-      className="w-full border border-[var(--dsw-border)] bg-[var(--dsw-input)]"
+      className="composer-form relative w-full border border-[var(--dsw-border)] bg-[var(--dsw-input)]"
       style={{ borderRadius: 'var(--dsw-radius-bubble)', boxShadow: 'var(--dsw-shadow-lv2)' }}
       onSubmit={onSubmit}
     >
+      {slash?.open ? (
+        <div className="composer-slash" role="listbox" aria-label="工具列表">
+          <div className="composer-slash-head">工具 · 输入过滤 · Enter 选用</div>
+          {filtered.length === 0 ? (
+            <div className="composer-slash-empty">没有匹配的工具</div>
+          ) : (
+            filtered.map((item, index) => (
+              <button
+                key={item.name}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                className={`composer-slash-item${index === activeIndex ? ' is-active' : ''}`}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => pickTool(item.name)}
+              >
+                <span className="composer-slash-name">/{item.name}</span>
+                <span className="composer-slash-desc">{item.description || '—'}</span>
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+
+      {picked.length ? (
+        <div className="composer-tool-chips" aria-label="本回合额外工具">
+          {picked.map((name) => (
+            <button
+              key={name}
+              type="button"
+              className="composer-tool-chip"
+              title={`移除 ${name}`}
+              onClick={() => {
+                setPicked((prev) => prev.filter((item) => item !== name))
+                scheduleCanSubmit(textareaRef.current?.value ?? '')
+              }}
+            >
+              <span>/{name}</span>
+              <span aria-hidden>×</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
       <textarea
         ref={textareaRef}
         className="max-h-40 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3.5 pb-2 text-[15px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)]"
         defaultValue=""
         rows={1}
-        placeholder={pending ? 'Steer while running…' : 'Message DeepSeek Harness…'}
+        placeholder={pending ? 'Steer while running…' : '输入 / 选择工具，或直接发消息…'}
         aria-label="对话输入"
-        onChange={(event) => scheduleCanSubmit(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key !== 'Enter' || event.shiftKey) return
-          // 中文等 IME 组字确认用的 Enter，不要当成发送
-          if (event.nativeEvent.isComposing || event.keyCode === 229) return
-          event.preventDefault()
-          event.currentTarget.form?.requestSubmit()
+        aria-expanded={Boolean(slash?.open)}
+        aria-controls={slash?.open ? undefined : undefined}
+        onChange={(event) => {
+          scheduleCanSubmit(event.target.value)
+          const next = readSlashAtCursor(event.target.value, event.target.selectionStart ?? event.target.value.length)
+          setSlash(next)
         }}
+        onClick={syncSlashFromTextarea}
+        onKeyUp={syncSlashFromTextarea}
+        onKeyDown={onKeyDown}
       />
       <div className="flex items-center justify-end gap-2 px-3 pb-3">
         {pending ? (

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -722,15 +722,20 @@ export class SessionViewService extends Service {
     })
   }
 
-  async send(text: string, kind: 'wake' | 'inject' = 'wake') {
+  async send(text: string, kind: 'wake' | 'inject' = 'wake', extraTools: string[] = []) {
     const content = text.trim()
     if (!content) return
     const sessionId = await this.ensureSession()
+    const tools = [...new Set(extraTools.map((name) => name.trim()).filter(Boolean))]
+    const body =
+      kind === 'inject'
+        ? { text: content, kind: 'inject' as const, ...(tools.length ? { extraTools: tools } : {}) }
+        : { text: content, ...(tools.length ? { extraTools: tools } : {}) }
     if (kind === 'inject') {
       const res = await fetch(`/api/sessions/${sessionId}/messages`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ text: content, kind: 'inject' }),
+        body: JSON.stringify(body),
       })
       const data = (await res.json()) as { error?: string }
       if (!res.ok) {
@@ -744,7 +749,7 @@ export class SessionViewService extends Service {
       const res = await fetch(`/api/sessions/${sessionId}/messages`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ text: content }),
+        body: JSON.stringify(body),
       })
       const data = (await res.json()) as { error?: string; sessionId?: string; text?: string }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)

--- a/src/style.css
+++ b/src/style.css
@@ -1435,3 +1435,87 @@ body {
     display: none;
   }
 }
+
+/* Composer slash tool picker */
+.composer-form {
+  position: relative;
+}
+
+.composer-slash {
+  position: absolute;
+  right: 10px;
+  bottom: calc(100% + 8px);
+  left: 10px;
+  z-index: 8;
+  max-height: 260px;
+  overflow: auto;
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--dsw-sidebar) 94%, #000);
+  box-shadow: var(--dsw-shadow-lv2);
+  backdrop-filter: blur(12px);
+}
+
+.composer-slash-head,
+.composer-slash-empty {
+  padding: 8px 12px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+}
+
+.composer-slash-item {
+  display: grid;
+  grid-template-columns: minmax(120px, 34%) minmax(0, 1fr);
+  gap: 10px;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--dsw-label);
+  text-align: left;
+  cursor: pointer;
+}
+
+.composer-slash-item:hover,
+.composer-slash-item.is-active {
+  background: var(--dsw-hover-strong);
+}
+
+.composer-slash-name {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--dsw-business);
+}
+
+.composer-slash-desc {
+  overflow: hidden;
+  color: var(--dsw-label-3);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-tool-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 12px 0;
+}
+
+.composer-tool-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 999px;
+  background: var(--dsw-business-soft);
+  padding: 3px 8px;
+  color: var(--dsw-label-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.composer-tool-chip:hover {
+  color: var(--dsw-business);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 输入框输入 `/` 唤起工具列表（全量 catalog，不受极简过滤）
- 选中后变成 chip；发送时作为本回合 `extraTools`，极简模式下也能临时用 bash/str_replace_editor 以外的工具
- 方向键 / Enter / Tab 选用，Esc 关闭

## Screenshots
[Slash tool menu](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fslash-tools-menu.png)
[Selected tool chip](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fslash-tools-chip.png)

## Test plan
- [x] 极简模式：`/` 能看到 fs_read 等全部工具
- [x] 选中工具后出现 chip
- [ ] 发送后模型能调用该额外工具
- [x] unit：extraTools 临时放开 minimal


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

