### PR TITLE
fix(sidebar): 侧栏交互丝滑化（折叠闪烁 / 乐观删除 / 静态头像）

### DIFF
--- a/src/plugins/contributors/chat-sidebar.tsx
+++ b/src/plugins/contributors/chat-sidebar.tsx
@@ -1,0 +1,256 @@
+import { memo, useCallback, useMemo } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import {
+  bindSessionView,
+  type SessionListItem,
+  type SessionViewService,
+} from '../infrastructure/session-view.ts'
+import {
+  UNGROUPED_PROJECT_KEY,
+  groupSessionsByProject,
+} from '../infrastructure/session-groups.ts'
+import { useSidebarCollapseStore } from '../infrastructure/sidebar-collapse-store.ts'
+import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
+import { resolveSessionMascot } from './mascot/session-mascot.ts'
+import { FolderGlyph } from './chat/project-panel.tsx'
+import {
+  LuChevronDown,
+  LuChevronRight,
+  LuLayoutDashboard,
+  LuPanelLeftClose,
+  LuPlus,
+  LuRadio,
+} from 'react-icons/lu'
+
+const SessionRow = memo(function SessionRow({
+  item,
+  active,
+  busy,
+  view,
+  onDelete,
+}: {
+  item: SessionListItem
+  active: boolean
+  busy: boolean
+  view: string
+  onDelete: (item: SessionListItem) => void
+}) {
+  const identity = resolveSessionMascot(item.id, item.mascot)
+  return (
+    <div
+      className={`group mb-px flex w-full items-stretch rounded-[6px] ${
+        active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
+      }`}
+    >
+      <Link
+        to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
+        className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-left text-[12px] leading-4"
+      >
+        <SidebarMascot
+          size={20}
+          sessionId={item.id}
+          identity={identity}
+          busy={busy}
+          title={`${identity.shape} · ${identity.color}`}
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {(item.type ?? 'chat') === 'live' ? (
+            <span className="mr-1 text-[9px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
+              live
+            </span>
+          ) : null}
+          {item.title}
+        </span>
+      </Link>
+      <button
+        type="button"
+        className="shrink-0 px-1.5 text-[var(--dsw-label-3)] opacity-0 hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
+        aria-label={`Delete session ${item.title}`}
+        title="Delete"
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onDelete(item)
+        }}
+      >
+        <svg viewBox="0 0 24 24" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.8">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
+        </svg>
+      </button>
+    </div>
+  )
+})
+
+export type ChatSidebarProps = {
+  visible: boolean
+  routeSessionId: string | null
+  useSessionView: ReturnType<typeof bindSessionView>
+  sessionView: SessionViewService
+  onCollapse: () => void
+}
+
+/**
+ * 独立订阅折叠态与 sessions：组展开/收缩只重渲侧栏，不拖垮 Shell 里的 Chat Markdown 主区。
+ */
+export const ChatSidebar = memo(function ChatSidebar({
+  visible,
+  routeSessionId,
+  useSessionView,
+  sessionView,
+  onCollapse,
+}: ChatSidebarProps) {
+  const navigate = useNavigate()
+  const sessions = useSessionView((state) => state.sessions)
+  const sessionId = useSessionView((state) => state.sessionId)
+  const view = useSessionView((state) => state.view)
+  const agentBusy = useSessionView((state) => state.agentStatus === 'running')
+  const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
+  const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
+  const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
+
+  const createChat = useCallback(
+    (opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) => {
+      void sessionView.newSession(opts).then((id) => navigate(`/s/${id}`))
+    },
+    [navigate, sessionView],
+  )
+
+  const deleteChat = useCallback(
+    (item: SessionListItem) => {
+      if (!window.confirm(`Delete session “${item.title}”?`)) return
+      const wasActive = item.id === sessionId
+      void sessionView.deleteSession(item.id).then(() => {
+        if (!wasActive) return
+        const next = sessionView.get().sessionId
+        navigate(next ? `/s/${next}` : '/')
+      })
+    },
+    [navigate, sessionId, sessionView],
+  )
+
+  return (
+    <aside
+      className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] ${
+        visible ? 'flex' : 'hidden'
+      }`}
+      aria-hidden={!visible}
+    >
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-3 pb-3">
+        <div className="mb-1 flex items-center justify-between gap-2 px-2">
+          <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
+          <button
+            type="button"
+            className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
+            title="Collapse sidebar"
+            aria-label="Collapse sidebar"
+            onClick={onCollapse}
+          >
+            <LuPanelLeftClose className="size-3.5" />
+          </button>
+        </div>
+
+        <div className="app-side-actions" role="navigation" aria-label="Chat actions">
+          <button
+            type="button"
+            className="app-side-actions-item"
+            title="添加聊天"
+            aria-label="添加聊天"
+            onClick={() => createChat({ type: 'chat' })}
+          >
+            <span className="app-side-actions-icon" aria-hidden>
+              <LuPlus className="size-4" />
+            </span>
+            <span className="app-side-actions-label">添加聊天</span>
+          </button>
+          <button
+            type="button"
+            className="app-side-actions-item"
+            title="新建 Live"
+            aria-label="新建 Live"
+            onClick={() => createChat({ type: 'live' })}
+          >
+            <span className="app-side-actions-icon" aria-hidden>
+              <LuRadio className="size-4" />
+            </span>
+            <span className="app-side-actions-label">新建 Live</span>
+          </button>
+          <Link to="/dashboard" className="app-side-actions-item" title="Dashboard" aria-label="Dashboard">
+            <span className="app-side-actions-icon" aria-hidden>
+              <LuLayoutDashboard className="size-4" />
+            </span>
+            <span className="app-side-actions-label">Dashboard</span>
+          </Link>
+        </div>
+
+        <div className="mt-2 space-y-1.5">
+          {sessions.length === 0 ? (
+            <p className="px-2 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
+          ) : (
+            projectGroups.map((group) => {
+              const hasRouteSession = Boolean(
+                routeSessionId && group.sessions.some((row) => row.id === routeSessionId),
+              )
+              const collapsed = Boolean(collapsedProjects[group.key]) && !hasRouteSession
+              const isUngrouped = group.key === UNGROUPED_PROJECT_KEY
+              return (
+                <div key={group.key} className="min-w-0">
+                  <div className="group/header mb-0.5 flex items-center gap-0.5 px-1">
+                    <button
+                      type="button"
+                      className="flex min-w-0 flex-1 items-center gap-1 rounded-[6px] px-1 py-0.5 text-left text-[11px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+                      title={group.path ?? group.label}
+                      aria-expanded={!collapsed}
+                      onClick={() => toggleProjectGroup(group.key)}
+                    >
+                      {collapsed ? (
+                        <LuChevronRight className="size-3 shrink-0" />
+                      ) : (
+                        <LuChevronDown className="size-3 shrink-0" />
+                      )}
+                      {isUngrouped ? (
+                        <span className="grid size-3 place-items-center text-[10px] opacity-70" aria-hidden>
+                          —
+                        </span>
+                      ) : (
+                        <FolderGlyph className="size-3 shrink-0 opacity-80" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate normal-case tracking-normal">{group.label}</span>
+                      <span className="shrink-0 font-mono text-[10px] opacity-60">{group.sessions.length}</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="grid size-5 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] opacity-0 hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] group-hover/header:opacity-100 focus:opacity-100"
+                      title={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
+                      aria-label={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
+                      onClick={() =>
+                        createChat({
+                          type: 'chat',
+                          ...(group.path ? { projectPath: group.path } : {}),
+                        })
+                      }
+                    >
+                      <LuPlus className="size-3" />
+                    </button>
+                  </div>
+                  {/* hidden 保活，避免展开时重新 mount 行（哪怕只有几条也少一次协调） */}
+                  <div className={`min-w-0 ${collapsed ? 'hidden' : ''}`} aria-hidden={collapsed}>
+                    {group.sessions.map((item) => (
+                      <SessionRow
+                        key={item.id}
+                        item={item}
+                        active={item.id === routeSessionId}
+                        busy={item.id === routeSessionId && agentBusy}
+                        view={view}
+                        onDelete={deleteChat}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )
+            })
+          )}
+        </div>
+      </div>
+    </aside>
+  )
+})

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -389,6 +389,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const sessions = useSessionView((state) => state.sessions)
   const error = useSessionView((state) => state.error)
+  const switchingSession = useSessionView((state) => state.switchingSession)
   const hasMoreOlder = useSessionView((state) => state.hasMoreOlder)
   const loadingOlder = useSessionView((state) => state.loadingOlder)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -507,7 +508,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     if (parent) parent.scrollTop = parent.scrollHeight
   }, [stickKey, nodes.length])
 
-  if (nodes.length === 0 && !pending && !error) {
+  if (nodes.length === 0 && !pending && !error && !switchingSession) {
     const session = sessions.find((item) => item.id === sessionId)
     const identity = sessionId
       ? resolveSessionMascot(sessionId, session?.mascot)
@@ -537,7 +538,13 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   }
 
   return (
-    <div ref={rootRef} className="w-full" data-chat-virtual={virtualize ? '1' : '0'}>
+    <div
+      ref={rootRef}
+      className="w-full"
+      data-chat-virtual={virtualize ? '1' : '0'}
+      data-switching={switchingSession ? '1' : undefined}
+      style={switchingSession ? { opacity: 0.72, transition: 'opacity 120ms ease' } : undefined}
+    >
       <StatusRow agentStatus={agentStatus} agentStep={agentStep} />
       {loadingOlder ? (
         <div className="mb-3 text-center text-[11px] text-[var(--dsw-label-3)]">加载更早消息…</div>

--- a/src/plugins/contributors/mascot/sidebar-mascot.tsx
+++ b/src/plugins/contributors/mascot/sidebar-mascot.tsx
@@ -5,6 +5,7 @@ import {
   remainingSidebarMascotIntroMs,
 } from '../../infrastructure/session-mascot-fresh.ts'
 import { GrokBotAvatar } from './grok-bot-avatar.tsx'
+import { StaticMascotMark } from './static-mascot-mark.tsx'
 import type { SessionMascotIdentity } from './grok-bot-types.ts'
 import { DEFAULT_SESSION_MASCOT } from './session-mascot.ts'
 
@@ -23,7 +24,9 @@ export type SidebarMascotProps = {
   followPointer?: boolean
 }
 
-/** Per-session Grok：默认静止；fresh intro 或 busy 时才动，busy 时右下角绿点。 */
+/**
+ * 侧栏头像：空闲用静态描边（轻）；仅 intro / busy 才挂完整 GrokCharacter。
+ */
 export const SidebarMascot = memo(function SidebarMascot({
   size = 44,
   busy = false,
@@ -46,6 +49,20 @@ export const SidebarMascot = memo(function SidebarMascot({
     }, left)
     return () => window.clearTimeout(timer)
   }, [sessionId])
+
+  const animated = busy || introMs > 0
+
+  if (!animated) {
+    return (
+      <StaticMascotMark
+        identity={identity}
+        size={size}
+        busy={false}
+        className={className}
+        title={title}
+      />
+    )
+  }
 
   return (
     <GrokBotAvatar

--- a/src/plugins/contributors/mascot/static-mascot-mark.tsx
+++ b/src/plugins/contributors/mascot/static-mascot-mark.tsx
@@ -1,0 +1,78 @@
+import { memo, useEffect, useState } from 'react'
+import { loadGrokGeo } from './grok-bot-loader.ts'
+import type { GrokColor, GrokShape, SessionMascotIdentity } from './grok-bot-types.ts'
+
+export type StaticMascotMarkProps = {
+  identity: SessionMascotIdentity
+  size?: number
+  busy?: boolean
+  className?: string
+  title?: string
+}
+
+/**
+ * 侧栏静止头像：只画 GROK_GEO 轮廓，不挂 GrokCharacter / RAF。
+ * 展开分组时避免 N 个完整角色同时构造拖垮主线程。
+ */
+export const StaticMascotMark = memo(function StaticMascotMark({
+  identity,
+  size = 28,
+  busy = false,
+  className,
+  title = 'Session mascot',
+}: StaticMascotMarkProps) {
+  const [ready, setReady] = useState(() => Boolean(typeof window !== 'undefined' && window.GROK_GEO))
+  const [path, setPath] = useState(() => (typeof window !== 'undefined' ? shapePath(identity.shape) : ''))
+  const [fill, setFill] = useState(() => (typeof window !== 'undefined' ? colorFill(identity.color) : '#1CC3B0'))
+  const viewBox =
+    typeof window !== 'undefined' ? window.GROK_GEO?.viewBox : undefined
+
+  useEffect(() => {
+    let cancelled = false
+    void loadGrokGeo().then(() => {
+      if (cancelled) return
+      setPath(shapePath(identity.shape))
+      setFill(colorFill(identity.color))
+      setReady(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [identity.shape, identity.color])
+
+  const vb = viewBox ?? { minX: -15, minY: -15, width: 259, height: 259 }
+
+  return (
+    <span
+      className={`sidebar-mascot session-mascot-mark${busy ? ' is-busy' : ''}${className ? ` ${className}` : ''}`}
+      style={{ width: size, height: size, display: 'inline-grid', placeItems: 'center' }}
+      title={title}
+      data-busy={busy ? 'true' : undefined}
+    >
+      <svg
+        role="img"
+        aria-label={title}
+        width={size}
+        height={size}
+        viewBox={`${vb.minX} ${vb.minY} ${vb.width} ${vb.height}`}
+        style={{
+          width: size,
+          height: size,
+          overflow: 'visible',
+          opacity: ready && path ? 1 : 0.35,
+        }}
+      >
+        {path ? <path d={path} fill={fill} /> : null}
+      </svg>
+      {busy ? <span className="sidebar-mascot-status" aria-hidden /> : null}
+    </span>
+  )
+})
+
+function shapePath(shape: GrokShape) {
+  return window.GROK_GEO?.shapes?.[shape]?.path ?? window.GROK_GEO?.shapes?.blob?.path ?? ''
+}
+
+function colorFill(color: GrokColor) {
+  return window.GROK_GEO?.palette?.[color]?.light ?? '#1CC3B0'
+}

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
@@ -134,7 +134,7 @@ function WorkspaceModule() {
   )
 }
 
-function SessionRow({
+const SessionRow = memo(function SessionRow({
   item,
   active,
   busy,
@@ -145,7 +145,7 @@ function SessionRow({
   active: boolean
   busy: boolean
   view: string
-  onDelete: () => void
+  onDelete: (item: SessionListItem) => void
 }) {
   const identity = resolveSessionMascot(item.id, item.mascot)
   return (
@@ -187,7 +187,7 @@ function SessionRow({
         onClick={(event) => {
           event.preventDefault()
           event.stopPropagation()
-          onDelete()
+          onDelete(item)
         }}
       >
         <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
@@ -196,7 +196,7 @@ function SessionRow({
       </button>
     </div>
   )
-}
+})
 
 function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
@@ -215,7 +215,6 @@ function Shell(props: SlotProps) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
   const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
-  const expandProjectGroup = useSidebarCollapseStore((state) => state.expand)
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
@@ -223,31 +222,24 @@ function Shell(props: SlotProps) {
   const agentHref = sessionId ? `/s/${sessionId}${view === 'debug' ? '/debug' : ''}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
   const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
-  const prevRouteSessionRef = useRef<string | null>(null)
-
-  // 仅在「切到」某组内会话时自动展开；手动折叠当前组不会被立刻顶开
-  useEffect(() => {
-    const prev = prevRouteSessionRef.current
-    prevRouteSessionRef.current = routeSessionId
-    if (!routeSessionId || prev === routeSessionId) return
-    const group = projectGroups.find((item) => item.sessions.some((row) => row.id === routeSessionId))
-    if (!group || !collapsedProjects[group.key]) return
-    expandProjectGroup(group.key)
-  }, [routeSessionId, projectGroups, collapsedProjects, expandProjectGroup])
 
   function createChat(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
     void sessionView.newSession(opts).then((id) => navigate(`/s/${id}`))
   }
 
-  function deleteChat(item: SessionListItem) {
-    if (!window.confirm(`Delete session “${item.title}”?`)) return
-    const wasActive = item.id === sessionId
-    void sessionView.deleteSession(item.id).then(() => {
-      if (!wasActive) return
-      const next = sessionView.get().sessionId
-      navigate(next ? `/s/${next}` : '/')
-    })
-  }
+  const deleteChat = useCallback(
+    (item: SessionListItem) => {
+      if (!window.confirm(`Delete session “${item.title}”?`)) return
+      const wasActive = item.id === sessionId
+      // 列表已乐观移除；切路由等 DELETE/load 完成后再跳，避免闪回
+      void sessionView.deleteSession(item.id).then(() => {
+        if (!wasActive) return
+        const next = sessionView.get().sessionId
+        navigate(next ? `/s/${next}` : '/')
+      })
+    },
+    [navigate, sessionId, sessionView],
+  )
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -353,7 +345,11 @@ function Shell(props: SlotProps) {
               <p className="px-2 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
             ) : (
               projectGroups.map((group) => {
-                const collapsed = Boolean(collapsedProjects[group.key])
+                // 含当前路由会话的组首帧就展开，避免「先塌再展开」闪一下
+                const hasRouteSession = Boolean(
+                  routeSessionId && group.sessions.some((row) => row.id === routeSessionId),
+                )
+                const collapsed = Boolean(collapsedProjects[group.key]) && !hasRouteSession
                 const isUngrouped = group.key === UNGROUPED_PROJECT_KEY
                 return (
                   <div key={group.key} className="min-w-0">
@@ -404,7 +400,7 @@ function Shell(props: SlotProps) {
                             active={item.id === routeSessionId}
                             busy={item.id === routeSessionId && agentBusy}
                             view={view}
-                            onDelete={() => deleteChat(item)}
+                            onDelete={deleteChat}
                           />
                         ))}
                       </div>

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -1,36 +1,24 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useState } from 'react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import type { Context } from 'cordis'
 import type { SlotProps } from '../registry/slots.ts'
 import { bindSnapshot, type Snapshot, type SnapshotService } from '../infrastructure/snapshot.ts'
-import { bindSessionView, type SessionListItem, type SessionViewService } from '../infrastructure/session-view.ts'
+import { bindSessionView, type SessionViewService } from '../infrastructure/session-view.ts'
 import { bindProjectView, type ProjectViewService } from '../infrastructure/project-view.ts'
 import { parseAppPath } from '../infrastructure/session-route.ts'
-import {
-  UNGROUPED_PROJECT_KEY,
-  groupSessionsByProject,
-} from '../infrastructure/session-groups.ts'
-import { useSidebarCollapseStore } from '../infrastructure/sidebar-collapse-store.ts'
 import {
   APP_MODULES,
   moduleIdFromPath,
   type AppModuleId,
 } from '../infrastructure/app-modules.ts'
 import { FishLogo } from './brand.tsx'
-import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
-import { resolveSessionMascot } from './mascot/session-mascot.ts'
+import { ChatSidebar } from './chat-sidebar.tsx'
 import { FolderGlyph } from './chat/project-panel.tsx'
 import { DashboardModule } from './dashboard-module.tsx'
 import {
   LuBug,
-  LuChevronDown,
-  LuChevronRight,
-  LuLayoutDashboard,
   LuMessageSquare,
   LuPanelLeft,
-  LuPanelLeftClose,
-  LuPlus,
-  LuRadio,
 } from 'react-icons/lu'
 
 export const name = 'shell'
@@ -134,66 +122,46 @@ function WorkspaceModule() {
   )
 }
 
-const SessionRow = memo(function SessionRow({
-  item,
-  active,
-  busy,
+/** 主区与侧栏折叠态解耦：组折叠时不重跑 stage/composer。 */
+const AgentMainPanels = memo(function AgentMainPanels({
   view,
-  onDelete,
+  renderSlot,
 }: {
-  item: SessionListItem
-  active: boolean
-  busy: boolean
   view: string
-  onDelete: (item: SessionListItem) => void
+  renderSlot: SlotProps['renderSlot']
 }) {
-  const identity = resolveSessionMascot(item.id, item.mascot)
   return (
-    <div
-      className={`group mb-0.5 flex w-full items-stretch rounded-[8px] ${
-        active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
-      }`}
-    >
-      <Link
-        to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
-        className="flex min-w-0 flex-1 items-center gap-2.5 px-2 py-1.5 text-left text-sm"
+    <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+      {/*
+        不用 display:none：大 Markdown DOM 被隐藏后再显示会重算布局（数百 ms longtask）。
+        absolute + visibility 保活布局，Chat↔Debug 只切可见性。
+      */}
+      <div
+        className={`absolute inset-0 min-h-0 overflow-hidden ${
+          view === 'chat' ? 'z-[1] flex' : 'pointer-events-none invisible z-0 flex'
+        }`}
+        aria-hidden={view !== 'chat'}
       >
-        <SidebarMascot
-          size={28}
-          sessionId={item.id}
-          identity={identity}
-          busy={busy}
-          title={`${identity.shape} · ${identity.color}`}
-        />
-        <span className="min-w-0 flex-1">
-          <div className="truncate font-medium">
-            {(item.type ?? 'chat') === 'live' ? (
-              <span className="mr-1.5 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
-                live
-              </span>
-            ) : null}
-            {item.title}
+        <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
+            {renderSlot('stage')}
           </div>
-          <div className="mt-0.5 font-mono text-[10px] opacity-70">
-            {item.id.slice(0, 8)} · {item.eventCount} events
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-6 pb-4 md:px-8 lg:px-10">
+            <div className="pointer-events-auto space-y-2 bg-transparent">
+              {renderSlot('dock')}
+              {renderSlot('composer')}
+            </div>
           </div>
-        </span>
-      </Link>
-      <button
-        type="button"
-        className="shrink-0 px-2 text-[var(--dsw-label-3)] opacity-0 transition-opacity hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
-        aria-label={`Delete session ${item.title}`}
-        title="Delete"
-        onClick={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          onDelete(item)
-        }}
+        </div>
+      </div>
+      <div
+        className={`absolute inset-0 min-h-0 overflow-hidden ${
+          view === 'debug' ? 'z-[1] flex flex-col' : 'pointer-events-none invisible z-0 flex flex-col'
+        }`}
+        aria-hidden={view !== 'debug'}
       >
-        <svg viewBox="0 0 24 24" className="size-4" fill="none" stroke="currentColor" strokeWidth="1.8">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6 7h12M10 7V5h4v2m-6 3v8m4-8v8m-7-11 1 14h10l1-14" />
-        </svg>
-      </button>
+        {renderSlot('trajectory')}
+      </div>
     </div>
   )
 })
@@ -206,40 +174,19 @@ function Shell(props: SlotProps) {
   const navigate = useNavigate()
   const location = useLocation()
   const live = useSnapshot((state: Snapshot) => state.plugins.some((plugin) => plugin.enabled))
-  const sessions = useSessionView((state) => state.sessions)
   const sessionId = useSessionView((state) => state.sessionId)
   const project = useSessionView((state) => state.project)
   const view = useSessionView((state) => state.view)
-  const agentBusy = useSessionView((state) => state.agentStatus === 'running')
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
-  const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
-  const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}${view === 'debug' ? '/debug' : ''}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
-  const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
-
-  function createChat(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
-    void sessionView.newSession(opts).then((id) => navigate(`/s/${id}`))
-  }
-
-  const deleteChat = useCallback(
-    (item: SessionListItem) => {
-      if (!window.confirm(`Delete session “${item.title}”?`)) return
-      const wasActive = item.id === sessionId
-      // 列表已乐观移除；切路由等 DELETE/load 完成后再跳，避免闪回
-      void sessionView.deleteSession(item.id).then(() => {
-        if (!wasActive) return
-        const next = sessionView.get().sessionId
-        navigate(next ? `/s/${next}` : '/')
-      })
-    },
-    [navigate, sessionId, sessionView],
-  )
+  const collapseSidebar = useCallback(() => setSidebarCollapsed(true), [])
+  const expandSidebar = useCallback(() => setSidebarCollapsed(false), [])
 
   // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
   useEffect(() => {
@@ -286,132 +233,13 @@ function Shell(props: SlotProps) {
         onSettings={() => setSettingsOpen(true)}
       />
 
-      {/* 模块切换用 hidden 保活，避免卸载重挂导致路由体感慢 */}
-      <aside
-        className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] ${
-          showChatSidebar ? 'flex' : 'hidden'
-        }`}
-        aria-hidden={!showChatSidebar}
-      >
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-3 pb-3">
-          <div className="mb-1 flex items-center justify-between gap-2 px-2">
-            <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
-            <button
-              type="button"
-              className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
-              title="Collapse sidebar"
-              aria-label="Collapse sidebar"
-              onClick={() => setSidebarCollapsed(true)}
-            >
-              <LuPanelLeftClose className="size-3.5" />
-            </button>
-          </div>
-
-          <div className="app-side-actions" role="navigation" aria-label="Chat actions">
-            <button
-              type="button"
-              className="app-side-actions-item"
-              title="添加聊天"
-              aria-label="添加聊天"
-              onClick={() => createChat({ type: 'chat' })}
-            >
-              <span className="app-side-actions-icon" aria-hidden>
-                <LuPlus className="size-4" />
-              </span>
-              <span className="app-side-actions-label">添加聊天</span>
-            </button>
-            <button
-              type="button"
-              className="app-side-actions-item"
-              title="新建 Live"
-              aria-label="新建 Live"
-              onClick={() => createChat({ type: 'live' })}
-            >
-              <span className="app-side-actions-icon" aria-hidden>
-                <LuRadio className="size-4" />
-              </span>
-              <span className="app-side-actions-label">新建 Live</span>
-            </button>
-            <Link to="/dashboard" className="app-side-actions-item" title="Dashboard" aria-label="Dashboard">
-              <span className="app-side-actions-icon" aria-hidden>
-                <LuLayoutDashboard className="size-4" />
-              </span>
-              <span className="app-side-actions-label">Dashboard</span>
-            </Link>
-          </div>
-
-          <div className="mt-2 space-y-2">
-            {sessions.length === 0 ? (
-              <p className="px-2 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
-            ) : (
-              projectGroups.map((group) => {
-                // 含当前路由会话的组首帧就展开，避免「先塌再展开」闪一下
-                const hasRouteSession = Boolean(
-                  routeSessionId && group.sessions.some((row) => row.id === routeSessionId),
-                )
-                const collapsed = Boolean(collapsedProjects[group.key]) && !hasRouteSession
-                const isUngrouped = group.key === UNGROUPED_PROJECT_KEY
-                return (
-                  <div key={group.key} className="min-w-0">
-                    <div className="group/header mb-0.5 flex items-center gap-0.5 px-1">
-                      <button
-                        type="button"
-                        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-[6px] px-1 py-1 text-left text-[11px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
-                        title={group.path ?? group.label}
-                        aria-expanded={!collapsed}
-                        onClick={() => toggleProjectGroup(group.key)}
-                      >
-                        {collapsed ? (
-                          <LuChevronRight className="size-3.5 shrink-0" />
-                        ) : (
-                          <LuChevronDown className="size-3.5 shrink-0" />
-                        )}
-                        {isUngrouped ? (
-                          <span className="grid size-3.5 place-items-center text-[10px] opacity-70" aria-hidden>
-                            —
-                          </span>
-                        ) : (
-                          <FolderGlyph className="size-3.5 shrink-0 opacity-80" />
-                        )}
-                        <span className="min-w-0 flex-1 truncate normal-case tracking-normal">{group.label}</span>
-                        <span className="shrink-0 font-mono text-[10px] opacity-60">{group.sessions.length}</span>
-                      </button>
-                      <button
-                        type="button"
-                        className="grid size-6 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] opacity-0 hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] group-hover/header:opacity-100 focus:opacity-100"
-                        title={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
-                        aria-label={isUngrouped ? '在未分组下添加聊天' : `在 ${group.label} 下添加聊天`}
-                        onClick={() =>
-                          createChat({
-                            type: 'chat',
-                            ...(group.path ? { projectPath: group.path } : {}),
-                          })
-                        }
-                      >
-                        <LuPlus className="size-3.5" />
-                      </button>
-                    </div>
-                    {collapsed ? null : (
-                      <div className="min-w-0">
-                        {group.sessions.map((item) => (
-                          <SessionRow
-                            key={item.id}
-                            item={item}
-                            active={item.id === routeSessionId}
-                            busy={item.id === routeSessionId && agentBusy}
-                            view={view}
-                            onDelete={deleteChat}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )
-              })
-            )}
-          </div>
-        </div>
-      </aside>
+      <ChatSidebar
+        visible={showChatSidebar}
+        routeSessionId={routeSessionId}
+        useSessionView={useSessionView}
+        sessionView={sessionView}
+        onCollapse={collapseSidebar}
+      />
 
       <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
         <div
@@ -426,7 +254,7 @@ function Shell(props: SlotProps) {
                   className="chat-view-header-expand"
                   title="Expand sidebar"
                   aria-label="Expand sidebar"
-                  onClick={() => setSidebarCollapsed(false)}
+                  onClick={expandSidebar}
                 >
                   <LuPanelLeft className="size-3.5" />
                 </button>
@@ -469,38 +297,7 @@ function Shell(props: SlotProps) {
             </nav>
             <div className="chat-view-header-right" aria-hidden />
           </header>
-          <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-            {/*
-              不用 display:none：大 Markdown DOM 被隐藏后再显示会重算布局（数百 ms longtask）。
-              absolute + visibility 保活布局，Chat↔Debug 只切可见性。
-            */}
-            <div
-              className={`absolute inset-0 min-h-0 overflow-hidden ${
-                view === 'chat' ? 'z-[1] flex' : 'pointer-events-none invisible z-0 flex'
-              }`}
-              aria-hidden={view !== 'chat'}
-            >
-              <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-                <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
-                  {props.renderSlot('stage')}
-                </div>
-                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-6 pb-4 md:px-8 lg:px-10">
-                  <div className="pointer-events-auto space-y-2 bg-transparent">
-                    {props.renderSlot('dock')}
-                    {props.renderSlot('composer')}
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div
-              className={`absolute inset-0 min-h-0 overflow-hidden ${
-                view === 'debug' ? 'z-[1] flex flex-col' : 'pointer-events-none invisible z-0 flex flex-col'
-              }`}
-              aria-hidden={view !== 'debug'}
-            >
-              {props.renderSlot('trajectory')}
-            </div>
-          </div>
+          <AgentMainPanels view={view} renderSlot={props.renderSlot} />
         </div>
         <div
           className={activeModule === 'dashboard' ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'hidden'}

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -225,7 +225,7 @@ test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () =>
   assert.equal(calls.some((url) => url.includes('/events/4/request')), true)
 })
 
-test('load clears previous chat immediately and does not wait on network', async () => {
+test('load keeps previous chat visible until new session fetch resolves', async () => {
   let release!: (value: unknown) => void
   const gate = new Promise((resolve) => {
     release = resolve
@@ -239,7 +239,12 @@ test('load clears previous chat immediately and does not wait on network', async
       return {
         ok: true,
         status: 200,
-        json: async () => ({ id: 'empty', events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }], hasMore: false, totalTurns: 0 }),
+        json: async () => ({
+          id: 'empty',
+          events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+          hasMore: false,
+          totalTurns: 0,
+        }),
       } as Response
     }
     if (url.includes('/api/sessions/busy?turns=')) {
@@ -272,15 +277,19 @@ test('load clears previous chat immediately and does not wait on network', async
   const view = ctx.sessionView as SessionViewService
   await view.load('busy', { view: 'chat', wait: true })
   assert.equal(view.get().nodes.length > 0, true)
+  const prevNodes = view.get().nodes.length
 
-  // 切到空会话：load 在网络返回前就 resolve；UI 已清空
+  // 切到空会话：网络返回前不闪空；仍立刻换 sessionId 并开始拉取
   await view.load('empty', { view: 'chat' })
   assert.equal(view.get().sessionId, 'empty')
-  assert.equal(view.get().nodes.length, 0)
+  assert.equal(view.get().switchingSession, true)
+  assert.equal(view.get().nodes.length, prevNodes)
   assert.equal(emptyFetchStarted, true)
   release(undefined)
   await new Promise((r) => setTimeout(r, 0))
   assert.equal(view.get().sessionId, 'empty')
+  assert.equal(view.get().switchingSession, false)
+  assert.equal(view.get().nodes.some((node) => node.kind === 'user'), false)
 })
 
 test('second load of same session hits memory cache without waiting on fetch', async () => {

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -408,3 +408,39 @@ test('deleteSession clears active session when list empty', async () => {
   assert.equal(view.get().sessionId, null)
   assert.equal(view.get().sessions.length, 0)
 })
+
+test('deleteSession removes from list before DELETE resolves', async () => {
+  let resolveDelete!: (value: Response) => void
+  const deleteGate = new Promise<Response>((resolve) => {
+    resolveDelete = resolve
+  })
+  let sessions: Array<{ id: string; title: string; eventCount: number; updatedAt: number }> = [
+    { id: 's1', title: 'a', eventCount: 1, updatedAt: 2 },
+    { id: 's2', title: 'b', eventCount: 1, updatedAt: 1 },
+  ]
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    const method = init?.method ?? 'GET'
+    if (url.endsWith('/api/sessions') && method === 'GET') {
+      return { ok: true, status: 200, json: async () => ({ sessions }) } as Response
+    }
+    if (url.includes('/api/sessions/s1') && method === 'DELETE') {
+      return deleteGate
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  const pending = view.deleteSession('s1')
+  assert.equal(view.get().sessions.map((row) => row.id).join(','), 's2')
+  sessions = [{ id: 's2', title: 'b', eventCount: 1, updatedAt: 1 }]
+  resolveDelete({ ok: true, status: 200, json: async () => ({ ok: true, id: 's1' }) } as Response)
+  await pending
+  assert.equal(view.get().sessions.map((row) => row.id).join(','), 's2')
+})

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -710,11 +710,40 @@ export class SessionViewService extends Service {
   }
 
   async deleteSession(id: string) {
-    const res = await fetch(`/api/sessions/${id}`, { method: 'DELETE' })
-    const body = (await res.json()) as { ok?: boolean; error?: string }
-    if (!res.ok) throw new Error(body.error || `删除失败：${res.status}`)
-    this.dropCache(id)
+    const prevSessions = this.value.sessions
     const wasActive = this.value.sessionId === id
+    // 乐观更新：先从侧栏拿掉，避免等网络才「卡一下消失」
+    this.dropCache(id)
+    this.replace({
+      sessions: prevSessions.filter((item) => item.id !== id),
+      ...(wasActive
+        ? {
+            sessionId: null,
+            events: [],
+            nodes: [],
+            trajectory: [],
+            pending: false,
+            agentStatus: 'idle' as const,
+            project: undefined,
+            hasMoreOlder: false,
+            loadingOlder: false,
+            trajectoryHasMore: false,
+            trajectoryLoading: false,
+            totalTurns: 0,
+            error: undefined,
+          }
+        : {}),
+    })
+
+    try {
+      const res = await fetch(`/api/sessions/${id}`, { method: 'DELETE' })
+      const body = (await res.json()) as { ok?: boolean; error?: string }
+      if (!res.ok) throw new Error(body.error || `删除失败：${res.status}`)
+    } catch (error) {
+      this.replace({ sessions: prevSessions, error: String(error) })
+      throw error
+    }
+
     await this.refreshSessions()
     if (!wasActive) return
     const next = this.value.sessions[0]?.id

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -55,6 +55,8 @@ export interface SessionViewState {
   trajectoryHasMore: boolean
   trajectoryLoading: boolean
   totalTurns: number
+  /** 切会话且无缓存：保留上一段画面直到新数据到齐，避免先闪 EmptyHero */
+  switchingSession: boolean
   error?: string
 }
 
@@ -74,6 +76,7 @@ const empty: SessionViewState = {
   trajectoryHasMore: false,
   trajectoryLoading: false,
   totalTurns: 0,
+  switchingSession: false,
 }
 
 type SessionPayload = {
@@ -180,6 +183,7 @@ export class SessionViewService extends Service {
         trajectoryHasMore: false,
         trajectoryLoading: false,
         totalTurns: 0,
+        switchingSession: false,
         error: undefined,
       })
       return
@@ -201,6 +205,7 @@ export class SessionViewService extends Service {
           trajectoryHasMore: false,
           trajectoryLoading: false,
           totalTurns: 0,
+          switchingSession: false,
         })
         throw error
       }
@@ -215,6 +220,11 @@ export class SessionViewService extends Service {
 
   ingest(sessionId: string, event: SessionEvent) {
     if (this.value.sessionId && this.value.sessionId !== sessionId) {
+      void this.refreshSessions()
+      return
+    }
+    // 切会话过渡期仍挂着上一段 nodes，勿把新 session 的流式事件混进去
+    if (this.value.switchingSession) {
       void this.refreshSessions()
       return
     }
@@ -380,6 +390,7 @@ export class SessionViewService extends Service {
 
     const cached = this.cache.get(sessionId)
     const needSwap = this.value.sessionId !== sessionId
+    const listedProject = this.value.sessions.find((item) => item.id === sessionId)?.project
 
     // 路由切换（含空会话 / 冷启动）：立刻换壳，网络只后台校对，绝不 await
     if (!wait) {
@@ -393,42 +404,76 @@ export class SessionViewService extends Service {
       }
       if (needSwap) {
         this.loadGen += 1
-        this.replace({
-          sessionId,
-          events: [],
-          nodes: [],
-          trajectory: [],
-          project: undefined,
-          view,
-          focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
-          error: undefined,
-          pending: false,
-          agentStatus: 'idle',
-          hasMoreOlder: false,
-          loadingOlder: false,
-          trajectoryHasMore: false,
-          trajectoryLoading: false,
-          totalTurns: 0,
-        })
+        // 有上一段内容时先保留画面，只换 sessionId；无缓存清空会闪 EmptyHero
+        if (this.value.sessionId && (this.value.nodes.length > 0 || this.value.events.length > 0)) {
+          this.replace({
+            sessionId,
+            trajectory: [],
+            project: listedProject,
+            view,
+            focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+            error: undefined,
+            pending: false,
+            agentStatus: 'idle',
+            loadingOlder: false,
+            trajectoryHasMore: false,
+            trajectoryLoading: false,
+            switchingSession: true,
+          })
+        } else {
+          this.replace({
+            sessionId,
+            events: [],
+            nodes: [],
+            trajectory: [],
+            project: listedProject,
+            view,
+            focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+            error: undefined,
+            pending: false,
+            agentStatus: 'idle',
+            hasMoreOlder: false,
+            loadingOlder: false,
+            trajectoryHasMore: false,
+            trajectoryLoading: false,
+            totalTurns: 0,
+            switchingSession: true,
+          })
+        }
         if (view === 'debug') void this.ensureTrajectory()
         void this.revalidate(sessionId, view)
         return
       }
     }
 
-    // wait：发送后等同会话刷新，必须等网络；切会话时也先乐观换壳再 await
+    // wait：发送后等同会话刷新，必须等网络；切会话时也先换目标再 await
     this.loadGen += 1
     if (needSwap) {
       if (cached) {
         this.touchCache(sessionId)
         this.applyCached(sessionId, cached, view)
+      } else if (this.value.sessionId && (this.value.nodes.length > 0 || this.value.events.length > 0)) {
+        this.replace({
+          sessionId,
+          trajectory: [],
+          project: listedProject,
+          view,
+          focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
+          error: undefined,
+          pending: false,
+          agentStatus: 'idle',
+          loadingOlder: false,
+          trajectoryHasMore: false,
+          trajectoryLoading: false,
+          switchingSession: true,
+        })
       } else {
         this.replace({
           sessionId,
           events: [],
           nodes: [],
           trajectory: [],
-          project: undefined,
+          project: listedProject,
           view,
           focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
           error: undefined,
@@ -439,6 +484,7 @@ export class SessionViewService extends Service {
           trajectoryHasMore: false,
           trajectoryLoading: false,
           totalTurns: 0,
+          switchingSession: true,
         })
       }
     }
@@ -464,6 +510,7 @@ export class SessionViewService extends Service {
             focusCallId: undefined,
             hasMoreOlder: false,
             totalTurns: 0,
+            switchingSession: false,
           })
         }
         return
@@ -486,7 +533,13 @@ export class SessionViewService extends Service {
         hasMoreOlder,
         totalTurns,
       })
-      if (sameTail && body.project?.path === this.value.project?.path && this.value.totalTurns === totalTurns) {
+      // 切会话 hold 期间即使 tail「碰巧相同」也必须落地，否则会一直停在上一段画面
+      if (
+        !this.value.switchingSession &&
+        sameTail &&
+        body.project?.path === this.value.project?.path &&
+        this.value.totalTurns === totalTurns
+      ) {
         return
       }
       this.replace({
@@ -497,6 +550,7 @@ export class SessionViewService extends Service {
         hasMoreOlder,
         totalTurns,
         trajectory: view === 'debug' ? this.value.trajectory : [],
+        switchingSession: false,
         error: undefined,
       })
       if (view === 'debug') void this.ensureTrajectory()
@@ -522,6 +576,7 @@ export class SessionViewService extends Service {
       trajectoryHasMore: false,
       trajectoryLoading: false,
       totalTurns: cached.totalTurns,
+      switchingSession: false,
     })
   }
 
@@ -730,6 +785,7 @@ export class SessionViewService extends Service {
             trajectoryHasMore: false,
             trajectoryLoading: false,
             totalTurns: 0,
+            switchingSession: false,
             error: undefined,
           }
         : {}),
@@ -768,6 +824,7 @@ export class SessionViewService extends Service {
       trajectoryHasMore: false,
       trajectoryLoading: false,
       totalTurns: 0,
+      switchingSession: false,
       error: undefined,
     })
   }

--- a/src/plugins/infrastructure/sidebar-collapse-store.test.ts
+++ b/src/plugins/infrastructure/sidebar-collapse-store.test.ts
@@ -76,6 +76,8 @@ test('zustand persist round-trips collapse map via custom storage', async () => 
   useStore.getState().expand('/tmp/legacy')
   assert.equal(useStore.getState().isCollapsed('/tmp/legacy'), false)
 
+  await new Promise((resolve) => setTimeout(resolve, 150))
+
   const saved = JSON.parse(mem.get(SIDEBAR_PROJECT_COLLAPSE_KEY)!) as {
     state: { collapsed: Record<string, boolean> }
   }

--- a/src/plugins/infrastructure/sidebar-collapse-store.ts
+++ b/src/plugins/infrastructure/sidebar-collapse-store.ts
@@ -29,10 +29,29 @@ export function parseSidebarCollapsePersisted(raw: string | null): string | null
 }
 
 export function createSidebarCollapseStorage(base: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>): StateStorage {
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let pending: { name: string; value: string } | null = null
   return {
     getItem: (name) => parseSidebarCollapsePersisted(base.getItem(name)),
-    setItem: (name, value) => base.setItem(name, value),
-    removeItem: (name) => base.removeItem(name),
+    setItem: (name, value) => {
+      pending = { name, value }
+      if (timer) clearTimeout(timer)
+      // 折叠点得很快时合并写盘，避免同步 localStorage 顶掉点击帧
+      timer = setTimeout(() => {
+        timer = null
+        if (!pending) return
+        base.setItem(pending.name, pending.value)
+        pending = null
+      }, 120)
+    },
+    removeItem: (name) => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      pending = null
+      base.removeItem(name)
+    },
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -310,9 +310,9 @@ body {
   align-items: center;
   gap: 8px;
   border-radius: 8px;
-  padding: 7px 8px;
+  padding: 5px 8px;
   color: var(--dsw-label-2);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   line-height: 1.2;
   text-align: left;

--- a/src/style.css
+++ b/src/style.css
@@ -317,7 +317,6 @@ body {
   line-height: 1.2;
   text-align: left;
   text-decoration: none;
-  transition: background 0.12s ease, color 0.12s ease;
 }
 
 .app-side-actions-icon {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
侧栏展开/收缩拖垮主区；Chat 行偏高；切 Chat 时右侧先消失再出现。

## 改动
1. **左右分离渲染**：`ChatSidebar` 独立订阅折叠 / sessions，组折叠不再重渲 Markdown 主区。
2. **行更紧凑**：头像 20px、单行标题。
3. **切会话不闪空**：无缓存时保留上一段 `nodes`，`switchingSession` 期间不进 EmptyHero，等 `revalidate` 再原子替换。

## 验证
- `npx tsc --noEmit`
- vitest session-view / sidebar-collapse
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

