### PR TITLE
ui: Step 横条改用数字标签

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -53,13 +53,9 @@ function formatTok(n: number) {
   return n.toLocaleString('en-US')
 }
 
-const STEP_LABELS = ['一', '二', '三', '四', '五', '六', '七', '八', '九', '十']
-
 function stepLabel(step: number) {
-  // event.step 从 0 起；展示用 Step 一 / Step 1
-  const ordinal = step + 1
-  if (ordinal >= 1 && ordinal <= STEP_LABELS.length) return `Step ${STEP_LABELS[ordinal - 1]}`
-  return `Step ${ordinal}`
+  // event.step 从 0 起；展示用 Step 1 / Step 2
+  return `Step ${step + 1}`
 }
 
 function StepBar({ stat }: { stat: ChatStepStat }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Step 横条标签改为数字：`Step 1` / `Step 2` / `Step 3`，不再用「一、二、三」。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

