### PR TITLE
fix(sidebar): 静态头像补眼睛，尺寸调到 24px

### DIFF
--- a/src/plugins/contributors/chat-sidebar.tsx
+++ b/src/plugins/contributors/chat-sidebar.tsx
@@ -43,7 +43,7 @@ const SessionRow = memo(function SessionRow({
         className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-left text-[12px] leading-4"
       >
         <SidebarMascot
-          size={20}
+          size={24}
           sessionId={item.id}
           identity={identity}
           busy={busy}

--- a/src/plugins/contributors/mascot/grok-bot-types.ts
+++ b/src/plugins/contributors/mascot/grok-bot-types.ts
@@ -72,9 +72,20 @@ declare global {
     GrokCharacter?: GrokCharacterCtor
     GROK_GEO?: {
       Re: number
+      G9e?: number
+      VJt?: number
       viewBox: { minX: number; minY: number; width: number; height: number }
-      shapes: Record<string, { path: string; tiltScale?: number }>
+      shapes: Record<
+        string,
+        {
+          path: string
+          tiltScale?: number
+          face?: { x?: number; y?: number; sx?: number; sy?: number; eye?: number; leftDX?: number }
+        }
+      >
       palette: Record<string, { light: string; dark: string }>
+      /** 各 morph 帧的左右眼多边形 */
+      eyes?: number[][][][]
     }
   }
 }

--- a/src/plugins/contributors/mascot/static-mascot-mark.tsx
+++ b/src/plugins/contributors/mascot/static-mascot-mark.tsx
@@ -10,9 +10,22 @@ export type StaticMascotMarkProps = {
   title?: string
 }
 
+type FaceTune = { x: number; y: number; sx: number; sy: number; eye: number }
+type GeoSnapshot = {
+  path: string
+  fill: string
+  eyePaths: [string, string] | null
+  face: FaceTune
+  Re: number
+  viewBox: { minX: number; minY: number; width: number; height: number }
+}
+
+const FACE_GAP = 1.18
+const DEFAULT_FACE: FaceTune = { x: 0, y: 0, sx: 1, sy: 1, eye: 1 }
+const DEFAULT_VB = { minX: -15, minY: -15, width: 259, height: 259 }
+
 /**
- * 侧栏静止头像：只画 GROK_GEO 轮廓，不挂 GrokCharacter / RAF。
- * 展开分组时避免 N 个完整角色同时构造拖垮主线程。
+ * 侧栏静止头像：身体轮廓 + 默认睁眼，不挂 GrokCharacter / RAF。
  */
 export const StaticMascotMark = memo(function StaticMascotMark({
   identity,
@@ -21,26 +34,21 @@ export const StaticMascotMark = memo(function StaticMascotMark({
   className,
   title = 'Session mascot',
 }: StaticMascotMarkProps) {
-  const [ready, setReady] = useState(() => Boolean(typeof window !== 'undefined' && window.GROK_GEO))
-  const [path, setPath] = useState(() => (typeof window !== 'undefined' ? shapePath(identity.shape) : ''))
-  const [fill, setFill] = useState(() => (typeof window !== 'undefined' ? colorFill(identity.color) : '#1CC3B0'))
-  const viewBox =
-    typeof window !== 'undefined' ? window.GROK_GEO?.viewBox : undefined
+  const [geo, setGeo] = useState<GeoSnapshot | null>(() => readGeo(identity))
 
   useEffect(() => {
     let cancelled = false
     void loadGrokGeo().then(() => {
       if (cancelled) return
-      setPath(shapePath(identity.shape))
-      setFill(colorFill(identity.color))
-      setReady(true)
+      setGeo(readGeo(identity))
     })
     return () => {
       cancelled = true
     }
   }, [identity.shape, identity.color])
 
-  const vb = viewBox ?? { minX: -15, minY: -15, width: 259, height: 259 }
+  const vb = geo?.viewBox ?? DEFAULT_VB
+  const ready = Boolean(geo?.path)
 
   return (
     <span
@@ -59,20 +67,60 @@ export const StaticMascotMark = memo(function StaticMascotMark({
           width: size,
           height: size,
           overflow: 'visible',
-          opacity: ready && path ? 1 : 0.35,
+          opacity: ready ? 1 : 0.35,
         }}
       >
-        {path ? <path d={path} fill={fill} /> : null}
+        {geo?.path ? <path d={geo.path} fill={geo.fill} /> : null}
+        {geo?.eyePaths ? (
+          <g transform={faceTransform(geo.Re, geo.face)}>
+            <path d={geo.eyePaths[0]} fill="#fff" />
+            <path d={geo.eyePaths[1]} fill="#fff" />
+          </g>
+        ) : null}
       </svg>
       {busy ? <span className="sidebar-mascot-status" aria-hidden /> : null}
     </span>
   )
 })
 
-function shapePath(shape: GrokShape) {
-  return window.GROK_GEO?.shapes?.[shape]?.path ?? window.GROK_GEO?.shapes?.blob?.path ?? ''
+function readGeo(identity: SessionMascotIdentity): GeoSnapshot | null {
+  const root = typeof window !== 'undefined' ? window.GROK_GEO : undefined
+  if (!root) return null
+  const shape = root.shapes?.[identity.shape] ?? root.shapes?.blob
+  const path = shape?.path ?? ''
+  if (!path) return null
+  const face = {
+    ...DEFAULT_FACE,
+    ...(shape && 'face' in shape && shape.face && typeof shape.face === 'object' ? shape.face : {}),
+  } as FaceTune
+  const frame = root.eyes?.[0]
+  const eyePaths =
+    frame && frame.length >= 2
+      ? ([polyPath(frame[0]!), polyPath(frame[1]!)] as [string, string])
+      : null
+  return {
+    path,
+    fill: root.palette?.[identity.color]?.light ?? '#1CC3B0',
+    eyePaths,
+    face,
+    Re: root.Re ?? 114.27,
+    viewBox: root.viewBox ?? DEFAULT_VB,
+  }
 }
 
-function colorFill(color: GrokColor) {
-  return window.GROK_GEO?.palette?.[color]?.light ?? '#1CC3B0'
+function polyPath(poly: number[][]) {
+  if (!poly.length) return ''
+  let d = ''
+  for (let i = 0; i < poly.length; i++) {
+    const [x, y] = poly[i]!
+    d += `${i === 0 ? 'M' : 'L'}${x} ${y}`
+  }
+  return `${d}Z`
+}
+
+/** 与运行时 FACE_TUNE.gap 对齐的粗略脸部摆位，让眼睛落在轮廓里。 */
+function faceTransform(Re: number, face: FaceTune) {
+  const sx = face.sx * FACE_GAP
+  const sy = face.sy
+  return `translate(${Re + face.x} ${Re + face.y}) scale(${sx} ${sy}) translate(${-Re} ${-Re})`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
侧栏静止头像看不见眼睛。

## 原因
不完全是尺寸：静态 mark 只画了身体 `path`，没画 `GROK_GEO.eyes`。

## 改动
- 静态头像补上默认睁眼多边形 + 脸部摆位
- 侧栏头像 20 → 24px（略放大、仍比原来 28 紧凑）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

