### PR TITLE
fix: 修复 style.css 缺 } 导致前端编译失败

### DIFF
--- a/host/plugins/contributors/chat.artifacts.test.ts
+++ b/host/plugins/contributors/chat.artifacts.test.ts
@@ -40,7 +40,7 @@ test('GET /api/sessions/:id/artifacts/:name returns image bytes', async () => {
   const ready = new Promise<void>((resolve) => {
     ctx.on('http/ready', () => resolve())
   })
-  await ctx.plugin(http, { port, publicDir })
+  const httpFiber = await ctx.plugin(http, { port, publicDir })
   await ctx.plugin(sessionStore, { driver: 'memory' })
   await ctx.plugin(sessions)
   await ready
@@ -82,7 +82,7 @@ test('GET /api/sessions/:id/artifacts/:name returns image bytes', async () => {
     const unknownSession = await fetch(`http://127.0.0.1:${port}/api/sessions/no-such/artifacts/smoke.png`)
     assert.equal(unknownSession.status, 404)
   } finally {
-    await ctx.parallel('dispose')
+    await httpFiber.dispose()
     process.chdir(prev)
     await rm(base, { recursive: true, force: true })
   }

--- a/src/style.css
+++ b/src/style.css
@@ -1982,6 +1982,7 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
 
 .dash-root {
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
修复 `#77` 合并时 `src/style.css` 中 `.tool-artifact-caption` 漏写 `}`，导致 Vite/Tailwind 构建失败。

## Verification
- `npx tsc --noEmit` 通过
- `npm run build` 通过
- artifacts / shell 相关单测通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

