### PR TITLE
feat(chat): 右侧检查器（工具来源 + Live 指挥台）

### DIFF
--- a/host/index.ts
+++ b/host/index.ts
@@ -20,6 +20,7 @@ import * as agentLoop from './plugins/orchestration/agent-loop.ts'
 import * as agents from './plugins/orchestration/agents.ts'
 import * as subagents from './plugins/seams/subagents.ts'
 import * as liveSessions from './plugins/seams/live-sessions.ts'
+import * as sessionInspector from './plugins/seams/session-inspector.ts'
 import * as hub from './plugins/registry/hub.ts'
 
 const publicDir = join(dirname(fileURLToPath(import.meta.url)), '../public')
@@ -59,6 +60,7 @@ async function boot() {
   await ctx.plugin(subagents)
   await ctx.plugin(liveSessions)
   await ctx.plugin(hub)
+  await ctx.plugin(sessionInspector)
 }
 
 boot().catch((error) => {

--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -25,6 +25,8 @@ interface ChatConfig {
   model: string
   systemPrompt: string
   agentMode: AgentToolMode
+  /** 极简模式下常驻额外工具（不含 minimal 底座与 live 调度工具） */
+  extraTools: string[]
 }
 
 function configPath() {
@@ -39,6 +41,7 @@ function defaults(): ChatConfig {
     model: process.env.CHAT_MODEL || (deepseek || !process.env.OPENAI_API_KEY ? 'deepseek-chat' : 'gpt-4o-mini'),
     systemPrompt: '你是控制台里的助手。需要时调用当前已注册的 tools；插件卸载后对应 tool 会消失。回答简洁。',
     agentMode: 'standard',
+    extraTools: [],
   }
 }
 
@@ -67,6 +70,7 @@ function writePersisted(config: ChatConfig) {
         model: config.model,
         systemPrompt: config.systemPrompt,
         agentMode: config.agentMode,
+        extraTools: config.extraTools,
         apiKey: config.apiKey,
       },
       null,
@@ -89,6 +93,9 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     systemPrompt: typeof saved.systemPrompt === 'string' ? saved.systemPrompt : base.systemPrompt,
     agentMode: parseAgentMode(saved.agentMode, base.agentMode),
     apiKey: !envKey && typeof saved.apiKey === 'string' && saved.apiKey.trim() ? saved.apiKey.trim() : base.apiKey,
+    extraTools: Array.isArray(saved.extraTools)
+      ? [...new Set(saved.extraTools.map((name) => String(name).trim()).filter(Boolean))]
+      : base.extraTools,
   }
 }
 
@@ -112,6 +119,7 @@ export class ChatService extends Service {
       hint: hint(this.config.apiKey),
       tools: this.ctx.tools.names(),
       toolCatalog: this.ctx.tools.catalog(),
+      extraTools: this.config.extraTools,
     }
   }
 
@@ -122,6 +130,7 @@ export class ChatService extends Service {
       model: string
       systemPrompt: string
       agentMode: AgentToolMode
+      extraTools: string[]
     }>,
     opts?: { persist?: boolean },
   ) {
@@ -130,6 +139,9 @@ export class ChatService extends Service {
     if (typeof next.systemPrompt === 'string') this.config.systemPrompt = next.systemPrompt
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) this.config.apiKey = next.apiKey.trim()
     if (next.agentMode === 'standard' || next.agentMode === 'minimal') this.config.agentMode = next.agentMode
+    if (Array.isArray(next.extraTools)) {
+      this.config.extraTools = [...new Set(next.extraTools.map((name) => String(name).trim()).filter(Boolean))]
+    }
     this.syncLlm()
     this.syncToolsMode()
     if (opts?.persist !== false) {
@@ -161,6 +173,7 @@ export class ChatService extends Service {
 
   private syncToolsMode() {
     this.ctx.tools.setMode(this.config.agentMode)
+    this.ctx.tools.setPinnedExtras(this.config.extraTools)
   }
 }
 
@@ -187,6 +200,7 @@ export function apply(ctx: Context) {
       model: string
       systemPrompt: string
       agentMode: AgentToolMode
+      extraTools: string[]
     }>
     route.send(200, chat.patch(payload ?? {}))
   })

--- a/host/plugins/registry/tools.ts
+++ b/host/plugins/registry/tools.ts
@@ -39,6 +39,8 @@ export class ToolsService extends Service {
   private tools = new Map<string, ToolSpec>()
   private guards: ToolGuard[] = []
   private mode: AgentToolMode = 'standard'
+  /** 极简模式下常驻额外工具（配置面板勾选，跨回合生效）。 */
+  private pinnedExtras: string[] = []
 
   constructor(ctx: Context) {
     super(ctx, 'tools')
@@ -55,9 +57,38 @@ export class ToolsService extends Service {
     this.ctx.emit('hub/change')
   }
 
+  getPinnedExtras() {
+    return [...this.pinnedExtras]
+  }
+
+  setPinnedExtras(names: readonly string[]) {
+    const liveSet = new Set<string>([
+      'session_list',
+      'session_inspect',
+      'session_progress',
+      'session_wake',
+      'session_inject',
+    ])
+    const cleaned = [
+      ...new Set(
+        names
+          .map((name) => name.trim())
+          .filter(Boolean)
+          .filter((name) => !(MINIMAL_TOOL_NAMES as readonly string[]).includes(name))
+          .filter((name) => !liveSet.has(name)),
+      ),
+    ]
+    const same =
+      cleaned.length === this.pinnedExtras.length && cleaned.every((name, i) => name === this.pinnedExtras[i])
+    if (same) return
+    this.pinnedExtras = cleaned
+    this.ctx.emit('hub/change')
+  }
+
   private visible(name: string) {
     if (this.mode === 'standard') return true
     if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return true
+    if (this.pinnedExtras.includes(name)) return true
     return extraToolsStorage.getStore()?.has(name) ?? false
   }
 

--- a/host/plugins/seams/session-inspector.test.ts
+++ b/host/plugins/seams/session-inspector.test.ts
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import {
+  buildInspectorTools,
+  isToolActiveForSession,
+  toolSourceOf,
+} from './session-inspector.ts'
+
+test('toolSourceOf tags minimal / live / plugin', () => {
+  assert.equal(toolSourceOf('bash'), 'minimal')
+  assert.equal(toolSourceOf('str_replace_editor'), 'minimal')
+  assert.equal(toolSourceOf('session_list'), 'live')
+  assert.equal(toolSourceOf('session_wake'), 'live')
+  assert.equal(toolSourceOf('fs_read'), 'plugin')
+})
+
+test('minimal live session unlocks live tools; pinned extras unlock plugins', () => {
+  assert.equal(
+    isToolActiveForSession({
+      name: 'bash',
+      mode: 'minimal',
+      sessionType: 'chat',
+      pinnedExtras: [],
+    }),
+    true,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'session_list',
+      mode: 'minimal',
+      sessionType: 'chat',
+      pinnedExtras: [],
+    }),
+    false,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'session_list',
+      mode: 'minimal',
+      sessionType: 'live',
+      pinnedExtras: [],
+    }),
+    true,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'fs_read',
+      mode: 'minimal',
+      sessionType: 'chat',
+      pinnedExtras: ['fs_read'],
+    }),
+    true,
+  )
+})
+
+test('buildInspectorTools marks configurable plugin tools in minimal mode', () => {
+  const rows = buildInspectorTools(
+    [
+      { name: 'bash', description: 'shell' },
+      { name: 'session_list', description: 'list sessions' },
+      { name: 'fs_read', description: 'read file' },
+    ],
+    { mode: 'minimal', sessionType: 'live', pinnedExtras: [] },
+  )
+  assert.equal(rows.find((row) => row.name === 'bash')?.active, true)
+  assert.equal(rows.find((row) => row.name === 'bash')?.configurable, false)
+  assert.equal(rows.find((row) => row.name === 'session_list')?.active, true)
+  assert.equal(rows.find((row) => row.name === 'session_list')?.configurable, false)
+  assert.equal(rows.find((row) => row.name === 'fs_read')?.active, false)
+  assert.equal(rows.find((row) => row.name === 'fs_read')?.configurable, true)
+})

--- a/host/plugins/seams/session-inspector.ts
+++ b/host/plugins/seams/session-inspector.ts
@@ -1,0 +1,166 @@
+import type { Context } from 'cordis'
+import '../../types.ts'
+import { MINIMAL_TOOL_NAMES, type AgentToolMode } from '../registry/tools.ts'
+import { LIVE_TOOL_NAMES, buildSessionProgress } from './live-sessions.ts'
+import { normalizeSessionType, type SessionType } from '../core/session-types.ts'
+
+export type ToolSourceId = 'minimal' | 'live' | 'plugin'
+
+export interface InspectorToolRow {
+  name: string
+  description: string
+  source: ToolSourceId
+  /** 当前 session 实际可用 */
+  active: boolean
+  /** 极简模式下可否勾选为常驻额外工具 */
+  configurable: boolean
+}
+
+export interface InspectorSourceInfo {
+  id: ToolSourceId
+  label: string
+  description: string
+}
+
+export interface InspectorWorkerRow {
+  id: string
+  title: string
+  type: SessionType
+  status: 'idle' | 'running'
+  turn: number | null
+  step: number | null
+  lastTool: string | null
+  assistantText: string
+  updatedAt: number
+  inboxPending: number
+  project?: string
+}
+
+const SOURCE_INFO: InspectorSourceInfo[] = [
+  {
+    id: 'minimal',
+    label: '极简模式',
+    description: 'agentMode=minimal 时的底座工具（bash、str_replace_editor）。',
+  },
+  {
+    id: 'live',
+    label: 'Live 调度',
+    description: '仅 live session 回合自动解锁的指挥工具。',
+  },
+  {
+    id: 'plugin',
+    label: '插件注册',
+    description: '各 seams/插件注册的工具；standard 全开，minimal 需勾选常驻或 slash 临时放开。',
+  },
+]
+
+export function toolSourceOf(name: string): ToolSourceId {
+  if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return 'minimal'
+  if ((LIVE_TOOL_NAMES as readonly string[]).includes(name)) return 'live'
+  return 'plugin'
+}
+
+export function isToolActiveForSession(opts: {
+  name: string
+  mode: AgentToolMode
+  sessionType: SessionType
+  pinnedExtras: readonly string[]
+}): boolean {
+  if (opts.mode === 'standard') return true
+  if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(opts.name)) return true
+  if (opts.sessionType === 'live' && (LIVE_TOOL_NAMES as readonly string[]).includes(opts.name)) {
+    return true
+  }
+  return opts.pinnedExtras.includes(opts.name)
+}
+
+export function buildInspectorTools(
+  catalog: Array<{ name: string; description: string }>,
+  opts: { mode: AgentToolMode; sessionType: SessionType; pinnedExtras: readonly string[] },
+): InspectorToolRow[] {
+  return catalog
+    .map((item) => {
+      const source = toolSourceOf(item.name)
+      return {
+        name: item.name,
+        description: item.description,
+        source,
+        active: isToolActiveForSession({
+          name: item.name,
+          mode: opts.mode,
+          sessionType: opts.sessionType,
+          pinnedExtras: opts.pinnedExtras,
+        }),
+        configurable: opts.mode === 'minimal' && source === 'plugin',
+      }
+    })
+    .sort((a, b) => {
+      const order = { minimal: 0, live: 1, plugin: 2 } as const
+      const diff = order[a.source] - order[b.source]
+      return diff !== 0 ? diff : a.name.localeCompare(b.name)
+    })
+}
+
+export async function buildLiveWorkers(ctx: Context, selfId: string): Promise<InspectorWorkerRow[]> {
+  const items = await ctx.sessions.listSummaries()
+  const workers: InspectorWorkerRow[] = []
+  for (const item of items) {
+    if (item.id === selfId) continue
+    if (normalizeSessionType(item.type) === 'live') continue
+    const record = await ctx.sessions.require(item.id)
+    const progress = buildSessionProgress(record.events, {
+      busy: ctx.agents.isBusy(item.id),
+      inboxPending: ctx.agents.inboxPending(item.id),
+      textLimit: 180,
+    })
+    workers.push({
+      id: item.id,
+      title: item.title,
+      type: normalizeSessionType(item.type),
+      status: progress.status,
+      turn: progress.turn,
+      step: progress.step,
+      lastTool: progress.lastTool?.name ?? null,
+      assistantText: progress.assistantText,
+      updatedAt: progress.updatedAt || item.updatedAt,
+      inboxPending: progress.inboxPending,
+      project: item.project?.name,
+    })
+  }
+  workers.sort((a, b) => {
+    if (a.status !== b.status) return a.status === 'running' ? -1 : 1
+    return b.updatedAt - a.updatedAt
+  })
+  return workers
+}
+
+export const name = 'session-inspector'
+export const inject = ['http', 'sessions', 'agents', 'tools', 'chat']
+
+export function apply(ctx: Context) {
+  ctx.http.route('GET', '/api/sessions/:id/inspector', async (route) => {
+    const id = route.params.id
+    const record = await ctx.sessions.get(id)
+    if (!record) return route.send(404, { error: 'unknown session' })
+    const sessionType = normalizeSessionType(record.type)
+    const view = ctx.chat.publicView() as {
+      agentMode?: string
+      extraTools?: string[]
+    }
+    const mode: AgentToolMode = view.agentMode === 'minimal' ? 'minimal' : 'standard'
+    const pinnedExtras = Array.isArray(view.extraTools) ? view.extraTools : []
+    const tools = buildInspectorTools(ctx.tools.catalog(), { mode, sessionType, pinnedExtras })
+    const body: Record<string, unknown> = {
+      sessionId: id,
+      type: sessionType,
+      agentMode: mode,
+      extraTools: pinnedExtras,
+      sources: SOURCE_INFO,
+      tools,
+    }
+    if (sessionType === 'live') {
+      body.workers = await buildLiveWorkers(ctx, id)
+    }
+    route.send(200, body)
+  })
+}

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -1,0 +1,279 @@
+import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { LuPanelRightClose, LuRadio, LuWrench } from 'react-icons/lu'
+import {
+  bindSessionView,
+  type SessionViewService,
+} from '../infrastructure/session-view.ts'
+
+type ToolSourceId = 'minimal' | 'live' | 'plugin'
+type AgentMode = 'standard' | 'minimal'
+type InspectorTab = 'tools' | 'live'
+
+interface InspectorTool {
+  name: string
+  description: string
+  source: ToolSourceId
+  active: boolean
+  configurable: boolean
+}
+
+interface InspectorSource {
+  id: ToolSourceId
+  label: string
+  description: string
+}
+
+interface InspectorWorker {
+  id: string
+  title: string
+  status: 'idle' | 'running'
+  turn: number | null
+  step: number | null
+  lastTool: string | null
+  assistantText: string
+  updatedAt: number
+  inboxPending: number
+  project?: string
+}
+
+interface InspectorPayload {
+  sessionId: string
+  type: 'chat' | 'live'
+  agentMode: AgentMode
+  extraTools: string[]
+  sources: InspectorSource[]
+  tools: InspectorTool[]
+  workers?: InspectorWorker[]
+}
+
+const SOURCE_TONE: Record<ToolSourceId, string> = {
+  minimal: 'inspector-source-minimal',
+  live: 'inspector-source-live',
+  plugin: 'inspector-source-plugin',
+}
+
+export type SessionInspectorProps = {
+  open: boolean
+  onClose: () => void
+  useSessionView: ReturnType<typeof bindSessionView>
+  sessionView: SessionViewService
+}
+
+export const SessionInspector = memo(function SessionInspector({
+  open,
+  onClose,
+  useSessionView,
+}: SessionInspectorProps) {
+  const sessionId = useSessionView((state) => state.sessionId)
+  const sessions = useSessionView((state) => state.sessions)
+  const sessionType = useMemo(() => {
+    const hit = sessions.find((item) => item.id === sessionId)
+    return (hit?.type ?? 'chat') as 'chat' | 'live'
+  }, [sessionId, sessions])
+
+  const [tab, setTab] = useState<InspectorTab>('tools')
+  const [data, setData] = useState<InspectorPayload | null>(null)
+  const [error, setError] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    setTab(sessionType === 'live' ? 'live' : 'tools')
+  }, [sessionType, sessionId])
+
+  const refresh = useCallback(async () => {
+    if (!sessionId || !open) return
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/inspector`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const body = (await res.json()) as InspectorPayload
+      setData(body)
+      setError('')
+    } catch (err) {
+      setError(String(err))
+    }
+  }, [sessionId, open])
+
+  useEffect(() => {
+    if (!open || !sessionId) return
+    void refresh()
+    const timer = window.setInterval(() => {
+      void refresh()
+    }, 2000)
+    return () => window.clearInterval(timer)
+  }, [open, sessionId, refresh])
+
+  async function patchConfig(next: { agentMode?: AgentMode; extraTools?: string[] }) {
+    setBusy(true)
+    setError('')
+    try {
+      const res = await fetch('/api/chat/config', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(next),
+      })
+      if (!res.ok) throw new Error(`保存失败 HTTP ${res.status}`)
+      await refresh()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function toggleExtra(name: string, checked: boolean) {
+    const current = data?.extraTools ?? []
+    const next = checked
+      ? [...new Set([...current, name])]
+      : current.filter((item) => item !== name)
+    void patchConfig({ extraTools: next })
+  }
+
+  if (!open) return null
+
+  const tools = data?.tools ?? []
+  const sources = data?.sources ?? []
+  const workers = data?.workers ?? []
+  const mode = data?.agentMode ?? 'standard'
+
+  return (
+    <aside className="session-inspector" data-testid="session-inspector" aria-label="会话检查器">
+      <div className="session-inspector-head">
+        <div className="session-inspector-title">
+          <span>检查器</span>
+          <span className="session-inspector-type">{sessionType}</span>
+        </div>
+        <button
+          type="button"
+          className="session-inspector-close"
+          title="收起右侧栏"
+          aria-label="收起右侧栏"
+          onClick={onClose}
+        >
+          <LuPanelRightClose className="size-3.5" />
+        </button>
+      </div>
+
+      <div className="session-inspector-tabs" role="tablist" aria-label="检查器分区">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'tools'}
+          className={`session-inspector-tab${tab === 'tools' ? ' is-active' : ''}`}
+          onClick={() => setTab('tools')}
+        >
+          <LuWrench className="size-3.5" />
+          工具
+        </button>
+        {sessionType === 'live' ? (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'live'}
+            className={`session-inspector-tab${tab === 'live' ? ' is-active' : ''}`}
+            onClick={() => setTab('live')}
+          >
+            <LuRadio className="size-3.5" />
+            指挥台
+          </button>
+        ) : null}
+      </div>
+
+      <div className="session-inspector-body">
+        {error ? <div className="session-inspector-error">{error}</div> : null}
+
+        {tab === 'tools' ? (
+          <div className="session-inspector-section">
+            <label className="session-inspector-field">
+              <span>Agent mode</span>
+              <select
+                value={mode}
+                disabled={busy}
+                data-testid="inspector-agent-mode"
+                onChange={(event) => {
+                  void patchConfig({ agentMode: event.target.value as AgentMode })
+                }}
+              >
+                <option value="standard">standard（全开）</option>
+                <option value="minimal">minimal（底座 + 勾选）</option>
+              </select>
+            </label>
+
+            <div className="session-inspector-sources">
+              {sources.map((source) => (
+                <div key={source.id} className={`session-inspector-source ${SOURCE_TONE[source.id]}`}>
+                  <div className="session-inspector-source-label">{source.label}</div>
+                  <div className="session-inspector-source-desc">{source.description}</div>
+                </div>
+              ))}
+            </div>
+
+            <ul className="session-inspector-tools" data-testid="inspector-tools">
+              {tools.map((tool) => (
+                <li
+                  key={tool.name}
+                  className={`session-inspector-tool${tool.active ? ' is-active' : ''}`}
+                  data-tool={tool.name}
+                >
+                  <div className="session-inspector-tool-top">
+                    {tool.configurable ? (
+                      <input
+                        type="checkbox"
+                        checked={(data?.extraTools ?? []).includes(tool.name)}
+                        disabled={busy}
+                        aria-label={`启用 ${tool.name}`}
+                        onChange={(event) => toggleExtra(tool.name, event.target.checked)}
+                      />
+                    ) : (
+                      <span className="session-inspector-tool-dot" aria-hidden />
+                    )}
+                    <code>{tool.name}</code>
+                    <span className={`session-inspector-badge ${SOURCE_TONE[tool.source]}`}>
+                      {tool.source}
+                    </span>
+                    <span className={`session-inspector-state${tool.active ? ' is-on' : ''}`}>
+                      {tool.active ? '可用' : '未开'}
+                    </span>
+                  </div>
+                  <p>{tool.description || '（无说明）'}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <div className="session-inspector-section">
+            <p className="session-inspector-hint">其它 chat session 的现场（只读，约 2s 刷新）。</p>
+            {workers.length === 0 ? (
+              <div className="session-inspector-empty">暂无 worker session</div>
+            ) : (
+              <ul className="session-inspector-workers" data-testid="inspector-workers">
+                {workers.map((worker) => (
+                  <li key={worker.id} className="session-inspector-worker">
+                    <div className="session-inspector-worker-top">
+                      <span className="session-inspector-worker-title">{worker.title}</span>
+                      <span
+                        className={`session-inspector-state${worker.status === 'running' ? ' is-on' : ''}`}
+                      >
+                        {worker.status}
+                      </span>
+                    </div>
+                    <div className="session-inspector-worker-meta">
+                      {worker.project ? <span>{worker.project}</span> : null}
+                      <span>
+                        t{worker.turn ?? '—'} / s{worker.step ?? '—'}
+                      </span>
+                      {worker.lastTool ? <span>{worker.lastTool}</span> : null}
+                      {worker.inboxPending > 0 ? <span>inbox {worker.inboxPending}</span> : null}
+                    </div>
+                    {worker.assistantText ? (
+                      <p className="session-inspector-worker-text">{worker.assistantText}</p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </aside>
+  )
+})

--- a/src/plugins/contributors/shell.tsx
+++ b/src/plugins/contributors/shell.tsx
@@ -13,12 +13,14 @@ import {
 } from '../infrastructure/app-modules.ts'
 import { FishLogo } from './brand.tsx'
 import { ChatSidebar } from './chat-sidebar.tsx'
+import { SessionInspector } from './session-inspector.tsx'
 import { FolderGlyph } from './chat/project-panel.tsx'
 import { DashboardModule } from './dashboard-module.tsx'
 import {
   LuBug,
   LuMessageSquare,
   LuPanelLeft,
+  LuPanelRight,
 } from 'react-icons/lu'
 
 export const name = 'shell'
@@ -179,6 +181,32 @@ function Shell(props: SlotProps) {
   const view = useSessionView((state) => state.view)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [inspectorOpen, setInspectorOpen] = useState(() => {
+    try {
+      return localStorage.getItem('cordis.inspector.open') === '1'
+    } catch {
+      return false
+    }
+  })
+  const toggleInspector = useCallback(() => {
+    setInspectorOpen((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
+      } catch {
+        /* ignore */
+      }
+      return next
+    })
+  }, [])
+  const closeInspector = useCallback(() => {
+    setInspectorOpen(false)
+    try {
+      localStorage.setItem('cordis.inspector.open', '0')
+    } catch {
+      /* ignore */
+    }
+  }, [])
   const activeModule = moduleIdFromPath(location.pathname)
   const appRoute = parseAppPath(location.pathname)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
@@ -220,9 +248,9 @@ function Shell(props: SlotProps) {
     <div
       className={`app-shell${
         activeModule === 'agent'
-          ? sidebarCollapsed
-            ? ' app-shell-agent is-sidebar-collapsed'
-            : ' app-shell-agent'
+          ? ` app-shell-agent${sidebarCollapsed ? ' is-sidebar-collapsed' : ''}${
+              inspectorOpen ? ' is-inspector-open' : ''
+            }`
           : ' app-shell-module'
       }`}
     >
@@ -295,7 +323,19 @@ function Shell(props: SlotProps) {
                 )}
               </NavLink>
             </nav>
-            <div className="chat-view-header-right" aria-hidden />
+            <div className="chat-view-header-right">
+              <button
+                type="button"
+                className={`chat-view-header-expand${inspectorOpen ? ' is-active' : ''}`}
+                title={inspectorOpen ? '收起检查器' : '打开检查器'}
+                aria-label={inspectorOpen ? '收起检查器' : '打开检查器'}
+                aria-pressed={inspectorOpen}
+                data-testid="inspector-toggle"
+                onClick={toggleInspector}
+              >
+                <LuPanelRight className="size-3.5" />
+              </button>
+            </div>
           </header>
           <AgentMainPanels view={view} renderSlot={props.renderSlot} />
         </div>
@@ -312,6 +352,15 @@ function Shell(props: SlotProps) {
           <WorkspaceModule />
         </div>
       </main>
+
+      {activeModule === 'agent' ? (
+        <SessionInspector
+          open={inspectorOpen}
+          onClose={closeInspector}
+          useSessionView={useSessionView}
+          sessionView={sessionView}
+        />
+      ) : null}
 
       <div
         className={`fixed inset-0 z-20 flex items-center justify-center bg-[var(--dsw-overlay)] ${settingsOpen ? '' : 'hidden'}`}

--- a/src/style.css
+++ b/src/style.css
@@ -297,6 +297,14 @@ body {
   grid-template-columns: 48px minmax(0, 1fr);
 }
 
+.app-shell-agent.is-inspector-open {
+  grid-template-columns: 48px 280px minmax(0, 1fr) 320px;
+}
+
+.app-shell-agent.is-sidebar-collapsed.is-inspector-open {
+  grid-template-columns: 48px minmax(0, 1fr) 320px;
+}
+
 .app-shell-module {
   grid-template-columns: 48px minmax(0, 1fr);
 }
@@ -2412,4 +2420,286 @@ body {
   .dash-root {
     padding: 20px 18px 32px;
   }
+}
+
+
+/* —— Session inspector (right sidebar) —— */
+.session-inspector {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  border-left: 1px solid var(--dsw-border);
+  background: var(--dsw-sidebar);
+  color: var(--dsw-label);
+}
+
+.session-inspector-head {
+  display: flex;
+  height: 36px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 0 10px;
+}
+
+.session-inspector-title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.session-inspector-type {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--dsw-business) 16%, transparent);
+  color: var(--dsw-business);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  text-transform: uppercase;
+}
+
+.session-inspector-close {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+}
+
+.session-inspector-close:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-business);
+}
+
+.session-inspector-tabs {
+  display: flex;
+  flex-shrink: 0;
+  gap: 4px;
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 6px 8px;
+}
+
+.session-inspector-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 5px 8px;
+}
+
+.session-inspector-tab:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-label);
+}
+
+.session-inspector-tab.is-active {
+  background: color-mix(in srgb, var(--dsw-business) 14%, transparent);
+  color: var(--dsw-business);
+}
+
+.session-inspector-body {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 10px;
+}
+
+.session-inspector-error {
+  margin-bottom: 8px;
+  border-radius: 8px;
+  background: color-mix(in srgb, #c44 16%, transparent);
+  color: #f08888;
+  font-size: 11px;
+  padding: 8px;
+}
+
+.session-inspector-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.session-inspector-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+}
+
+.session-inspector-field select {
+  border: 1px solid var(--dsw-border);
+  border-radius: 8px;
+  background: var(--dsw-surface);
+  color: var(--dsw-label);
+  font-size: 12px;
+  padding: 6px 8px;
+}
+
+.session-inspector-sources {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.session-inspector-source {
+  border-radius: 8px;
+  border: 1px solid var(--dsw-border);
+  padding: 8px;
+}
+
+.session-inspector-source-label {
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.session-inspector-source-desc {
+  margin-top: 2px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.inspector-source-minimal {
+  border-color: color-mix(in srgb, #3b82f6 35%, var(--dsw-border));
+}
+
+.inspector-source-live {
+  border-color: color-mix(in srgb, #10b981 35%, var(--dsw-border));
+}
+
+.inspector-source-plugin {
+  border-color: color-mix(in srgb, #a855f7 35%, var(--dsw-border));
+}
+
+.session-inspector-tools,
+.session-inspector-workers {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.session-inspector-tool,
+.session-inspector-worker {
+  border: 1px solid var(--dsw-border);
+  border-radius: 10px;
+  background: var(--dsw-surface);
+  padding: 8px;
+}
+
+.session-inspector-tool.is-active {
+  border-color: color-mix(in srgb, var(--dsw-business) 40%, var(--dsw-border));
+}
+
+.session-inspector-tool-top,
+.session-inspector-worker-top {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.session-inspector-tool-top code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+.session-inspector-tool-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--dsw-border);
+}
+
+.session-inspector-tool p,
+.session-inspector-worker-text,
+.session-inspector-hint,
+.session-inspector-empty {
+  margin: 6px 0 0;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.session-inspector-badge {
+  flex-shrink: 0;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  padding: 2px 6px;
+  text-transform: uppercase;
+}
+
+.session-inspector-badge.inspector-source-minimal {
+  background: color-mix(in srgb, #3b82f6 18%, transparent);
+  color: #60a5fa;
+}
+
+.session-inspector-badge.inspector-source-live {
+  background: color-mix(in srgb, #10b981 18%, transparent);
+  color: #34d399;
+}
+
+.session-inspector-badge.inspector-source-plugin {
+  background: color-mix(in srgb, #a855f7 18%, transparent);
+  color: #c084fc;
+}
+
+.session-inspector-state {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--dsw-label-3);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.session-inspector-state.is-on {
+  color: var(--dsw-ok, #34d399);
+}
+
+.session-inspector-worker-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.session-inspector-worker-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  color: var(--dsw-label-3);
+  font-size: 10px;
+}
+
+.chat-view-header-expand.is-active {
+  background: color-mix(in srgb, var(--dsw-business) 16%, transparent);
+  color: var(--dsw-business);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做什么

右侧可折叠「检查器」侧栏：

1. **工具**：按来源分组展示当前 session 可用工具
   - `minimal`：极简底座（bash / str_replace_editor）
   - `live`：Live 会话自动解锁的调度工具
   - `plugin`：其它插件注册工具
   - 每项有说明、可用状态；极简模式下可勾选常驻额外工具（`extraTools` 持久化）
   - 可切换 `agentMode`

2. **指挥台**（仅 live session）：只读 worker 列表（idle/running、turn/step、最近摘要），约 2s 刷新

顶栏右侧按钮展开/收起；状态记在 `localStorage`。

## API

- `GET /api/sessions/:id/inspector`
- `POST /api/chat/config` 增加 `extraTools`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

