### PR TITLE
feat(session): 打开会话拉全量历史，渲染仍虚表

### DIFF
--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -144,7 +144,7 @@ test('ingest coalesces consecutive chunks and skips trajectory on chat view', as
   assert.equal(view.get().trajectory.length, 0)
 })
 
-test('load fetches tail turns and skips trajectory until ensureTrajectory', async () => {
+test('load fetches full session turns and skips trajectory until ensureTrajectory', async () => {
   const calls: string[] = []
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     const url = String(input)
@@ -191,7 +191,7 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
   await view.load('s1', { view: 'chat', wait: true })
-  assert.equal(calls.some((url) => url.includes('turns=24')), true)
+  assert.equal(calls.some((url) => url.includes('turns=all')), true)
   assert.equal(view.get().events.some((event) => event.type === 'assistant/chunk'), false)
   assert.equal(view.get().trajectory.length, 0)
   assert.equal(
@@ -205,7 +205,7 @@ test('load fetches tail turns and skips trajectory until ensureTrajectory', asyn
   await view.ensureTrajectory()
   assert.equal(calls.some((url) => url.includes('/trajectory?turns=')), true)
   assert.equal(view.get().trajectory.length, 1)
-  assert.equal(calls.some((url) => url.includes('turns=all')), false)
+  assert.equal(calls.some((url) => url.includes('turns=24')), false)
 })
 
 test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () => {

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -30,9 +30,11 @@ export interface SessionListItem {
 export type ConversationView = 'chat' | 'debug'
 export type ApprovalMode = 'auto' | 'hold'
 
-/** 与 host DEFAULT_TAIL_TURNS / DEFAULT_TRAJECTORY_TURNS 对齐 */
+/** 与 host DEFAULT_TAIL_TURNS 对齐；仅 loadOlder 分页仍用窗口拉取 */
 export const SESSION_TAIL_TURNS = 24
 export const TRAJECTORY_TAIL_TURNS = 48
+/** 打开会话一次拉全量：上滑不再等网络；渲染仍靠虚表只挂可见行 */
+export const SESSION_LOAD_TURNS = 'all' as const
 
 export interface SessionViewState {
   sessionId: string | null
@@ -496,7 +498,7 @@ export class SessionViewService extends Service {
   private async revalidate(sessionId: string, view: ConversationView) {
     const gen = this.loadGen
     try {
-      const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_TAIL_TURNS}`)
+      const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_LOAD_TURNS}`)
       if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
       if (!res.ok) {
         if (res.status === 404) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 动机
上滑看更早消息时再等网络太慢。数据可以一次拉全，渲染继续只挂可见行。

## 改动
- 打开/校验会话：`GET ?turns=all`（不再只拉 24 turn）
- 前端虚表 / idle hydrate 不变：只渲染可见部分
- `loadOlder` 仍保留作兜底（全量时 `hasMore` 一般为 false）

## 验证
- vitest session-view
- `tsc` / `build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

