### PR TITLE
fix(chat): 统计栏贴合请求气泡（上圆下方）

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1395,7 +1395,7 @@ body {
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 6px;
+  gap: 0;
 }
 
 .chat-user-bubble {
@@ -1412,25 +1412,41 @@ body {
   outline: none;
 }
 
+/* 有统计栏时：气泡上圆下方，与下面统计栏无缝贴合 */
+.chat-user-row:has(.chat-user-turn-bar) .chat-user-bubble {
+  border-radius: var(--dsw-radius-bubble) var(--dsw-radius-bubble) 0 0;
+}
+
 .chat-user-tag {
   margin-bottom: 4px;
   color: var(--dsw-label-3);
   font-size: 10px;
 }
 
-/* 回合统计挂在发起请求的用户消息下（不含复制/Fork）；右侧为发送时间 */
+/* 回合统计贴在请求气泡正下方（同底色、下圆角）；文字垂直居中 */
 .chat-user-turn-bar {
   display: flex;
-  min-height: 24px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 30px;
+  min-height: 30px;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 0 4px 0 2px;
+  padding: 0 12px;
+  border: 0;
+  border-top: 1px solid color-mix(in srgb, var(--dsw-border) 70%, transparent);
+  border-radius: 0 0 var(--dsw-radius-bubble) var(--dsw-radius-bubble);
+  background: var(--dsw-bubble);
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  line-height: 1;
 }
 
 .chat-user-turn-bar-main {
   display: flex;
   min-width: 0;
+  min-height: 100%;
   flex: 1;
   align-items: center;
   gap: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动

- 有回合统计栏时，请求气泡改为**上圆下方**（`border-radius` 仅顶部）
- 统计栏与气泡同底色、无缝贴在正下方，底部保留圆角
- 统计栏固定高度 30px，内容上下居中

无统计栏时气泡仍为完整圆角。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

