### PR TITLE
ui: turn 底栏 + Cursor 风格输入框 + 绑定目录名

### DIFF
--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { LuChevronDown, LuPlus } from 'react-icons/lu'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
@@ -7,6 +8,21 @@ import { bindSessionView, type SessionViewService } from '../../infrastructure/s
 const INPUT_DEBOUNCE_MS = 120
 
 type ToolCatalogItem = { name: string; description: string }
+type ChatProvider = 'deepseek' | 'openai'
+
+type ModelOption = {
+  id: string
+  label: string
+  provider: ChatProvider
+  model: string
+}
+
+const MODEL_OPTIONS: ModelOption[] = [
+  { id: 'deepseek-chat', label: 'DeepSeek Chat', provider: 'deepseek', model: 'deepseek-chat' },
+  { id: 'deepseek-reasoner', label: 'DeepSeek Reasoner', provider: 'deepseek', model: 'deepseek-reasoner' },
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini', provider: 'openai', model: 'gpt-4o-mini' },
+  { id: 'gpt-4o', label: 'GPT-4o', provider: 'openai', model: 'gpt-4o' },
+]
 
 type SlashState = {
   open: boolean
@@ -24,20 +40,51 @@ function readSlashAtCursor(value: string, cursor: number): SlashState | null {
   return { open: true, query: token, start, end: cursor }
 }
 
+function matchModelOption(provider: string, model: string): ModelOption {
+  return (
+    MODEL_OPTIONS.find((item) => item.provider === provider && item.model === model) ??
+    MODEL_OPTIONS.find((item) => item.model === model) ?? {
+      id: `${provider}:${model}`,
+      label: model,
+      provider: provider === 'openai' ? 'openai' : 'deepseek',
+      model,
+    }
+  )
+}
+
 export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const canSubmitRef = useRef(false)
   const [canSubmit, setCanSubmit] = useState(false)
+  const [expanded, setExpanded] = useState(false)
   const [catalog, setCatalog] = useState<ToolCatalogItem[]>([])
   const [picked, setPicked] = useState<string[]>([])
   const [slash, setSlash] = useState<SlashState | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
+  const [modelOpen, setModelOpen] = useState(false)
+  const [modelOption, setModelOption] = useState<ModelOption>(MODEL_OPTIONS[0]!)
+  const [modelBusy, setModelBusy] = useState(false)
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
   const sessionView = props.sessionView as SessionViewService
   const navigate = useNavigate()
   const location = useLocation()
+
+  function syncComposerShape(
+    el: HTMLTextAreaElement | null = textareaRef.current,
+    toolsCount = picked.length,
+  ) {
+    if (!el) {
+      setExpanded(toolsCount > 0)
+      return
+    }
+    el.style.height = 'auto'
+    const next = Math.min(el.scrollHeight, 140)
+    el.style.height = `${Math.max(28, next)}px`
+    const multi = next > 36 || el.value.includes('\n') || toolsCount > 0
+    setExpanded(multi)
+  }
 
   useEffect(
     () => () => {
@@ -50,10 +97,11 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     let cancelled = false
     void fetch('/api/chat/config')
       .then((res) => res.json())
-      .then((data: { toolCatalog?: ToolCatalogItem[] }) => {
+      .then((data: { toolCatalog?: ToolCatalogItem[]; provider?: string; model?: string }) => {
         if (cancelled) return
         const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
         setCatalog(items.filter((item) => item?.name))
+        if (data.provider && data.model) setModelOption(matchModelOption(data.provider, data.model))
       })
       .catch(() => {
         /* ignore */
@@ -63,12 +111,25 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
   }, [])
 
+  useEffect(() => {
+    if (!modelOpen) return
+    const onPointer = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.closest('.composer-model')) return
+      setModelOpen(false)
+    }
+    window.addEventListener('mousedown', onPointer)
+    return () => window.removeEventListener('mousedown', onPointer)
+  }, [modelOpen])
+
   const filtered = useMemo(() => {
     if (!slash?.open) return []
     const q = slash.query.trim().toLowerCase()
     const base = catalog.filter((item) => !picked.includes(item.name))
     if (!q) return base.slice(0, 12)
-    return base.filter((item) => item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q)).slice(0, 12)
+    return base
+      .filter((item) => item.name.toLowerCase().includes(q) || item.description.toLowerCase().includes(q))
+      .slice(0, 12)
   }, [catalog, picked, slash])
 
   useEffect(() => {
@@ -79,7 +140,6 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     const next = Boolean(value.trim()) || tools.length > 0
     if (debounceRef.current != null) clearTimeout(debounceRef.current)
     if (next === canSubmitRef.current) {
-      // still flush quickly when already true after pick
       if (next) {
         canSubmitRef.current = true
         setCanSubmit(true)
@@ -99,12 +159,42 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       debounceRef.current = null
     }
     const el = textareaRef.current
-    if (el) el.value = ''
+    if (el) {
+      el.value = ''
+      el.style.height = '28px'
+    }
     canSubmitRef.current = false
     setCanSubmit(false)
     setSlash(null)
     setPicked([])
+    setExpanded(false)
   }
+
+  const openSlashMenu = useCallback(() => {
+    const el = textareaRef.current
+    if (!el) return
+    const start = el.selectionStart ?? el.value.length
+    const needsSpace = start > 0 && !/\s$/.test(el.value.slice(0, start))
+    const insert = `${needsSpace ? ' ' : ''}/`
+    el.value = `${el.value.slice(0, start)}${insert}${el.value.slice(el.selectionEnd ?? start)}`
+    const caret = start + insert.length
+    el.focus()
+    el.setSelectionRange(caret, caret)
+    scheduleCanSubmit(el.value)
+    syncComposerShape(el)
+    setSlash(readSlashAtCursor(el.value, caret))
+    if (catalog.length === 0) {
+      void fetch('/api/chat/config')
+        .then((res) => res.json())
+        .then((data: { toolCatalog?: ToolCatalogItem[] }) => {
+          const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
+          setCatalog(items.filter((item) => item?.name))
+        })
+        .catch(() => {
+          /* ignore */
+        })
+    }
+  }, [catalog.length, picked])
 
   const syncSlashFromTextarea = useCallback(() => {
     const el = textareaRef.current
@@ -124,28 +214,56 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
   }, [catalog.length])
 
-  const pickTool = useCallback((name: string, slashState: SlashState | null = slash) => {
-    const el = textareaRef.current
-    setPicked((prev) => {
-      const nextTools = prev.includes(name) ? prev : [...prev, name]
-      if (el && slashState) {
-        const before = el.value.slice(0, slashState.start)
-        const after = el.value.slice(slashState.end)
-        el.value = `${before}${after}`.replace(/\s{2,}/g, ' ')
-        const caret = Math.min(before.length, el.value.length)
-        el.focus()
-        el.setSelectionRange(caret, caret)
-        scheduleCanSubmit(el.value, nextTools)
-      } else {
-        scheduleCanSubmit(el?.value ?? '', nextTools)
-      }
-      return nextTools
-    })
-    setSlash(null)
-  }, [slash, picked])
+  const pickTool = useCallback(
+    (name: string, slashState: SlashState | null = slash) => {
+      const el = textareaRef.current
+      setPicked((prev) => {
+        const nextTools = prev.includes(name) ? prev : [...prev, name]
+        if (el && slashState) {
+          const before = el.value.slice(0, slashState.start)
+          const after = el.value.slice(slashState.end)
+          el.value = `${before}${after}`.replace(/\s{2,}/g, ' ')
+          const caret = Math.min(before.length, el.value.length)
+          el.focus()
+          el.setSelectionRange(caret, caret)
+          scheduleCanSubmit(el.value, nextTools)
+          syncComposerShape(el, nextTools.length)
+        } else {
+          scheduleCanSubmit(el?.value ?? '', nextTools)
+          syncComposerShape(el, nextTools.length)
+        }
+        return nextTools
+      })
+      setSlash(null)
+    },
+    [slash, picked],
+  )
+
+  async function selectModel(option: ModelOption) {
+    if (modelBusy || option.id === modelOption.id) {
+      setModelOpen(false)
+      return
+    }
+    setModelBusy(true)
+    try {
+      const res = await fetch('/api/chat/config', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ provider: option.provider, model: option.model }),
+      })
+      if (!res.ok) return
+      const data = (await res.json()) as { provider?: string; model?: string }
+      if (data.provider && data.model) setModelOption(matchModelOption(data.provider, data.model))
+      else setModelOption(option)
+      setModelOpen(false)
+    } finally {
+      setModelBusy(false)
+    }
+  }
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
+    if (pending) return
     if (slash?.open && filtered.length) {
       const item = filtered[activeIndex] ?? filtered[0]
       if (item) pickTool(item.name)
@@ -158,12 +276,10 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     const content = (textareaRef.current?.value ?? '').trim()
     if (!content && !picked.length) return
     const tools = [...picked]
-    const text =
-      content ||
-      (tools.length ? `请使用工具：${tools.join(', ')}` : '')
+    const text = content || (tools.length ? `请使用工具：${tools.join(', ')}` : '')
     clearInput()
     try {
-      await sessionView.send(text, pending ? 'inject' : 'wake', tools)
+      await sessionView.send(text, 'wake', tools)
       const id = sessionView.get().sessionId
       if (id && !location.pathname.startsWith(`/s/${id}`)) navigate(`/s/${id}`)
     } catch {
@@ -205,16 +321,13 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
     if (event.key !== 'Enter' || event.shiftKey) return
     if (event.nativeEvent.isComposing || event.keyCode === 229) return
+    if (pending) return
     event.preventDefault()
     event.currentTarget.form?.requestSubmit()
   }
 
   return (
-    <form
-      className="composer-form relative w-full border border-[var(--dsw-border)] bg-[var(--dsw-input)]"
-      style={{ borderRadius: 'var(--dsw-radius-bubble)', boxShadow: 'var(--dsw-shadow-lv2)' }}
-      onSubmit={onSubmit}
-    >
+    <form className={`composer-pill${expanded ? ' is-expanded' : ''}`} onSubmit={onSubmit}>
       {slash?.open ? (
         <div className="composer-slash" role="listbox" aria-label="工具列表">
           <div className="composer-slash-head">工具 · 输入过滤 · Enter 选用</div>
@@ -248,8 +361,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               className="composer-tool-chip"
               title={`移除 ${name}`}
               onClick={() => {
-                setPicked((prev) => prev.filter((item) => item !== name))
-                scheduleCanSubmit(textareaRef.current?.value ?? '')
+                setPicked((prev) => {
+                  const next = prev.filter((item) => item !== name)
+                  scheduleCanSubmit(textareaRef.current?.value ?? '', next)
+                  syncComposerShape(textareaRef.current, next.length)
+                  return next
+                })
               }}
             >
               <span>/{name}</span>
@@ -259,56 +376,95 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         </div>
       ) : null}
 
-      <textarea
-        ref={textareaRef}
-        className="max-h-40 min-h-[52px] w-full resize-none bg-transparent px-4 pt-3.5 pb-2 text-[15px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)]"
-        defaultValue=""
-        rows={1}
-        placeholder={pending ? 'Steer while running…' : '输入 / 选择工具，或直接发消息…'}
-        aria-label="对话输入"
-        aria-expanded={Boolean(slash?.open)}
-        aria-controls={slash?.open ? undefined : undefined}
-        onChange={(event) => {
-          scheduleCanSubmit(event.target.value)
-          const next = readSlashAtCursor(event.target.value, event.target.selectionStart ?? event.target.value.length)
-          setSlash(next)
-        }}
-        onClick={syncSlashFromTextarea}
-        onKeyUp={syncSlashFromTextarea}
-        onKeyDown={onKeyDown}
-      />
-      <div className="flex items-center justify-end gap-2 px-3 pb-3">
-        {pending ? (
-          <>
+      <div className="composer-pill-row">
+        <button
+          type="button"
+          className="composer-plus"
+          title="添加工具 (/)"
+          aria-label="添加工具"
+          onClick={openSlashMenu}
+        >
+          <LuPlus className="size-4" />
+        </button>
+
+        <textarea
+          ref={textareaRef}
+          className="composer-pill-input"
+          defaultValue=""
+          rows={1}
+          placeholder={pending ? 'Add a follow up' : 'Add a follow up'}
+          aria-label="对话输入"
+          aria-expanded={Boolean(slash?.open)}
+          onChange={(event) => {
+            scheduleCanSubmit(event.target.value)
+            syncComposerShape(event.target)
+            const next = readSlashAtCursor(
+              event.target.value,
+              event.target.selectionStart ?? event.target.value.length,
+            )
+            setSlash(next)
+          }}
+          onClick={syncSlashFromTextarea}
+          onKeyUp={syncSlashFromTextarea}
+          onKeyDown={onKeyDown}
+        />
+
+        <div className="composer-pill-right">
+          <div className="composer-model">
             <button
-              className="rounded-full border border-[var(--dsw-border)] px-3 py-1.5 text-xs text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)]"
               type="button"
+              className="composer-model-trigger"
+              aria-haspopup="listbox"
+              aria-expanded={modelOpen}
+              disabled={modelBusy}
+              title="选择模型"
+              onClick={() => setModelOpen((open) => !open)}
+            >
+              <span className="composer-model-label">{modelOption.label}</span>
+              <LuChevronDown className="size-3.5 opacity-70" />
+            </button>
+            {modelOpen ? (
+              <div className="composer-model-menu" role="listbox" aria-label="模型">
+                {MODEL_OPTIONS.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    role="option"
+                    aria-selected={option.id === modelOption.id}
+                    className={`composer-model-item${option.id === modelOption.id ? ' is-active' : ''}`}
+                    onClick={() => void selectModel(option)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+
+          {pending ? (
+            <button
+              type="button"
+              className="composer-stop"
+              title="停止"
+              aria-label="停止生成"
               onClick={() => void sessionView.cancel()}
             >
-              Cancel
+              <span className="composer-stop-square" aria-hidden />
             </button>
+          ) : (
             <button
-              className="rounded-full px-3 py-1.5 text-xs text-[var(--dsw-bg)] disabled:opacity-40"
-              style={{ background: 'var(--dsw-business)' }}
               type="submit"
+              className="composer-send"
               disabled={!canSubmit}
+              aria-label="Send"
+              title="发送"
             >
-              Steer
+              <svg viewBox="0 0 24 24" className="size-3.5" fill="currentColor" aria-hidden>
+                <path d="M3.4 20.6 21 12 3.4 3.4 3 10.3 15 12 3 13.7z" />
+              </svg>
             </button>
-          </>
-        ) : (
-          <button
-            className="grid size-8 place-items-center rounded-full text-[var(--dsw-bg)] disabled:opacity-40"
-            style={{ background: 'var(--dsw-business)' }}
-            type="submit"
-            disabled={!canSubmit}
-            aria-label="Send"
-          >
-            <svg viewBox="0 0 24 24" className="size-4" fill="currentColor">
-              <path d="M3.4 20.6 21 12 3.4 3.4 3 10.3 15 12 3 13.7z" />
-            </svg>
-          </button>
-        )}
+          )}
+        </div>
       </div>
     </form>
   )

--- a/src/plugins/contributors/chat/project-panel.tsx
+++ b/src/plugins/contributors/chat/project-panel.tsx
@@ -1,7 +1,7 @@
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindProjectView, type ProjectViewService } from '../../infrastructure/project-view.ts'
 
-/** 紧凑项目绑定：仅文件夹图标，与标准/极简胶囊同一行。 */
+/** 紧凑项目绑定：未绑定时仅图标；绑定后显示文件夹名。 */
 export function SessionProjectPanel(props: SlotProps) {
   const useProjectView = props.useProjectView as ReturnType<typeof bindProjectView>
   const projectView = props.projectView as ProjectViewService
@@ -19,18 +19,20 @@ export function SessionProjectPanel(props: SlotProps) {
   }
 
   const label = project?.path ?? '选择本机文件夹并绑定为 Session cwd'
+  const bound = Boolean(project)
 
   return (
     <div className="project-chip-wrap">
       <button
         type="button"
-        className={`project-chip project-chip-icon-only${project ? ' is-bound' : ' project-chip-empty'}${busy ? ' is-busy' : ''}`}
+        className={`project-chip${bound ? ' is-bound' : ' project-chip-icon-only project-chip-empty'}${busy ? ' is-busy' : ''}`}
         disabled={busy}
         title={label}
-        aria-label={project ? `已绑定 ${project.name}` : '绑定项目文件夹'}
+        aria-label={bound ? `已绑定 ${project!.name}` : '绑定项目文件夹'}
         onClick={() => void projectView.openFolderForSession(sessionId).catch(() => undefined)}
       >
         <FolderGlyph />
+        {bound ? <span className="project-chip-name">{project!.name}</span> : null}
       </button>
       {error ? <span className="project-chip-error" title={error}>!</span> : null}
     </div>

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -1,10 +1,14 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { LuCheck, LuCopy, LuGitFork } from 'react-icons/lu'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
-import type { ChatNode } from '../../infrastructure/session-project.ts'
+import {
+  formatTrajectoryUsage,
+  type ChatNode,
+  type TrajectoryUsage,
+} from '../../infrastructure/session-project.ts'
 import { SidebarMascot } from '../mascot/sidebar-mascot.tsx'
 import { DEFAULT_SESSION_MASCOT, resolveSessionMascot } from '../mascot/session-mascot.ts'
 import type { SessionMascotIdentity } from '../mascot/grok-bot-types.ts'
@@ -15,7 +19,7 @@ const NEAR_BOTTOM_PX = 96
 /** 提早预取更早消息，避免滑到顶才开始请求 */
 const PREFETCH_OLDER_PX = 720
 const ROW_GAP_PX = 16
-const ESTIMATE_ROW_PX = 160
+const ESTIMATE_ROW_PX = 220
 /** 消息很少时全量渲染更简单，也避免虚表测量抖动 */
 const VIRTUALIZE_AFTER = 12
 /** 加大 overscan：快速上滑时预挂载更多行，减少白屏 */
@@ -33,9 +37,61 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   return null
 }
 
+function formatDuration(ms: number) {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
+  if (ms < 60_000) {
+    const sec = ms / 1000
+    return `${sec < 10 ? sec.toFixed(1) : Math.round(sec)}s`
+  }
+  const minutes = Math.floor(ms / 60_000)
+  const seconds = Math.round((ms % 60_000) / 1000)
+  return `${minutes}m ${seconds}s`
+}
+
+function formatTok(n: number) {
+  return n.toLocaleString('en-US')
+}
+
+function cacheHitPct(usage: TrajectoryUsage): number | null {
+  if (!usage.inputTokens || !usage.cacheReadTokens) return null
+  return Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100))
+}
+
+function UsageInline({ usage }: { usage: TrajectoryUsage }) {
+  const pct = cacheHitPct(usage)
+  const inStyle: CSSProperties | undefined =
+    pct != null
+      ? {
+          backgroundImage: `linear-gradient(90deg, rgba(34, 140, 90, 0.28) 0%, rgba(34, 140, 90, 0.28) ${pct}%, rgba(15, 17, 21, 0.06) ${pct}%, rgba(15, 17, 21, 0.06) 100%)`,
+        }
+      : undefined
+  return (
+    <span className="traj-usage" title={formatTrajectoryUsage(usage)}>
+      <span
+        className={`traj-usage-in-wrap${pct != null ? ' has-cache' : ''}`}
+        style={inStyle}
+        title={
+          pct != null
+            ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct}% (${formatTok(usage.cacheReadTokens!)})`
+            : `input ${formatTok(usage.inputTokens)}`
+        }
+      >
+        <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
+        {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
+      </span>
+      <span className="traj-usage-arrow" aria-hidden>
+        →
+      </span>
+      <span className="traj-usage-out" title="output tokens">
+        {formatTok(usage.outputTokens)}
+      </span>
+    </span>
+  )
+}
+
 function RowLoading({ kind }: { kind: ChatNode['kind'] }) {
   const label =
-    kind === 'user' ? '消息加载中' : kind === 'assistant' ? '回复加载中' : kind === 'tool' ? '工具加载中' : '加载中'
+    kind === 'user' ? '消息加载中' : kind === 'reply' ? '回复加载中' : kind === 'turn' ? '状态加载中' : '加载中'
   return (
     <div className="chat-row-loading" aria-busy="true" aria-label={label}>
       <span className="chat-row-loading-dot" />
@@ -45,7 +101,7 @@ function RowLoading({ kind }: { kind: ChatNode['kind'] }) {
   )
 }
 
-function AssistantActions({
+function ReplyActions({
   text,
   onFork,
 }: {
@@ -77,12 +133,12 @@ function AssistantActions({
   }
 
   return (
-    <div className="chat-assistant-actions" role="group" aria-label="消息操作">
+    <div className="chat-reply-actions" role="group" aria-label="回合操作">
       <button
         type="button"
         className={`chat-assistant-action${copied ? ' is-done' : ''}`}
         title={copied ? '已复制' : '复制'}
-        aria-label={copied ? '已复制' : '复制回复'}
+        aria-label={copied ? '已复制' : '复制本回合回复'}
         onClick={() => void copy()}
       >
         {copied ? <LuCheck className="size-3.5" /> : <LuCopy className="size-3.5" />}
@@ -127,27 +183,52 @@ function NodeView({
       </div>
     )
   }
-  if (node.kind === 'assistant') {
+
+  if (node.kind === 'reply') {
     const streaming = Boolean(node.streaming)
+    const showFooter = !streaming
     return (
-      <div className="chat-assistant-row">
-        <div className="chat-assistant-main">
-          <div className="chat-assistant-body">
-            {node.text ? (
-              <MarkdownBody text={node.text} streaming={streaming} />
-            ) : streaming ? (
-              '…'
-            ) : null}
-            {streaming ? <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span> : null}
-          </div>
+      <div className={`chat-reply-card${streaming ? ' is-streaming' : ''}`}>
+        <div className="chat-reply-body">
+          {node.parts.map((part) => {
+            if (part.kind === 'assistant') {
+              const partStreaming = Boolean(part.streaming)
+              return (
+                <div key={part.id} className="chat-assistant-body">
+                  {part.text ? (
+                    <MarkdownBody text={part.text} streaming={partStreaming} />
+                  ) : partStreaming ? (
+                    '…'
+                  ) : null}
+                  {partStreaming ? (
+                    <span className="ml-1 inline-block animate-pulse text-[var(--dsw-label-3)]">▍</span>
+                  ) : null}
+                </div>
+              )
+            }
+            return <ToolCard key={part.id} node={part} onInspect={onInspect} />
+          })}
         </div>
-        {!streaming && node.text.trim() ? <AssistantActions text={node.text} onFork={onFork} /> : null}
+        {showFooter ? (
+          <div className="chat-reply-footer">
+            <div className="chat-reply-meta">
+              {node.durationMs != null ? (
+                <span className="chat-reply-duration" title="本回合耗时">
+                  {formatDuration(node.durationMs)}
+                </span>
+              ) : null}
+              {node.usage ? <UsageInline usage={node.usage} /> : null}
+              {!node.usage && node.durationMs == null ? (
+                <span className="chat-reply-meta-empty">—</span>
+              ) : null}
+            </div>
+            {node.copyText.trim() ? <ReplyActions text={node.copyText} onFork={onFork} /> : null}
+          </div>
+        ) : null}
       </div>
     )
   }
-  if (node.kind === 'tool') {
-    return <ToolCard node={node} onInspect={onInspect} />
-  }
+
   return <div className="self-center text-xs text-[var(--dsw-label-3)]">{node.text}</div>
 }
 
@@ -303,8 +384,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const lastNode = nodes.at(-1)
   // 流式时按 ~96 字符步进 stickKey，避免每个 delta 都触发布局滚动
   const stickKey =
-    lastNode?.kind === 'assistant'
-      ? `${lastNode.id}:${lastNode.streaming ? Math.floor(lastNode.text.length / 96) : lastNode.text.length}:${lastNode.streaming ? 1 : 0}`
+    lastNode?.kind === 'reply' && lastNode.streaming
+      ? `${lastNode.id}:${Math.floor(lastNode.copyText.length / 96)}:1`
       : `${nodes.length}:${pending ? 1 : 0}:${error ?? ''}`
 
   useLayoutEffect(() => {
@@ -324,8 +405,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
 
   const rowHydrated = (node: ChatNode) => {
     if (hydratedRef.current.has(node.id)) return true
-    // 流式助手：直接展示流式文本，不走 loading
-    if (node.kind === 'assistant' && node.streaming) {
+    // 流式回复：直接展示，不走 loading
+    if (node.kind === 'reply' && node.streaming) {
       hydratedRef.current.add(node.id)
       return true
     }

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import type { ChatNode } from '../../infrastructure/session-project.ts'
+import type { ChatToolPart } from '../../infrastructure/session-project.ts'
 import {
   diffStats,
   formatToolDetail,
@@ -169,7 +169,7 @@ export function ToolCard({
   node,
   onInspect,
 }: {
-  node: Extract<ChatNode, { kind: 'tool' }>
+  node: ChatToolPart
   onInspect: (callId: string) => void
 }) {
   const parsed = useMemo(() => parseToolCall(node.name, node.arguments), [node.name, node.arguments])

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -24,10 +24,18 @@ test('projects user, streaming assistant, tool call/result from session events',
   const nodes = projectNodes(events)
   assert.deepEqual(
     nodes.map((node) => node.kind),
-    ['user', 'assistant', 'tool', 'assistant'],
+    ['user', 'reply'],
   )
-  assert.equal(nodes[1]?.kind === 'assistant' && nodes[1].text, 'hello')
-  assert.equal(nodes[2]?.kind === 'tool' && nodes[2].result?.detail, 'ok')
+  const reply = nodes[1]
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  assert.deepEqual(
+    reply.parts.map((part) => part.kind),
+    ['assistant', 'tool', 'assistant'],
+  )
+  assert.equal(reply.copyText, 'hello\n\ndone')
+  assert.equal(reply.parts[0]?.kind === 'assistant' && reply.parts[0].text, 'hello')
+  assert.equal(reply.parts[1]?.kind === 'tool' && reply.parts[1].result?.detail, 'ok')
 })
 
 test('turn/end non-complete becomes a status row', () => {
@@ -37,6 +45,37 @@ test('turn/end non-complete becomes a status row', () => {
   ])
   assert.equal(nodes[0]?.kind, 'turn')
   assert.match(nodes[0]?.kind === 'turn' ? nodes[0].text : '', /cancelled/)
+})
+
+test('reply aggregates turn duration and usage for footer', () => {
+  const nodes = projectNodes([
+    { type: 'turn/start', turn: 1, seq: 1, ts: 1000 },
+    { type: 'user/message', text: 'hi', kind: 'wake', seq: 2, ts: 1100 },
+    {
+      type: 'assistant/message',
+      text: 'hello',
+      usage: { inputTokens: 20, outputTokens: 8, cacheReadTokens: 4 },
+      seq: 3,
+      ts: 1500,
+    },
+    { type: 'turn/end', turn: 1, reason: 'complete', seq: 4, ts: 2800 },
+  ])
+  assert.deepEqual(
+    nodes.map((node) => node.kind),
+    ['user', 'reply'],
+  )
+  const reply = nodes[1]
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  assert.equal(reply.finished, true)
+  assert.equal(reply.durationMs, 1800)
+  assert.deepEqual(reply.usage, {
+    inputTokens: 20,
+    outputTokens: 8,
+    totalTokens: 28,
+    cacheReadTokens: 4,
+  })
+  assert.equal(reply.copyText, 'hello')
 })
 
 test('projectTrajectory skips assistant/chunk (dsh-style; message is authoritative)', () => {

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -26,17 +26,44 @@ export type SessionEvent = {
   | { type: 'tool/result'; id: string; name: string; ok: boolean; detail: string }
 )
 
+export interface TrajectoryUsage {
+  inputTokens: number
+  outputTokens: number
+  totalTokens?: number
+  cacheReadTokens?: number
+}
+
 /** 精简 ConversationNode：事件 → 可渲染行。 */
+export type ChatToolPart = {
+  id: string
+  kind: 'tool'
+  callId: string
+  name: string
+  arguments: string
+  result?: { ok: boolean; detail: string }
+}
+
+export type ChatAssistantPart = {
+  id: string
+  kind: 'assistant'
+  text: string
+  streaming?: boolean
+}
+
+export type ChatReplyPart = ChatAssistantPart | ChatToolPart
+
 export type ChatNode =
   | { id: string; kind: 'user'; text: string; kindTag?: string }
-  | { id: string; kind: 'assistant'; text: string; streaming?: boolean }
   | {
       id: string
-      kind: 'tool'
-      callId: string
-      name: string
-      arguments: string
-      result?: { ok: boolean; detail: string }
+      kind: 'reply'
+      parts: ChatReplyPart[]
+      /** 本回合所有助手正文，供一键复制 */
+      copyText: string
+      usage?: TrajectoryUsage
+      durationMs?: number
+      streaming?: boolean
+      finished?: boolean
     }
   | { id: string; kind: 'turn'; text: string }
 
@@ -90,77 +117,152 @@ export function projectRequestMessages(events: SessionEvent[], assistantSeq: num
 
 export function projectNodes(events: SessionEvent[]): ChatNode[] {
   const nodes: ChatNode[] = []
-  let streamingId: string | null = null
-  const tools = new Map<string, Extract<ChatNode, { kind: 'tool' }>>()
+  let turnStartTs: number | undefined
+  let reply: {
+    id: string
+    parts: ChatReplyPart[]
+    streamingId: string | null
+    tools: Map<string, ChatToolPart>
+    usage: { input: number; output: number; total: number; cache: number; hit: boolean }
+    streaming: boolean
+  } | null = null
+
+  function ensureReply(seq: number) {
+    if (!reply) {
+      reply = {
+        id: `r-${seq}`,
+        parts: [],
+        streamingId: null,
+        tools: new Map(),
+        usage: { input: 0, output: 0, total: 0, cache: 0, hit: false },
+        streaming: false,
+      }
+    }
+    return reply
+  }
+
+  function addUsage(usage: NonNullable<Extract<SessionEvent, { type: 'assistant/message' }>['usage']>) {
+    const r = reply
+    if (!r) return
+    r.usage.hit = true
+    r.usage.input += usage.inputTokens
+    r.usage.output += usage.outputTokens
+    r.usage.total += usage.totalTokens ?? usage.inputTokens + usage.outputTokens
+    r.usage.cache += usage.cacheReadTokens ?? 0
+  }
+
+  function flushReply(endTs?: number, finished = false) {
+    if (!reply || reply.parts.length === 0) {
+      reply = null
+      return
+    }
+    const copyText = reply.parts
+      .filter((part): part is ChatAssistantPart => part.kind === 'assistant')
+      .map((part) => part.text.trim())
+      .filter(Boolean)
+      .join('\n\n')
+    const usage: TrajectoryUsage | undefined = reply.usage.hit
+      ? {
+          inputTokens: reply.usage.input,
+          outputTokens: reply.usage.output,
+          totalTokens: reply.usage.total,
+          ...(reply.usage.cache ? { cacheReadTokens: reply.usage.cache } : {}),
+        }
+      : undefined
+    const durationMs =
+      finished && turnStartTs != null && endTs != null ? Math.max(0, endTs - turnStartTs) : undefined
+    nodes.push({
+      id: reply.id,
+      kind: 'reply',
+      parts: reply.parts,
+      copyText,
+      ...(usage ? { usage } : {}),
+      ...(durationMs != null ? { durationMs } : {}),
+      streaming: reply.streaming && !finished,
+      finished,
+    })
+    reply = null
+  }
 
   for (const event of events) {
-    if (event.type === 'user/message') {
-      streamingId = null
+    if (event.type === 'turn/start') {
+      flushReply()
+      turnStartTs = event.ts
+    } else if (event.type === 'user/message') {
+      flushReply()
       nodes.push({ id: `u-${event.seq}`, kind: 'user', text: event.text, kindTag: event.kind })
     } else if (event.type === 'assistant/chunk') {
-      if (streamingId) {
-        const idx = nodes.findIndex((node) => node.id === streamingId)
-        const current = idx >= 0 ? nodes[idx] : undefined
+      const r = ensureReply(event.seq)
+      if (r.streamingId) {
+        const idx = r.parts.findIndex((part) => part.id === r.streamingId)
+        const current = idx >= 0 ? r.parts[idx] : undefined
         if (current?.kind === 'assistant') {
-          nodes[idx] = { ...current, text: current.text + event.text, streaming: true }
+          r.parts[idx] = { ...current, text: current.text + event.text, streaming: true }
         }
       } else {
-        streamingId = `a-${event.seq}`
-        nodes.push({ id: streamingId, kind: 'assistant', text: event.text, streaming: true })
+        r.streamingId = `a-${event.seq}`
+        r.parts.push({ id: r.streamingId, kind: 'assistant', text: event.text, streaming: true })
       }
+      r.streaming = true
     } else if (event.type === 'assistant/message') {
-      if (streamingId) {
-        const idx = nodes.findIndex((node) => node.id === streamingId)
-        if (idx >= 0 && nodes[idx]?.kind === 'assistant') {
-          nodes[idx] = { id: streamingId, kind: 'assistant', text: event.text, streaming: false }
+      const r = ensureReply(event.seq)
+      if (event.usage) addUsage(event.usage)
+      if (r.streamingId) {
+        const idx = r.parts.findIndex((part) => part.id === r.streamingId)
+        if (idx >= 0 && r.parts[idx]?.kind === 'assistant') {
+          r.parts[idx] = { id: r.streamingId, kind: 'assistant', text: event.text, streaming: false }
         }
-        streamingId = null
+        r.streamingId = null
+        r.streaming = false
       } else if (event.text || !event.tool_calls?.length) {
-        nodes.push({ id: `a-${event.seq}`, kind: 'assistant', text: event.text })
+        r.parts.push({ id: `a-${event.seq}`, kind: 'assistant', text: event.text })
       }
     } else if (event.type === 'tool/call') {
-      streamingId = null
-      const node: Extract<ChatNode, { kind: 'tool' }> = {
+      const r = ensureReply(event.seq)
+      r.streamingId = null
+      r.streaming = false
+      const part: ChatToolPart = {
         id: `t-${event.id}`,
         kind: 'tool',
         callId: event.id,
         name: event.name,
         arguments: event.arguments,
       }
-      tools.set(event.id, node)
-      nodes.push(node)
+      r.tools.set(event.id, part)
+      r.parts.push(part)
     } else if (event.type === 'tool/result') {
-      const existing = tools.get(event.id)
+      const r = ensureReply(event.seq)
+      const existing = r.tools.get(event.id)
       if (existing) {
         const next = { ...existing, result: { ok: event.ok, detail: event.detail } }
-        tools.set(event.id, next)
-        const idx = nodes.findIndex((node) => node.id === existing.id)
-        if (idx >= 0) nodes[idx] = next
+        r.tools.set(event.id, next)
+        const idx = r.parts.findIndex((part) => part.id === existing.id)
+        if (idx >= 0) r.parts[idx] = next
       } else {
-        nodes.push({
+        const part: ChatToolPart = {
           id: `t-${event.id}`,
           kind: 'tool',
           callId: event.id,
           name: event.name,
           arguments: '',
           result: { ok: event.ok, detail: event.detail },
-        })
+        }
+        r.tools.set(event.id, part)
+        r.parts.push(part)
       }
-    } else if (event.type === 'turn/end' && event.reason && event.reason !== 'complete') {
-      nodes.push({ id: `turn-${event.seq}`, kind: 'turn', text: `回合结束：${event.reason}` })
+    } else if (event.type === 'turn/end') {
+      flushReply(event.ts, true)
+      turnStartTs = undefined
+      if (event.reason && event.reason !== 'complete') {
+        nodes.push({ id: `turn-${event.seq}`, kind: 'turn', text: `回合结束：${event.reason}` })
+      }
     }
   }
+  flushReply()
   return nodes
 }
 
 /** Lean Trajectory 行：官方 ui-trajectory 的瘦投影，不搬虚表/搜索索引。 */
-export interface TrajectoryUsage {
-  inputTokens: number
-  outputTokens: number
-  totalTokens?: number
-  cacheReadTokens?: number
-}
-
 export interface TrajectoryRow {
   id: string
   seq: number

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -110,9 +110,9 @@ test('ingest coalesces consecutive chunks and skips trajectory on chat view', as
     'hello',
   )
   assert.equal(view.get().trajectory, trajBefore)
-  const assistant = view.get().nodes.find((node) => node.kind === 'assistant')
-  assert.equal(assistant?.kind === 'assistant' && assistant.text, 'hello')
-  assert.equal(assistant?.kind === 'assistant' && assistant.streaming, true)
+  const assistant = view.get().nodes.find((node) => node.kind === 'reply')
+  assert.equal(assistant?.kind === 'reply' && assistant.parts[0]?.kind === 'assistant' && assistant.parts[0].text, 'hello')
+  assert.equal(assistant?.kind === 'reply' && assistant.streaming, true)
 
   view.ingest('s1', { type: 'assistant/message', text: 'hello', seq: 4, ts: 5 })
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
@@ -170,7 +170,14 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   assert.equal(calls.some((url) => url.includes('turns=24')), true)
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
   assert.equal(view.get().trajectory.length, 0)
-  assert.equal(view.get().nodes.some((node) => node.kind === 'assistant' && node.text === 'ab'), true)
+  assert.equal(
+    view.get().nodes.some(
+      (node) =>
+        node.kind === 'reply' &&
+        node.parts.some((part) => part.kind === 'assistant' && part.text === 'ab'),
+    ),
+    true,
+  )
   await view.ensureTrajectory()
   assert.equal(calls.some((url) => url.includes('/trajectory?turns=')), true)
   assert.equal(view.get().trajectory.length, 1)

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -821,11 +821,33 @@ function patchStreamingNodes(
   chunk: Extract<SessionEvent, { type: 'assistant/chunk' }>,
 ): ChatNode[] {
   const last = nodes.at(-1)
-  if (last?.kind === 'assistant' && last.streaming) {
-    if (last.text === chunk.text) return nodes
-    return [...nodes.slice(0, -1), { ...last, text: chunk.text, streaming: true }]
+  if (last?.kind === 'reply') {
+    const parts = [...last.parts]
+    const lastPart = parts.at(-1)
+    if (lastPart?.kind === 'assistant' && lastPart.streaming) {
+      if (lastPart.text === chunk.text) return nodes
+      parts[parts.length - 1] = { ...lastPart, text: chunk.text, streaming: true }
+    } else {
+      parts.push({ id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true })
+    }
+    const copyText = parts
+      .filter((part) => part.kind === 'assistant')
+      .map((part) => (part.kind === 'assistant' ? part.text.trim() : ''))
+      .filter(Boolean)
+      .join('\n\n')
+    return [...nodes.slice(0, -1), { ...last, parts, copyText, streaming: true, finished: false }]
   }
-  return [...nodes, { id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true }]
+  return [
+    ...nodes,
+    {
+      id: `r-${chunk.seq}`,
+      kind: 'reply',
+      parts: [{ id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true }],
+      copyText: chunk.text,
+      streaming: true,
+      finished: false,
+    },
+  ]
 }
 
 export function bindSessionView(source: SessionViewService) {

--- a/src/style.css
+++ b/src/style.css
@@ -366,6 +366,16 @@ body {
   padding: 0;
 }
 
+.project-chip-name {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  line-height: 1.2;
+  color: inherit;
+}
+
 .dock-seg {
   display: flex;
   flex-shrink: 0;
@@ -1191,6 +1201,72 @@ body {
   max-width: 100%;
 }
 
+.chat-reply-card {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px 14px 10px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--dsw-surface) 72%, transparent);
+}
+
+.chat-reply-card.is-streaming {
+  border-color: color-mix(in srgb, var(--dsw-border) 80%, transparent);
+}
+
+.chat-reply-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--dsw-label);
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.chat-reply-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 2px;
+  border-top: 1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent);
+}
+
+.chat-reply-meta {
+  display: inline-flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+}
+
+.chat-reply-duration {
+  font-variant-numeric: tabular-nums;
+  color: var(--dsw-label-2);
+}
+
+.chat-reply-meta-empty {
+  color: var(--dsw-label-3);
+}
+
+.chat-reply-actions {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 2px;
+  margin-left: auto;
+  opacity: 0.78;
+}
+
+.chat-reply-card:hover .chat-reply-actions {
+  opacity: 1;
+}
+
 .chat-assistant-actions {
   display: flex;
   flex-shrink: 0;
@@ -1436,7 +1512,175 @@ body {
   }
 }
 
-/* Composer slash tool picker */
+/* Composer slash tool picker + Cursor-like pill input */
+.composer-pill {
+  position: relative;
+  width: 100%;
+  border: 1px solid color-mix(in srgb, var(--dsw-border) 90%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--dsw-input) 92%, #1a1814);
+  box-shadow: 0 0 0 1px rgba(242, 241, 237, 0.04), 0 10px 28px rgba(0, 0, 0, 0.28);
+  transition: border-radius 0.12s ease;
+}
+
+.composer-pill.is-expanded {
+  border-radius: 16px;
+}
+
+.composer-pill-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  min-height: 48px;
+  padding: 8px 10px;
+}
+
+.composer-pill.is-expanded .composer-pill-row {
+  align-items: flex-end;
+  padding: 10px 12px 10px;
+}
+
+.composer-plus {
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin-bottom: 2px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+}
+
+.composer-plus:hover {
+  color: var(--dsw-label);
+  background: var(--dsw-hover);
+}
+
+.composer-pill-input {
+  flex: 1;
+  min-width: 0;
+  max-height: 140px;
+  min-height: 28px;
+  margin: 2px 0;
+  resize: none;
+  border: 0;
+  background: transparent;
+  color: var(--dsw-label);
+  font-size: 14px;
+  line-height: 1.45;
+  outline: none;
+}
+
+.composer-pill-input::placeholder {
+  color: var(--dsw-label-3);
+}
+
+.composer-pill-right {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 1px;
+}
+
+.composer-model {
+  position: relative;
+}
+
+.composer-model-trigger {
+  display: inline-flex;
+  max-width: 180px;
+  align-items: center;
+  gap: 4px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 4px 6px;
+  color: var(--dsw-label-2);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.composer-model-trigger:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-label);
+}
+
+.composer-model-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.composer-model-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 9;
+  min-width: 180px;
+  overflow: hidden;
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--dsw-sidebar) 96%, #000);
+  box-shadow: var(--dsw-shadow-lv2);
+}
+
+.composer-model-item {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: 8px 12px;
+  color: var(--dsw-label-2);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.composer-model-item:hover,
+.composer-model-item.is-active {
+  background: var(--dsw-hover-strong);
+  color: var(--dsw-label);
+}
+
+.composer-send,
+.composer-stop {
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.composer-send {
+  background: var(--dsw-business);
+  color: var(--dsw-bg);
+}
+
+.composer-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.composer-stop {
+  background: #f2f1ed;
+  color: #14120f;
+}
+
+.composer-stop-square {
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-radius: 1.5px;
+  background: #14120f;
+}
+
 .composer-form {
   position: relative;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 每个 turn 回复成卡片：左下角耗时 + usage（含 cache），右下角 Copy / Fork
- 绑定项目后文件夹图标旁显示目录名
- Composer 参考 Cursor：单行胶囊、多行变圆角方框；`+` / 模型选择 / 生成中停止（无语音）

## Screenshots
[Pill composer](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcomposer-pill.png)
[Expanded composer](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fcomposer-expanded.png)
[Turn footer](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fturn-footer.png)
[Project name chip](https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fproject-name-chip.png)

## Test plan
- [x] turn 底栏 usage + Copy/Fork
- [x] 单行胶囊 / 多行圆角方框
- [x] 模型下拉
- [x] 绑定后显示目录名


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

