### PR TITLE
feat: bash 截图 artifacts 落盘并在对话出图

### DIFF
--- a/host/plugins/contributors/chat.artifacts.test.ts
+++ b/host/plugins/contributors/chat.artifacts.test.ts
@@ -1,0 +1,89 @@
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import '../../types.ts'
+import * as http from '../registry/http.ts'
+import * as sessionStore from '../storage/session-store.ts'
+import * as sessions from '../core/sessions.ts'
+import { artifactsDir, readArtifactFile } from '../core/artifacts.ts'
+
+async function freePort() {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer()
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('no port'))
+        return
+      }
+      const port = addr.port
+      server.close((error) => (error ? reject(error) : resolve(port)))
+    })
+    server.on('error', reject)
+  })
+}
+
+test('GET /api/sessions/:id/artifacts/:name returns image bytes', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'cordis-art-http-'))
+  const prev = process.cwd()
+  process.chdir(base)
+  const port = await freePort()
+  const publicDir = join(base, 'public')
+  await mkdir(publicDir, { recursive: true })
+  await writeFile(join(publicDir, 'index.html'), '<html></html>')
+
+  const ctx = new Context()
+  const ready = new Promise<void>((resolve) => {
+    ctx.on('http/ready', () => resolve())
+  })
+  await ctx.plugin(http, { port, publicDir })
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ready
+
+  // 与 chat.ts 同源处理：二进制直出，不走 route.send JSON
+  ctx.http.route('GET', '/api/sessions/:id/artifacts/:name', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const file = await readArtifactFile(route.params.id, route.params.name)
+    if (!file) return route.send(404, { error: 'unknown artifact' })
+    if (route.res.headersSent) return
+    route.res.writeHead(200, {
+      'content-type': file.mime,
+      'cache-control': 'private, max-age=3600',
+      'content-length': file.data.byteLength,
+    })
+    route.res.end(file.data)
+  })
+
+  try {
+    const record = await ctx.sessions.create()
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    )
+    const dir = artifactsDir(record.id)
+    await mkdir(dir, { recursive: true })
+    await writeFile(join(dir, 'smoke.png'), png)
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/sessions/${record.id}/artifacts/smoke.png`)
+    const body = Buffer.from(await res.arrayBuffer())
+    assert.equal(res.status, 200)
+    assert.equal(res.headers.get('content-type'), 'image/png')
+    assert.deepEqual(body, png)
+
+    const missing = await fetch(`http://127.0.0.1:${port}/api/sessions/${record.id}/artifacts/nope.png`)
+    assert.equal(missing.status, 404)
+
+    const unknownSession = await fetch(`http://127.0.0.1:${port}/api/sessions/no-such/artifacts/smoke.png`)
+    assert.equal(unknownSession.status, 404)
+  } finally {
+    await ctx.parallel('dispose')
+    process.chdir(prev)
+    await rm(base, { recursive: true, force: true })
+  }
+})

--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -12,6 +12,7 @@ import {
   buildTrajectoryWindow,
   findEvent,
 } from '../core/trajectory-index.ts'
+import { readArtifactFile } from '../core/artifacts.ts'
 
 export type { ChatMessage }
 
@@ -280,6 +281,19 @@ export function apply(ctx: Context) {
       oldestSeq: window.oldestSeq,
       newestSeq: window.newestSeq,
     })
+  })
+  ctx.http.route('GET', '/api/sessions/:id/artifacts/:name', async (route) => {
+    const record = await ctx.sessions.get(route.params.id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const file = await readArtifactFile(route.params.id, route.params.name)
+    if (!file) return route.send(404, { error: 'unknown artifact' })
+    if (route.res.headersSent) return
+    route.res.writeHead(200, {
+      'content-type': file.mime,
+      'cache-control': 'private, max-age=3600',
+      'content-length': file.data.byteLength,
+    })
+    route.res.end(file.data)
   })
   ctx.http.route('GET', '/api/sessions/:id/events/:seq', async (route) => {
     const record = await ctx.sessions.get(route.params.id)

--- a/host/plugins/core/artifacts.test.ts
+++ b/host/plugins/core/artifacts.test.ts
@@ -1,0 +1,49 @@
+import { mkdtemp, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  extractImagePathCandidates,
+  ingestSessionImages,
+  readArtifactFile,
+  resolveArtifactFile,
+} from './artifacts.ts'
+
+test('extractImagePathCandidates finds relative and absolute image paths', () => {
+  const text = 'saved shot.png\nalso ./shots/a.jpg and /tmp/out.webp done'
+  assert.deepEqual(extractImagePathCandidates(text), ['shot.png', './shots/a.jpg', '/tmp/out.webp'])
+})
+
+test('ingestSessionImages copies workspace images into .cordis/artifacts', async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'cordis-art-'))
+  const workspace = join(baseDir, 'ws')
+  await mkdir(join(workspace, 'shots'), { recursive: true })
+  const png = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+    'base64',
+  )
+  await writeFile(join(workspace, 'shots', 'demo.png'), png)
+
+  const artifacts = await ingestSessionImages({
+    sessionId: 'sess-1',
+    candidates: ['shots/demo.png', '../escape.png', 'missing.png'],
+    workspaceRoot: workspace,
+    baseDir,
+  })
+  assert.equal(artifacts.length, 1)
+  assert.equal(artifacts[0]?.name, 'demo.png')
+  assert.equal(artifacts[0]?.mime, 'image/png')
+  assert.equal(artifacts[0]?.url, '/api/sessions/sess-1/artifacts/demo.png')
+
+  const file = await readArtifactFile('sess-1', 'demo.png', baseDir)
+  assert.ok(file)
+  assert.equal(file.mime, 'image/png')
+  assert.deepEqual(file.data, png)
+})
+
+test('resolveArtifactFile rejects path traversal', () => {
+  assert.equal(resolveArtifactFile('s1', '../x.png'), null)
+  assert.equal(resolveArtifactFile('s1', 'a/b.png'), null)
+  assert.equal(resolveArtifactFile('s1', 'ok.png')?.endsWith('ok.png'), true)
+})

--- a/host/plugins/core/artifacts.ts
+++ b/host/plugins/core/artifacts.ts
@@ -1,0 +1,138 @@
+import { copyFile, mkdir, readFile, access } from 'node:fs/promises'
+import { basename, extname, isAbsolute, join, resolve, relative } from 'node:path'
+import { constants } from 'node:fs'
+
+export const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'])
+
+export type ArtifactMeta = {
+  name: string
+  mime: string
+  url: string
+  source?: string
+}
+
+const PATH_CANDIDATE =
+  /(?:^|[\s"'=`(,\[{])((?:\/|\.\/|\.\.\/)?[^\s"'`)\]},;]+?\.(?:png|jpe?g|gif|webp|svg))\b/gi
+
+export function artifactsDir(sessionId: string, baseDir = process.cwd()) {
+  return join(baseDir, '.cordis', 'artifacts', sessionId)
+}
+
+export function artifactMime(name: string) {
+  switch (extname(name).toLowerCase()) {
+    case '.png':
+      return 'image/png'
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg'
+    case '.gif':
+      return 'image/gif'
+    case '.webp':
+      return 'image/webp'
+    case '.svg':
+      return 'image/svg+xml'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
+export function isImagePath(path: string) {
+  return IMAGE_EXTENSIONS.has(extname(path).toLowerCase())
+}
+
+/** 从 bash stdout/stderr 里抠出看起来像图片路径的片段。 */
+export function extractImagePathCandidates(text: string): string[] {
+  if (!text) return []
+  const found: string[] = []
+  const seen = new Set<string>()
+  for (const match of text.matchAll(PATH_CANDIDATE)) {
+    const raw = match[1]?.trim()
+    if (!raw || seen.has(raw)) continue
+    seen.add(raw)
+    found.push(raw)
+  }
+  return found
+}
+
+function safeArtifactName(sourcePath: string, used: Set<string>) {
+  const base = basename(sourcePath).replace(/[^\w.\-]+/g, '_') || 'image.png'
+  const ext = extname(base) || '.png'
+  const stem = basename(base, ext) || 'image'
+  let name = `${stem}${ext}`
+  let i = 1
+  while (used.has(name)) {
+    name = `${stem}-${i}${ext}`
+    i += 1
+  }
+  used.add(name)
+  return name
+}
+
+async function fileExists(path: string) {
+  try {
+    await access(path, constants.R_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** 将工作区内的图片复制到 `.cordis/artifacts/<sessionId>/`，返回可给前端用的元数据。 */
+export async function ingestSessionImages(options: {
+  sessionId: string
+  candidates: string[]
+  workspaceRoot: string
+  baseDir?: string
+}): Promise<ArtifactMeta[]> {
+  const { sessionId, candidates, workspaceRoot } = options
+  const baseDir = options.baseDir ?? process.cwd()
+  if (!sessionId || candidates.length === 0) return []
+
+  const root = resolve(workspaceRoot)
+  const dir = artifactsDir(sessionId, baseDir)
+  await mkdir(dir, { recursive: true })
+
+  const used = new Set<string>()
+  const out: ArtifactMeta[] = []
+
+  for (const candidate of candidates) {
+    const full = isAbsolute(candidate) ? resolve(candidate) : resolve(root, candidate)
+    const rel = relative(root, full)
+    if (rel.startsWith('..') || !isImagePath(full)) continue
+    if (!(await fileExists(full))) continue
+
+    const name = safeArtifactName(full, used)
+    const dest = join(dir, name)
+    await copyFile(full, dest)
+    out.push({
+      name,
+      mime: artifactMime(name),
+      url: `/api/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(name)}`,
+      source: rel || basename(full),
+    })
+  }
+
+  return out
+}
+
+/** 解析并校验 artifact 文件路径；非法或穿越返回 null。 */
+export function resolveArtifactFile(sessionId: string, name: string, baseDir = process.cwd()) {
+  if (!sessionId || !name) return null
+  if (name.includes('/') || name.includes('\\') || name.includes('..')) return null
+  if (!/^[\w.\-]+$/.test(name)) return null
+  const dir = artifactsDir(sessionId, baseDir)
+  const full = join(dir, name)
+  if (relative(dir, full).startsWith('..')) return null
+  return full
+}
+
+export async function readArtifactFile(sessionId: string, name: string, baseDir = process.cwd()) {
+  const full = resolveArtifactFile(sessionId, name, baseDir)
+  if (!full) return null
+  try {
+    const data = await readFile(full)
+    return { path: full, data, mime: artifactMime(name) }
+  } catch {
+    return null
+  }
+}

--- a/host/plugins/seams/shell.test.ts
+++ b/host/plugins/seams/shell.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'vitest'
@@ -11,21 +11,23 @@ import * as sandbox from './sandbox.ts'
 import * as subprocess from './subprocess.ts'
 import * as shell from './shell.ts'
 import * as jobs from './jobs.ts'
+import { runWithSession } from '../core/session-scope.ts'
+import { readArtifactFile } from '../core/artifacts.ts'
 
-async function runtime() {
+async function runtime(root?: string) {
   const ctx = new Context()
   await ctx.plugin(tools)
-  const root = await mkdtemp(join(tmpdir(), 'cordis-sh-'))
-  await ctx.plugin(fs, { root })
+  const workspace = root ?? (await mkdtemp(join(tmpdir(), 'cordis-sh-')))
+  await ctx.plugin(fs, { root: workspace })
   await ctx.plugin(sandbox)
   await ctx.plugin(subprocess)
   await ctx.plugin(shell)
   await ctx.plugin(jobs)
-  return ctx
+  return { ctx, workspace }
 }
 
 test('bash and jobs run inside sandbox', async () => {
-  const ctx = await runtime()
+  const { ctx } = await runtime()
   const bash = (await ctx.tools.invoke('bash', { command: 'echo hi' })) as { stdout: string; code: number | null }
   assert.equal(bash.code, 0)
   assert.match(bash.stdout, /hi/)
@@ -41,8 +43,39 @@ test('bash and jobs run inside sandbox', async () => {
 })
 
 test('shell seam runner can be swapped without changing the bash tool', async () => {
-  const ctx = await runtime()
+  const { ctx } = await runtime()
   ctx.shell.setRunner(async () => ({ code: 0, stdout: 'swapped\n', stderr: '' }))
   const bash = (await ctx.tools.invoke('bash', { command: 'ignored' })) as { stdout: string }
   assert.match(bash.stdout, /swapped/)
+})
+
+test('bash copies printed image paths into session artifacts', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'cordis-sh-art-'))
+  const prev = process.cwd()
+  process.chdir(base)
+  try {
+    const { ctx, workspace } = await runtime(join(base, 'ws'))
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    )
+    await writeFile(join(workspace, 'shot.png'), png)
+    const result = await runWithSession('sess-shot', () =>
+      ctx.tools.invoke('bash', { command: 'printf "%s\\n" shot.png' }),
+    )
+    const bash = result as {
+      code: number | null
+      stdout: string
+      artifacts?: Array<{ name: string; url: string; mime: string }>
+    }
+    assert.equal(bash.code, 0)
+    assert.equal(bash.artifacts?.length, 1)
+    assert.equal(bash.artifacts?.[0]?.name, 'shot.png')
+    assert.equal(bash.artifacts?.[0]?.url, '/api/sessions/sess-shot/artifacts/shot.png')
+    const file = await readArtifactFile('sess-shot', 'shot.png', base)
+    assert.ok(file)
+    assert.deepEqual(file.data, png)
+  } finally {
+    process.chdir(prev)
+  }
 })

--- a/host/plugins/seams/shell.ts
+++ b/host/plugins/seams/shell.ts
@@ -1,6 +1,8 @@
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { SpawnResult } from './subprocess.ts'
+import { currentSessionId } from '../core/session-scope.ts'
+import { extractImagePathCandidates, ingestSessionImages } from '../core/artifacts.ts'
 
 /** Capability seam 定义：换沙箱/远程 shell 只换 runner，不改 tool 名与 loop。 */
 export type ShellRunner = (command: string, signal?: AbortSignal) => Promise<SpawnResult>
@@ -24,13 +26,13 @@ export class ShellService extends Service {
 }
 
 export const name = 'shell'
-export const inject = ['subprocess', 'tools']
+export const inject = ['subprocess', 'tools', 'fs']
 
 export function apply(ctx: Context) {
   const shell = new ShellService(ctx)
   ctx.tools.register({
     name: 'bash',
-    description: '在沙箱工作区执行命令（/bin/sh -c）',
+    description: '在沙箱工作区执行命令（/bin/sh -c）。若命令输出图片路径（png/jpg/…），会自动拷到会话 artifacts 供前端展示。',
     parameters: {
       type: 'object',
       properties: { command: { type: 'string' } },
@@ -38,7 +40,28 @@ export function apply(ctx: Context) {
     },
     execute: async (args, signal) => {
       const result = await shell.run(String(args.command), signal)
-      return { code: result.code, stdout: result.stdout, stderr: result.stderr }
+      const base = {
+        code: result.code,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      }
+      const sessionId = currentSessionId()
+      if (!sessionId) return base
+
+      const candidates = extractImagePathCandidates(`${result.stdout}\n${result.stderr}`)
+      if (candidates.length === 0) return base
+
+      try {
+        const artifacts = await ingestSessionImages({
+          sessionId,
+          candidates,
+          workspaceRoot: ctx.fs.effectiveRoot(),
+        })
+        if (artifacts.length === 0) return base
+        return { ...base, artifacts }
+      } catch {
+        return base
+      }
     },
   })
 }

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -53,24 +53,37 @@ function DetailView({ detail }: { detail: FormattedDetail }) {
   if (detail.kind === 'bash') {
     const hasOut = Boolean(detail.stdout)
     const hasErr = Boolean(detail.stderr)
+    const artifacts = detail.artifacts ?? []
     return (
-      <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-[#1e1f24]">
-        <div className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-1.5">
-          <span className="font-mono text-[10px] tracking-wide text-white/45 uppercase">output</span>
-          <span
-            className={`font-mono text-[10px] tabular-nums ${
-              detail.code === 0 || detail.code == null ? 'text-[#7dcea0]' : 'text-[#f1948a]'
-            }`}
-          >
-            exit {detail.code ?? '—'}
-          </span>
+      <div className="space-y-2">
+        <div className="overflow-hidden rounded-[10px] border border-[var(--dsw-border)] bg-[#1e1f24]">
+          <div className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-1.5">
+            <span className="font-mono text-[10px] tracking-wide text-white/45 uppercase">output</span>
+            <span
+              className={`font-mono text-[10px] tabular-nums ${
+                detail.code === 0 || detail.code == null ? 'text-[#7dcea0]' : 'text-[#f1948a]'
+              }`}
+            >
+              exit {detail.code ?? '—'}
+            </span>
+          </div>
+          <pre className="max-h-72 overflow-auto px-3 py-2 font-mono text-[11px] leading-5 text-[#e8eaed]">
+            {hasOut ? <span className="whitespace-pre-wrap">{detail.stdout.replace(/\n$/, '')}</span> : null}
+            {hasOut && hasErr ? '\n\n' : null}
+            {hasErr ? <span className="whitespace-pre-wrap text-[#f5b7b1]">{detail.stderr.replace(/\n$/, '')}</span> : null}
+            {!hasOut && !hasErr ? <span className="text-white/35">(empty)</span> : null}
+          </pre>
         </div>
-        <pre className="max-h-72 overflow-auto px-3 py-2 font-mono text-[11px] leading-5 text-[#e8eaed]">
-          {hasOut ? <span className="whitespace-pre-wrap">{detail.stdout.replace(/\n$/, '')}</span> : null}
-          {hasOut && hasErr ? '\n\n' : null}
-          {hasErr ? <span className="whitespace-pre-wrap text-[#f5b7b1]">{detail.stderr.replace(/\n$/, '')}</span> : null}
-          {!hasOut && !hasErr ? <span className="text-white/35">(empty)</span> : null}
-        </pre>
+        {artifacts.length > 0 ? (
+          <div className="tool-artifacts" aria-label="Artifacts">
+            {artifacts.map((item) => (
+              <a key={item.url} className="tool-artifact" href={item.url} target="_blank" rel="noreferrer">
+                <img className="tool-artifact-img" src={item.url} alt={item.name} loading="lazy" />
+                <span className="tool-artifact-caption">{item.source || item.name}</span>
+              </a>
+            ))}
+          </div>
+        ) : null}
       </div>
     )
   }

--- a/src/plugins/contributors/chat/tool-format.test.ts
+++ b/src/plugins/contributors/chat/tool-format.test.ts
@@ -66,6 +66,22 @@ test('formatToolDetail unwraps bash stdout/stderr json', () => {
   assert.equal(formatted.stderr, '')
 })
 
+test('formatToolDetail keeps bash artifacts for chat rendering', () => {
+  const formatted = formatToolDetail(
+    JSON.stringify({
+      code: 0,
+      stdout: 'shot.png\n',
+      stderr: '',
+      artifacts: [{ name: 'shot.png', url: '/api/sessions/s1/artifacts/shot.png', mime: 'image/png' }],
+    }),
+    'bash',
+  )
+  assert.equal(formatted?.kind, 'bash')
+  if (formatted?.kind !== 'bash') return
+  assert.equal(formatted.artifacts?.length, 1)
+  assert.equal(formatted.artifacts?.[0]?.url, '/api/sessions/s1/artifacts/shot.png')
+})
+
 test('formatToolDetail pretty-prints generic json objects', () => {
   const formatted = formatToolDetail('{"a":1,"b":[2,3]}')
   assert.equal(formatted?.kind, 'json')

--- a/src/plugins/contributors/chat/tool-format.ts
+++ b/src/plugins/contributors/chat/tool-format.ts
@@ -85,10 +85,36 @@ function parseJsonValue(raw: string): unknown | undefined {
 }
 
 /** 把工具结果里的 JSON 变得可读；bash 特判 stdout/stderr。 */
+export type ToolArtifact = {
+  name: string
+  url: string
+  mime?: string
+  source?: string
+}
+
 export type FormattedDetail =
-  | { kind: 'bash'; code: number | null; stdout: string; stderr: string }
+  | { kind: 'bash'; code: number | null; stdout: string; stderr: string; artifacts?: ToolArtifact[] }
   | { kind: 'text'; text: string }
   | { kind: 'json'; text: string }
+
+function parseArtifacts(raw: unknown): ToolArtifact[] | undefined {
+  if (!Array.isArray(raw) || raw.length === 0) return undefined
+  const items: ToolArtifact[] = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue
+    const item = entry as Record<string, unknown>
+    const name = typeof item.name === 'string' ? item.name : ''
+    const url = typeof item.url === 'string' ? item.url : ''
+    if (!name || !url) continue
+    items.push({
+      name,
+      url,
+      ...(typeof item.mime === 'string' ? { mime: item.mime } : {}),
+      ...(typeof item.source === 'string' ? { source: item.source } : {}),
+    })
+  }
+  return items.length ? items : undefined
+}
 
 export function formatToolDetail(detail: string | undefined, toolKind?: ParsedToolCall['kind']): FormattedDetail | null {
   if (detail == null || detail === '') return null
@@ -96,7 +122,7 @@ export function formatToolDetail(detail: string | undefined, toolKind?: ParsedTo
 
   if (toolKind === 'bash' || trimmed.startsWith('{')) {
     const obj = parseJsonObject(trimmed)
-    if (obj && ('stdout' in obj || 'stderr' in obj || 'code' in obj)) {
+    if (obj && ('stdout' in obj || 'stderr' in obj || 'code' in obj || 'artifacts' in obj)) {
       const codeRaw = obj.code
       const code =
         typeof codeRaw === 'number'
@@ -106,11 +132,13 @@ export function formatToolDetail(detail: string | undefined, toolKind?: ParsedTo
             : typeof codeRaw === 'string' && /^-?\d+$/.test(codeRaw)
               ? Number(codeRaw)
               : null
+      const artifacts = parseArtifacts(obj.artifacts)
       return {
         kind: 'bash',
         code,
         stdout: typeof obj.stdout === 'string' ? obj.stdout : obj.stdout != null ? String(obj.stdout) : '',
         stderr: typeof obj.stderr === 'string' ? obj.stderr : obj.stderr != null ? String(obj.stderr) : '',
+        ...(artifacts ? { artifacts } : {}),
       }
     }
   }

--- a/src/style.css
+++ b/src/style.css
@@ -1894,3 +1894,43 @@ body {
 .composer-tool-chip:hover {
   color: var(--dsw-business);
 }
+
+.tool-artifacts {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.tool-artifact {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow: hidden;
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  background: var(--dsw-surface);
+  text-decoration: none;
+  color: inherit;
+}
+
+.tool-artifact:hover {
+  border-color: color-mix(in srgb, var(--dsw-business) 45%, var(--dsw-border));
+}
+
+.tool-artifact-img {
+  display: block;
+  width: 100%;
+  max-height: 220px;
+  object-fit: contain;
+  background: color-mix(in srgb, var(--dsw-sidebar) 88%, #000);
+}
+
+.tool-artifact-caption {
+  padding: 0 10px 8px;
+  color: var(--dsw-label-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bash 截图等图片可进入对话：

1. 工具输出里出现图片路径（png/jpg/gif/webp/svg）时，拷贝到 `.cordis/artifacts/<sessionId>/`
2. `GET /api/sessions/:id/artifacts/:name` 以二进制返回图片
3. 聊天气泡 `ToolCard` 解析 `artifacts` 并渲染缩略图

## Merge
已与最新 `hmr-dev`（含 #76 Dashboard/Debug）合并。唯一冲突是 `src/style.css` 末尾两段追加 CSS（tool-artifacts vs dash-*），已保留两边。

## Verification
- 单测：落盘、bash 接入、HTTP 200/`image/png` 取图、404 缺失文件
- Vite 已代理 `/api` → host `:3141`

## Notes
- 需要 bash stdout/stderr **打印出图片路径**（相对工作区或工作区内绝对路径）才会自动收录
- 会话需在 agent turn 的 ALS 内（正常对话即有）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

