### PR TITLE
ui: 侧栏添加聊天/Dashboard + Trajectory 改为 Debug

### DIFF
--- a/host/plugins/contributors/dashboard.ts
+++ b/host/plugins/contributors/dashboard.ts
@@ -1,8 +1,60 @@
 import type { Context } from 'cordis'
 import '../../types.ts'
+import type { SessionEvent } from '../core/session-types.ts'
 
 export const name = 'dashboard'
-export const inject = ['http', 'hub']
+export const inject = ['http', 'hub', 'sessions']
+
+type UsageBucket = {
+  key: string
+  label: string
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  turns: number
+}
+
+type ProjectStat = {
+  name: string
+  path?: string
+  sessions: number
+  events: number
+}
+
+function emptyUsage() {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 }
+}
+
+function addUsage(
+  target: { inputTokens: number; outputTokens: number; cacheReadTokens: number; turns?: number },
+  usage: { inputTokens: number; outputTokens: number; cacheReadTokens?: number },
+) {
+  target.inputTokens += usage.inputTokens
+  target.outputTokens += usage.outputTokens
+  target.cacheReadTokens += usage.cacheReadTokens ?? 0
+}
+
+function hourKey(ts: number) {
+  const d = new Date(ts)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const h = String(d.getHours()).padStart(2, '0')
+  return `${y}-${m}-${day}T${h}`
+}
+
+function dayKey(ts: number) {
+  const d = new Date(ts)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function hourLabel(key: string) {
+  const hour = key.slice(11, 13)
+  return `${hour}:00`
+}
 
 export function apply(ctx: Context) {
   ctx.http.route('GET', '/api/snapshot', (route) => {
@@ -15,5 +67,104 @@ export function apply(ctx: Context) {
     } catch (error) {
       route.send(400, { error: String(error) })
     }
+  })
+
+  ctx.http.route('GET', '/api/stats/overview', async (route) => {
+    const now = Date.now()
+    const todayKey = dayKey(now)
+    const hourStart = now - 24 * 60 * 60 * 1000
+    const dayStart = now - 7 * 24 * 60 * 60 * 1000
+
+    const today = emptyUsage()
+    const hourlyMap = new Map<string, UsageBucket>()
+    const dailyMap = new Map<string, UsageBucket>()
+    const projects = new Map<string, ProjectStat>()
+    let sessionCount = 0
+    let eventCount = 0
+
+    const summaries = await ctx.sessions.listSummaries()
+    // 最近会话优先，避免全量扫爆
+    const recent = [...summaries].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 80)
+    sessionCount = summaries.length
+
+    for (const summary of recent) {
+      eventCount += summary.eventCount
+      if (summary.project?.name) {
+        const key = summary.project.path || summary.project.name
+        const prev = projects.get(key) ?? {
+          name: summary.project.name,
+          ...(summary.project.path ? { path: summary.project.path } : {}),
+          sessions: 0,
+          events: 0,
+        }
+        prev.sessions += 1
+        prev.events += summary.eventCount
+        projects.set(key, prev)
+      }
+
+      const record = await ctx.sessions.get(summary.id)
+      if (!record) continue
+      for (const event of record.events as SessionEvent[]) {
+        if (event.type === 'turn/start') {
+          if (dayKey(event.ts) === todayKey) today.turns += 1
+          if (event.ts >= hourStart) {
+            const key = hourKey(event.ts)
+            const bucket =
+              hourlyMap.get(key) ??
+              ({ key, label: hourLabel(key), inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 } satisfies UsageBucket)
+            bucket.turns += 1
+            hourlyMap.set(key, bucket)
+          }
+          if (event.ts >= dayStart) {
+            const key = dayKey(event.ts)
+            const bucket =
+              dailyMap.get(key) ??
+              ({ key, label: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 } satisfies UsageBucket)
+            bucket.turns += 1
+            dailyMap.set(key, bucket)
+          }
+        }
+        if (event.type !== 'assistant/message' || !event.usage) continue
+        const usage = {
+          inputTokens: event.usage.inputTokens,
+          outputTokens: event.usage.outputTokens,
+          cacheReadTokens: event.usage.cacheReadTokens,
+        }
+        if (dayKey(event.ts) === todayKey) addUsage(today, usage)
+        if (event.ts >= hourStart) {
+          const key = hourKey(event.ts)
+          const bucket =
+            hourlyMap.get(key) ??
+            ({ key, label: hourLabel(key), inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 } satisfies UsageBucket)
+          addUsage(bucket, usage)
+          hourlyMap.set(key, bucket)
+        }
+        if (event.ts >= dayStart) {
+          const key = dayKey(event.ts)
+          const bucket =
+            dailyMap.get(key) ??
+            ({ key, label: key, inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 } satisfies UsageBucket)
+          addUsage(bucket, usage)
+          dailyMap.set(key, bucket)
+        }
+      }
+    }
+
+    const hourly = [...hourlyMap.values()].sort((a, b) => a.key.localeCompare(b.key))
+    const daily = [...dailyMap.values()].sort((a, b) => a.key.localeCompare(b.key))
+    const projectStats = [...projects.values()].sort((a, b) => b.events - a.events).slice(0, 12)
+
+    route.send(200, {
+      generatedAt: now,
+      totals: {
+        sessions: sessionCount,
+        events: eventCount,
+        scannedSessions: recent.length,
+      },
+      today,
+      hourly,
+      daily,
+      projects: projectStats,
+    })
   })
 }

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -329,7 +329,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const onInspect = useCallback(
     (callId: string) => {
       sessionView.inspectCall(callId)
-      if (sessionId) navigate(`/s/${sessionId}/trajectory`)
+      if (sessionId) navigate(`/s/${sessionId}/debug`)
     },
     [sessionView, sessionId, navigate],
   )

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -206,7 +206,7 @@ export function ToolCard({
           className="shrink-0 rounded-[8px] px-2 py-1 text-[11px] text-[var(--dsw-business)] hover:bg-[var(--dsw-business-soft)]"
           onClick={() => onInspect(node.callId)}
         >
-          Trajectory
+          Debug
         </button>
       </div>
       {!open && previewLines && previewLines.length > 0 ? (

--- a/src/plugins/contributors/chat/trajectory.tsx
+++ b/src/plugins/contributors/chat/trajectory.tsx
@@ -183,7 +183,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
     return (
       <div className="traj-empty">
         <p className="traj-empty-title">No session</p>
-        <p className="traj-empty-body">Open or create a session to inspect its append-only event ledger.</p>
+        <p className="traj-empty-body">打开或新建会话后，可在此查看调试日志。</p>
       </div>
     )
   }
@@ -191,7 +191,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
   if (!rows.length && trajectoryLoading) {
     return (
       <div className="traj-empty">
-        <p className="traj-empty-title">Loading trajectory…</p>
+        <p className="traj-empty-title">Loading debug log…</p>
       </div>
     )
   }

--- a/src/plugins/contributors/dashboard-module.tsx
+++ b/src/plugins/contributors/dashboard-module.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react'
+
+type UsageTotals = {
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  turns: number
+}
+
+type UsageBucket = UsageTotals & {
+  key: string
+  label: string
+}
+
+type ProjectStat = {
+  name: string
+  path?: string
+  sessions: number
+  events: number
+}
+
+type StatsOverview = {
+  generatedAt: number
+  totals: { sessions: number; events: number; scannedSessions: number }
+  today: UsageTotals
+  hourly: UsageBucket[]
+  daily: UsageBucket[]
+  projects: ProjectStat[]
+}
+
+function formatTok(n: number) {
+  return n.toLocaleString('en-US')
+}
+
+function BarRow({ label, value, max }: { label: string; value: number; max: number }) {
+  const pct = max > 0 ? Math.max(4, Math.round((value / max) * 100)) : 0
+  return (
+    <div className="dash-bar-row">
+      <span className="dash-bar-label">{label}</span>
+      <div className="dash-bar-track">
+        <div className="dash-bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <span className="dash-bar-value">{formatTok(value)}</span>
+    </div>
+  )
+}
+
+export function DashboardModule() {
+  const [data, setData] = useState<StatsOverview | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    void fetch('/api/stats/overview')
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return (await res.json()) as StatsOverview
+      })
+      .then((next) => {
+        if (cancelled) return
+        setData(next)
+        setError('')
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(String(err))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const hourlyMax = Math.max(1, ...(data?.hourly.map((item) => item.inputTokens + item.outputTokens) ?? [1]))
+  const dailyMax = Math.max(1, ...(data?.daily.map((item) => item.inputTokens + item.outputTokens) ?? [1]))
+
+  return (
+    <div className="dash-root">
+      <header className="dash-header">
+        <div>
+          <h1 className="dash-title">Dashboard</h1>
+          <p className="dash-subtitle">控制台 · 用量与今日项目概览</p>
+        </div>
+        {data ? (
+          <span className="dash-updated">扫描 {data.totals.scannedSessions}/{data.totals.sessions} 会话</span>
+        ) : null}
+      </header>
+
+      {loading ? <p className="dash-muted">加载统计中…</p> : null}
+      {error ? <p className="dash-error">{error}</p> : null}
+
+      {data ? (
+        <>
+          <section className="dash-cards" aria-label="今日概览">
+            <article className="dash-card">
+              <div className="dash-card-label">今日回合</div>
+              <div className="dash-card-value">{formatTok(data.today.turns)}</div>
+            </article>
+            <article className="dash-card">
+              <div className="dash-card-label">今日 Input</div>
+              <div className="dash-card-value">{formatTok(data.today.inputTokens)}</div>
+            </article>
+            <article className="dash-card">
+              <div className="dash-card-label">今日 Output</div>
+              <div className="dash-card-value">{formatTok(data.today.outputTokens)}</div>
+            </article>
+            <article className="dash-card">
+              <div className="dash-card-label">今日 Cache</div>
+              <div className="dash-card-value">{formatTok(data.today.cacheReadTokens)}</div>
+            </article>
+          </section>
+
+          <div className="dash-grid">
+            <section className="dash-panel">
+              <h2 className="dash-panel-title">近 24 小时用量</h2>
+              <div className="dash-bars">
+                {data.hourly.length === 0 ? (
+                  <p className="dash-muted">暂无小时数据</p>
+                ) : (
+                  data.hourly.map((item) => (
+                    <BarRow
+                      key={item.key}
+                      label={item.label}
+                      value={item.inputTokens + item.outputTokens}
+                      max={hourlyMax}
+                    />
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="dash-panel">
+              <h2 className="dash-panel-title">近 7 天用量</h2>
+              <div className="dash-bars">
+                {data.daily.length === 0 ? (
+                  <p className="dash-muted">暂无日数据</p>
+                ) : (
+                  data.daily.map((item) => (
+                    <BarRow
+                      key={item.key}
+                      label={item.label.slice(5)}
+                      value={item.inputTokens + item.outputTokens}
+                      max={dailyMax}
+                    />
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="dash-panel dash-panel-wide">
+              <h2 className="dash-panel-title">今日项目情况</h2>
+              {data.projects.length === 0 ? (
+                <p className="dash-muted">还没有绑定项目的会话</p>
+              ) : (
+                <table className="dash-table">
+                  <thead>
+                    <tr>
+                      <th>项目</th>
+                      <th>会话</th>
+                      <th>事件</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.projects.map((item) => (
+                      <tr key={item.path || item.name}>
+                        <td>
+                          <div className="dash-project-name">{item.name}</div>
+                          {item.path ? <div className="dash-project-path">{item.path}</div> : null}
+                        </td>
+                        <td>{item.sessions}</td>
+                        <td>{item.events}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </section>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -15,12 +15,27 @@ import { FishLogo } from './brand.tsx'
 import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
 import { resolveSessionMascot } from './mascot/session-mascot.ts'
 import { FolderGlyph } from './chat/project-panel.tsx'
-import { LuMessageSquare, LuPanelLeft, LuPanelLeftClose, LuPlus, LuWaypoints } from 'react-icons/lu'
+import { DashboardModule } from './dashboard-module.tsx'
+import {
+  LuBug,
+  LuLayoutDashboard,
+  LuMessageSquare,
+  LuPanelLeft,
+  LuPanelLeftClose,
+  LuPlus,
+} from 'react-icons/lu'
 
 export const name = 'shell'
 export const inject = ['slots', 'snapshot', 'sessionView', 'projectView']
 
 function ModuleIcon({ id }: { id: AppModuleId }) {
+  if (id === 'dashboard') {
+    return (
+      <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4 4.5h7v7H4zM13 4.5h7v4h-7zM13 11.5h7v8h-7zM4 14.5h7v5H4z" />
+      </svg>
+    )
+  }
   if (id === 'workspace') {
     return (
       <svg viewBox="0 0 24 24" className="size-5" fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden>
@@ -130,7 +145,7 @@ function Shell(props: SlotProps) {
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
-  const agentHref = sessionId ? `/s/${sessionId}${view === 'trajectory' ? '/trajectory' : ''}` : '/'
+  const agentHref = sessionId ? `/s/${sessionId}${view === 'debug' ? '/debug' : ''}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
@@ -188,28 +203,15 @@ function Shell(props: SlotProps) {
         <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-4">
           <div className="mb-2 flex items-center justify-between gap-2 px-1">
             <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
-            <div className="flex items-center gap-0.5">
-              <button
-                type="button"
-                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
-                title="Collapse sidebar"
-                aria-label="Collapse sidebar"
-                onClick={() => setSidebarCollapsed(true)}
-              >
-                <LuPanelLeftClose className="size-3.5" />
-              </button>
-              <button
-                type="button"
-                className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
-                title="New Session"
-                aria-label="New Session"
-                onClick={() => {
-                  void sessionView.newSession().then((id) => navigate(`/s/${id}`))
-                }}
-              >
-                <LuPlus className="size-3.5" />
-              </button>
-            </div>
+            <button
+              type="button"
+              className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
+              title="Collapse sidebar"
+              aria-label="Collapse sidebar"
+              onClick={() => setSidebarCollapsed(true)}
+            >
+              <LuPanelLeftClose className="size-3.5" />
+            </button>
           </div>
           {sessions.length === 0 ? (
             <p className="px-1 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
@@ -225,7 +227,7 @@ function Shell(props: SlotProps) {
                   }`}
                 >
                   <Link
-                    to={`/s/${item.id}${view === 'trajectory' ? '/trajectory' : ''}`}
+                    to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
                     className="flex min-w-0 flex-1 items-center gap-2.5 px-2.5 py-2 text-left text-sm"
                   >
                     <SidebarMascot
@@ -267,6 +269,24 @@ function Shell(props: SlotProps) {
               )
             })
           )}
+        </div>
+        <div className="app-side-footer">
+          <button
+            type="button"
+            className="app-side-footer-item"
+            title="添加聊天"
+            aria-label="添加聊天"
+            onClick={() => {
+              void sessionView.newSession().then((id) => navigate(`/s/${id}`))
+            }}
+          >
+            <LuPlus className="size-4 shrink-0" aria-hidden />
+            <span>添加聊天</span>
+          </button>
+          <Link to="/dashboard" className="app-side-footer-item" title="Dashboard" aria-label="Dashboard">
+            <LuLayoutDashboard className="size-4 shrink-0" aria-hidden />
+            <span>Dashboard</span>
+          </Link>
         </div>
       </aside>
 
@@ -311,14 +331,14 @@ function Shell(props: SlotProps) {
                 )}
               </NavLink>
               <NavLink
-                to={sessionId ? `/s/${sessionId}/trajectory` : '/'}
-                title="Trajectory"
-                aria-label="Trajectory"
+                to={sessionId ? `/s/${sessionId}/debug` : '/'}
+                title="Debug"
+                aria-label="Debug"
                 className={({ isActive }) => `chat-view-tab${isActive ? ' is-active' : ''}`}
               >
                 {({ isActive }) => (
                   <>
-                    <LuWaypoints className="size-3.5" />
+                    <LuBug className="size-3.5" />
                     {isActive ? <span className="chat-view-tab-underline" /> : null}
                   </>
                 )}
@@ -329,7 +349,7 @@ function Shell(props: SlotProps) {
           <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
             {/*
               不用 display:none：大 Markdown DOM 被隐藏后再显示会重算布局（数百 ms longtask）。
-              absolute + visibility 保活布局，Chat↔Trajectory 只切可见性。
+              absolute + visibility 保活布局，Chat↔Debug 只切可见性。
             */}
             <div
               className={`absolute inset-0 min-h-0 overflow-hidden ${
@@ -351,13 +371,19 @@ function Shell(props: SlotProps) {
             </div>
             <div
               className={`absolute inset-0 min-h-0 overflow-hidden ${
-                view === 'trajectory' ? 'z-[1] flex flex-col' : 'pointer-events-none invisible z-0 flex flex-col'
+                view === 'debug' ? 'z-[1] flex flex-col' : 'pointer-events-none invisible z-0 flex flex-col'
               }`}
-              aria-hidden={view !== 'trajectory'}
+              aria-hidden={view !== 'debug'}
             >
               {props.renderSlot('trajectory')}
             </div>
           </div>
+        </div>
+        <div
+          className={activeModule === 'dashboard' ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'hidden'}
+          aria-hidden={activeModule !== 'dashboard'}
+        >
+          <DashboardModule />
         </div>
         <div
           className={activeModule === 'workspace' ? 'flex min-h-0 flex-1 flex-col' : 'hidden'}

--- a/src/plugins/infrastructure/app-modules.test.ts
+++ b/src/plugins/infrastructure/app-modules.test.ts
@@ -2,17 +2,23 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { APP_MODULES, isAgentPath, moduleById, moduleIdFromPath } from './app-modules.ts'
 
-test('APP_MODULES lists agent first', () => {
+test('APP_MODULES lists agent first and includes dashboard', () => {
   assert.equal(APP_MODULES[0]?.id, 'agent')
   assert.equal(moduleById('workspace').path, '/workspace')
+  assert.equal(moduleById('dashboard').path, '/dashboard')
+  assert.ok(APP_MODULES.some((item) => item.id === 'dashboard'))
 })
 
-test('moduleIdFromPath maps agent and workspace routes', () => {
+test('moduleIdFromPath maps agent, dashboard, and workspace routes', () => {
   assert.equal(moduleIdFromPath('/'), 'agent')
   assert.equal(moduleIdFromPath('/s/abc'), 'agent')
   assert.equal(moduleIdFromPath('/s/abc/trajectory'), 'agent')
+  assert.equal(moduleIdFromPath('/s/abc/debug'), 'agent')
+  assert.equal(moduleIdFromPath('/dashboard'), 'dashboard')
+  assert.equal(moduleIdFromPath('/dashboard/'), 'dashboard')
   assert.equal(moduleIdFromPath('/workspace'), 'workspace')
   assert.equal(moduleIdFromPath('/workspace/'), 'workspace')
   assert.equal(isAgentPath('/s/x'), true)
+  assert.equal(isAgentPath('/dashboard'), false)
   assert.equal(isAgentPath('/workspace'), false)
 })

--- a/src/plugins/infrastructure/app-modules.ts
+++ b/src/plugins/infrastructure/app-modules.ts
@@ -1,5 +1,5 @@
 /** 应用级模块：Agent 只是其中之一，路由决定当前模块。 */
-export type AppModuleId = 'agent' | 'workspace'
+export type AppModuleId = 'agent' | 'workspace' | 'dashboard'
 
 export interface AppModule {
   id: AppModuleId
@@ -14,7 +14,13 @@ export const APP_MODULES: AppModule[] = [
     id: 'agent',
     label: 'Agent',
     path: '/',
-    description: 'Session chat, tools, and trajectory ledger',
+    description: 'Session chat, tools, and debug event log',
+  },
+  {
+    id: 'dashboard',
+    label: 'Dashboard',
+    path: '/dashboard',
+    description: 'Usage and project overview console',
   },
   {
     id: 'workspace',
@@ -31,6 +37,7 @@ export function moduleById(id: AppModuleId): AppModule {
 /** Agent 相关 path（含历史 `/s/:id`）→ agent；其余按模块 path。 */
 export function moduleIdFromPath(pathname: string): AppModuleId {
   const path = pathname.replace(/\/+$/, '') || '/'
+  if (path === '/dashboard' || path.startsWith('/dashboard/')) return 'dashboard'
   if (path === '/workspace' || path.startsWith('/workspace/')) return 'workspace'
   return 'agent'
 }

--- a/src/plugins/infrastructure/renderer.tsx
+++ b/src/plugins/infrastructure/renderer.tsx
@@ -38,7 +38,7 @@ function AppShell({ slots }: { slots: SlotsService }) {
   return <Outlet slots={slots} name="root" kind="single" />
 }
 
-/** 单壳常驻：路由变化不卸载 Shell，避免 Chat/Trajectory/模块切换整树重挂。 */
+/** 单壳常驻：路由变化不卸载 Shell，避免 Chat/Debug/模块切换整树重挂。 */
 function Root({ slots }: { slots: SlotsService }) {
   const location = useLocation()
   if (!isKnownAppPath(location.pathname)) {

--- a/src/plugins/infrastructure/session-route.test.ts
+++ b/src/plugins/infrastructure/session-route.test.ts
@@ -2,25 +2,33 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { buildAppPath, isKnownAppPath, parseAppPath, routeFromState } from './session-route.ts'
 
-test('parseAppPath covers home, session chat, trajectory, and workspace module', () => {
+test('parseAppPath covers home, session chat, debug, dashboard, and workspace module', () => {
   assert.deepEqual(parseAppPath('/'), { kind: 'home' })
   assert.deepEqual(parseAppPath('/s/abc'), { kind: 'session', sessionId: 'abc', view: 'chat' })
   assert.deepEqual(parseAppPath('/s/abc/'), { kind: 'session', sessionId: 'abc', view: 'chat' })
   assert.deepEqual(parseAppPath('/s/abc/chat'), { kind: 'session', sessionId: 'abc', view: 'chat' })
+  assert.deepEqual(parseAppPath('/s/abc/debug'), {
+    kind: 'session',
+    sessionId: 'abc',
+    view: 'debug',
+  })
   assert.deepEqual(parseAppPath('/s/abc/trajectory'), {
     kind: 'session',
     sessionId: 'abc',
-    view: 'trajectory',
+    view: 'debug',
   })
+  assert.deepEqual(parseAppPath('/dashboard'), { kind: 'module', moduleId: 'dashboard' })
   assert.deepEqual(parseAppPath('/workspace'), { kind: 'module', moduleId: 'workspace' })
   assert.deepEqual(parseAppPath('/unknown'), { kind: 'home' })
 })
 
 test('isKnownAppPath accepts app surfaces and rejects noise', () => {
   assert.equal(isKnownAppPath('/'), true)
+  assert.equal(isKnownAppPath('/dashboard'), true)
   assert.equal(isKnownAppPath('/workspace'), true)
   assert.equal(isKnownAppPath('/s/abc'), true)
   assert.equal(isKnownAppPath('/s/abc/chat'), true)
+  assert.equal(isKnownAppPath('/s/abc/debug'), true)
   assert.equal(isKnownAppPath('/s/abc/trajectory'), true)
   assert.equal(isKnownAppPath('/unknown'), false)
   assert.equal(isKnownAppPath('/s/abc/extra'), false)
@@ -30,7 +38,8 @@ test('buildAppPath round-trips with parseAppPath', () => {
   const routes = [
     { kind: 'home' as const },
     { kind: 'session' as const, sessionId: 's1', view: 'chat' as const },
-    { kind: 'session' as const, sessionId: 's1', view: 'trajectory' as const },
+    { kind: 'session' as const, sessionId: 's1', view: 'debug' as const },
+    { kind: 'module' as const, moduleId: 'dashboard' as const },
     { kind: 'module' as const, moduleId: 'workspace' as const },
   ]
   for (const route of routes) {
@@ -40,9 +49,9 @@ test('buildAppPath round-trips with parseAppPath', () => {
 
 test('routeFromState maps sessionView fields', () => {
   assert.deepEqual(routeFromState(null, 'chat'), { kind: 'home' })
-  assert.deepEqual(routeFromState('x', 'trajectory'), {
+  assert.deepEqual(routeFromState('x', 'debug'), {
     kind: 'session',
     sessionId: 'x',
-    view: 'trajectory',
+    view: 'debug',
   })
 })

--- a/src/plugins/infrastructure/session-route.ts
+++ b/src/plugins/infrastructure/session-route.ts
@@ -1,35 +1,41 @@
-/** `/` | `/s/:id` | `/s/:id/trajectory` | `/workspace` */
-export type RouteView = 'chat' | 'trajectory'
+/** `/` | `/s/:id` | `/s/:id/debug` | `/workspace` | `/dashboard`（兼容旧 `/trajectory`） */
+export type RouteView = 'chat' | 'debug'
 
 export type AppRoute =
   | { kind: 'home' }
   | { kind: 'session'; sessionId: string; view: RouteView }
-  | { kind: 'module'; moduleId: 'workspace' }
+  | { kind: 'module'; moduleId: 'workspace' | 'dashboard' }
 
 export function parseAppPath(pathname: string): AppRoute {
   const path = normalizePath(pathname)
   if (path === '/workspace') return { kind: 'module', moduleId: 'workspace' }
+  if (path === '/dashboard') return { kind: 'module', moduleId: 'dashboard' }
   if (path === '/') return { kind: 'home' }
-  const match = path.match(/^\/s\/([^/]+)(?:\/(chat|trajectory))?$/)
+  const match = path.match(/^\/s\/([^/]+)(?:\/(chat|debug|trajectory))?$/)
   if (!match?.[1]) return { kind: 'home' }
+  const segment = match[2]
   return {
     kind: 'session',
     sessionId: decodeURIComponent(match[1]),
-    view: match[2] === 'trajectory' ? 'trajectory' : 'chat',
+    view: segment === 'debug' || segment === 'trajectory' ? 'debug' : 'chat',
   }
 }
 
 /** 已知应用 path（未知则 Navigate 回 `/`，且不拆 Shell）。 */
 export function isKnownAppPath(pathname: string): boolean {
   const path = normalizePath(pathname)
-  if (path === '/' || path === '/workspace') return true
-  return /^\/s\/[^/]+(?:\/(chat|trajectory))?$/.test(path)
+  if (path === '/' || path === '/workspace' || path === '/dashboard') return true
+  return /^\/s\/[^/]+(?:\/(chat|debug|trajectory))?$/.test(path)
 }
 
 export function buildAppPath(route: AppRoute): string {
   if (route.kind === 'home') return '/'
-  if (route.kind === 'module') return route.moduleId === 'workspace' ? '/workspace' : '/'
-  if (route.view === 'trajectory') return `/s/${encodeURIComponent(route.sessionId)}/trajectory`
+  if (route.kind === 'module') {
+    if (route.moduleId === 'workspace') return '/workspace'
+    if (route.moduleId === 'dashboard') return '/dashboard'
+    return '/'
+  }
+  if (route.view === 'debug') return `/s/${encodeURIComponent(route.sessionId)}/debug`
   return `/s/${encodeURIComponent(route.sessionId)}`
 }
 

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -86,7 +86,7 @@ test('inspectCall switches to trajectory with focus', async () => {
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
   view.inspectCall('c1')
-  assert.equal(view.get().view, 'trajectory')
+  assert.equal(view.get().view, 'debug')
   assert.equal(view.get().focusCallId, 'c1')
 })
 

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -25,7 +25,7 @@ export interface SessionListItem {
   mascot?: { shape: string; color: string }
 }
 
-export type ConversationView = 'chat' | 'trajectory'
+export type ConversationView = 'chat' | 'debug'
 export type ApprovalMode = 'auto' | 'hold'
 
 /** 与 host DEFAULT_TAIL_TURNS / DEFAULT_TRAJECTORY_TURNS 对齐 */
@@ -145,11 +145,11 @@ export class SessionViewService extends Service {
 
   setView(view: ConversationView) {
     this.replace({ view, focusCallId: view === 'chat' ? undefined : this.value.focusCallId })
-    if (view === 'trajectory') void this.ensureTrajectory()
+    if (view === 'debug') void this.ensureTrajectory()
   }
 
   inspectCall(callId: string) {
-    this.replace({ view: 'trajectory', focusCallId: callId })
+    this.replace({ view: 'debug', focusCallId: callId })
     void this.ensureTrajectory()
   }
 
@@ -207,7 +207,7 @@ export class SessionViewService extends Service {
         focusCallId: route.view === 'chat' ? undefined : this.value.focusCallId,
       })
     }
-    if (route.view === 'trajectory') await this.ensureTrajectory()
+    if (route.view === 'debug') await this.ensureTrajectory()
   }
 
   ingest(sessionId: string, event: SessionEvent) {
@@ -229,7 +229,7 @@ export class SessionViewService extends Service {
     })
     this.stashCurrent()
     // Trajectory 索引走独立接口；运行中只做轻量刷新，不塞全文 events
-    if (this.value.view === 'trajectory') void this.refreshTrajectoryIndex()
+    if (this.value.view === 'debug') void this.refreshTrajectoryIndex()
     void this.refreshSessions()
   }
 
@@ -366,7 +366,7 @@ export class SessionViewService extends Service {
         this.touchCache(sessionId)
         this.loadGen += 1
         this.applyCached(sessionId, cached, view)
-        if (view === 'trajectory') void this.ensureTrajectory()
+        if (view === 'debug') void this.ensureTrajectory()
         void this.revalidate(sessionId, view)
         return
       }
@@ -389,7 +389,7 @@ export class SessionViewService extends Service {
           trajectoryLoading: false,
           totalTurns: 0,
         })
-        if (view === 'trajectory') void this.ensureTrajectory()
+        if (view === 'debug') void this.ensureTrajectory()
         void this.revalidate(sessionId, view)
         return
       }
@@ -422,7 +422,7 @@ export class SessionViewService extends Service {
       }
     }
     await this.revalidate(sessionId, view)
-    if (view === 'trajectory') await this.ensureTrajectory()
+    if (view === 'debug') await this.ensureTrajectory()
   }
 
   /** 静默拉取并套用；若用户已切走则丢弃 */
@@ -475,10 +475,10 @@ export class SessionViewService extends Service {
         project: body.project,
         hasMoreOlder,
         totalTurns,
-        trajectory: view === 'trajectory' ? this.value.trajectory : [],
+        trajectory: view === 'debug' ? this.value.trajectory : [],
         error: undefined,
       })
-      if (view === 'trajectory') void this.ensureTrajectory()
+      if (view === 'debug') void this.ensureTrajectory()
     } catch {
       /* 静默 */
     }
@@ -578,7 +578,7 @@ export class SessionViewService extends Service {
     const sessionId = this.value.sessionId
     if (!sessionId) return
     if (this.value.trajectoryLoading) return
-    this.replace({ trajectoryLoading: true, view: 'trajectory' })
+    this.replace({ trajectoryLoading: true, view: 'debug' })
     try {
       const res = await fetch(
         `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,
@@ -590,7 +590,7 @@ export class SessionViewService extends Service {
         trajectoryHasMore: Boolean(body.hasMore),
         trajectoryLoading: false,
         totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
-        view: 'trajectory',
+        view: 'debug',
       })
     } catch (error) {
       this.replace({ trajectoryLoading: false, error: String(error) })
@@ -599,7 +599,7 @@ export class SessionViewService extends Service {
 
   async refreshTrajectoryIndex() {
     const sessionId = this.value.sessionId
-    if (!sessionId || this.value.view !== 'trajectory') return
+    if (!sessionId || this.value.view !== 'debug') return
     try {
       const res = await fetch(
         `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,

--- a/src/style.css
+++ b/src/style.css
@@ -297,6 +297,35 @@ body {
   grid-template-columns: 48px minmax(0, 1fr);
 }
 
+.app-side-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
+  border-top: 1px solid var(--dsw-border);
+  padding: 10px 12px 12px;
+}
+
+.app-side-footer-item {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  border-radius: 10px;
+  padding: 9px 10px;
+  color: var(--dsw-label-2);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.2;
+  text-align: left;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.app-side-footer-item:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-business);
+}
+
 .app-activity-bar {
   display: flex;
   min-height: 0;
@@ -611,7 +640,7 @@ body {
   outline: none;
 }
 
-/* Trajectory — compact profiler-style ledger (full bleed, no outer card) */
+/* Debug log — compact event ledger (full bleed, no outer card) */
 .traj-root {
   display: flex;
   flex: 1;
@@ -1893,4 +1922,207 @@ body {
 
 .composer-tool-chip:hover {
   color: var(--dsw-business);
+}
+
+.dash-root {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 20px;
+  overflow: auto;
+  padding: 28px 32px 40px;
+}
+
+.dash-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dash-title {
+  margin: 0;
+  color: var(--dsw-label);
+  font-size: 28px;
+  font-weight: 650;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+}
+
+.dash-subtitle {
+  margin: 6px 0 0;
+  color: var(--dsw-label-3);
+  font-size: 13px;
+}
+
+.dash-updated {
+  color: var(--dsw-label-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.dash-muted {
+  margin: 0;
+  color: var(--dsw-label-3);
+  font-size: 13px;
+}
+
+.dash-error {
+  margin: 0;
+  color: var(--dsw-danger);
+  font-size: 13px;
+}
+
+.dash-cards {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.dash-card {
+  border: 1px solid var(--dsw-border);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--dsw-surface) 92%, var(--dsw-business-soft));
+  padding: 14px 16px;
+}
+
+.dash-card-label {
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dash-card-value {
+  margin-top: 8px;
+  color: var(--dsw-label);
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.dash-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dash-panel {
+  border: 1px solid var(--dsw-border);
+  border-radius: 16px;
+  background: var(--dsw-surface);
+  padding: 16px 18px 18px;
+}
+
+.dash-panel-wide {
+  grid-column: 1 / -1;
+}
+
+.dash-panel-title {
+  margin: 0 0 14px;
+  color: var(--dsw-label);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.dash-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dash-bar-row {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) 72px;
+  align-items: center;
+  gap: 10px;
+}
+
+.dash-bar-label,
+.dash-bar-value {
+  color: var(--dsw-label-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.dash-bar-value {
+  text-align: right;
+  color: var(--dsw-label-2);
+}
+
+.dash-bar-track {
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--dsw-hover);
+}
+
+.dash-bar-fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--dsw-business) 70%, #8fd3c8),
+    var(--dsw-business)
+  );
+}
+
+.dash-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.dash-table th,
+.dash-table td {
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--dsw-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.dash-table th {
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.dash-table td:nth-child(2),
+.dash-table td:nth-child(3),
+.dash-table th:nth-child(2),
+.dash-table th:nth-child(3) {
+  width: 72px;
+  text-align: right;
+  font-family: var(--font-mono);
+}
+
+.dash-project-name {
+  color: var(--dsw-label);
+  font-weight: 550;
+}
+
+.dash-project-path {
+  margin-top: 2px;
+  color: var(--dsw-label-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+@media (max-width: 960px) {
+  .dash-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dash-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dash-root {
+    padding: 20px 18px 32px;
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 聊天侧栏顶部去掉「+」，底部改为 **Icon + 添加聊天**，其下 **Icon + Dashboard**
- 新增 `/dashboard` 控制台：今日回合/用量卡片、近 24h 与近 7 天条形图、今日项目会话统计（`GET /api/stats/overview`）
- 顶栏原 Trajectory（航点图标）改为 **Debug**（虫标），路由 `/s/:id/debug`；旧 `/trajectory` 仍可打开

## Notes
- Activity bar 同步有 Dashboard 入口，离开 Agent 侧栏后仍可进入
- 后端事件索引 API 仍为 `/api/sessions/:id/trajectory`（内部命名未大改）
- 未做截图验证（按产品约定）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

