### PR TITLE
refactor: 侧栏折叠状态用 zustand 持久化

### DIFF
--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -9,9 +9,8 @@ import { parseAppPath } from '../infrastructure/session-route.ts'
 import {
   UNGROUPED_PROJECT_KEY,
   groupSessionsByProject,
-  readCollapsedProjects,
-  writeCollapsedProjects,
 } from '../infrastructure/session-groups.ts'
+import { useSidebarCollapseStore } from '../infrastructure/sidebar-collapse-store.ts'
 import {
   APP_MODULES,
   moduleIdFromPath,
@@ -214,9 +213,9 @@ function Shell(props: SlotProps) {
   const agentBusy = useSessionView((state) => state.agentStatus === 'running')
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const [collapsedProjects, setCollapsedProjects] = useState<Record<string, boolean>>(() =>
-    readCollapsedProjects(),
-  )
+  const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
+  const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
+  const expandProjectGroup = useSidebarCollapseStore((state) => state.expand)
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
@@ -233,21 +232,8 @@ function Shell(props: SlotProps) {
     if (!routeSessionId || prev === routeSessionId) return
     const group = projectGroups.find((item) => item.sessions.some((row) => row.id === routeSessionId))
     if (!group || !collapsedProjects[group.key]) return
-    setCollapsedProjects((prevCollapsed) => {
-      if (!prevCollapsed[group.key]) return prevCollapsed
-      const next = { ...prevCollapsed, [group.key]: false }
-      writeCollapsedProjects(next)
-      return next
-    })
-  }, [routeSessionId, projectGroups, collapsedProjects])
-
-  function toggleProjectGroup(key: string) {
-    setCollapsedProjects((prev) => {
-      const next = { ...prev, [key]: !prev[key] }
-      writeCollapsedProjects(next)
-      return next
-    })
-  }
+    expandProjectGroup(group.key)
+  }, [routeSessionId, projectGroups, collapsedProjects, expandProjectGroup])
 
   function createChat(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
     void sessionView.newSession(opts).then((id) => navigate(`/s/${id}`))

--- a/src/plugins/infrastructure/session-groups.test.ts
+++ b/src/plugins/infrastructure/session-groups.test.ts
@@ -4,8 +4,6 @@ import {
   UNGROUPED_PROJECT_KEY,
   folderNameFromPath,
   groupSessionsByProject,
-  readCollapsedProjects,
-  writeCollapsedProjects,
 } from './session-groups.ts'
 import type { SessionListItem } from './session-view.ts'
 
@@ -61,16 +59,4 @@ test('groupSessionsByProject groups by path and puts bare chats in Ungrouped', (
 test('folderNameFromPath takes the last segment', () => {
   assert.equal(folderNameFromPath('/Users/me/work/cordis-web/'), 'cordis-web')
   assert.equal(folderNameFromPath('C:\\repos\\demo'), 'demo')
-})
-
-test('collapsed project map round-trips through storage', () => {
-  const store = new Map<string, string>()
-  const storage = {
-    getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => {
-      store.set(key, value)
-    },
-  }
-  writeCollapsedProjects({ '/tmp/a': true }, storage)
-  assert.deepEqual(readCollapsedProjects(storage), { '/tmp/a': true })
 })

--- a/src/plugins/infrastructure/session-groups.ts
+++ b/src/plugins/infrastructure/session-groups.ts
@@ -50,25 +50,3 @@ export function folderNameFromPath(path: string) {
   const parts = cleaned.split(/[\\/]/).filter(Boolean)
   return parts.at(-1) || path
 }
-
-export function readCollapsedProjects(storage: Pick<Storage, 'getItem'> = localStorage): Record<string, boolean> {
-  try {
-    const raw = storage.getItem('cordis.sidebar.projectCollapsed')
-    if (!raw) return {}
-    const parsed = JSON.parse(raw) as Record<string, boolean>
-    return parsed && typeof parsed === 'object' ? parsed : {}
-  } catch {
-    return {}
-  }
-}
-
-export function writeCollapsedProjects(
-  value: Record<string, boolean>,
-  storage: Pick<Storage, 'setItem'> = localStorage,
-) {
-  try {
-    storage.setItem('cordis.sidebar.projectCollapsed', JSON.stringify(value))
-  } catch {
-    /* ignore quota */
-  }
-}

--- a/src/plugins/infrastructure/sidebar-collapse-store.test.ts
+++ b/src/plugins/infrastructure/sidebar-collapse-store.test.ts
@@ -1,0 +1,84 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import {
+  SIDEBAR_PROJECT_COLLAPSE_KEY,
+  createSidebarCollapseStorage,
+  parseSidebarCollapsePersisted,
+  type SidebarCollapseState,
+} from './sidebar-collapse-store.ts'
+
+test('parseSidebarCollapsePersisted migrates flat legacy map', () => {
+  const migrated = parseSidebarCollapsePersisted(JSON.stringify({ '/tmp/a': true }))
+  assert.ok(migrated)
+  const parsed = JSON.parse(migrated!) as { state: { collapsed: Record<string, boolean> } }
+  assert.deepEqual(parsed.state.collapsed, { '/tmp/a': true })
+})
+
+test('parseSidebarCollapsePersisted keeps zustand envelope', () => {
+  const raw = JSON.stringify({ state: { collapsed: { x: true } }, version: 0 })
+  assert.equal(parseSidebarCollapsePersisted(raw), raw)
+})
+
+test('zustand persist round-trips collapse map via custom storage', async () => {
+  const mem = new Map<string, string>()
+  const base = {
+    getItem: (key: string) => mem.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      mem.set(key, value)
+    },
+    removeItem: (key: string) => {
+      mem.delete(key)
+    },
+  }
+  // seed legacy flat format
+  base.setItem(SIDEBAR_PROJECT_COLLAPSE_KEY, JSON.stringify({ '/tmp/legacy': true }))
+
+  const useStore = create<SidebarCollapseState>()(
+    persist(
+      (set, get) => ({
+        collapsed: {},
+        isCollapsed: (key) => Boolean(get().collapsed[key]),
+        toggle: (key) =>
+          set((state) => ({
+            collapsed: { ...state.collapsed, [key]: !state.collapsed[key] },
+          })),
+        setCollapsed: (key, collapsed) =>
+          set((state) => ({
+            collapsed: { ...state.collapsed, [key]: collapsed },
+          })),
+        expand: (key) =>
+          set((state) => {
+            if (!state.collapsed[key]) return state
+            return { collapsed: { ...state.collapsed, [key]: false } }
+          }),
+      }),
+      {
+        name: SIDEBAR_PROJECT_COLLAPSE_KEY,
+        storage: createJSONStorage(() => createSidebarCollapseStorage(base)),
+        partialize: (state) => ({ collapsed: state.collapsed }),
+      },
+    ),
+  )
+
+  await new Promise<void>((resolve) => {
+    const unsub = useStore.persist.onFinishHydration(() => {
+      unsub()
+      resolve()
+    })
+    useStore.persist.rehydrate()
+  })
+
+  assert.equal(useStore.getState().isCollapsed('/tmp/legacy'), true)
+  useStore.getState().toggle('/tmp/b')
+  assert.equal(useStore.getState().isCollapsed('/tmp/b'), true)
+  useStore.getState().expand('/tmp/legacy')
+  assert.equal(useStore.getState().isCollapsed('/tmp/legacy'), false)
+
+  const saved = JSON.parse(mem.get(SIDEBAR_PROJECT_COLLAPSE_KEY)!) as {
+    state: { collapsed: Record<string, boolean> }
+  }
+  assert.equal(saved.state.collapsed['/tmp/b'], true)
+  assert.equal(saved.state.collapsed['/tmp/legacy'], false)
+})

--- a/src/plugins/infrastructure/sidebar-collapse-store.ts
+++ b/src/plugins/infrastructure/sidebar-collapse-store.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware'
+
+export const SIDEBAR_PROJECT_COLLAPSE_KEY = 'cordis.sidebar.projectCollapsed'
+
+export type SidebarCollapseState = {
+  collapsed: Record<string, boolean>
+  isCollapsed: (key: string) => boolean
+  toggle: (key: string) => void
+  setCollapsed: (key: string, collapsed: boolean) => void
+  expand: (key: string) => void
+}
+
+/** 兼容旧版扁平 `{ [key]: boolean }` 与 zustand persist 包装格式。 */
+export function parseSidebarCollapsePersisted(raw: string | null): string | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object' && 'state' in (parsed as object)) {
+      return raw
+    }
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return JSON.stringify({ state: { collapsed: parsed }, version: 0 })
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+export function createSidebarCollapseStorage(base: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>): StateStorage {
+  return {
+    getItem: (name) => parseSidebarCollapsePersisted(base.getItem(name)),
+    setItem: (name, value) => base.setItem(name, value),
+    removeItem: (name) => base.removeItem(name),
+  }
+}
+
+export const useSidebarCollapseStore = create<SidebarCollapseState>()(
+  persist(
+    (set, get) => ({
+      collapsed: {},
+      isCollapsed: (key) => Boolean(get().collapsed[key]),
+      toggle: (key) =>
+        set((state) => ({
+          collapsed: { ...state.collapsed, [key]: !state.collapsed[key] },
+        })),
+      setCollapsed: (key, collapsed) =>
+        set((state) => ({
+          collapsed: { ...state.collapsed, [key]: collapsed },
+        })),
+      expand: (key) =>
+        set((state) => {
+          if (!state.collapsed[key]) return state
+          return { collapsed: { ...state.collapsed, [key]: false } }
+        }),
+    }),
+    {
+      name: SIDEBAR_PROJECT_COLLAPSE_KEY,
+      storage: createJSONStorage(() => createSidebarCollapseStorage(localStorage)),
+      partialize: (state) => ({ collapsed: state.collapsed }),
+    },
+  ),
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
侧栏项目组展开/折叠改为 **zustand + localStorage persist**：

- `useSidebarCollapseStore`（`cordis.sidebar.projectCollapsed`）
- 兼容旧版扁平 `{ [key]: boolean }` 格式自动迁移
- Shell 不再手写 `useState` + 手动读写

## Test plan
- [x] vitest sidebar-collapse-store + session-groups
- [x] `tsc --noEmit`
- [x] `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

