### PR TITLE
fix: bash 截图 artifacts 真正可进对话

### DIFF
--- a/host/plugins/core/artifacts.test.ts
+++ b/host/plugins/core/artifacts.test.ts
@@ -5,10 +5,16 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import {
   extractImagePathCandidates,
+  findRecentImageFiles,
   ingestSessionImages,
   readArtifactFile,
   resolveArtifactFile,
 } from './artifacts.ts'
+
+const TINY_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+)
 
 test('extractImagePathCandidates finds relative and absolute image paths', () => {
   const text = 'saved shot.png\nalso ./shots/a.jpg and /tmp/out.webp done'
@@ -19,11 +25,7 @@ test('ingestSessionImages copies workspace images into .cordis/artifacts', async
   const baseDir = await mkdtemp(join(tmpdir(), 'cordis-art-'))
   const workspace = join(baseDir, 'ws')
   await mkdir(join(workspace, 'shots'), { recursive: true })
-  const png = Buffer.from(
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
-    'base64',
-  )
-  await writeFile(join(workspace, 'shots', 'demo.png'), png)
+  await writeFile(join(workspace, 'shots', 'demo.png'), TINY_PNG)
 
   const artifacts = await ingestSessionImages({
     sessionId: 'sess-1',
@@ -39,7 +41,34 @@ test('ingestSessionImages copies workspace images into .cordis/artifacts', async
   const file = await readArtifactFile('sess-1', 'demo.png', baseDir)
   assert.ok(file)
   assert.equal(file.mime, 'image/png')
-  assert.deepEqual(file.data, png)
+  assert.deepEqual(file.data, TINY_PNG)
+})
+
+test('ingestSessionImages accepts absolute paths outside workspace', async () => {
+  const baseDir = await mkdtemp(join(tmpdir(), 'cordis-art-abs-'))
+  const workspace = join(baseDir, 'ws')
+  const outside = join(baseDir, 'outside.png')
+  await mkdir(workspace, { recursive: true })
+  await writeFile(outside, TINY_PNG)
+
+  const artifacts = await ingestSessionImages({
+    sessionId: 'sess-abs',
+    candidates: [outside],
+    workspaceRoot: workspace,
+    baseDir,
+  })
+  assert.equal(artifacts.length, 1)
+  assert.equal(artifacts[0]?.name, 'outside.png')
+  const file = await readArtifactFile('sess-abs', 'outside.png', baseDir)
+  assert.deepEqual(file?.data, TINY_PNG)
+})
+
+test('findRecentImageFiles picks up newly written workspace images', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'cordis-art-recent-'))
+  const since = Date.now() - 1000
+  await writeFile(join(workspace, 'fresh.png'), TINY_PNG)
+  const found = await findRecentImageFiles(workspace, since)
+  assert.ok(found.some((path) => path.endsWith('fresh.png')))
 })
 
 test('resolveArtifactFile rejects path traversal', () => {

--- a/host/plugins/core/artifacts.ts
+++ b/host/plugins/core/artifacts.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, readFile, access } from 'node:fs/promises'
+import { copyFile, mkdir, readFile, access, readdir, stat } from 'node:fs/promises'
 import { basename, extname, isAbsolute, join, resolve, relative } from 'node:path'
 import { constants } from 'node:fs'
 
@@ -40,7 +40,7 @@ export function isImagePath(path: string) {
   return IMAGE_EXTENSIONS.has(extname(path).toLowerCase())
 }
 
-/** 从 bash stdout/stderr 里抠出看起来像图片路径的片段。 */
+/** 从 bash stdout/stderr/命令行里抠出看起来像图片路径的片段。 */
 export function extractImagePathCandidates(text: string): string[] {
   if (!text) return []
   const found: string[] = []
@@ -77,7 +77,41 @@ async function fileExists(path: string) {
   }
 }
 
-/** 将工作区内的图片复制到 `.cordis/artifacts/<sessionId>/`，返回可给前端用的元数据。 */
+/** 扫工作区浅层目录，找出命令执行期间新写入/改动的图片（截图常不打印路径）。 */
+export async function findRecentImageFiles(root: string, sinceMs: number, maxDepth = 2): Promise<string[]> {
+  const base = resolve(root)
+  const out: string[] = []
+
+  async function walk(dir: string, depth: number) {
+    if (depth > maxDepth || out.length >= 24) return
+    let entries
+    try {
+      entries = await readdir(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === '.cordis') continue
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walk(full, depth + 1)
+        continue
+      }
+      if (!entry.isFile() || !isImagePath(entry.name)) continue
+      try {
+        const info = await stat(full)
+        if (info.mtimeMs >= sinceMs) out.push(full)
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  await walk(base, 0)
+  return out
+}
+
+/** 将图片复制到 `.cordis/artifacts/<sessionId>/`。工作区内相对路径 + 可读绝对路径均可。 */
 export async function ingestSessionImages(options: {
   sessionId: string
   candidates: string[]
@@ -93,13 +127,18 @@ export async function ingestSessionImages(options: {
   await mkdir(dir, { recursive: true })
 
   const used = new Set<string>()
+  const seenSource = new Set<string>()
   const out: ArtifactMeta[] = []
 
   for (const candidate of candidates) {
     const full = isAbsolute(candidate) ? resolve(candidate) : resolve(root, candidate)
+    if (!isImagePath(full) || seenSource.has(full)) continue
     const rel = relative(root, full)
-    if (rel.startsWith('..') || !isImagePath(full)) continue
+    const insideWorkspace = !rel.startsWith('..') && !isAbsolute(rel)
+    // 相对路径必须在工作区内；绝对路径只要文件存在可读即可（bash 截图常落 /tmp）
+    if (!isAbsolute(candidate) && !insideWorkspace) continue
     if (!(await fileExists(full))) continue
+    seenSource.add(full)
 
     const name = safeArtifactName(full, used)
     const dest = join(dir, name)
@@ -108,7 +147,7 @@ export async function ingestSessionImages(options: {
       name,
       mime: artifactMime(name),
       url: `/api/sessions/${encodeURIComponent(sessionId)}/artifacts/${encodeURIComponent(name)}`,
-      source: rel || basename(full),
+      source: insideWorkspace ? rel || basename(full) : full,
     })
   }
 

--- a/host/plugins/seams/shell.test.ts
+++ b/host/plugins/seams/shell.test.ts
@@ -79,3 +79,26 @@ test('bash copies printed image paths into session artifacts', async () => {
     process.chdir(prev)
   }
 })
+
+test('bash ingests silently written workspace screenshots without printing path', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'cordis-sh-silent-'))
+  const prev = process.cwd()
+  process.chdir(base)
+  try {
+    const { ctx, workspace } = await runtime(join(base, 'ws'))
+    const result = await runWithSession('sess-silent', () =>
+      ctx.tools.invoke('bash', {
+        command:
+          'python3 -c "import base64,pathlib; pathlib.Path(\'silent.png\').write_bytes(base64.b64decode(\'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==\'))"',
+      }),
+    )
+    const bash = result as { artifacts?: Array<{ name: string; url: string }> }
+    assert.ok(bash.artifacts?.some((item) => item.name === 'silent.png'))
+    const file = await readArtifactFile('sess-silent', 'silent.png', base)
+    assert.ok(file)
+    assert.equal(file.data.byteLength > 0, true)
+    void workspace
+  } finally {
+    process.chdir(prev)
+  }
+})

--- a/host/plugins/seams/shell.ts
+++ b/host/plugins/seams/shell.ts
@@ -2,7 +2,11 @@ import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { SpawnResult } from './subprocess.ts'
 import { currentSessionId } from '../core/session-scope.ts'
-import { extractImagePathCandidates, ingestSessionImages } from '../core/artifacts.ts'
+import {
+  extractImagePathCandidates,
+  findRecentImageFiles,
+  ingestSessionImages,
+} from '../core/artifacts.ts'
 
 /** Capability seam 定义：换沙箱/远程 shell 只换 runner，不改 tool 名与 loop。 */
 export type ShellRunner = (command: string, signal?: AbortSignal) => Promise<SpawnResult>
@@ -32,14 +36,17 @@ export function apply(ctx: Context) {
   const shell = new ShellService(ctx)
   ctx.tools.register({
     name: 'bash',
-    description: '在沙箱工作区执行命令（/bin/sh -c）。若命令输出图片路径（png/jpg/…），会自动拷到会话 artifacts 供前端展示。',
+    description:
+      '在沙箱工作区执行命令（/bin/sh -c）。截图/图片文件会尽量收录到会话 artifacts，并在对话里展示（命令或输出中带图片路径，或工作区内新写入的图片）。',
     parameters: {
       type: 'object',
       properties: { command: { type: 'string' } },
       required: ['command'],
     },
     execute: async (args, signal) => {
-      const result = await shell.run(String(args.command), signal)
+      const command = String(args.command)
+      const startedAt = Date.now() - 1500
+      const result = await shell.run(command, signal)
       const base = {
         code: result.code,
         stdout: result.stdout,
@@ -48,14 +55,24 @@ export function apply(ctx: Context) {
       const sessionId = currentSessionId()
       if (!sessionId) return base
 
-      const candidates = extractImagePathCandidates(`${result.stdout}\n${result.stderr}`)
+      const workspaceRoot = ctx.fs.effectiveRoot()
+      const candidates = [
+        ...extractImagePathCandidates(`${result.stdout}\n${result.stderr}`),
+        ...extractImagePathCandidates(command),
+      ]
+      try {
+        const recent = await findRecentImageFiles(workspaceRoot, startedAt)
+        candidates.push(...recent)
+      } catch {
+        /* ignore scan failures */
+      }
       if (candidates.length === 0) return base
 
       try {
         const artifacts = await ingestSessionImages({
           sessionId,
           candidates,
-          workspaceRoot: ctx.fs.effectiveRoot(),
+          workspaceRoot,
         })
         if (artifacts.length === 0) return base
         return { ...base, artifacts }

--- a/src/plugins/contributors/chat/tool-card.tsx
+++ b/src/plugins/contributors/chat/tool-card.tsx
@@ -49,6 +49,20 @@ function DiffBlock({ lines, path }: { lines: DiffLine[]; path?: string }) {
   )
 }
 
+function ArtifactGallery({ artifacts }: { artifacts: NonNullable<Extract<FormattedDetail, { kind: 'bash' }>['artifacts']> }) {
+  if (!artifacts.length) return null
+  return (
+    <div className="tool-artifacts" aria-label="Artifacts">
+      {artifacts.map((item) => (
+        <a key={item.url} className="tool-artifact" href={item.url} target="_blank" rel="noreferrer">
+          <img className="tool-artifact-img" src={item.url} alt={item.name} loading="lazy" />
+          <span className="tool-artifact-caption">{item.source || item.name}</span>
+        </a>
+      ))}
+    </div>
+  )
+}
+
 function DetailView({ detail }: { detail: FormattedDetail }) {
   if (detail.kind === 'bash') {
     const hasOut = Boolean(detail.stdout)
@@ -74,16 +88,7 @@ function DetailView({ detail }: { detail: FormattedDetail }) {
             {!hasOut && !hasErr ? <span className="text-white/35">(empty)</span> : null}
           </pre>
         </div>
-        {artifacts.length > 0 ? (
-          <div className="tool-artifacts" aria-label="Artifacts">
-            {artifacts.map((item) => (
-              <a key={item.url} className="tool-artifact" href={item.url} target="_blank" rel="noreferrer">
-                <img className="tool-artifact-img" src={item.url} alt={item.name} loading="lazy" />
-                <span className="tool-artifact-caption">{item.source || item.name}</span>
-              </a>
-            ))}
-          </div>
-        ) : null}
+        <ArtifactGallery artifacts={artifacts} />
       </div>
     )
   }
@@ -186,13 +191,19 @@ export function ToolCard({
   onInspect: (callId: string) => void
 }) {
   const parsed = useMemo(() => parseToolCall(node.name, node.arguments), [node.name, node.arguments])
-  const [open, setOpen] = useState(() => shouldAutoOpenTool(parsed))
+  const formatted = useMemo(
+    () => formatToolDetail(node.result?.detail, parsed.kind),
+    [node.result?.detail, parsed.kind],
+  )
+  const [open, setOpen] = useState(() => shouldAutoOpenTool(parsed, node.result?.detail))
   const summary = toolSummary(parsed, node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…')
   const title = toolTitle(parsed, node.name)
   const previewLines = useMemo(() => {
     if (parsed.kind !== 'str_replace' || open) return null
     return lineDiff(parsed.oldStr, parsed.newStr).filter((line) => line.type !== 'equal').slice(0, 4)
   }, [parsed, open])
+  const collapsedArtifacts =
+    !open && formatted?.kind === 'bash' && formatted.artifacts?.length ? formatted.artifacts : null
 
   return (
     <div className="w-full self-stretch">
@@ -225,6 +236,11 @@ export function ToolCard({
       {!open && previewLines && previewLines.length > 0 ? (
         <div className="mt-1 px-2">
           <DiffBlock path={parsed.kind === 'str_replace' ? parsed.path : undefined} lines={previewLines} />
+        </div>
+      ) : null}
+      {collapsedArtifacts ? (
+        <div className="mt-1 px-2">
+          <ArtifactGallery artifacts={collapsedArtifacts} />
         </div>
       ) : null}
       {open ? (

--- a/src/plugins/contributors/chat/tool-format.ts
+++ b/src/plugins/contributors/chat/tool-format.ts
@@ -259,8 +259,15 @@ export function toolTitle(parsed: ParsedToolCall, name: string): string {
   }
 }
 
-export function shouldAutoOpenTool(parsed: ParsedToolCall): boolean {
-  return parsed.kind === 'str_replace' || parsed.kind === 'create' || parsed.kind === 'insert'
+export function shouldAutoOpenTool(parsed: ParsedToolCall, detail?: string): boolean {
+  if (parsed.kind === 'str_replace' || parsed.kind === 'create' || parsed.kind === 'insert') return true
+  if (!detail) return false
+  try {
+    const obj = JSON.parse(detail) as { artifacts?: unknown }
+    return Array.isArray(obj.artifacts) && obj.artifacts.length > 0
+  } catch {
+    return false
+  }
 }
 
 export function diffStats(lines: DiffLine[]): { added: number; removed: number } {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
截图进对话实际不生效：
1. 运行中的 host **没挂上** artifacts 路由（旧进程）
2. 收录条件太严：必须打印工作区内路径；截图常静默写文件或写到 `/tmp`
3. Bash 工具卡片默认折叠，即使有图也看不见

## Fix
- bash：从 stdout/命令行抽路径；扫工作区新写入图片；允许绝对路径拷贝
- 前端：有 `artifacts` 时自动展开，折叠时也渲染缩略图
- 本地验证：`tsc` / `build` / 单测通过；重启 host 后 API 返回 `200 image/png`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

