### PR TITLE
ui: 回复底栏轮次/耗时/用量（Icon+值）

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -1,7 +1,7 @@
-import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { LuCheck, LuCopy, LuGitFork } from 'react-icons/lu'
+import { LuCheck, LuCopy, LuGitFork, LuHash, LuTimer, LuCoins } from 'react-icons/lu'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
@@ -85,6 +85,25 @@ function UsageInline({ usage }: { usage: TrajectoryUsage }) {
       <span className="traj-usage-out" title="output tokens">
         {formatTok(usage.outputTokens)}
       </span>
+    </span>
+  )
+}
+
+function MetaItem({
+  icon,
+  value,
+  title,
+}: {
+  icon: ReactNode
+  value: ReactNode
+  title: string
+}) {
+  return (
+    <span className="chat-reply-meta-item" title={title}>
+      <span className="chat-reply-meta-icon" aria-hidden>
+        {icon}
+      </span>
+      <span className="chat-reply-meta-value">{value}</span>
     </span>
   )
 }
@@ -214,13 +233,20 @@ function NodeView({
         {showFooter ? (
           <div className="chat-reply-bar" aria-label="回合摘要">
             <div className="chat-reply-meta">
-              {node.durationMs != null ? (
-                <span className="chat-reply-duration" title="本回合耗时">
-                  {formatDuration(node.durationMs)}
-                </span>
+              {node.turn != null ? (
+                <MetaItem icon={<LuHash className="size-3" />} value={node.turn} title={`第 ${node.turn} 轮`} />
               ) : null}
-              {node.usage ? <UsageInline usage={node.usage} /> : null}
-              {!node.usage && node.durationMs == null ? (
+              {node.durationMs != null ? (
+                <MetaItem
+                  icon={<LuTimer className="size-3" />}
+                  value={formatDuration(node.durationMs)}
+                  title="本回合耗时"
+                />
+              ) : null}
+              {node.usage ? (
+                <MetaItem icon={<LuCoins className="size-3" />} value={<UsageInline usage={node.usage} />} title="Token 用量" />
+              ) : null}
+              {node.turn == null && node.durationMs == null && !node.usage ? (
                 <span className="chat-reply-meta-empty">—</span>
               ) : null}
             </div>

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -68,6 +68,7 @@ test('reply aggregates turn duration and usage for footer', () => {
   assert.equal(reply?.kind, 'reply')
   if (reply?.kind !== 'reply') return
   assert.equal(reply.finished, true)
+  assert.equal(reply.turn, 1)
   assert.equal(reply.durationMs, 1800)
   assert.deepEqual(reply.usage, {
     inputTokens: 20,

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -60,6 +60,7 @@ export type ChatNode =
       parts: ChatReplyPart[]
       /** 本回合所有助手正文，供一键复制 */
       copyText: string
+      turn?: number
       usage?: TrajectoryUsage
       durationMs?: number
       streaming?: boolean
@@ -118,6 +119,7 @@ export function projectRequestMessages(events: SessionEvent[], assistantSeq: num
 export function projectNodes(events: SessionEvent[]): ChatNode[] {
   const nodes: ChatNode[] = []
   let turnStartTs: number | undefined
+  let currentTurn: number | undefined
   let reply: {
     id: string
     parts: ChatReplyPart[]
@@ -125,6 +127,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
     tools: Map<string, ChatToolPart>
     usage: { input: number; output: number; total: number; cache: number; hit: boolean }
     streaming: boolean
+    turn?: number
   } | null = null
 
   function ensureReply(seq: number) {
@@ -136,6 +139,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
         tools: new Map(),
         usage: { input: 0, output: 0, total: 0, cache: 0, hit: false },
         streaming: false,
+        ...(currentTurn != null ? { turn: currentTurn } : {}),
       }
     }
     return reply
@@ -176,6 +180,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       kind: 'reply',
       parts: reply.parts,
       copyText,
+      ...(reply.turn != null ? { turn: reply.turn } : {}),
       ...(usage ? { usage } : {}),
       ...(durationMs != null ? { durationMs } : {}),
       streaming: reply.streaming && !finished,
@@ -188,6 +193,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
     if (event.type === 'turn/start') {
       flushReply()
       turnStartTs = event.ts
+      currentTurn = event.turn
     } else if (event.type === 'user/message') {
       flushReply()
       nodes.push({ id: `u-${event.seq}`, kind: 'user', text: event.text, kindTag: event.kind })
@@ -253,6 +259,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
     } else if (event.type === 'turn/end') {
       flushReply(event.ts, true)
       turnStartTs = undefined
+      currentTurn = undefined
       if (event.reason && event.reason !== 'complete') {
         nodes.push({ id: `turn-${event.seq}`, kind: 'turn', text: `回合结束：${event.reason}` })
       }

--- a/src/style.css
+++ b/src/style.css
@@ -1272,7 +1272,10 @@ body {
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 8px;
+  overflow: hidden;
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--dsw-surface) 72%, transparent);
 }
 
 .chat-reply-card {
@@ -1281,12 +1284,16 @@ body {
   flex-direction: column;
   gap: 12px;
   padding: 12px 14px;
-  border: 1px solid var(--dsw-border);
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--dsw-surface) 72%, transparent);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .chat-reply-card.is-streaming {
+  /* keep streaming look on the outer block via parent if needed */
+}
+
+.chat-reply-block:has(.chat-reply-card.is-streaming) {
   border-color: color-mix(in srgb, var(--dsw-border) 80%, transparent);
 }
 
@@ -1302,15 +1309,17 @@ body {
 
 .chat-reply-bar {
   display: flex;
-  height: 32px;
+  height: 30px;
+  flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 0 10px 0 12px;
-  border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--dsw-bg) 78%, var(--dsw-surface));
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22);
+  padding: 0 8px 0 12px;
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--dsw-bg) 55%, var(--dsw-surface));
+  box-shadow: none;
 }
 
 .chat-reply-meta {
@@ -1338,6 +1347,7 @@ body {
 
 .chat-reply-actions {
   display: inline-flex;
+  height: 100%;
   flex-shrink: 0;
   align-items: center;
   gap: 2px;
@@ -1347,6 +1357,11 @@ body {
 
 .chat-reply-block:hover .chat-reply-actions {
   opacity: 1;
+}
+
+.chat-reply-actions .chat-assistant-action {
+  width: 26px;
+  height: 26px;
 }
 
 .chat-assistant-actions {

--- a/src/style.css
+++ b/src/style.css
@@ -1327,17 +1327,35 @@ body {
   min-width: 0;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   overflow: hidden;
   color: var(--dsw-label-3);
   font-size: 11px;
   line-height: 1;
 }
 
-.chat-reply-duration {
+.chat-reply-meta-item {
+  display: inline-flex;
+  min-width: 0;
   flex-shrink: 0;
-  font-variant-numeric: tabular-nums;
+  align-items: center;
+  gap: 4px;
   color: var(--dsw-label-2);
+  line-height: 1;
+}
+
+.chat-reply-meta-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  color: var(--dsw-label-3);
+}
+
+.chat-reply-meta-value {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 回复统计条吸附在卡片底部（共享圆角）
- 展示：轮次 `#`、耗时 ⏱、用量 💰（含 cache 的 input→output）
- 每项均为 Icon + 数值；右侧仍为 Copy / Fork

## Test plan
- [ ] 完成一轮后底栏出现轮次 / 时间 / 用量
- [ ] 图标与数字垂直居中
- [ ] Copy / Fork 仍可用

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

