### PR TITLE
fix(chat): 粘性消息不再挡住输入栏与悬浮按钮

### DIFF
--- a/src/plugins/contributors/chat/composer-stack.test.ts
+++ b/src/plugins/contributors/chat/composer-stack.test.ts
@@ -1,0 +1,25 @@
+/**
+ * 粘性用户消息不得压过底部输入栏 / dock 悬浮控件。
+ * sticky 的 z-index 被关在 .chat-stage（isolation）内；
+ * .chat-composer-dock 用更高的 z-index 保证机轴最顶。
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const root = resolve(import.meta.dirname, '../../..')
+
+describe('composer dock stacking above sticky user', () => {
+  it('isolates chat-stage and keeps composer-dock above sticky user z-index', () => {
+    const css = readFileSync(resolve(root, 'src/style.css'), 'utf8')
+    const shell = readFileSync(resolve(root, 'src/plugins/contributors/shell.tsx'), 'utf8')
+
+    expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
+    expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)
+    expect(css).toMatch(
+      /\.chat-msg-row\[data-chat-kind='user'\]\s*\{[^}]*z-index:\s*1(?:\s|;|})/s,
+    )
+    expect(shell).toContain('chat-composer-dock')
+    expect(shell).not.toMatch(/bottom-0 z-\[2\]/)
+  })
+})

--- a/src/plugins/contributors/chat/composer-stack.test.ts
+++ b/src/plugins/contributors/chat/composer-stack.test.ts
@@ -7,7 +7,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const root = resolve(import.meta.dirname, '../../..')
+const root = resolve(import.meta.dirname, '../../../..')
 
 describe('composer dock stacking above sticky user', () => {
   it('isolates chat-stage and keeps composer-dock above sticky user z-index', () => {

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -146,7 +146,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
           <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
             {renderSlot('stage')}
           </div>
-          <div className="pointer-events-none absolute inset-x-0 bottom-0 z-[2] bg-transparent px-6 pb-4 md:px-8 lg:px-10">
+          <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-4 md:px-8 lg:px-10">
             <div className="pointer-events-auto space-y-2 bg-transparent">
               {renderSlot('dock')}
               {renderSlot('composer')}

--- a/src/style.css
+++ b/src/style.css
@@ -1386,8 +1386,15 @@ body {
 
 /* 右侧主对话区：统一正文字号，子元素用 em 相对缩放 */
 .chat-stage {
+  /* 把 sticky 用户消息的 z-index 关在滚动层内，避免压过底部输入栏/悬浮按钮 */
+  isolation: isolate;
   font-size: var(--dsw-chat-font-size);
   line-height: var(--dsw-chat-line-height);
+}
+
+/* 底部输入栏 + dock 悬浮控件：叠在对话内容之上 */
+.chat-composer-dock {
+  z-index: 20;
 }
 
 /* Chat messages — Cursor-like: full-width gray user row, bare assistant + actions */
@@ -1675,7 +1682,8 @@ body {
 .chat-msg-row[data-chat-kind='user'] {
   position: sticky;
   top: 0;
-  z-index: 6;
+  /* 仅需盖住本滚动层内的回复；不得高于 .chat-composer-dock */
+  z-index: 1;
   margin-top: -4px;
   padding-top: 8px;
   padding-bottom: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

粘性用户消息用了 `z-index: 6`，且对话滚动层未隔离堆叠上下文，导致 sticky 会压过底部 `z-[2]` 的输入栏和 dock 悬浮按钮。

## 修复

- `.chat-stage` 使用 `isolation: isolate`，把 sticky 的 z-index 关在滚动层内
- 粘性用户消息改为 `z-index: 1`（仍盖住下面回复）
- 底部输入栏/dock 使用 `.chat-composer-dock { z-index: 20 }`，保证机轴最上

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

