### PR TITLE
chore: 增加 make auto（轮询 pull 后自动 restart）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev host web test install stop restart
+.PHONY: dev host web test install stop restart auto
 
 # 默认：装依赖并同时起 host(:3141) + Vite(:5173)
 dev: install
@@ -25,6 +25,12 @@ stop:
 restart: stop
 	@sleep 0.5
 	@$(MAKE) --no-print-directory dev
+
+# 本地轮询远端：有更新则 git pull + make restart
+# 用法: make auto   或   AUTO_INTERVAL=10 make auto
+# Git/GitHub 不能主动推送到你的电脑执行命令；要自动更新只能本机轮询（或自建 webhook）。
+auto:
+	@bash scripts/auto-pull-restart.sh
 
 test:
 	npm test

--- a/scripts/auto-pull-restart.sh
+++ b/scripts/auto-pull-restart.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# 定时 git fetch/pull；远端有更新则 make restart。
+# Git/GitHub 无法主动推送到本机执行命令，本地只能轮询（或自建 webhook 接收端）。
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+INTERVAL="${AUTO_INTERVAL:-20}"
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+DEV_PID=""
+
+log() {
+  printf '[auto %s] %s\n' "$(date '+%H:%M:%S')" "$*"
+}
+
+stop_dev() {
+  if [[ -n "${DEV_PID}" ]] && kill -0 "${DEV_PID}" 2>/dev/null; then
+    kill "${DEV_PID}" 2>/dev/null || true
+    wait "${DEV_PID}" 2>/dev/null || true
+  fi
+  DEV_PID=""
+  make --no-print-directory stop >/dev/null 2>&1 || true
+}
+
+restart_dev() {
+  stop_dev
+  sleep 0.5
+  log "make restart"
+  # 后台跑，脚本继续轮询；端口由 make stop 回收
+  make --no-print-directory restart &
+  DEV_PID=$!
+}
+
+cleanup() {
+  log "stopping"
+  stop_dev
+}
+trap cleanup EXIT INT TERM
+
+if ! git rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
+  log "no upstream for ${BRANCH}; set with: git push -u origin ${BRANCH}"
+  exit 1
+fi
+
+log "branch=${BRANCH} every ${INTERVAL}s (AUTO_INTERVAL=秒数 可改)"
+log "Git 不会主动通知本机；本命令是本地轮询 pull"
+restart_dev
+
+while true; do
+  sleep "${INTERVAL}"
+
+  if [[ -n "${DEV_PID}" ]] && ! kill -0 "${DEV_PID}" 2>/dev/null; then
+    log "dev exited; restarting"
+    restart_dev
+    continue
+  fi
+
+  before="$(git rev-parse HEAD)"
+  if ! git fetch --quiet origin; then
+    log "fetch failed; retry later"
+    continue
+  fi
+
+  remote="$(git rev-parse "origin/${BRANCH}" 2>/dev/null || true)"
+  if [[ -z "${remote}" ]]; then
+    log "missing origin/${BRANCH}; skip"
+    continue
+  fi
+
+  if [[ "${before}" == "${remote}" ]]; then
+    continue
+  fi
+
+  log "update ${before:0:7} → ${remote:0:7}; pulling"
+  if ! git pull --ff-only origin "${BRANCH}"; then
+    log "pull failed (need fast-forward); skip restart"
+    continue
+  fi
+  restart_dev
+done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 说明

Git/GitHub **不能**主动通知你的本机去执行 `git pull` / `make restart`。要自动更新，本机只能：

1. **轮询**（本 PR）：`make auto`
2. 或自建 webhook 接收端（本机开服务 + 公网/内网穿透）— 更重

## 用法

```bash
make auto
# 或缩短间隔
AUTO_INTERVAL=10 make auto
```

默认每 20 秒 `git fetch`；当前分支远端有新提交则 `git pull --ff-only`，成功后 `make restart`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

