### PR TITLE
feat(live): worker turn/end 自动旁白回指挥席

### DIFF
--- a/host/plugins/core/sessions.test.ts
+++ b/host/plugins/core/sessions.test.ts
@@ -174,3 +174,23 @@ test('sqlite persists session type across reopen', async () => {
   assert.equal(loaded?.type, 'live')
   assert.equal((await ctx2.sessions.listSummaries())[0]?.type, 'live')
 })
+
+
+test('sessions.subscribe filters by session and is disposable', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const a = await ctx.sessions.create()
+  const b = await ctx.sessions.create()
+  const seen: string[] = []
+  const stop = ctx.sessions.subscribe(a.id, (event) => {
+    seen.push(event.type)
+  }, ctx)
+  await ctx.sessions.append(a.id, { type: 'user/message', text: 'a1', kind: 'wake' })
+  await ctx.sessions.append(b.id, { type: 'user/message', text: 'b1', kind: 'wake' })
+  await ctx.sessions.append(a.id, { type: 'assistant/message', text: 'a2' })
+  assert.deepEqual(seen, ['user/message', 'assistant/message'])
+  stop()
+  await ctx.sessions.append(a.id, { type: 'assistant/message', text: 'a3' })
+  assert.deepEqual(seen, ['user/message', 'assistant/message'])
+})

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -110,6 +110,23 @@ export class SessionsService extends Service {
     return event
   }
 
+  /**
+   * 订阅某 session 后续 append 事件。返回撤销函数（cordis disposable）。
+   * 传入 `owner` 时挂到该 ctx 的 fiber：插件卸载会自动撤销；也可手动调用返回值提前撤销。
+   */
+  subscribe(
+    sessionId: string,
+    listener: (event: SessionEvent) => void | Promise<void>,
+    owner: Context = this.ctx,
+  ): () => boolean {
+    const target = String(sessionId || '').trim()
+    if (!target) return () => false
+    return owner.on('session/event', ({ sessionId: id, event }) => {
+      if (id !== target) return
+      void listener(event)
+    })
+  }
+
   deriveMessages(id: string) {
     const record = this.cache.get(id)
     if (!record) throw new Error(`unknown session: ${id}`)

--- a/host/plugins/seams/live-sessions.test.ts
+++ b/host/plugins/seams/live-sessions.test.ts
@@ -212,6 +212,7 @@ test('worker turn/end appends a live旁白 once per turn', async () => {
         item.text.includes('all green'),
     )
   })
+  assert.equal(liveSessions.listLiveWatchesForTests(chat.id).length, 0)
 
   const before = (await ctx.sessions.require(live.id)).events.filter(
     (item) => item.type === 'assistant/message' && item.text.includes('[指挥席]'),
@@ -272,6 +273,7 @@ test('session_wake wait=false watches; wait=true does not; turn/end notifies liv
         item.text.includes('task finished from factory'),
     )
   })
+  assert.equal(liveSessions.listLiveWatchesForTests(chat.id).length, 0)
 
   liveSessions.resetLiveWatchesForTests()
   const chat2 = await ctx.sessions.create()

--- a/host/plugins/seams/live-sessions.test.ts
+++ b/host/plugins/seams/live-sessions.test.ts
@@ -46,14 +46,17 @@ test('live tools list/inspect/inject; reject from chat sessions', async () => {
   )) as { recent: Array<{ text: string }> }
   assert.equal(inspected.recent.some((item) => item.text.includes('hello worker')), true)
 
+  liveSessions.resetLiveWatchesForTests()
   const injected = (await runWithSession(live.id, () =>
     ctx.tools.invoke(
       'session_inject',
       { sessionId: chat.id, text: 'keep going' },
       new AbortController().signal,
     ),
-  )) as { queued: boolean }
+  )) as { queued: boolean; watched: boolean }
   assert.equal(injected.queued, true)
+  assert.equal(injected.watched, true)
+  assert.equal(liveSessions.listLiveWatchesForTests(chat.id).length, 1)
 })
 
 test('live session turn unlocks session_* tools on top of minimal mode', async () => {
@@ -160,3 +163,134 @@ test('session_progress and async wake work for live caller', async () => {
   )) as { sessions: Array<{ id: string; status: string }> }
   assert.equal(listed.sessions.find((item) => item.id === chat.id)?.status, 'idle')
 })
+
+test('formatLiveTurnEndNote summarizes complete vs other reasons', () => {
+  const done = liveSessions.formatLiveTurnEndNote({
+    title: 'Worker A',
+    workerSessionId: 'abcdefgh-1234',
+    turn: 2,
+    reason: 'complete',
+    assistantText: '  shipped the fix  ',
+  })
+  assert.equal(done, '[指挥席] Worker A 已完成 · turn 2\nshipped the fix')
+
+  const aborted = liveSessions.formatLiveTurnEndNote({
+    workerSessionId: 'abcdefgh-1234',
+    turn: 3,
+    reason: 'abort',
+  })
+  assert.equal(aborted, '[指挥席] abcdefgh 结束（abort） · turn 3')
+})
+
+test('worker turn/end appends a live旁白 once per turn', async () => {
+  liveSessions.resetLiveWatchesForTests()
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  await ctx.plugin(liveSessions)
+
+  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  const chat = await ctx.sessions.create()
+  liveSessions.watchWorker(live.id, chat.id, -1)
+
+  await ctx.sessions.append(chat.id, { type: 'turn/start', turn: 1 })
+  await ctx.sessions.append(chat.id, { type: 'assistant/message', text: 'all green' })
+  await ctx.sessions.append(chat.id, { type: 'turn/end', turn: 1, reason: 'complete' })
+
+  await waitFor(async () => {
+    const events = (await ctx.sessions.require(live.id)).events
+    return events.some(
+      (item) =>
+        item.type === 'assistant/message' &&
+        item.text.includes('[指挥席]') &&
+        item.text.includes('已完成') &&
+        item.text.includes('all green'),
+    )
+  })
+
+  const before = (await ctx.sessions.require(live.id)).events.filter(
+    (item) => item.type === 'assistant/message' && item.text.includes('[指挥席]'),
+  ).length
+  await ctx.sessions.append(chat.id, { type: 'turn/end', turn: 1, reason: 'complete' })
+  await new Promise((resolve) => setImmediate(resolve))
+  const after = (await ctx.sessions.require(live.id)).events.filter(
+    (item) => item.type === 'assistant/message' && item.text.includes('[指挥席]'),
+  ).length
+  assert.equal(after, before)
+})
+
+test('session_wake wait=false watches; wait=true does not; turn/end notifies live', async () => {
+  liveSessions.resetLiveWatchesForTests()
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  await ctx.plugin(liveSessions)
+
+  ctx.agentLoop.setFactory((_llm, sessionId) => ({
+    run: async () => {
+      await ctx.sessions.append(sessionId, { type: 'turn/start', turn: 1 })
+      await ctx.sessions.append(sessionId, {
+        type: 'assistant/message',
+        text: 'task finished from factory',
+      })
+      await ctx.sessions.append(sessionId, { type: 'turn/end', turn: 1, reason: 'complete' })
+      return { text: 'task finished from factory', steps: [] }
+    },
+  }))
+  ctx.agents.configure({ provider: 'deepseek', apiKey: '', model: 'x' })
+
+  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  const chat = await ctx.sessions.create()
+
+  const queued = (await runWithSession(live.id, () =>
+    ctx.tools.invoke(
+      'session_wake',
+      { sessionId: chat.id, text: 'please finish', wait: false },
+      new AbortController().signal,
+    ),
+  )) as { queued: boolean; watched: boolean }
+  assert.equal(queued.queued, true)
+  assert.equal(queued.watched, true)
+  assert.equal(liveSessions.listLiveWatchesForTests(chat.id).length, 1)
+
+  await waitFor(async () => {
+    const events = (await ctx.sessions.require(live.id)).events
+    return events.some(
+      (item) =>
+        item.type === 'assistant/message' &&
+        item.text.includes('[指挥席]') &&
+        item.text.includes('task finished from factory'),
+    )
+  })
+
+  liveSessions.resetLiveWatchesForTests()
+  const chat2 = await ctx.sessions.create()
+  const waited = (await runWithSession(live.id, () =>
+    ctx.tools.invoke(
+      'session_wake',
+      { sessionId: chat2.id, text: 'sync please', wait: true },
+      new AbortController().signal,
+    ),
+  )) as { wait: boolean; text: string }
+  assert.equal(waited.wait, true)
+  assert.match(waited.text, /task finished from factory/)
+  assert.equal(liveSessions.listLiveWatchesForTests(chat2.id).length, 0)
+})
+
+async function waitFor(check: () => Promise<boolean>, tries = 40) {
+  for (let i = 0; i < tries; i += 1) {
+    if (await check()) return
+    await new Promise((resolve) => setTimeout(resolve, 25))
+  }
+  assert.fail('timed out waiting for live turn-end note')
+}

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -13,6 +13,7 @@ export const LIVE_TOOL_NAMES = [
 
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
 工作流：session_list / session_inspect 了解现场 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。
+异步派工后，worker 的 turn/end 会自动写成旁白落到本会话；仍可主动 session_progress。
 向用户汇报要克制：只在关键节点、明显卡住、或用户追问时旁白，不要刷屏。
 回答简洁：说明调度了谁、当前状态、下一步。`
 
@@ -29,6 +30,73 @@ export interface SessionProgressSnapshot {
   newestSeq: number
   updatedAt: number
   inboxPending: number
+}
+
+/** live 盯着的 worker：wait=false 的 wake / inject 会登记。 */
+export interface LiveWorkerWatch {
+  liveSessionId: string
+  workerSessionId: string
+  sinceSeq: number
+  watchedAt: number
+  /** 已旁白过的 turn，避免同一 turn/end 重复通知 */
+  notifiedTurns: Set<number>
+}
+
+/** workerSessionId → watches（可被多个 live 同时盯） */
+const workerWatches = new Map<string, LiveWorkerWatch[]>()
+
+/** 测试用：清空派遣订阅。 */
+export function resetLiveWatchesForTests() {
+  workerWatches.clear()
+}
+
+/** 测试用：查看某 worker 当前被谁盯着。 */
+export function listLiveWatchesForTests(workerSessionId?: string) {
+  if (workerSessionId) return [...(workerWatches.get(workerSessionId) ?? [])]
+  return [...workerWatches.values()].flat()
+}
+
+export function watchWorker(liveSessionId: string, workerSessionId: string, sinceSeq = -1) {
+  if (!liveSessionId || !workerSessionId || liveSessionId === workerSessionId) return
+  const bucket = workerWatches.get(workerSessionId) ?? []
+  const existing = bucket.find((item) => item.liveSessionId === liveSessionId)
+  if (existing) {
+    existing.sinceSeq = Math.min(existing.sinceSeq, sinceSeq)
+    existing.watchedAt = Date.now()
+    return existing
+  }
+  const watch: LiveWorkerWatch = {
+    liveSessionId,
+    workerSessionId,
+    sinceSeq,
+    watchedAt: Date.now(),
+    notifiedTurns: new Set(),
+  }
+  bucket.push(watch)
+  workerWatches.set(workerSessionId, bucket)
+  return watch
+}
+
+function formatWorkerLabel(title: string | undefined, workerSessionId: string) {
+  const trimmed = title?.trim()
+  if (trimmed) return trimmed
+  return workerSessionId.slice(0, 8)
+}
+
+export function formatLiveTurnEndNote(opts: {
+  title?: string
+  workerSessionId: string
+  turn: number
+  reason: string
+  assistantText?: string
+}) {
+  const label = formatWorkerLabel(opts.title, opts.workerSessionId)
+  const done = opts.reason === 'complete' || opts.reason === 'completed'
+  const status = done ? '已完成' : `结束（${opts.reason}）`
+  const summary = (opts.assistantText ?? '').trim().replace(/\s+/g, ' ').slice(0, 280)
+  return summary
+    ? `[指挥席] ${label} ${status} · turn ${opts.turn}\n${summary}`
+    : `[指挥席] ${label} ${status} · turn ${opts.turn}`
 }
 
 /** 从事件日志推导 worker 进度快照（供 Live 抽查）。 */
@@ -142,6 +210,48 @@ function recentMessages(events: SessionEvent[], limit = 12) {
   return out.reverse()
 }
 
+async function notifyLiveOfWorkerTurnEnd(
+  ctx: Context,
+  workerSessionId: string,
+  event: Extract<SessionEvent, { type: 'turn/end' }>,
+) {
+  const watches = workerWatches.get(workerSessionId)
+  if (!watches?.length) return
+
+  const worker = await ctx.sessions.get(workerSessionId)
+  if (!worker) return
+  const progress = buildSessionProgress(worker.events, {
+    afterSeq: Math.min(...watches.map((item) => item.sinceSeq)),
+    textLimit: 280,
+    busy: false,
+  })
+  const title =
+    (await ctx.sessions.listSummaries()).find((item) => item.id === workerSessionId)?.title ??
+    undefined
+  const note = formatLiveTurnEndNote({
+    title,
+    workerSessionId,
+    turn: event.turn,
+    reason: event.reason,
+    assistantText: progress.assistantText,
+  })
+
+  for (const watch of watches) {
+    if (watch.notifiedTurns.has(event.turn)) continue
+    // 旁白本身会再 emit session/event；旁白写在 live 上，不会匹配 worker watches
+    watch.notifiedTurns.add(event.turn)
+    try {
+      await ctx.sessions.append(watch.liveSessionId, {
+        type: 'assistant/message',
+        text: note,
+      })
+    } catch (error) {
+      watch.notifiedTurns.delete(event.turn)
+      console.warn('[live-sessions] failed to append turn-end note', error)
+    }
+  }
+}
+
 export const name = 'live-sessions'
 export const inject = ['tools', 'sessions', 'agents', 'systemPrompt']
 
@@ -151,6 +261,12 @@ export function apply(ctx: Context) {
     if (!sessionId) return ''
     const type = normalizeSessionType(ctx.sessions.peek(sessionId)?.type)
     return type === 'live' ? LIVE_PROMPT : ''
+  })
+
+  // 单点订阅：sessions.append → session/event；只处理已登记 worker 的 turn/end
+  ctx.on('session/event', ({ sessionId, event }) => {
+    if (event.type !== 'turn/end') return
+    void notifyLiveOfWorkerTurnEnd(ctx, sessionId, event)
   })
 
   ctx.tools.register({
@@ -252,7 +368,7 @@ export function apply(ctx: Context) {
   ctx.tools.register({
     name: 'session_wake',
     description:
-      '向目标 chat session 发送 wake 并启动 agent。wait=false 时立即返回，可用 session_progress 抽查。',
+      '向目标 chat session 发送 wake 并启动 agent。wait=false 时立即返回，完成时自动旁白回 Live。',
     parameters: {
       type: 'object',
       properties: {
@@ -279,8 +395,10 @@ export function apply(ctx: Context) {
       }
       const agent = await ctx.agents.create(targetId)
       if (!wait) {
+        // 先登记再派工，避免极快完成时丢掉 turn/end
+        watchWorker(selfId, targetId, target.events.at(-1)?.seq ?? -1)
         void agent.send(text, { wait: false })
-        return { sessionId: targetId, queued: true, wait: false }
+        return { sessionId: targetId, queued: true, wait: false, watched: true }
       }
       const turn = await agent.send(text, { wait: true })
       return {
@@ -295,7 +413,7 @@ export function apply(ctx: Context) {
 
   ctx.tools.register({
     name: 'session_inject',
-    description: '向目标 session 注入补充指示（inject）；若对方正在跑会进入 inbox。',
+    description: '向目标 session 注入补充指示（inject）；若对方正在跑会进入 inbox。完成后旁白回 Live。',
     parameters: {
       type: 'object',
       properties: {
@@ -311,10 +429,11 @@ export function apply(ctx: Context) {
       if (!targetId) throw new Error('sessionId required')
       if (!text) throw new Error('text required')
       if (targetId === selfId) throw new Error('cannot inject into the current live session')
-      await ctx.sessions.require(targetId)
+      const target = await ctx.sessions.require(targetId)
+      watchWorker(selfId, targetId, target.events.at(-1)?.seq ?? -1)
       const agent = await ctx.agents.create(targetId)
       agent.inject(text)
-      return { sessionId: targetId, queued: true }
+      return { sessionId: targetId, queued: true, watched: true }
     },
   })
 }

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -32,49 +32,49 @@ export interface SessionProgressSnapshot {
   inboxPending: number
 }
 
-/** live 盯着的 worker：wait=false 的 wake / inject 会登记。 */
+/** live → worker 的可撤销订阅（turn/end 旁白后 dispose）。 */
 export interface LiveWorkerWatch {
   liveSessionId: string
   workerSessionId: string
   sinceSeq: number
   watchedAt: number
-  /** 已旁白过的 turn，避免同一 turn/end 重复通知 */
-  notifiedTurns: Set<number>
 }
 
-/** workerSessionId → watches（可被多个 live 同时盯） */
-const workerWatches = new Map<string, LiveWorkerWatch[]>()
+interface ArmedWatch extends LiveWorkerWatch {
+  dispose: () => void
+}
 
-/** 测试用：清空派遣订阅。 */
+/** liveId\\0workerId → 当前订阅；插件卸载 / turn/end 时撤销 */
+const armedWatches = new Map<string, ArmedWatch>()
+
+type ArmWatch = (liveSessionId: string, workerSessionId: string, sinceSeq?: number) => LiveWorkerWatch | undefined
+
+let armWatch: ArmWatch | null = null
+
+function watchKey(liveSessionId: string, workerSessionId: string) {
+  return `${liveSessionId}\0${workerSessionId}`
+}
+
+/** 测试用：撤销并清空所有派遣订阅。 */
 export function resetLiveWatchesForTests() {
-  workerWatches.clear()
+  for (const arm of armedWatches.values()) arm.dispose()
+  armedWatches.clear()
 }
 
 /** 测试用：查看某 worker 当前被谁盯着。 */
-export function listLiveWatchesForTests(workerSessionId?: string) {
-  if (workerSessionId) return [...(workerWatches.get(workerSessionId) ?? [])]
-  return [...workerWatches.values()].flat()
+export function listLiveWatchesForTests(workerSessionId?: string): LiveWorkerWatch[] {
+  const all = [...armedWatches.values()].map(({ dispose: _dispose, ...rest }) => rest)
+  if (workerSessionId) return all.filter((item) => item.workerSessionId === workerSessionId)
+  return all
 }
 
+/**
+ * 订阅 worker 的下一轮 turn/end（可撤销）。
+ * 需在 live-sessions apply 之后调用；结束时会自动 dispose。
+ */
 export function watchWorker(liveSessionId: string, workerSessionId: string, sinceSeq = -1) {
-  if (!liveSessionId || !workerSessionId || liveSessionId === workerSessionId) return
-  const bucket = workerWatches.get(workerSessionId) ?? []
-  const existing = bucket.find((item) => item.liveSessionId === liveSessionId)
-  if (existing) {
-    existing.sinceSeq = Math.min(existing.sinceSeq, sinceSeq)
-    existing.watchedAt = Date.now()
-    return existing
-  }
-  const watch: LiveWorkerWatch = {
-    liveSessionId,
-    workerSessionId,
-    sinceSeq,
-    watchedAt: Date.now(),
-    notifiedTurns: new Set(),
-  }
-  bucket.push(watch)
-  workerWatches.set(workerSessionId, bucket)
-  return watch
+  if (!armWatch) throw new Error('live-sessions is not applied')
+  return armWatch(liveSessionId, workerSessionId, sinceSeq)
 }
 
 function formatWorkerLabel(title: string | undefined, workerSessionId: string) {
@@ -210,18 +210,17 @@ function recentMessages(events: SessionEvent[], limit = 12) {
   return out.reverse()
 }
 
-async function notifyLiveOfWorkerTurnEnd(
+async function appendLiveTurnEndNote(
   ctx: Context,
+  liveSessionId: string,
   workerSessionId: string,
   event: Extract<SessionEvent, { type: 'turn/end' }>,
+  sinceSeq: number,
 ) {
-  const watches = workerWatches.get(workerSessionId)
-  if (!watches?.length) return
-
   const worker = await ctx.sessions.get(workerSessionId)
   if (!worker) return
   const progress = buildSessionProgress(worker.events, {
-    afterSeq: Math.min(...watches.map((item) => item.sinceSeq)),
+    afterSeq: sinceSeq,
     textLimit: 280,
     busy: false,
   })
@@ -235,20 +234,13 @@ async function notifyLiveOfWorkerTurnEnd(
     reason: event.reason,
     assistantText: progress.assistantText,
   })
-
-  for (const watch of watches) {
-    if (watch.notifiedTurns.has(event.turn)) continue
-    // 旁白本身会再 emit session/event；旁白写在 live 上，不会匹配 worker watches
-    watch.notifiedTurns.add(event.turn)
-    try {
-      await ctx.sessions.append(watch.liveSessionId, {
-        type: 'assistant/message',
-        text: note,
-      })
-    } catch (error) {
-      watch.notifiedTurns.delete(event.turn)
-      console.warn('[live-sessions] failed to append turn-end note', error)
-    }
+  try {
+    await ctx.sessions.append(liveSessionId, {
+      type: 'assistant/message',
+      text: note,
+    })
+  } catch (error) {
+    console.warn('[live-sessions] failed to append turn-end note', error)
   }
 }
 
@@ -256,17 +248,53 @@ export const name = 'live-sessions'
 export const inject = ['tools', 'sessions', 'agents', 'systemPrompt']
 
 export function apply(ctx: Context) {
+  const arm: ArmWatch = (liveSessionId, workerSessionId, sinceSeq = -1) => {
+    if (!liveSessionId || !workerSessionId || liveSessionId === workerSessionId) return
+    const key = watchKey(liveSessionId, workerSessionId)
+    armedWatches.get(key)?.dispose()
+
+    let disposed = false
+    const dispose = () => {
+      if (disposed) return
+      disposed = true
+      stop()
+      if (armedWatches.get(key)?.dispose === dispose) armedWatches.delete(key)
+    }
+
+    // 挂在 live 插件 fiber 上：插件卸载自动撤销；turn/end 时手动撤销
+    const stop = ctx.sessions.subscribe(
+      workerSessionId,
+      (event) => {
+        if (event.type !== 'turn/end') return
+        const since = armedWatches.get(key)?.sinceSeq ?? sinceSeq
+        dispose()
+        void appendLiveTurnEndNote(ctx, liveSessionId, workerSessionId, event, since)
+      },
+      ctx,
+    )
+
+    const watch: ArmedWatch = {
+      liveSessionId,
+      workerSessionId,
+      sinceSeq,
+      watchedAt: Date.now(),
+      dispose,
+    }
+    armedWatches.set(key, watch)
+    return watch
+  }
+
+  armWatch = arm
+  ctx.effect(() => () => {
+    resetLiveWatchesForTests()
+    if (armWatch === arm) armWatch = null
+  })
+
   ctx.systemPrompt.register('live.persona', () => {
     const sessionId = currentSessionId()
     if (!sessionId) return ''
     const type = normalizeSessionType(ctx.sessions.peek(sessionId)?.type)
     return type === 'live' ? LIVE_PROMPT : ''
-  })
-
-  // 单点订阅：sessions.append → session/event；只处理已登记 worker 的 turn/end
-  ctx.on('session/event', ({ sessionId, event }) => {
-    if (event.type !== 'turn/end') return
-    void notifyLiveOfWorkerTurnEnd(ctx, sessionId, event)
   })
 
   ctx.tools.register({
@@ -395,8 +423,8 @@ export function apply(ctx: Context) {
       }
       const agent = await ctx.agents.create(targetId)
       if (!wait) {
-        // 先登记再派工，避免极快完成时丢掉 turn/end
-        watchWorker(selfId, targetId, target.events.at(-1)?.seq ?? -1)
+        // 先订阅再派工，避免极快完成时丢掉 turn/end；结束后自动 dispose
+        arm(selfId, targetId, target.events.at(-1)?.seq ?? -1)
         void agent.send(text, { wait: false })
         return { sessionId: targetId, queued: true, wait: false, watched: true }
       }
@@ -430,7 +458,7 @@ export function apply(ctx: Context) {
       if (!text) throw new Error('text required')
       if (targetId === selfId) throw new Error('cannot inject into the current live session')
       const target = await ctx.sessions.require(targetId)
-      watchWorker(selfId, targetId, target.events.at(-1)?.seq ?? -1)
+      arm(selfId, targetId, target.events.at(-1)?.seq ?? -1)
       const agent = await ctx.agents.create(targetId)
       agent.inject(text)
       return { sessionId: targetId, queued: true, watched: true }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `sessions.subscribe(sessionId, listener, owner?)`：按 session 过滤的可撤销订阅（挂 owner fiber，符合 cordis disposable）
- Live 在 `session_wake(wait=false)` / `session_inject` 时 `subscribe` worker；`turn/end` 旁白后立刻 dispose；插件卸载也会清掉
- 去掉全局 `workerWatches` 常驻 Map + 永久 `session/event` 监听

## Test plan
- [x] `npx vitest run host/plugins/seams/live-sessions.test.ts host/plugins/core/sessions.test.ts`（18 过）
- [x] turn/end 后 `listLiveWatchesForTests` 为空
- [ ] 手工：Live 异步派工完成后出现旁白，且不再重复

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

