### PR TITLE
fix(chat): 缩小字号，虚表挂载即渲染

### DIFF
--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -23,12 +23,10 @@ const ROW_GAP_PX = 16
 const ESTIMATE_ROW_PX = 220
 /** 超过该条数才上虚表；过低阈值会抖，过高则短会话也会一次挂满 Markdown */
 const VIRTUALIZE_AFTER = 4
-/** overscan 过大时可视区外仍挂大量 Markdown DOM，拖死主线程 */
-const OVERSCAN = 3
-/** 滚动停下多久后，给尚未 hydrate 的行补上完整渲染 */
+/** overscan：只挂可视区附近行；太大拖死主线程，太小快速滑动会闪空白 */
+const OVERSCAN = 4
+/** 滚动中暂停 measure，停下后再量真实高度（虚表常见做法） */
 const SCROLL_IDLE_MS = 140
-/** 停下后每帧最多新 hydrate 几行，避免一次补齐打爆主线程 */
-const HYDRATE_PER_IDLE = 1
 
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
   let node = el?.parentElement ?? null
@@ -190,18 +188,6 @@ function UsageInline({ usage }: { usage: TrajectoryUsage }) {
   )
 }
 
-function RowLoading({ kind }: { kind: ChatNode['kind'] }) {
-  const label =
-    kind === 'user' ? '消息加载中' : kind === 'reply' ? '回复加载中' : kind === 'turn' ? '状态加载中' : '加载中'
-  return (
-    <div className="chat-row-loading" aria-busy="true" aria-label={label}>
-      <span className="chat-row-loading-dot" />
-      <span className="chat-row-loading-dot" />
-      <span className="chat-row-loading-dot" />
-    </div>
-  )
-}
-
 function ReplyActions({
   text,
   onFork,
@@ -262,18 +248,11 @@ function NodeView({
   node,
   onInspect,
   onFork,
-  hydrated,
 }: {
   node: ChatNode
   onInspect: (callId: string) => void
   onFork: () => void | Promise<void>
-  /** false = 滚动中新进视口，只显示 loading，不动已 hydrate 的 Markdown */
-  hydrated: boolean
 }) {
-  if (!hydrated) {
-    return <RowLoading kind={node.kind} />
-  }
-
   if (node.kind === 'user') {
     return (
       <div className="chat-user-row">
@@ -399,12 +378,9 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const stickToBottomRef = useRef(true)
   const scrollIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const prefetchingRef = useRef(false)
-  /** 已完整渲染过的行：滚动中也不降级成原文 / stub */
-  const hydratedRef = useRef(new Set<string>())
   const [scrollEpoch, setScrollEpoch] = useState(0)
+  /** 滚动中暂停 measure，避免每帧重测；停下后再量真实高度 */
   const [isScrolling, setIsScrolling] = useState(false)
-  /** 允许从列表末尾往前 hydrate 的条数；idle 时递增，避免一次挂满 Markdown */
-  const [hydrateQuota, setHydrateQuota] = useState(4)
 
   const virtualize = nodes.length >= VIRTUALIZE_AFTER
 
@@ -423,30 +399,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   }, [sessionView, navigate])
 
   useEffect(() => {
-    hydratedRef.current = new Set()
     setIsScrolling(false)
-    setHydrateQuota(4)
   }, [sessionId])
-
-  useEffect(() => {
-    if (isScrolling) return
-    if (hydrateQuota >= nodes.length) return
-    let cancelled = false
-    let handle = 0
-    const bump = () => {
-      if (cancelled) return
-      setHydrateQuota((value) => Math.min(nodes.length, value + HYDRATE_PER_IDLE))
-    }
-    handle =
-      typeof requestIdleCallback === 'function'
-        ? requestIdleCallback(bump, { timeout: 200 })
-        : window.setTimeout(bump, 32)
-    return () => {
-      cancelled = true
-      if (typeof cancelIdleCallback === 'function') cancelIdleCallback(handle)
-      else window.clearTimeout(handle)
-    }
-  }, [isScrolling, hydrateQuota, nodes.length, sessionId])
 
   useLayoutEffect(() => {
     const parent = findScrollParent(rootRef.current)
@@ -547,24 +501,6 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     )
   }
 
-  const rowHydrated = (node: ChatNode, index: number) => {
-    if (hydratedRef.current.has(node.id)) return true
-    // 流式回复：直接展示，不走 loading
-    if (node.kind === 'reply' && node.streaming) {
-      hydratedRef.current.add(node.id)
-      return true
-    }
-    // 滚动中：新进视口的行先 stub，避免一边滑一边 remark
-    if (virtualize && isScrolling) return false
-    // 从底部往上按配额 hydrate（用户通常看最新）
-    const fromEnd = nodes.length - 1 - index
-    if (fromEnd < hydrateQuota) {
-      hydratedRef.current.add(node.id)
-      return true
-    }
-    return false
-  }
-
   return (
     <div
       ref={rootRef}
@@ -582,35 +518,23 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
           {virtualizer.getVirtualItems().map((item) => {
             const node = nodes[item.index]
             if (!node) return null
-            const hydrated = rowHydrated(node, item.index)
             return (
               <div
                 key={item.key}
                 data-index={item.index}
-                ref={isScrolling && !hydrated ? undefined : virtualizer.measureElement}
+                ref={isScrolling ? undefined : virtualizer.measureElement}
                 className="chat-virt-row absolute top-0 left-0 w-full"
                 style={{ transform: `translateY(${item.start}px)` }}
               >
-                <NodeViewMemo
-                  node={node}
-                  onInspect={onInspect}
-                  onFork={onFork}
-                  hydrated={hydrated}
-                />
+                <NodeViewMemo node={node} onInspect={onInspect} onFork={onFork} />
               </div>
             )
           })}
         </div>
       ) : (
         <div className="flex flex-col gap-4">
-          {nodes.map((node, index) => (
-            <NodeViewMemo
-              key={node.id}
-              node={node}
-              onInspect={onInspect}
-              onFork={onFork}
-              hydrated={rowHydrated(node, index)}
-            />
+          {nodes.map((node) => (
+            <NodeViewMemo key={node.id} node={node} onInspect={onInspect} onFork={onFork} />
           ))}
         </div>
       )}

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -143,7 +143,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
         aria-hidden={view !== 'chat'}
       >
         <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
+          <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
             {renderSlot('stage')}
           </div>
           <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-6 pb-4 md:px-8 lg:px-10">

--- a/src/style.css
+++ b/src/style.css
@@ -35,6 +35,10 @@
   /* Hairline-first depth (Cursor prefers border rings over heavy elevation) */
   --dsw-shadow-lv2: 0 0 0 1px rgba(242, 241, 237, 0.06), 0 8px 24px rgba(0, 0, 0, 0.35);
   --dsw-chat-width: 748px;
+  /* 右侧对话正文字号（略小于原先 15px，更接近 Cursor 阅读密度） */
+  --dsw-chat-font-size: 13px;
+  --dsw-chat-line-height: 1.6;
+  --dsw-chat-composer-font-size: 13px;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
     "Microsoft YaHei", system-ui, sans-serif;
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Consolas, monospace;
@@ -1380,6 +1384,12 @@ body {
   word-break: break-word;
 }
 
+/* 右侧主对话区：统一正文字号，子元素用 em 相对缩放 */
+.chat-stage {
+  font-size: var(--dsw-chat-font-size);
+  line-height: var(--dsw-chat-line-height);
+}
+
 /* Chat messages — Cursor-like: full-width gray user row, bare assistant + actions */
 .chat-user-row {
   display: flex;
@@ -1389,14 +1399,14 @@ body {
 .chat-user-bubble {
   width: 100%;
   max-width: 100%;
-  padding: 12px 14px;
+  padding: 10px 12px;
   border: 0;
   border-radius: var(--dsw-radius-bubble);
   background: var(--dsw-bubble);
   box-shadow: none;
   color: var(--dsw-label);
-  font-size: 15px;
-  line-height: 1.55;
+  font-size: var(--dsw-chat-font-size);
+  line-height: var(--dsw-chat-line-height);
   outline: none;
 }
 
@@ -1413,8 +1423,8 @@ body {
   align-items: flex-start;
   gap: 6px;
   color: var(--dsw-label);
-  font-size: 15px;
-  line-height: 1.7;
+  font-size: var(--dsw-chat-font-size);
+  line-height: var(--dsw-chat-line-height);
 }
 
 .chat-assistant-main {
@@ -1460,10 +1470,10 @@ body {
   display: flex;
   min-width: 0;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
   color: var(--dsw-label);
-  font-size: 15px;
-  line-height: 1.7;
+  font-size: var(--dsw-chat-font-size);
+  line-height: var(--dsw-chat-line-height);
 }
 
 .chat-step-bar {
@@ -1863,7 +1873,7 @@ body {
   border: 0;
   background: transparent;
   color: var(--dsw-label);
-  font-size: 14px;
+  font-size: var(--dsw-chat-composer-font-size);
   line-height: 28px;
   outline: none;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动
- 右侧对话正文字号 15px → **13px**（`--dsw-chat-font-size`），composer 同步略缩
- **去掉**滚动中 stub + hydrate 配额：虚表挂上哪一行就立刻渲染正文（对齐 LobeChat / Cherry「拉到哪渲到哪」）
- 滚动中仍暂停 `measureElement`，停下再量高；Markdown 仍走 Worker + LRU

## 为何这样更接近 Cursor
开源 Agent 聊天（LobeChat virtua、Cherry MessageVirtualList）核心不是「再懒加载一层」，而是：**虚表只挂可视区** + **进视口立刻出内容** + **解析/高亮不堵主线程**。我们之前的配额 stub 反而制造了「旧消息又懒加载」的感觉。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

