### PR TITLE
fix: 未分组可正常折叠

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
@@ -224,13 +224,18 @@ function Shell(props: SlotProps) {
   const agentHref = sessionId ? `/s/${sessionId}${view === 'debug' ? '/debug' : ''}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
   const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
+  const prevRouteSessionRef = useRef<string | null>(null)
 
+  // 仅在「切到」某组内会话时自动展开；手动折叠当前组不会被立刻顶开
   useEffect(() => {
-    if (!routeSessionId) return
+    const prev = prevRouteSessionRef.current
+    prevRouteSessionRef.current = routeSessionId
+    if (!routeSessionId || prev === routeSessionId) return
     const group = projectGroups.find((item) => item.sessions.some((row) => row.id === routeSessionId))
     if (!group || !collapsedProjects[group.key]) return
-    setCollapsedProjects((prev) => {
-      const next = { ...prev, [group.key]: false }
+    setCollapsedProjects((prevCollapsed) => {
+      if (!prevCollapsed[group.key]) return prevCollapsed
+      const next = { ...prevCollapsed, [group.key]: false }
       writeCollapsedProjects(next)
       return next
     })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
当前会话在「未分组」时，自动展开逻辑会立刻把折叠顶开。改为仅在**切换到**该组内会话时才自动展开。

## Test plan
- [x] `tsc --noEmit`
- [x] `npm run build`
- [ ] 打开未分组内会话 → 折叠未分组应保持收起

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

