### PR TITLE
feat: 侧栏按项目文件夹分组折叠

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
 import { bindSnapshot, type Snapshot, type SnapshotService } from '../infrastructure/snapshot.ts'
-import { bindSessionView, type SessionViewService } from '../infrastructure/session-view.ts'
+import { bindSessionView, type SessionListItem, type SessionViewService } from '../infrastructure/session-view.ts'
 import { bindProjectView, type ProjectViewService } from '../infrastructure/project-view.ts'
 import { parseAppPath } from '../infrastructure/session-route.ts'
+import {
+  UNGROUPED_PROJECT_KEY,
+  groupSessionsByProject,
+  readCollapsedProjects,
+  writeCollapsedProjects,
+} from '../infrastructure/session-groups.ts'
 import {
   APP_MODULES,
   moduleIdFromPath,
@@ -18,6 +24,8 @@ import { FolderGlyph } from './chat/project-panel.tsx'
 import { DashboardModule } from './dashboard-module.tsx'
 import {
   LuBug,
+  LuChevronDown,
+  LuChevronRight,
   LuLayoutDashboard,
   LuMessageSquare,
   LuPanelLeft,
@@ -127,6 +135,69 @@ function WorkspaceModule() {
   )
 }
 
+function SessionRow({
+  item,
+  active,
+  busy,
+  view,
+  onDelete,
+}: {
+  item: SessionListItem
+  active: boolean
+  busy: boolean
+  view: string
+  onDelete: () => void
+}) {
+  const identity = resolveSessionMascot(item.id, item.mascot)
+  return (
+    <div
+      className={`group mb-0.5 flex w-full items-stretch rounded-[8px] ${
+        active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
+      }`}
+    >
+      <Link
+        to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
+        className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-1.5 text-left text-sm"
+      >
+        <SidebarMascot
+          size={28}
+          identity={identity}
+          busy={busy}
+          title={`${identity.shape} · ${identity.color}`}
+        />
+        <span className="min-w-0 flex-1">
+          <div className="truncate font-medium">
+            {(item.type ?? 'chat') === 'live' ? (
+              <span className="mr-1.5 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
+                live
+              </span>
+            ) : null}
+            {item.title}
+          </div>
+          <div className="mt-0.5 font-mono text-[10px] opacity-70">
+            {item.id.slice(0, 8)} · {item.eventCount} events
+          </div>
+        </span>
+      </Link>
+      <button
+        type="button"
+        className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
+        aria-label={`Delete session ${item.title}`}
+        title="Delete"
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onDelete()
+        }}
+      >
+        <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
 function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
@@ -142,12 +213,49 @@ function Shell(props: SlotProps) {
   const agentBusy = useSessionView((state) => state.agentStatus === 'running')
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [collapsedProjects, setCollapsedProjects] = useState<Record<string, boolean>>(() =>
+    readCollapsedProjects(),
+  )
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}${view === 'debug' ? '/debug' : ''}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
+  const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
+
+  useEffect(() => {
+    if (!routeSessionId) return
+    const group = projectGroups.find((item) => item.sessions.some((row) => row.id === routeSessionId))
+    if (!group || !collapsedProjects[group.key]) return
+    setCollapsedProjects((prev) => {
+      const next = { ...prev, [group.key]: false }
+      writeCollapsedProjects(next)
+      return next
+    })
+  }, [routeSessionId, projectGroups, collapsedProjects])
+
+  function toggleProjectGroup(key: string) {
+    setCollapsedProjects((prev) => {
+      const next = { ...prev, [key]: !prev[key] }
+      writeCollapsedProjects(next)
+      return next
+    })
+  }
+
+  function createChat(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
+    void sessionView.newSession(opts).then((id) => navigate(`/s/${id}`))
+  }
+
+  function deleteChat(item: SessionListItem) {
+    if (!window.confirm(`Delete session “${item.title}”?`)) return
+    const wasActive = item.id === sessionId
+    void sessionView.deleteSession(item.id).then(() => {
+      if (!wasActive) return
+      const next = sessionView.get().sessionId
+      navigate(next ? `/s/${next}` : '/')
+    })
+  }
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -221,9 +329,7 @@ function Shell(props: SlotProps) {
               className="app-side-actions-item"
               title="添加聊天"
               aria-label="添加聊天"
-              onClick={() => {
-                void sessionView.newSession({ type: 'chat' }).then((id) => navigate(`/s/${id}`))
-              }}
+              onClick={() => createChat({ type: 'chat' })}
             >
               <span className="app-side-actions-icon" aria-hidden>
                 <LuPlus className="size-4" />
@@ -235,9 +341,7 @@ function Shell(props: SlotProps) {
               className="app-side-actions-item"
               title="新建 Live"
               aria-label="新建 Live"
-              onClick={() => {
-                void sessionView.newSession({ type: 'live' }).then((id) => navigate(`/s/${id}`))
-              }}
+              onClick={() => createChat({ type: 'live' })}
             >
               <span className="app-side-actions-icon" aria-hidden>
                 <LuRadio className="size-4" />
@@ -252,66 +356,67 @@ function Shell(props: SlotProps) {
             </Link>
           </div>
 
-          <div className="mt-2">
+          <div className="mt-2 space-y-2">
             {sessions.length === 0 ? (
               <p className="px-2 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
             ) : (
-              sessions.map((item) => {
-                const active = item.id === routeSessionId
-                const identity = resolveSessionMascot(item.id, item.mascot)
+              projectGroups.map((group) => {
+                const collapsed = Boolean(collapsedProjects[group.key])
+                const isUngrouped = group.key === UNGROUPED_PROJECT_KEY
                 return (
-                  <div
-                    key={item.id}
-                    className={`group mb-0.5 flex w-full items-stretch rounded-[8px] ${
-                      active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
-                    }`}
-                  >
-                    <Link
-                      to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
-                      className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-1.5 text-left text-sm"
-                    >
-                      <SidebarMascot
-                        size={28}
-                        identity={identity}
-                        busy={active && agentBusy}
-                        title={`${identity.shape} · ${identity.color}`}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <div className="truncate font-medium">
-                          {(item.type ?? 'chat') === 'live' ? (
-                            <span className="mr-1.5 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
-                              live
-                            </span>
-                          ) : null}
-                          {item.title}
-                        </div>
-                        <div className="mt-0.5 font-mono text-[10px] opacity-70">
-                          {item.id.slice(0, 8)} · {item.eventCount} events
-                          {item.project ? ` · ${item.project.name}` : ''}
-                        </div>
-                      </span>
-                    </Link>
-                    <button
-                      type="button"
-                      className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
-                      aria-label={`Delete session ${item.title}`}
-                      title="Delete"
-                      onClick={(event) => {
-                        event.preventDefault()
-                        event.stopPropagation()
-                        if (!window.confirm(`Delete session “${item.title}”?`)) return
-                        const wasActive = item.id === sessionId
-                        void sessionView.deleteSession(item.id).then(() => {
-                          if (!wasActive) return
-                          const next = sessionView.get().sessionId
-                          navigate(next ? `/s/${next}` : '/')
-                        })
-                      }}
-                    >
-                      <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
-                      </svg>
-                    </button>
+                  <div key={group.key} className="min-w-0">
+                    <div className="group/header mb-0.5 flex items-center gap-0.5 px-1">
+                      <button
+                        type="button"
+                        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[6px] px-1 py-1 text-left text-[11px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+                        title={group.path ?? group.label}
+                        aria-expanded={!collapsed}
+                        onClick={() => toggleProjectGroup(group.key)}
+                      >
+                        {collapsed ? (
+                          <LuChevronRight className="size-3.5 shrink-0" />
+                        ) : (
+                          <LuChevronDown className="size-3.5 shrink-0" />
+                        )}
+                        {isUngrouped ? (
+                          <span className="grid size-3.5 place-items-center text-[10px] opacity-70" aria-hidden>
+                            —
+                          </span>
+                        ) : (
+                          <FolderGlyph className="size-3.5 shrink-0 opacity-80" />
+                        )}
+                        <span className="min-w-0 flex-1 truncate normal-case tracking-normal">{group.label}</span>
+                        <span className="shrink-0 font-mono text-[10px] opacity-60">{group.sessions.length}</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="grid size-6 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] opacity-0 hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] group-hover/header:opacity-100 focus:opacity-100"
+                        title={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
+                        aria-label={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
+                        onClick={() =>
+                          createChat({
+                            type: 'chat',
+                            ...(group.path ? { projectPath: group.path } : {}),
+                          })
+                        }
+                      >
+                        <LuPlus className="size-3.5" />
+                      </button>
+                    </div>
+                    {collapsed ? null : (
+                      <div className="min-w-0">
+                        {group.sessions.map((item) => (
+                          <SessionRow
+                            key={item.id}
+                            item={item}
+                            active={item.id === routeSessionId}
+                            busy={item.id === routeSessionId && agentBusy}
+                            view={view}
+                            onDelete={() => deleteChat(item)}
+                          />
+                        ))}
+                      </div>
+                    )}
                   </div>
                 )
               })

--- a/src/plugins/infrastructure/session-groups.test.ts
+++ b/src/plugins/infrastructure/session-groups.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  UNGROUPED_PROJECT_KEY,
+  folderNameFromPath,
+  groupSessionsByProject,
+  readCollapsedProjects,
+  writeCollapsedProjects,
+} from './session-groups.ts'
+import type { SessionListItem } from './session-view.ts'
+
+function item(partial: Partial<SessionListItem> & { id: string }): SessionListItem {
+  return {
+    title: partial.title ?? partial.id,
+    eventCount: partial.eventCount ?? 1,
+    updatedAt: partial.updatedAt ?? 0,
+    ...partial,
+  }
+}
+
+test('groupSessionsByProject groups by path and puts bare chats in Ungrouped', () => {
+  const groups = groupSessionsByProject([
+    item({
+      id: 'a',
+      updatedAt: 10,
+      project: { name: 'alpha', path: '/tmp/alpha', boundAt: 1 },
+    }),
+    item({ id: 'b', updatedAt: 30 }),
+    item({
+      id: 'c',
+      updatedAt: 20,
+      project: { name: 'alpha', path: '/tmp/alpha', boundAt: 2 },
+    }),
+    item({
+      id: 'd',
+      updatedAt: 40,
+      project: { name: 'beta', path: '/tmp/beta', boundAt: 3 },
+    }),
+  ])
+
+  assert.equal(groups.length, 3)
+  assert.equal(groups[0]?.key, '/tmp/beta')
+  assert.equal(groups[0]?.label, 'beta')
+  assert.deepEqual(
+    groups[0]?.sessions.map((row) => row.id),
+    ['d'],
+  )
+  assert.equal(groups[1]?.key, '/tmp/alpha')
+  assert.deepEqual(
+    groups[1]?.sessions.map((row) => row.id),
+    ['c', 'a'],
+  )
+  assert.equal(groups[2]?.key, UNGROUPED_PROJECT_KEY)
+  assert.equal(groups[2]?.label, '未分组')
+  assert.deepEqual(
+    groups[2]?.sessions.map((row) => row.id),
+    ['b'],
+  )
+})
+
+test('folderNameFromPath takes the last segment', () => {
+  assert.equal(folderNameFromPath('/Users/me/work/cordis-web/'), 'cordis-web')
+  assert.equal(folderNameFromPath('C:\\repos\\demo'), 'demo')
+})
+
+test('collapsed project map round-trips through storage', () => {
+  const store = new Map<string, string>()
+  const storage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+  }
+  writeCollapsedProjects({ '/tmp/a': true }, storage)
+  assert.deepEqual(readCollapsedProjects(storage), { '/tmp/a': true })
+})

--- a/src/plugins/infrastructure/session-groups.ts
+++ b/src/plugins/infrastructure/session-groups.ts
@@ -1,0 +1,74 @@
+import type { SessionListItem } from './session-view.ts'
+
+export const UNGROUPED_PROJECT_KEY = '__ungrouped__'
+
+export interface SessionProjectGroup {
+  key: string
+  /** 展示名：文件夹名，或 Ungrouped */
+  label: string
+  path?: string
+  sessions: SessionListItem[]
+  updatedAt: number
+}
+
+/** 按绑定文件夹 path 分组；无 path 归入 Ungrouped。组内与组间均按 updatedAt 降序。 */
+export function groupSessionsByProject(sessions: SessionListItem[]): SessionProjectGroup[] {
+  const map = new Map<string, SessionProjectGroup>()
+  for (const item of sessions) {
+    const path = item.project?.path?.trim()
+    const key = path || UNGROUPED_PROJECT_KEY
+    const label = path ? item.project?.name?.trim() || folderNameFromPath(path) : '未分组'
+    let group = map.get(key)
+    if (!group) {
+      group = {
+        key,
+        label,
+        ...(path ? { path } : {}),
+        sessions: [],
+        updatedAt: 0,
+      }
+      map.set(key, group)
+    }
+    group.sessions.push(item)
+    if (item.updatedAt > group.updatedAt) group.updatedAt = item.updatedAt
+  }
+
+  const groups = [...map.values()]
+  for (const group of groups) {
+    group.sessions.sort((a, b) => b.updatedAt - a.updatedAt || a.id.localeCompare(b.id))
+  }
+  groups.sort((a, b) => {
+    if (a.key === UNGROUPED_PROJECT_KEY) return 1
+    if (b.key === UNGROUPED_PROJECT_KEY) return -1
+    return b.updatedAt - a.updatedAt || a.label.localeCompare(b.label)
+  })
+  return groups
+}
+
+export function folderNameFromPath(path: string) {
+  const cleaned = path.replace(/[\\/]+$/, '')
+  const parts = cleaned.split(/[\\/]/).filter(Boolean)
+  return parts.at(-1) || path
+}
+
+export function readCollapsedProjects(storage: Pick<Storage, 'getItem'> = localStorage): Record<string, boolean> {
+  try {
+    const raw = storage.getItem('cordis.sidebar.projectCollapsed')
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as Record<string, boolean>
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function writeCollapsedProjects(
+  value: Record<string, boolean>,
+  storage: Pick<Storage, 'setItem'> = localStorage,
+) {
+  try {
+    storage.setItem('cordis.sidebar.projectCollapsed', JSON.stringify(value))
+  } catch {
+    /* ignore quota */
+  }
+}

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -339,7 +339,7 @@ export class SessionViewService extends Service {
     this.replace({ approvalMode: body.mode === 'hold' ? 'hold' : 'auto' })
   }
 
-  async newSession(opts: { type?: 'chat' | 'live' } = {}) {
+  async newSession(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
     const type = opts.type === 'live' ? 'live' : 'chat'
     const res = await fetch('/api/sessions', {
       method: 'POST',
@@ -348,6 +348,18 @@ export class SessionViewService extends Service {
     })
     const body = (await res.json()) as { id?: string }
     if (!body.id) throw new Error('无法创建 session')
+    const projectPath = opts.projectPath?.trim()
+    if (projectPath) {
+      const bind = await fetch(`/api/sessions/${body.id}/project`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: projectPath }),
+      })
+      if (!bind.ok) {
+        const err = (await bind.json().catch(() => ({}))) as { error?: string }
+        throw new Error(err.error || `绑定项目失败：${bind.status}`)
+      }
+    }
     await this.load(body.id, { view: 'chat' })
     await this.refreshSessions()
     return body.id


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
侧栏按绑定文件夹（project path）分组，可展开/折叠：

- 同一 `project.path` 下的 chat 归为一组
- 无文件夹的进 **未分组**
- 组头 `+` 可在该项目下新建并自动绑定 path
- 折叠状态写入 `localStorage`；当前会话所在组会自动展开

## Test plan
- [x] vitest `session-groups`
- [x] `tsc --noEmit`
- [x] `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

