### PR TITLE
fix: Live 在极简底座上增量放开调度工具

### DIFF
--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -2,8 +2,10 @@ import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { AssistantReply, ChatOptions, LlmClient, LlmConfig, LlmMessage } from './llm.ts'
 import type { InboxKind } from '../core/session-types.ts'
+import { normalizeSessionType } from '../core/session-types.ts'
 import { runWithSession } from '../core/session-scope.ts'
 import { runWithExtraTools } from '../registry/tools.ts'
+import { LIVE_TOOL_NAMES } from '../seams/live-sessions.ts'
 
 export interface AgentTurn {
   text: string
@@ -42,6 +44,12 @@ export class AgentLoop implements AgentRunner {
     const extras = [
       ...new Set(claimed.flatMap((item) => item.extraTools ?? []).map((name) => name.trim()).filter(Boolean)),
     ]
+    // 极简是底座；Slash / Live 都是增量放开。live session 回合自动加上调度工具。
+    if (normalizeSessionType(this.ctx.sessions.peek(this.sessionId)?.type) === 'live') {
+      for (const name of LIVE_TOOL_NAMES) {
+        if (!extras.includes(name)) extras.push(name)
+      }
+    }
     return runWithSession(this.sessionId, () => runWithExtraTools(extras, () => this.runInSession(claimed)))
   }
 

--- a/host/plugins/seams/live-sessions.test.ts
+++ b/host/plugins/seams/live-sessions.test.ts
@@ -55,3 +55,48 @@ test('live tools list/inspect/inject; reject from chat sessions', async () => {
   )) as { queued: boolean }
   assert.equal(injected.queued, true)
 })
+
+test('live session turn unlocks session_* tools on top of minimal mode', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  await ctx.plugin(liveSessions)
+
+  // 模拟极简底座已有 bash；live 工具应作为增量挂上
+  ctx.tools.register({
+    name: 'bash',
+    description: 'bash',
+    parameters: { type: 'object', properties: {} },
+    execute: () => 'ok',
+  })
+  ctx.tools.setMode('minimal')
+  assert.deepEqual(ctx.tools.names().sort(), ['bash'])
+  assert.equal(ctx.tools.names().includes('session_list'), false)
+
+  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  let seen: string[] = []
+  const { AgentLoop } = await import('../orchestration/agent-loop.ts')
+  const loop = new AgentLoop(
+    ctx,
+    {
+      async chat(_messages, toolSchemas) {
+        seen = (toolSchemas as Array<{ function: { name: string } }>).map((item) => item.function.name).sort()
+        return { content: 'ok', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } }
+      },
+    },
+    live.id,
+    new AbortController().signal,
+  )
+  await loop.run([{ kind: 'wake', text: 'list sessions' }])
+  assert.equal(seen.includes('bash'), true)
+  for (const name of liveSessions.LIVE_TOOL_NAMES) {
+    assert.equal(seen.includes(name), true, `expected ${name} in schemas during live turn`)
+  }
+  // 回合外仍回到极简底座
+  assert.deepEqual(ctx.tools.names().sort(), ['bash'])
+})

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -3,6 +3,13 @@ import '../../types.ts'
 import { currentSessionId } from '../core/session-scope.ts'
 import { normalizeSessionType, type SessionEvent, type SessionType } from '../core/session-types.ts'
 
+export const LIVE_TOOL_NAMES = [
+  'session_list',
+  'session_inspect',
+  'session_wake',
+  'session_inject',
+] as const
+
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
 优先用 session_list / session_inspect 了解现场，再用 session_wake（新任务）或 session_inject（补充指示）派工。
 回答简洁：说明你调度了谁、做了什么、结果如何。`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
极简模式仍是底座（bash + str_replace_editor）。Live session 发 message 时，像 Slash 一样**增量**挂上 `session_list` / `session_inspect` / `session_wake` / `session_inject`，不再被极简滤掉。

## Test plan
- [x] vitest: live-sessions + agent-loop + tools
- [x] `tsc --noEmit`
- [x] `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

