### PR TITLE
fix(chat): Details 等到整轮 turn 结束再收起

### DIFF
--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -41,6 +41,41 @@ test('projects user, streaming assistant, tool call/result from session events',
   if (user?.kind === 'user') assert.equal(user.ts, 2)
 })
 
+test('keeps reply streaming across tools until turn/end (Details stay open)', () => {
+  const base: SessionEvent[] = [
+    { type: 'turn/start', turn: 1, seq: 0, ts: 1 },
+    { type: 'step/start', turn: 1, step: 0, seq: 1, ts: 2 },
+    { type: 'assistant/chunk', text: 'thinking', seq: 2, ts: 3 },
+    { type: 'assistant/message', text: 'thinking', tool_calls: [{ id: 'c1', name: 'bash', arguments: '{}' }], seq: 3, ts: 4 },
+    { type: 'tool/call', id: 'c1', name: 'bash', arguments: '{}', seq: 4, ts: 5 },
+    { type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 5, ts: 6 },
+    { type: 'step/end', turn: 1, step: 0, seq: 6, ts: 7 },
+  ]
+
+  const mid = projectNodes(base)
+  const midReply = mid.find((node) => node.kind === 'reply')
+  assert.equal(midReply?.kind, 'reply')
+  if (midReply?.kind === 'reply') {
+    assert.equal(midReply.streaming, true)
+    assert.equal(midReply.finished, false)
+  }
+
+  const done = projectNodes([
+    ...base,
+    { type: 'step/start', turn: 1, step: 1, seq: 7, ts: 8 },
+    { type: 'assistant/message', text: 'final answer', seq: 8, ts: 9 },
+    { type: 'step/end', turn: 1, step: 1, seq: 9, ts: 10 },
+    { type: 'turn/end', turn: 1, reason: 'complete', seq: 10, ts: 11 },
+  ])
+  const doneReply = done.find((node) => node.kind === 'reply')
+  assert.equal(doneReply?.kind, 'reply')
+  if (doneReply?.kind === 'reply') {
+    assert.equal(doneReply.streaming, false)
+    assert.equal(doneReply.finished, true)
+    assert.equal(doneReply.copyText.includes('final answer'), true)
+  }
+})
+
 test('turn/end non-complete becomes a status row', () => {
   const nodes = projectNodes([
     { type: 'turn/start', turn: 1, seq: 0, ts: 1 },

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -154,10 +154,13 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
         streamingId: null,
         tools: new Map(),
         usage: { input: 0, output: 0, total: 0, cache: 0, hit: false },
-        streaming: false,
+        // 回合未结束前保持 streaming，Details 不因中间 tool/message 收起
+        streaming: currentTurn != null,
         steps: new Map(),
         ...(currentTurn != null ? { turn: currentTurn } : {}),
       }
+    } else if (currentTurn != null) {
+      reply.streaming = true
     }
     return reply
   }
@@ -235,7 +238,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
 
   for (const event of events) {
     if (event.type === 'turn/start') {
-      flushReply()
+      flushReply(undefined, true)
       turnStartTs = event.ts
       currentTurn = event.turn
       currentStep = undefined
@@ -246,7 +249,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
     } else if (event.type === 'step/end') {
       if (currentStep === event.step) currentStep = undefined
     } else if (event.type === 'user/message') {
-      flushReply()
+      flushReply(undefined, true)
       nodes.push({
         id: `u-${event.seq}`,
         kind: 'user',
@@ -296,7 +299,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
           }
         }
         r.streamingId = null
-        r.streaming = false
+        // 不在这里清 reply.streaming：整轮 turn/end 前 Details 保持展开
       } else if (event.text || !event.tool_calls?.length) {
         r.parts.push({
           id: `a-${event.seq}`,
@@ -305,10 +308,11 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
           ...(currentStep != null ? { step: currentStep } : {}),
         })
       }
+      if (currentTurn != null) r.streaming = true
     } else if (event.type === 'tool/call') {
       const r = ensureReply(event.seq)
       r.streamingId = null
-      r.streaming = false
+      if (currentTurn != null) r.streaming = true
       if (currentStep != null) ensureStepStat(currentStep).toolCount += 1
       const part: ChatToolPart = {
         id: `t-${event.id}`,
@@ -322,6 +326,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       r.parts.push(part)
     } else if (event.type === 'tool/result') {
       const r = ensureReply(event.seq)
+      if (currentTurn != null) r.streaming = true
       const existing = r.tools.get(event.id)
       if (existing) {
         const next = { ...existing, result: { ok: event.ok, detail: event.detail } }
@@ -352,7 +357,8 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       }
     }
   }
-  flushReply()
+  // 仍在 open turn 内：未结束，继续 streaming；否则按历史定稿收尾
+  flushReply(undefined, currentTurn == null)
   return nodes
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Agent loop 里每出一个 tool / 中间 assistant message，就会把 reply 的 `streaming` 清掉，Details 跟着收起，体验像「一步一折」。

## 修复

- 回合进行中保持 `streaming=true`
- 只在 `turn/end`（或新 user/turn 冲刷）时把 reply 定稿并收起 Details
- 补测试：工具穿插期间仍 streaming，turn/end 后结束

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

