### PR TITLE
fix: 侧栏机器人默认静止，忙碌绿点 + 新建 intro

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -332,13 +332,27 @@ function NodeView({
 
 const NodeViewMemo = memo(NodeView)
 
-function EmptyHero({ identity, busy }: { identity: SessionMascotIdentity; busy: boolean }) {
+function EmptyHero({
+  identity,
+  busy,
+  sessionId,
+}: {
+  identity: SessionMascotIdentity
+  busy: boolean
+  sessionId?: string
+}) {
   return (
     <div className="chat-empty-hero">
       <div className="chat-empty-hero-glow" aria-hidden />
       <div className="chat-empty-hero-inner">
         <div className="chat-empty-hero-mascot">
-          <SidebarMascot size={112} identity={identity} busy={busy} title={`${identity.shape} · ${identity.color}`} />
+          <SidebarMascot
+            size={112}
+            sessionId={sessionId}
+            identity={identity}
+            busy={busy}
+            title={`${identity.shape} · ${identity.color}`}
+          />
         </div>
         <h2 className="chat-empty-hero-title">Need a hand?</h2>
       </div>
@@ -498,7 +512,13 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     const identity = sessionId
       ? resolveSessionMascot(sessionId, session?.mascot)
       : DEFAULT_SESSION_MASCOT
-    return <EmptyHero identity={identity} busy={agentStatus === 'running'} />
+    return (
+      <EmptyHero
+        identity={identity}
+        busy={agentStatus === 'running'}
+        sessionId={sessionId ?? undefined}
+      />
+    )
   }
 
   const rowHydrated = (node: ChatNode) => {

--- a/src/plugins/contributors/mascot/grok-bot-avatar.tsx
+++ b/src/plugins/contributors/mascot/grok-bot-avatar.tsx
@@ -12,8 +12,10 @@ export type GrokBotAvatarProps = {
   shape: GrokShape
   color: GrokColor
   size?: number
-  /** Agent running → thinking; else onboarding expression playlist */
+  /** Agent running → thinking + green status dot */
   busy?: boolean
+  /** 刚创建：播放 intro 动画（毫秒），默认 0 表示不播 */
+  introMs?: number
   /** Force-pause (e.g. offscreen). Visibility also auto-pauses. */
   paused?: boolean
   followPointer?: boolean
@@ -32,15 +34,22 @@ type BotInternal = GrokCharacterLike & {
   hopAt?: number
 }
 
+function moodFor(busy: boolean, intro: boolean): 'static' | 'intro' | 'busy' {
+  if (busy) return 'busy'
+  if (intro) return 'intro'
+  return 'static'
+}
+
 /**
- * Animated Grok Bot for the session list.
- * Shared ~30fps ticker; onboarding cycles rich expressions; hop/spin tricks stay off.
+ * Sidebar / hero Grok bot.
+ * 默认静止；仅 busy 或 intro 窗口内才跑 shared ticker，减轻侧栏开销。
  */
 export const GrokBotAvatar = memo(function GrokBotAvatar({
   shape,
   color,
   size = 44,
   busy = false,
+  introMs = 0,
   paused = false,
   followPointer = false,
   className,
@@ -51,12 +60,27 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
   const botRef = useRef<GrokCharacterLike | null>(null)
   const [ready, setReady] = useState(false)
   const [visible, setVisible] = useState(true)
+  const [introActive, setIntroActive] = useState(introMs > 0)
   const shapeRef = useRef(shape)
   const colorRef = useRef(color)
   const busyRef = useRef(busy)
+  const introRef = useRef(introActive)
   shapeRef.current = shape
   colorRef.current = color
   busyRef.current = busy
+  introRef.current = introActive
+
+  const shouldAnimate = busy || introActive
+
+  useEffect(() => {
+    if (introMs <= 0) {
+      setIntroActive(false)
+      return
+    }
+    setIntroActive(true)
+    const timer = window.setTimeout(() => setIntroActive(false), introMs)
+    return () => window.clearTimeout(timer)
+  }, [introMs])
 
   useEffect(() => {
     const el = wrapRef.current
@@ -90,21 +114,23 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
         detachSharedTicker(botRef.current)
         botRef.current.destroy()
       }
+      const mood = moodFor(busyRef.current, introRef.current)
       const bot = new window.GrokCharacter(svgRef.current, {
         shape: shapeRef.current,
         color: colorRef.current,
         scheme: 'light',
         loginWrap: true,
         sizePx: size,
-        mode: busyRef.current ? 'hold' : 'onboarding',
-        state: busyRef.current ? 'thinking' : 'idle',
+        mode: mood === 'intro' ? 'onboarding' : 'hold',
+        state: mood === 'busy' ? 'thinking' : 'idle',
         followPointer,
         paused: true,
         eyeColor: '#f3efe6',
       }) as BotInternal
-      applySidebarMood(bot, busyRef.current)
+      applySidebarMood(bot, mood)
       attachSharedTicker(bot)
-      bot.setPaused(paused || !visible)
+      const animate = busyRef.current || introRef.current
+      bot.setPaused(paused || !visible || !animate)
       botRef.current = bot
       setReady(true)
     })
@@ -125,27 +151,27 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
     if (!bot || !ready) return
     bot.setShape(shape)
     bot.setColor(color, 'light')
-    // setShape can re-arm tricks — keep them off.
     suppressSidebarTricks(bot)
-    applySidebarMood(bot, busy)
-  }, [shape, color, ready, busy])
+    applySidebarMood(bot, moodFor(busy, introActive))
+  }, [shape, color, ready, busy, introActive])
 
   useEffect(() => {
     const bot = botRef.current
     if (!bot || !ready) return
-    applySidebarMood(bot, busy)
-  }, [busy, ready])
+    applySidebarMood(bot, moodFor(busy, introActive))
+  }, [busy, introActive, ready])
 
   useEffect(() => {
-    botRef.current?.setPaused(paused || !visible)
-  }, [paused, visible, ready])
+    botRef.current?.setPaused(paused || !visible || !shouldAnimate)
+  }, [paused, visible, ready, shouldAnimate])
 
   return (
     <span
       ref={wrapRef}
-      className={`sidebar-mascot grok-bot-avatar${className ? ` ${className}` : ''}`}
+      className={`sidebar-mascot grok-bot-avatar${busy ? ' is-busy' : ''}${className ? ` ${className}` : ''}`}
       style={{ width: size, height: size, display: 'inline-grid', placeItems: 'center' }}
       title={title}
+      data-busy={busy ? 'true' : undefined}
     >
       <svg
         ref={svgRef}
@@ -160,9 +186,9 @@ export const GrokBotAvatar = memo(function GrokBotAvatar({
           colorScheme: 'light',
           opacity: ready ? 1 : 0.35,
           transform: 'translateZ(0)',
-          willChange: 'transform',
         }}
       />
+      {busy ? <span className="sidebar-mascot-status" aria-hidden /> : null}
     </span>
   )
 })

--- a/src/plugins/contributors/mascot/grok-bot-scheduler.ts
+++ b/src/plugins/contributors/mascot/grok-bot-scheduler.ts
@@ -14,24 +14,31 @@ let lastDrive = 0
 const FRAME_MS = 1000 / 30
 
 function drive(now: number) {
-  rafId = requestAnimationFrame(drive)
-  if (now - lastDrive < FRAME_MS) return
-  lastDrive = now
+  if (now - lastDrive >= FRAME_MS) {
+    lastDrive = now
+    for (const bot of bots) {
+      if (bot.paused) continue
+      bot._tick(now)
+    }
+  }
+  let anyActive = false
   for (const bot of bots) {
-    if (bot.paused) continue
-    bot._tick(now)
+    if (!bot.paused) {
+      anyActive = true
+      break
+    }
   }
-  if (bots.size === 0 && rafId) {
-    cancelAnimationFrame(rafId)
+  if (!anyActive || bots.size === 0) {
     rafId = 0
+    return
   }
+  rafId = requestAnimationFrame(drive)
 }
 
 function ensureLoop() {
-  if (!rafId) {
-    lastDrive = 0
-    rafId = requestAnimationFrame(drive)
-  }
+  if (rafId) return
+  lastDrive = 0
+  rafId = requestAnimationFrame(drive)
 }
 
 /**
@@ -39,7 +46,7 @@ function ensureLoop() {
  * Safe to call once per instance after construction.
  */
 export function attachSharedTicker(bot: object) {
-  const raw = bot as Tickable
+  const raw = bot as Tickable & { setPaused?: (v: boolean) => void }
   if (raw.__shared) return
   if (raw._raf) {
     cancelAnimationFrame(raw._raf)
@@ -54,6 +61,14 @@ export function attachSharedTicker(bot: object) {
     if (raw._raf && raw._raf !== prevRaf) {
       cancelAnimationFrame(raw._raf)
       raw._raf = 0
+    }
+  }
+
+  const innerSetPaused = raw.setPaused?.bind(raw)
+  if (innerSetPaused) {
+    raw.setPaused = (value: boolean) => {
+      innerSetPaused(value)
+      if (!value) ensureLoop()
     }
   }
 
@@ -91,17 +106,22 @@ export function suppressSidebarTricks(bot: object) {
   raw.hopAt = -1
 }
 
-/** Idle: onboarding mood playlist (curious/happy/playful/…). Busy: thinking. */
-export function applySidebarMood(bot: object, busy: boolean) {
+/** Idle static / intro onboarding / busy thinking. */
+export function applySidebarMood(bot: object, mood: 'static' | 'intro' | 'busy') {
   const raw = bot as {
     setMode?: (m: string) => void
     setState?: (s: string, o?: { resetEyes?: boolean }) => void
   }
   suppressSidebarTricks(bot)
-  if (busy) {
+  if (mood === 'busy') {
     raw.setMode?.('hold')
     raw.setState?.('thinking', { resetEyes: false })
     return
   }
-  raw.setMode?.('onboarding')
+  if (mood === 'intro') {
+    raw.setMode?.('onboarding')
+    return
+  }
+  raw.setMode?.('hold')
+  raw.setState?.('idle', { resetEyes: false })
 }

--- a/src/plugins/contributors/mascot/sidebar-mascot.tsx
+++ b/src/plugins/contributors/mascot/sidebar-mascot.tsx
@@ -1,11 +1,20 @@
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
+import {
+  SIDEBAR_MASCOT_INTRO_MS,
+  clearSidebarMascotFresh,
+  remainingSidebarMascotIntroMs,
+} from '../../infrastructure/session-mascot-fresh.ts'
 import { GrokBotAvatar } from './grok-bot-avatar.tsx'
 import type { SessionMascotIdentity } from './grok-bot-types.ts'
 import { DEFAULT_SESSION_MASCOT } from './session-mascot.ts'
 
+export { SIDEBAR_MASCOT_INTRO_MS, markSidebarMascotFresh } from '../../infrastructure/session-mascot-fresh.ts'
+
 export type SidebarMascotProps = {
   size?: number
   busy?: boolean
+  /** 用于匹配 markSidebarMascotFresh；有剩余 intro 时才播放动画 */
+  sessionId?: string
   className?: string
   title?: string
   /** Per-chat role; defaults to brand mascot when omitted. */
@@ -14,22 +23,37 @@ export type SidebarMascotProps = {
   followPointer?: boolean
 }
 
-/** Animated per-session Grok role (stable instance; off-screen pauses RAF). */
+/** Per-session Grok：默认静止；fresh intro 或 busy 时才动，busy 时右下角绿点。 */
 export const SidebarMascot = memo(function SidebarMascot({
   size = 44,
   busy = false,
+  sessionId,
   className,
   title = 'Harness',
   identity = DEFAULT_SESSION_MASCOT,
   paused = false,
   followPointer = false,
 }: SidebarMascotProps) {
+  const [introMs, setIntroMs] = useState(() => remainingSidebarMascotIntroMs(sessionId))
+
+  useEffect(() => {
+    const left = remainingSidebarMascotIntroMs(sessionId)
+    setIntroMs(left)
+    if (left <= 0) return
+    const timer = window.setTimeout(() => {
+      if (sessionId) clearSidebarMascotFresh(sessionId)
+      setIntroMs(0)
+    }, left)
+    return () => window.clearTimeout(timer)
+  }, [sessionId])
+
   return (
     <GrokBotAvatar
       shape={identity.shape}
       color={identity.color}
       size={size}
       busy={busy}
+      introMs={introMs}
       paused={paused}
       followPointer={followPointer}
       className={className}

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -161,6 +161,7 @@ function SessionRow({
       >
         <SidebarMascot
           size={28}
+          sessionId={item.id}
           identity={identity}
           busy={busy}
           title={`${identity.shape} · ${identity.color}`}

--- a/src/plugins/infrastructure/session-mascot-fresh.test.ts
+++ b/src/plugins/infrastructure/session-mascot-fresh.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  SIDEBAR_MASCOT_INTRO_MS,
+  clearSidebarMascotFresh,
+  markSidebarMascotFresh,
+  remainingSidebarMascotIntroMs,
+} from './session-mascot-fresh.ts'
+
+test('markSidebarMascotFresh keeps intro window then clears', () => {
+  markSidebarMascotFresh('s-fresh', 50)
+  assert.ok(remainingSidebarMascotIntroMs('s-fresh') > 0)
+  assert.ok(remainingSidebarMascotIntroMs('s-fresh') <= SIDEBAR_MASCOT_INTRO_MS)
+  clearSidebarMascotFresh('s-fresh')
+  assert.equal(remainingSidebarMascotIntroMs('s-fresh'), 0)
+})

--- a/src/plugins/infrastructure/session-mascot-fresh.ts
+++ b/src/plugins/infrastructure/session-mascot-fresh.ts
@@ -1,0 +1,25 @@
+/** 侧栏头像 intro：新建 session 后短暂可播放动画。 */
+export const SIDEBAR_MASCOT_INTRO_MS = 3000
+
+const freshUntilById = new Map<string, number>()
+
+export function markSidebarMascotFresh(sessionId: string, ms = SIDEBAR_MASCOT_INTRO_MS) {
+  if (!sessionId) return
+  freshUntilById.set(sessionId, Date.now() + ms)
+}
+
+export function remainingSidebarMascotIntroMs(sessionId: string | undefined) {
+  if (!sessionId) return 0
+  const until = freshUntilById.get(sessionId)
+  if (!until) return 0
+  const left = until - Date.now()
+  if (left <= 0) {
+    freshUntilById.delete(sessionId)
+    return 0
+  }
+  return left
+}
+
+export function clearSidebarMascotFresh(sessionId: string) {
+  freshUntilById.delete(sessionId)
+}

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -9,6 +9,7 @@ import {
   type TrajectoryRow,
 } from './session-project.ts'
 import type { AppRoute } from './session-route.ts'
+import { markSidebarMascotFresh } from './session-mascot-fresh.ts'
 
 export interface ApprovalItem {
   id: string
@@ -360,6 +361,7 @@ export class SessionViewService extends Service {
         throw new Error(err.error || `绑定项目失败：${bind.status}`)
       }
     }
+    markSidebarMascotFresh(body.id)
     await this.load(body.id, { view: 'chat' })
     await this.refreshSessions()
     return body.id

--- a/src/style.css
+++ b/src/style.css
@@ -369,9 +369,23 @@ body {
 }
 
 .sidebar-mascot {
+  position: relative;
   flex-shrink: 0;
   overflow: visible;
   line-height: 0;
+}
+
+.sidebar-mascot-status {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--dsw-ok, #22c55e);
+  border: 1.5px solid var(--dsw-sidebar, #fff);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--dsw-ok, #22c55e) 35%, transparent);
+  pointer-events: none;
 }
 
 .grok-bot-avatar svg,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
侧栏机器人头像性能与状态：

- **默认静止**（不再空闲 onboarding 循环）
- **新建约 3 秒** intro 动画
- **工作时** 动画 + 右下角绿色状态点
- 全部 paused 时停掉 shared RAF

## Test plan
- [x] vitest session-mascot-fresh
- [x] `tsc --noEmit`
- [x] `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

