### PR TITLE
fix(ui): 侧栏 hover 跟手 + 减轻 Markdown 占主线程

### DIFF
--- a/src/plugins/contributors/chat-sidebar.tsx
+++ b/src/plugins/contributors/chat-sidebar.tsx
@@ -37,11 +37,7 @@ const SessionRow = memo(function SessionRow({
 }) {
   const identity = resolveSessionMascot(item.id, item.mascot)
   return (
-    <div
-      className={`group mb-px flex w-full items-stretch rounded-[6px] ${
-        active ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'hover:bg-[var(--dsw-hover)]'
-      }`}
-    >
+    <div className={`chat-session-row group${active ? ' is-active' : ''}`}>
       <Link
         to={`/s/${item.id}${view === 'debug' ? '/debug' : ''}`}
         className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-left text-[12px] leading-4"
@@ -64,7 +60,7 @@ const SessionRow = memo(function SessionRow({
       </Link>
       <button
         type="button"
-        className="shrink-0 px-1.5 text-[var(--dsw-label-3)] opacity-0 hover:text-[var(--dsw-danger)] group-hover:opacity-100 focus:opacity-100"
+        className="chat-session-row-delete"
         aria-label={`Delete session ${item.title}`}
         title="Delete"
         onClick={(event) => {

--- a/src/plugins/contributors/chat/markdown.tsx
+++ b/src/plugins/contributors/chat/markdown.tsx
@@ -1,10 +1,14 @@
-import { memo } from 'react'
+import { memo, useDeferredValue } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 const REMARK_PLUGINS = [remarkGfm]
 
-/** 对话气泡内的 Markdown 渲染（GFM：表格/任务列表/删除线等）。 */
+/**
+ * 对话气泡内的 Markdown（GFM）。
+ * 流式用纯文本；结束后用 useDeferredValue 推迟 remark 解析，
+ * 避免一次长任务占死主线程（侧栏点击/hover 跟着卡）。
+ */
 export const MarkdownBody = memo(function MarkdownBody({
   text,
   className = '',
@@ -15,17 +19,23 @@ export const MarkdownBody = memo(function MarkdownBody({
   /** 流式中跳过 remark，避免每帧全量重解析 */
   streaming?: boolean
 }) {
+  const deferredText = useDeferredValue(text)
+  // 紧急更新（切会话 / 流式结束）时先继续显示纯文本，等过渡帧再跑 remark
+  const pendingParse = !streaming && deferredText !== text
+
   if (!text) return null
-  if (streaming) {
+
+  if (streaming || pendingParse) {
     return (
       <div className={`chat-md chat-md-stream ${className}`.trim()}>
         <pre className="chat-md-stream-pre">{text}</pre>
       </div>
     )
   }
+
   return (
     <div className={`chat-md ${className}`.trim()}>
-      <Markdown remarkPlugins={REMARK_PLUGINS}>{text}</Markdown>
+      <Markdown remarkPlugins={REMARK_PLUGINS}>{deferredText}</Markdown>
     </div>
   )
 })

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -21,12 +21,14 @@ const NEAR_BOTTOM_PX = 96
 const PREFETCH_OLDER_PX = 720
 const ROW_GAP_PX = 16
 const ESTIMATE_ROW_PX = 220
-/** 消息很少时全量渲染更简单，也避免虚表测量抖动 */
-const VIRTUALIZE_AFTER = 12
-/** 加大 overscan：快速上滑时预挂载更多行，减少白屏 */
-const OVERSCAN = 18
+/** 超过该条数才上虚表；过低阈值会抖，过高则短会话也会一次挂满 Markdown */
+const VIRTUALIZE_AFTER = 4
+/** overscan 过大时可视区外仍挂大量 remark DOM，拖死主线程 */
+const OVERSCAN = 6
 /** 滚动停下多久后，给尚未 hydrate 的行补上完整渲染 */
 const SCROLL_IDLE_MS = 120
+/** 停下后每帧最多新 hydrate 几行，避免一次补齐打爆主线程 */
+const HYDRATE_PER_IDLE = 2
 
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node = el?.parentElement ?? null
@@ -401,6 +403,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const hydratedRef = useRef(new Set<string>())
   const [scrollEpoch, setScrollEpoch] = useState(0)
   const [isScrolling, setIsScrolling] = useState(false)
+  /** 允许从列表末尾往前 hydrate 的条数；idle 时递增，避免一次挂满 Markdown */
+  const [hydrateQuota, setHydrateQuota] = useState(4)
 
   const virtualize = nodes.length >= VIRTUALIZE_AFTER
 
@@ -421,7 +425,28 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   useEffect(() => {
     hydratedRef.current = new Set()
     setIsScrolling(false)
+    setHydrateQuota(4)
   }, [sessionId])
+
+  useEffect(() => {
+    if (isScrolling) return
+    if (hydrateQuota >= nodes.length) return
+    let cancelled = false
+    let handle = 0
+    const bump = () => {
+      if (cancelled) return
+      setHydrateQuota((value) => Math.min(nodes.length, value + HYDRATE_PER_IDLE))
+    }
+    handle =
+      typeof requestIdleCallback === 'function'
+        ? requestIdleCallback(bump, { timeout: 200 })
+        : window.setTimeout(bump, 32)
+    return () => {
+      cancelled = true
+      if (typeof cancelIdleCallback === 'function') cancelIdleCallback(handle)
+      else window.clearTimeout(handle)
+    }
+  }, [isScrolling, hydrateQuota, nodes.length, sessionId])
 
   useLayoutEffect(() => {
     const parent = findScrollParent(rootRef.current)
@@ -522,15 +547,18 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     )
   }
 
-  const rowHydrated = (node: ChatNode) => {
+  const rowHydrated = (node: ChatNode, index: number) => {
     if (hydratedRef.current.has(node.id)) return true
     // 流式回复：直接展示，不走 loading
     if (node.kind === 'reply' && node.streaming) {
       hydratedRef.current.add(node.id)
       return true
     }
-    // 静止或非虚表：完整渲染，并记下，下次滚动不再拆掉
-    if (!virtualize || !isScrolling) {
+    // 滚动中：新进视口的行先 stub，避免一边滑一边 remark
+    if (virtualize && isScrolling) return false
+    // 从底部往上按配额 hydrate（用户通常看最新）
+    const fromEnd = nodes.length - 1 - index
+    if (fromEnd < hydrateQuota) {
       hydratedRef.current.add(node.id)
       return true
     }
@@ -554,7 +582,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
           {virtualizer.getVirtualItems().map((item) => {
             const node = nodes[item.index]
             if (!node) return null
-            const hydrated = rowHydrated(node)
+            const hydrated = rowHydrated(node, item.index)
             return (
               <div
                 key={item.key}
@@ -575,13 +603,13 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
         </div>
       ) : (
         <div className="flex flex-col gap-4">
-          {nodes.map((node) => (
+          {nodes.map((node, index) => (
             <NodeViewMemo
               key={node.id}
               node={node}
               onInspect={onInspect}
               onFork={onFork}
-              hydrated
+              hydrated={rowHydrated(node, index)}
             />
           ))}
         </div>

--- a/src/style.css
+++ b/src/style.css
@@ -297,6 +297,13 @@ body {
   grid-template-columns: 48px minmax(0, 1fr);
 }
 
+/* 侧栏独立合成层：右侧 Markdown 重绘时少拖累左侧 :hover */
+.app-side-bar {
+  contain: layout paint style;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+}
+
 .app-side-actions {
   display: flex;
   flex-direction: column;
@@ -305,6 +312,8 @@ body {
 }
 
 .app-side-actions-item {
+  position: relative;
+  isolation: isolate;
   display: flex;
   width: 100%;
   align-items: center;
@@ -317,6 +326,31 @@ body {
   line-height: 1.2;
   text-align: left;
   text-decoration: none;
+  /* 禁止任何 transition，hover 必须跟手 */
+  transition: none;
+}
+
+.app-side-actions-item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: transparent;
+}
+
+.app-side-actions-item > * {
+  position: relative;
+  z-index: 1;
+}
+
+.app-side-actions-item:hover {
+  color: var(--dsw-label);
+}
+
+.app-side-actions-item:hover::before {
+  background: var(--dsw-hover);
 }
 
 .app-side-actions-icon {
@@ -336,13 +370,65 @@ body {
   white-space: nowrap;
 }
 
-.app-side-actions-item:hover {
-  background: var(--dsw-hover);
+.app-side-actions-item:hover .app-side-actions-icon {
   color: var(--dsw-label);
 }
 
-.app-side-actions-item:hover .app-side-actions-icon {
-  color: var(--dsw-label);
+/* Session 行：高亮画在 ::before，避免每次 hover 重绘头像 SVG */
+.chat-session-row {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  width: 100%;
+  align-items: stretch;
+  margin-bottom: 1px;
+  border-radius: 6px;
+  contain: layout style;
+  transition: none;
+}
+
+.chat-session-row::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: transparent;
+}
+
+.chat-session-row > * {
+  position: relative;
+  z-index: 1;
+}
+
+.chat-session-row:hover:not(.is-active)::before {
+  background: var(--dsw-hover);
+}
+
+.chat-session-row.is-active {
+  color: var(--dsw-business);
+}
+
+.chat-session-row.is-active::before {
+  background: var(--dsw-business-soft);
+}
+
+.chat-session-row-delete {
+  flex-shrink: 0;
+  padding: 0 6px;
+  color: var(--dsw-label-3);
+  opacity: 0;
+  transition: none;
+}
+
+.chat-session-row:hover .chat-session-row-delete,
+.chat-session-row-delete:focus {
+  opacity: 1;
+}
+
+.chat-session-row-delete:hover {
+  color: var(--dsw-danger);
 }
 
 .app-activity-bar {
@@ -372,6 +458,8 @@ body {
   flex-shrink: 0;
   overflow: visible;
   line-height: 0;
+  /* 侧栏行 hover 时不要跟着父级背景一起重绘 */
+  contain: layout paint;
 }
 
 .sidebar-mascot-status {
@@ -1520,6 +1608,8 @@ body {
 .chat-md {
   max-width: 100%;
   overflow-wrap: anywhere;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 120px;
 }
 
 .chat-md-stream-pre {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
右侧已渲染完时，侧栏上下划过 Session，高亮仍不跟手。

## 原因
高亮画在整行 `background` 上，每次 `:hover` 连带重绘行内 mascot SVG；侧栏又未与右侧合成层隔离。

## 改动
1. Session / 顶部 actions 高亮改到 `::before`，`transition: none`
2. `.app-side-bar` `contain` + 独立合成层
3. 顺带：Markdown `useDeferredValue`、虚表 overscan 收紧、底部 idle hydrate（减轻右侧占主线程）

## 验证
- `npx tsc --noEmit`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

