### PR TITLE
ui: 侧栏添加聊天/Dashboard 移到列表上方

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -200,7 +200,25 @@ function Shell(props: SlotProps) {
         }`}
         aria-hidden={!showChatSidebar}
       >
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-4">
+        <div className="app-side-actions">
+          <button
+            type="button"
+            className="app-side-actions-item"
+            title="添加聊天"
+            aria-label="添加聊天"
+            onClick={() => {
+              void sessionView.newSession().then((id) => navigate(`/s/${id}`))
+            }}
+          >
+            <LuPlus className="size-4 shrink-0" aria-hidden />
+            <span>添加聊天</span>
+          </button>
+          <Link to="/dashboard" className="app-side-actions-item" title="Dashboard" aria-label="Dashboard">
+            <LuLayoutDashboard className="size-4 shrink-0" aria-hidden />
+            <span>Dashboard</span>
+          </Link>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-3 pt-3">
           <div className="mb-2 flex items-center justify-between gap-2 px-1">
             <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
             <button
@@ -269,24 +287,6 @@ function Shell(props: SlotProps) {
               )
             })
           )}
-        </div>
-        <div className="app-side-footer">
-          <button
-            type="button"
-            className="app-side-footer-item"
-            title="添加聊天"
-            aria-label="添加聊天"
-            onClick={() => {
-              void sessionView.newSession().then((id) => navigate(`/s/${id}`))
-            }}
-          >
-            <LuPlus className="size-4 shrink-0" aria-hidden />
-            <span>添加聊天</span>
-          </button>
-          <Link to="/dashboard" className="app-side-footer-item" title="Dashboard" aria-label="Dashboard">
-            <LuLayoutDashboard className="size-4 shrink-0" aria-hidden />
-            <span>Dashboard</span>
-          </Link>
         </div>
       </aside>
 

--- a/src/style.css
+++ b/src/style.css
@@ -297,16 +297,16 @@ body {
   grid-template-columns: 48px minmax(0, 1fr);
 }
 
-.app-side-footer {
+.app-side-actions {
   display: flex;
   flex-direction: column;
   gap: 2px;
   flex-shrink: 0;
-  border-top: 1px solid var(--dsw-border);
-  padding: 10px 12px 12px;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 12px 12px 10px;
 }
 
-.app-side-footer-item {
+.app-side-actions-item {
   display: flex;
   width: 100%;
   align-items: center;
@@ -321,7 +321,7 @@ body {
   transition: background 0.12s ease, color 0.12s ease;
 }
 
-.app-side-footer-item:hover {
+.app-side-actions-item:hover {
   background: var(--dsw-hover);
   color: var(--dsw-business);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
把侧栏底部的 **添加聊天** / **Dashboard** 挪到会话列表上方，更方便点到。

## Change
- `shell.tsx`：动作区在 Chat 列表之前
- CSS：`app-side-footer` → `app-side-actions`（底边分隔）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

