### PR TITLE
fix(sidebar): 分组可折叠 + 干活时头像继续动画

### DIFF
--- a/src/plugins/contributors/chat-sidebar.tsx
+++ b/src/plugins/contributors/chat-sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import {
   bindSessionView,
@@ -99,10 +99,24 @@ export const ChatSidebar = memo(function ChatSidebar({
   const sessions = useSessionView((state) => state.sessions)
   const sessionId = useSessionView((state) => state.sessionId)
   const view = useSessionView((state) => state.view)
-  const agentBusy = useSessionView((state) => state.agentStatus === 'running')
+  const agentBusy = useSessionView(
+    (state) => state.agentStatus === 'running' || state.pending,
+  )
   const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
   const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
+  const expandProjectGroup = useSidebarCollapseStore((state) => state.expand)
   const projectGroups = useMemo(() => groupSessionsByProject(sessions), [sessions])
+  const prevRouteSessionRef = useRef<string | null>(null)
+
+  // 仅在「切到」另一会话时展开其所在组；列表刷新不会顶开用户刚折叠的组
+  useLayoutEffect(() => {
+    const prev = prevRouteSessionRef.current
+    prevRouteSessionRef.current = routeSessionId
+    if (!routeSessionId || prev === routeSessionId) return
+    const group = projectGroups.find((item) => item.sessions.some((row) => row.id === routeSessionId))
+    if (!group) return
+    expandProjectGroup(group.key)
+  }, [routeSessionId, projectGroups, expandProjectGroup])
 
   const createChat = useCallback(
     (opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) => {
@@ -183,10 +197,7 @@ export const ChatSidebar = memo(function ChatSidebar({
             <p className="px-2 text-[11px] leading-4 text-[var(--dsw-label-3)]">No chats yet. Send a message or create one.</p>
           ) : (
             projectGroups.map((group) => {
-              const hasRouteSession = Boolean(
-                routeSessionId && group.sessions.some((row) => row.id === routeSessionId),
-              )
-              const collapsed = Boolean(collapsedProjects[group.key]) && !hasRouteSession
+              const collapsed = Boolean(collapsedProjects[group.key])
               const isUngrouped = group.key === UNGROUPED_PROJECT_KEY
               return (
                 <div key={group.key} className="min-w-0">

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -77,6 +77,30 @@ test('send inject posts kind without clearing running state', async () => {
   assert.equal(view.get().pending, true)
 })
 
+test('send wake keeps running after HTTP so WS agent/status owns idle', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', eventCount: 1, updatedAt: 1 }] }),
+    '/api/sessions/s1?turns=': () => ({
+      id: 's1',
+      events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+      hasMore: false,
+      totalTurns: 0,
+    }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+    '/api/sessions/s1/messages': () => ({ sessionId: 's1', text: 'ok' }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  await view.send('hi')
+  assert.equal(view.get().agentStatus, 'running')
+  assert.equal(view.get().pending, true)
+  view.setAgentStatus('idle')
+  assert.equal(view.get().agentStatus, 'idle')
+  assert.equal(view.get().pending, false)
+})
+
 test('inspectCall switches to trajectory with focus', async () => {
   mockFetch({
     '/api/sessions': () => ({ sessions: [] }),

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -290,7 +290,7 @@ export class SessionViewService extends Service {
       this.replace({ agentStatus: 'running', agentStep: step, pending: true })
       return
     }
-    this.replace({ agentStatus: 'idle', agentStep: step })
+    this.replace({ agentStatus: 'idle', agentStep: step, pending: false })
   }
 
   upsertApproval(item: ApprovalItem) {
@@ -876,9 +876,8 @@ export class SessionViewService extends Service {
       }
       this.replace({ error: String(error), pending: false, agentStatus: 'idle' })
       throw error
-    } finally {
-      this.replace({ pending: false, agentStatus: 'idle' })
     }
+    // 成功后不要在 finally 里强行 idle：agent 仍在跑，状态交给 WS agent/status
   }
 
   async cancel() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
1. 有的项目组「展开/折叠点了没反应」（看起来随机）
2. Agent 干活时侧栏头像不再播动画

## 原因
1. 为防闪烁曾写成：当前路由所在组**永远视为展开** → 点折叠只改 store，UI 不动
2. `send()` 的 `finally` 在 HTTP 一结束就 `agentStatus: idle`，把 WS 的 running 盖掉，忙碌动画被掐断

## 改动
- 折叠完全跟 store；仅在**切换会话**时用 `useLayoutEffect` 展开目标组
- `send` 成功后不再强行 idle；`setAgentStatus('idle')` 同时清 `pending`
- 侧栏 busy 判定：`running || pending`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

