### PR TITLE
feat: Live session_progress 进度回读 + 异步 wake

### DIFF
--- a/host/plugins/orchestration/agents.test.ts
+++ b/host/plugins/orchestration/agents.test.ts
@@ -45,3 +45,31 @@ test('inject waits for the next wake and is logged first', async () => {
   assert.deepEqual(users.map((item) => ('text' in item ? item.text : '')), ['note', 'go'])
   assert.equal(users[0] && 'kind' in users[0] ? users[0].kind : '', 'inject')
 })
+
+test('send wait:false returns immediately; isBusy clears when done', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  ctx.agents.configure({ provider: 'deepseek', apiKey: '', model: 'x' })
+  const agent = await ctx.agents.create()
+  const pending = agent.send('async-hi', { wait: false })
+  assert.equal(ctx.agents.isBusy(agent.sessionId), true)
+  const early = await pending
+  assert.deepEqual(early, { text: '', steps: [] })
+  // 等后台回合结束
+  for (let i = 0; i < 50 && ctx.agents.isBusy(agent.sessionId); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  assert.equal(ctx.agents.isBusy(agent.sessionId), false)
+  assert.equal(
+    (await ctx.sessions.require(agent.sessionId)).events.some(
+      (event) => event.type === 'assistant/message',
+    ),
+    true,
+  )
+})

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -7,6 +7,8 @@ export type { AgentTurn, LlmConfig }
 
 export interface AgentSendOptions {
   extraTools?: string[]
+  /** false：入队后立即返回，不阻塞等回合结束（Live 派工后可再 progress）。默认 true。 */
+  wait?: boolean
 }
 
 export interface AgentHandle {
@@ -34,6 +36,15 @@ export class AgentsService extends Service {
 
   configure(llm: LlmConfig) {
     this.llm = llm
+  }
+
+  /** Live progress：该 session 的 agent 是否正在跑回合。 */
+  isBusy(sessionId: string) {
+    return Boolean(this.lives.get(sessionId)?.running)
+  }
+
+  inboxPending(sessionId: string) {
+    return this.lives.get(sessionId)?.inbox.length ?? 0
   }
 
   async create(sessionId?: string): Promise<AgentHandle> {
@@ -64,22 +75,33 @@ export class AgentsService extends Service {
         const trimmed = text.trim()
         if (!trimmed) return { text: '请先输入内容。', steps: [] }
         const extraTools = sanitizeExtraTools(opts?.extraTools)
+        const wait = opts?.wait !== false
         live.inbox.push({
           kind: 'wake',
           text: trimmed,
           ...(extraTools.length ? { extraTools } : {}),
         })
-        if (live.running) await live.running
-        let result: AgentTurn = { text: '', steps: [] }
+        if (live.running) {
+          if (!wait) return { text: '', steps: [] }
+          await live.running
+        }
         live.abort = new AbortController()
-        live.running = kick().then((turn) => {
+        let result: AgentTurn = { text: '', steps: [] }
+        const running = kick().then((turn) => {
           result = turn
         })
+        live.running = running
+        if (!wait) {
+          void running.finally(() => {
+            if (live.running === running) live.running = undefined
+          })
+          return { text: '', steps: [] }
+        }
         try {
-          await live.running
+          await running
           return result
         } finally {
-          live.running = undefined
+          if (live.running === running) live.running = undefined
         }
       },
       inject: (text: string, opts?: AgentSendOptions) => {

--- a/host/plugins/seams/live-sessions.test.ts
+++ b/host/plugins/seams/live-sessions.test.ts
@@ -100,3 +100,63 @@ test('live session turn unlocks session_* tools on top of minimal mode', async (
   // 回合外仍回到极简底座
   assert.deepEqual(ctx.tools.names().sort(), ['bash'])
 })
+
+test('buildSessionProgress derives turn/step/status and afterSeq delta text', () => {
+  const events = [
+    { type: 'session/open' as const, version: 1, seq: 0, ts: 1 },
+    { type: 'turn/start' as const, turn: 1, seq: 1, ts: 2 },
+    { type: 'step/start' as const, turn: 1, step: 1, seq: 2, ts: 3 },
+    { type: 'tool/call' as const, id: '1', name: 'bash', arguments: '{}', seq: 3, ts: 4 },
+    { type: 'tool/result' as const, id: '1', name: 'bash', ok: true, detail: 'ok', seq: 4, ts: 5 },
+    { type: 'assistant/message' as const, text: 'working on it', seq: 5, ts: 6 },
+    { type: 'step/end' as const, turn: 1, step: 1, seq: 6, ts: 7 },
+  ]
+  const mid = liveSessions.buildSessionProgress(events, { busy: true })
+  assert.equal(mid.status, 'running')
+  assert.equal(mid.turn, 1)
+  assert.equal(mid.step, 1)
+  assert.equal(mid.lastTool?.name, 'bash')
+  assert.equal(mid.lastTool?.ok, true)
+  assert.equal(mid.assistantText, 'working on it')
+
+  const more = [
+    ...events,
+    { type: 'assistant/message' as const, text: 'almost done', seq: 7, ts: 8 },
+    { type: 'turn/end' as const, turn: 1, reason: 'complete', seq: 8, ts: 9 },
+  ]
+  const done = liveSessions.buildSessionProgress(more, { afterSeq: 6, busy: false })
+  assert.equal(done.status, 'idle')
+  assert.equal(done.reason, 'complete')
+  assert.equal(done.assistantText, 'almost done')
+  assert.equal(done.newestSeq, 8)
+})
+
+test('session_progress and async wake work for live caller', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  await ctx.plugin(liveSessions)
+
+  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  const chat = await ctx.sessions.create()
+  await ctx.sessions.append(chat.id, { type: 'turn/start', turn: 1 })
+  await ctx.sessions.append(chat.id, { type: 'step/start', turn: 1, step: 2 })
+  await ctx.sessions.append(chat.id, { type: 'assistant/message', text: 'halfway' })
+
+  const progress = (await runWithSession(live.id, () =>
+    ctx.tools.invoke('session_progress', { sessionId: chat.id }, new AbortController().signal),
+  )) as { status: string; step: number; assistantText: string }
+  assert.equal(progress.status, 'running')
+  assert.equal(progress.step, 2)
+  assert.equal(progress.assistantText, 'halfway')
+
+  const listed = (await runWithSession(live.id, () =>
+    ctx.tools.invoke('session_list', {}, new AbortController().signal),
+  )) as { sessions: Array<{ id: string; status: string }> }
+  assert.equal(listed.sessions.find((item) => item.id === chat.id)?.status, 'idle')
+})

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -6,13 +6,118 @@ import { normalizeSessionType, type SessionEvent, type SessionType } from '../co
 export const LIVE_TOOL_NAMES = [
   'session_list',
   'session_inspect',
+  'session_progress',
   'session_wake',
   'session_inject',
 ] as const
 
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
-优先用 session_list / session_inspect 了解现场，再用 session_wake（新任务）或 session_inject（补充指示）派工。
-回答简洁：说明你调度了谁、做了什么、结果如何。`
+工作流：session_list / session_inspect 了解现场 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。
+向用户汇报要克制：只在关键节点、明显卡住、或用户追问时旁白，不要刷屏。
+回答简洁：说明调度了谁、当前状态、下一步。`
+
+export interface SessionProgressSnapshot {
+  sessionId: string
+  type: SessionType
+  status: 'idle' | 'running'
+  turn: number | null
+  step: number | null
+  reason?: string
+  lastTool?: { name: string; ok?: boolean } | null
+  assistantText: string
+  eventCount: number
+  newestSeq: number
+  updatedAt: number
+  inboxPending: number
+}
+
+/** 从事件日志推导 worker 进度快照（供 Live 抽查）。 */
+export function buildSessionProgress(
+  events: SessionEvent[],
+  opts: { afterSeq?: number; textLimit?: number; busy?: boolean; inboxPending?: number } = {},
+): Omit<SessionProgressSnapshot, 'sessionId' | 'type'> {
+  const textLimit = Math.min(2000, Math.max(80, opts.textLimit ?? 600))
+  const afterSeq =
+    opts.afterSeq == null || !Number.isFinite(opts.afterSeq) ? undefined : opts.afterSeq
+
+  let turn: number | null = null
+  let step: number | null = null
+  let reason: string | undefined
+  let openTurn = false
+  let lastTool: { name: string; ok?: boolean } | null = null
+  let assistantText = ''
+  const chunkParts: string[] = []
+  let deltaTool: { name: string; ok?: boolean } | null = null
+  let deltaAssistant = ''
+  const deltaChunks: string[] = []
+
+  for (const event of events) {
+    const inDelta = afterSeq == null || event.seq > afterSeq
+    if (event.type === 'turn/start') {
+      turn = event.turn
+      step = null
+      reason = undefined
+      openTurn = true
+      chunkParts.length = 0
+      assistantText = ''
+      if (inDelta) {
+        deltaChunks.length = 0
+        deltaAssistant = ''
+      }
+    } else if (event.type === 'turn/end') {
+      turn = event.turn
+      reason = event.reason
+      openTurn = false
+      step = null
+    } else if (event.type === 'step/start') {
+      turn = event.turn
+      step = event.step
+      openTurn = true
+    } else if (event.type === 'step/end') {
+      turn = event.turn
+      step = event.step
+    } else if (event.type === 'tool/call') {
+      lastTool = { name: event.name }
+      if (inDelta) deltaTool = { name: event.name }
+    } else if (event.type === 'tool/result') {
+      lastTool = { name: event.name, ok: event.ok }
+      if (inDelta) deltaTool = { name: event.name, ok: event.ok }
+    } else if (event.type === 'assistant/message') {
+      if (event.text.trim()) {
+        assistantText = event.text
+        chunkParts.length = 0
+        if (inDelta) {
+          deltaAssistant = event.text
+          deltaChunks.length = 0
+        }
+      }
+    } else if (event.type === 'assistant/chunk') {
+      chunkParts.push(event.text)
+      if (inDelta) deltaChunks.push(event.text)
+    }
+  }
+
+  if (!assistantText.trim() && chunkParts.length) assistantText = chunkParts.join('')
+  let reportText = afterSeq == null ? assistantText : deltaAssistant
+  if (!reportText.trim() && afterSeq != null && deltaChunks.length) reportText = deltaChunks.join('')
+  if (!reportText.trim()) reportText = assistantText
+  if (reportText.length > textLimit) reportText = `${reportText.slice(0, textLimit)}…`
+
+  const newest = events.at(-1)
+  const busy = Boolean(opts.busy) || openTurn
+  return {
+    status: busy ? 'running' : 'idle',
+    turn,
+    step,
+    ...(reason ? { reason } : {}),
+    lastTool: afterSeq == null ? lastTool : deltaTool ?? lastTool,
+    assistantText: reportText,
+    eventCount: events.length,
+    newestSeq: newest?.seq ?? -1,
+    updatedAt: newest?.ts ?? 0,
+    inboxPending: opts.inboxPending ?? 0,
+  }
+}
 
 async function requireLiveCaller(ctx: Context) {
   const sessionId = currentSessionId()
@@ -50,7 +155,7 @@ export function apply(ctx: Context) {
 
   ctx.tools.register({
     name: 'session_list',
-    description: '列出其他 session（含 type/status 摘要）。Live 指挥席专用。',
+    description: '列出其他 session（含 type 与 busy 状态）。Live 指挥席专用。',
     parameters: {
       type: 'object',
       properties: {
@@ -72,6 +177,7 @@ export function apply(ctx: Context) {
           id: item.id,
           title: item.title,
           type: normalizeSessionType(item.type),
+          status: ctx.agents.isBusy(item.id) ? ('running' as const) : ('idle' as const),
           eventCount: item.eventCount,
           updatedAt: item.updatedAt,
           project: item.project?.name,
@@ -100,6 +206,7 @@ export function apply(ctx: Context) {
       return {
         id: record.id,
         type: normalizeSessionType(record.type),
+        status: ctx.agents.isBusy(targetId) ? 'running' : 'idle',
         project: record.project,
         eventCount: record.events.length,
         recent: recentMessages(record.events, limit),
@@ -108,13 +215,53 @@ export function apply(ctx: Context) {
   })
 
   ctx.tools.register({
+    name: 'session_progress',
+    description:
+      '抽查目标 session 的运行进度（turn/step/status/最近 assistant 摘要）。派工后用于旁白，勿高频刷屏。',
+    parameters: {
+      type: 'object',
+      properties: {
+        sessionId: { type: 'string' },
+        afterSeq: { type: 'number', description: '只看该 seq 之后的事件（增量抽查）' },
+        textLimit: { type: 'number', description: 'assistant 摘要最大字符，默认 600' },
+      },
+      required: ['sessionId'],
+    },
+    execute: async (args) => {
+      await requireLiveCaller(ctx)
+      const targetId = String(args.sessionId || '').trim()
+      if (!targetId) throw new Error('sessionId required')
+      const record = await ctx.sessions.require(targetId)
+      const afterSeq =
+        args.afterSeq == null || args.afterSeq === '' ? undefined : Number(args.afterSeq)
+      const textLimit = args.textLimit == null ? undefined : Number(args.textLimit)
+      const progress = buildSessionProgress(record.events, {
+        afterSeq: Number.isFinite(afterSeq) ? afterSeq : undefined,
+        textLimit: Number.isFinite(textLimit) ? textLimit : undefined,
+        busy: ctx.agents.isBusy(targetId),
+        inboxPending: ctx.agents.inboxPending(targetId),
+      })
+      return {
+        sessionId: record.id,
+        type: normalizeSessionType(record.type),
+        ...progress,
+      } satisfies SessionProgressSnapshot
+    },
+  })
+
+  ctx.tools.register({
     name: 'session_wake',
-    description: '向目标 chat session 发送一条 wake 用户消息并启动其 agent 回合。',
+    description:
+      '向目标 chat session 发送 wake 并启动 agent。wait=false 时立即返回，可用 session_progress 抽查。',
     parameters: {
       type: 'object',
       properties: {
         sessionId: { type: 'string' },
         text: { type: 'string' },
+        wait: {
+          type: 'boolean',
+          description: '默认 true 等回合结束；false 则入队后立即返回 queued',
+        },
       },
       required: ['sessionId', 'text'],
     },
@@ -122,6 +269,7 @@ export function apply(ctx: Context) {
       const selfId = await requireLiveCaller(ctx)
       const targetId = String(args.sessionId || '').trim()
       const text = String(args.text || '').trim()
+      const wait = args.wait !== false && args.wait !== 'false'
       if (!targetId) throw new Error('sessionId required')
       if (!text) throw new Error('text required')
       if (targetId === selfId) throw new Error('cannot wake the current live session')
@@ -130,10 +278,15 @@ export function apply(ctx: Context) {
         throw new Error('cannot wake another live session; target a chat session')
       }
       const agent = await ctx.agents.create(targetId)
-      const turn = await agent.send(text)
+      if (!wait) {
+        void agent.send(text, { wait: false })
+        return { sessionId: targetId, queued: true, wait: false }
+      }
+      const turn = await agent.send(text, { wait: true })
       return {
         sessionId: targetId,
         queued: false,
+        wait: true,
         text: turn.text.slice(0, 1200),
         steps: turn.steps.length,
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Live 指挥席可抽查 worker 进度，并可选异步派工：

- 新工具 `session_progress`：turn / step / status / assistant 摘要 / lastTool（支持 `afterSeq` 增量）
- `session_wake` 支持 `wait=false`：入队即返回，再用 progress 旁白
- `session_list` / `inspect` 带 busy；prompt 引导克制旁白
- `agents.isBusy` / `inboxPending`；`send({ wait: false })`

## Test plan
- [x] vitest live-sessions + agents
- [x] `tsc --noEmit`
- [x] `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

