### PR TITLE
ui: Step 横条 Icon+数值，与对话底栏一致

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { LuCheck, LuCoins, LuCopy, LuGitFork, LuHash, LuLayers, LuTimer } from 'react-icons/lu'
+import { LuCheck, LuCoins, LuCopy, LuGitFork, LuHash, LuLayers, LuTimer, LuType, LuWrench } from 'react-icons/lu'
 import type { SlotProps } from '../../registry/slots.ts'
 import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
@@ -58,31 +58,47 @@ function stepLabel(step: number) {
   return `Step ${step + 1}`
 }
 
+function MetaItem({
+  icon,
+  value,
+  title,
+}: {
+  icon: ReactNode
+  value: ReactNode
+  title: string
+}) {
+  return (
+    <span className="chat-reply-meta-item" title={title}>
+      <span className="chat-reply-meta-icon" aria-hidden>
+        {icon}
+      </span>
+      <span className="chat-reply-meta-value">{value}</span>
+    </span>
+  )
+}
+
 function StepBar({ stat }: { stat: ChatStepStat }) {
-  const total = stat.inputTokens + stat.outputTokens
+  const usage: TrajectoryUsage = {
+    inputTokens: stat.inputTokens,
+    outputTokens: stat.outputTokens,
+    totalTokens: stat.inputTokens + stat.outputTokens,
+    ...(stat.cacheReadTokens ? { cacheReadTokens: stat.cacheReadTokens } : {}),
+  }
   return (
     <div className="chat-step-bar" role="group" aria-label={stepLabel(stat.step)}>
-      <div className="chat-step-bar-main">
-        <span className="chat-step-bar-title">{stepLabel(stat.step)}</span>
-        <span className="chat-step-bar-sep" aria-hidden>
-          ·
-        </span>
-        <span className="chat-step-bar-stat" title="Token 用量">
-          {formatTok(stat.inputTokens)}→{formatTok(stat.outputTokens)}
-          {total ? <span className="chat-step-bar-muted"> · Σ{formatTok(total)}</span> : null}
-        </span>
-        <span className="chat-step-bar-sep" aria-hidden>
-          ·
-        </span>
-        <span className="chat-step-bar-stat" title="本步工具数">
-          {stat.toolCount} tools
-        </span>
-        <span className="chat-step-bar-sep" aria-hidden>
-          ·
-        </span>
-        <span className="chat-step-bar-stat" title="本步 Message 字数">
-          {formatTok(stat.messageChars)} chars
-        </span>
+      <div className="chat-reply-meta">
+        <MetaItem icon={<LuLayers className="size-3" />} value={stat.step + 1} title={stepLabel(stat.step)} />
+        <MetaItem
+          icon={<LuCoins className="size-3" />}
+          value={<UsageInline usage={usage} />}
+          title="本步 Token 用量"
+        />
+        <MetaItem icon={<LuWrench className="size-3" />} value={stat.toolCount} title={`本步 ${stat.toolCount} 个工具`} />
+        <MetaItem
+          icon={<LuType className="size-3" />}
+          value={formatTok(stat.messageChars)}
+          title={`本步 Message ${formatTok(stat.messageChars)} 字`}
+        />
       </div>
     </div>
   )
@@ -168,25 +184,6 @@ function UsageInline({ usage }: { usage: TrajectoryUsage }) {
       <span className="traj-usage-out" title="output tokens">
         {formatTok(usage.outputTokens)}
       </span>
-    </span>
-  )
-}
-
-function MetaItem({
-  icon,
-  value,
-  title,
-}: {
-  icon: ReactNode
-  value: ReactNode
-  title: string
-}) {
-  return (
-    <span className="chat-reply-meta-item" title={title}>
-      <span className="chat-reply-meta-icon" aria-hidden>
-        {icon}
-      </span>
-      <span className="chat-reply-meta-value">{value}</span>
     </span>
   )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1367,46 +1367,19 @@ body {
 
 .chat-step-bar {
   display: flex;
+  height: 30px;
   align-items: center;
   width: 100%;
-  min-height: 30px;
   margin: 2px 0;
-  border: 1px solid var(--dsw-border);
+  border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--dsw-sidebar) 88%, var(--dsw-business-soft));
+  background: color-mix(in srgb, var(--dsw-bg) 55%, var(--dsw-surface));
   padding: 0 12px;
+  box-shadow: none;
 }
 
-.chat-step-bar-main {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  color: var(--dsw-label-2);
-  font-family: var(--font-mono);
-  font-size: 11px;
-  line-height: 1.2;
-}
-
-.chat-step-bar-title {
-  color: var(--dsw-business);
-  font-weight: 650;
-  letter-spacing: 0.02em;
-}
-
-.chat-step-bar-sep {
-  opacity: 0.45;
-}
-
-.chat-step-bar-stat {
-  color: var(--dsw-label-2);
-  white-space: nowrap;
-}
-
-.chat-step-bar-muted {
-  color: var(--dsw-label-3);
+.chat-step-bar .chat-reply-meta {
+  width: 100%;
 }
 
 .chat-reply-bar {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Step 横条与对话底栏对齐：
- **Icon + 数值**：Layers（Step）、Coins（用量）、Wrench（Tools）、Type（字数）
- Token 用量复用底栏同一套 `UsageInline` UI
- 横条视觉接近底栏 meta 行

## Verification
`tsc` / `build` / 相关单测已通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

