### PR TITLE
fix(live): 被指挥 Agent busy 时侧栏/检查器有 mascot 动画

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -225,6 +225,7 @@ export function apply(ctx: Context) {
         title: item.title,
         updatedAt: item.updatedAt,
         type: item.type ?? 'chat',
+        busy: ctx.agents.isBusy(item.id),
         ...(item.project ? { project: item.project } : {}),
         ...(item.mascot ? { mascot: item.mascot } : {}),
       })),

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -62,7 +62,7 @@ export class AgentLoop implements AgentRunner {
     req = this.ctx.waterfall('agent/pre-step', req, () => req)
     if (req.reject) {
       await session.append(this.sessionId, { type: 'turn/end', turn, reason: req.reject })
-      this.ctx.emit('agent/status', { status: 'idle' })
+      this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle' })
       return { text: req.reject, steps: [] }
     }
     if (!req.messages.length) {
@@ -113,7 +113,7 @@ export class AgentLoop implements AgentRunner {
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
         throw new Error('cancelled')
       }
-      this.ctx.emit('agent/status', { status: 'running', step })
+      this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'running', step })
       await session.append(this.sessionId, { type: 'step/start', turn, step })
 
       const messages = session.deriveMessages(this.sessionId)
@@ -129,7 +129,7 @@ export class AgentLoop implements AgentRunner {
         await flushChunks()
         if (this.signal.aborted) {
           await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
-          this.ctx.emit('agent/status', { status: 'idle' })
+          this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle' })
           throw new Error('cancelled')
         }
         const detail = String(error)
@@ -137,7 +137,7 @@ export class AgentLoop implements AgentRunner {
         await session.append(this.sessionId, { type: 'assistant/message', text })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'llm-error' })
-        this.ctx.emit('agent/status', { status: 'idle' })
+        this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle' })
         return { text, steps }
       }
 
@@ -150,7 +150,7 @@ export class AgentLoop implements AgentRunner {
         })
         await session.append(this.sessionId, { type: 'step/end', turn, step })
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'complete' })
-        this.ctx.emit('agent/status', { status: 'idle', step })
+        this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle', step })
         return { text: final, steps }
       }
 

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -91,6 +91,7 @@ export class AgentsService extends Service {
           result = turn
         })
         live.running = running
+        this.ctx.emit('agent/status', { sessionId: id, status: 'running', step: 0 })
         if (!wait) {
           void running.finally(() => {
             if (live.running === running) live.running = undefined

--- a/host/plugins/seams/session-inspector.ts
+++ b/host/plugins/seams/session-inspector.ts
@@ -34,6 +34,7 @@ export interface InspectorWorkerRow {
   updatedAt: number
   inboxPending: number
   project?: string
+  mascot?: { shape: string; color: string }
 }
 
 const SOURCE_INFO: InspectorSourceInfo[] = [
@@ -125,6 +126,7 @@ export async function buildLiveWorkers(ctx: Context, selfId: string): Promise<In
       updatedAt: progress.updatedAt || item.updatedAt,
       inboxPending: progress.inboxPending,
       project: item.project?.name,
+      ...(item.mascot ? { mascot: item.mascot } : {}),
     })
   }
   workers.sort((a, b) => {

--- a/host/types.ts
+++ b/host/types.ts
@@ -73,7 +73,7 @@ declare module 'cordis' {
   interface Events {
     'http/ready'(info: { port: number }): void
     'hub/change'(): void
-    'agent/status'(payload: { status: 'idle' | 'running'; step?: number }): void
+    'agent/status'(payload: { sessionId: string; status: 'idle' | 'running'; step?: number }): void
     'agent/pre-step'(req: PreStepReq, next: () => PreStepReq): PreStepReq
     'session/event'(payload: { sessionId: string; event: SessionEvent }): void
     'tools/pre-execute'(req: ToolRequest, next: () => ToolRequest): ToolRequest

--- a/src/plugins/contributors/chat-sidebar.tsx
+++ b/src/plugins/contributors/chat-sidebar.tsx
@@ -102,6 +102,7 @@ export const ChatSidebar = memo(function ChatSidebar({
   const agentBusy = useSessionView(
     (state) => state.agentStatus === 'running' || state.pending,
   )
+  const busySessions = useSessionView((state) => state.busySessions)
   const collapsedProjects = useSidebarCollapseStore((state) => state.collapsed)
   const toggleProjectGroup = useSidebarCollapseStore((state) => state.toggle)
   const expandProjectGroup = useSidebarCollapseStore((state) => state.expand)
@@ -246,7 +247,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                         key={item.id}
                         item={item}
                         active={item.id === routeSessionId}
-                        busy={item.id === routeSessionId && agentBusy}
+                        busy={Boolean(busySessions[item.id]) || (item.id === routeSessionId && agentBusy)}
                         view={view}
                         onDelete={deleteChat}
                       />

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -4,6 +4,8 @@ import {
   bindSessionView,
   type SessionViewService,
 } from '../infrastructure/session-view.ts'
+import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
+import { resolveSessionMascot } from './mascot/session-mascot.ts'
 
 type ToolSourceId = 'minimal' | 'live' | 'plugin'
 type AgentMode = 'standard' | 'minimal'
@@ -34,6 +36,7 @@ interface InspectorWorker {
   updatedAt: number
   inboxPending: number
   project?: string
+  mascot?: { shape: string; color: string }
 }
 
 interface InspectorPayload {
@@ -249,6 +252,13 @@ export const SessionInspector = memo(function SessionInspector({
                 {workers.map((worker) => (
                   <li key={worker.id} className="session-inspector-worker">
                     <div className="session-inspector-worker-top">
+                      <SidebarMascot
+                        size={22}
+                        sessionId={worker.id}
+                        identity={resolveSessionMascot(worker.id, worker.mascot)}
+                        busy={worker.status === 'running'}
+                        title={worker.title}
+                      />
                       <span className="session-inspector-worker-title">{worker.title}</span>
                       <span
                         className={`session-inspector-state${worker.status === 'running' ? ' is-on' : ''}`}

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -96,9 +96,29 @@ test('send wake keeps running after HTTP so WS agent/status owns idle', async ()
   await view.send('hi')
   assert.equal(view.get().agentStatus, 'running')
   assert.equal(view.get().pending, true)
+  assert.equal(view.get().busySessions.s1, true)
   view.setAgentStatus('idle')
   assert.equal(view.get().agentStatus, 'idle')
   assert.equal(view.get().pending, false)
+  assert.equal(view.get().busySessions.s1, undefined)
+})
+
+test('setAgentStatus with other sessionId only updates busySessions', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('live-1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  assert.equal(view.get().sessionId, 'live-1')
+  view.setAgentStatus('running', 0, 'worker-2')
+  assert.equal(view.get().agentStatus, 'idle')
+  assert.equal(view.get().pending, false)
+  assert.equal(view.get().busySessions['worker-2'], true)
+  view.setAgentStatus('idle', undefined, 'worker-2')
+  assert.equal(view.get().busySessions['worker-2'], undefined)
 })
 
 test('inspectCall switches to trajectory with focus', async () => {

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -300,17 +300,16 @@ export class SessionViewService extends Service {
       if (status === 'running') busySessions[id] = true
       else delete busySessions[id]
     }
-    const currentId = this.value.sessionId
-    const affectsCurrent = Boolean(id) && id === currentId
-    if (affectsCurrent) {
-      if (status === 'running') {
-        this.replace({ busySessions, agentStatus: 'running', agentStep: step, pending: true })
-        return
-      }
-      this.replace({ busySessions, agentStatus: 'idle', agentStep: step, pending: false })
+    // 显式指向「其它」session：只改 busySessions，不动当前会话 chrome
+    if (sessionId && this.value.sessionId && sessionId !== this.value.sessionId) {
+      this.replace({ busySessions })
       return
     }
-    this.replace({ busySessions })
+    if (status === 'running') {
+      this.replace({ busySessions, agentStatus: 'running', agentStep: step, pending: true })
+      return
+    }
+    this.replace({ busySessions, agentStatus: 'idle', agentStep: step, pending: false })
   }
 
   /** 切会话时按 busySessions 恢复当前栏 pending/agentStatus */
@@ -474,8 +473,7 @@ export class SessionViewService extends Service {
             view,
             focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
             error: undefined,
-            pending: false,
-            agentStatus: 'idle',
+            ...this.busyFlagsFor(sessionId),
             loadingOlder: false,
             trajectoryHasMore: false,
             trajectoryLoading: false,
@@ -491,8 +489,7 @@ export class SessionViewService extends Service {
             view,
             focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
             error: undefined,
-            pending: false,
-            agentStatus: 'idle',
+            ...this.busyFlagsFor(sessionId),
             hasMoreOlder: false,
             loadingOlder: false,
             trajectoryHasMore: false,
@@ -521,8 +518,7 @@ export class SessionViewService extends Service {
           view,
           focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
           error: undefined,
-          pending: false,
-          agentStatus: 'idle',
+          ...this.busyFlagsFor(sessionId),
           loadingOlder: false,
           trajectoryHasMore: false,
           trajectoryLoading: false,
@@ -538,8 +534,7 @@ export class SessionViewService extends Service {
           view,
           focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
           error: undefined,
-          pending: false,
-          agentStatus: 'idle',
+          ...this.busyFlagsFor(sessionId),
           hasMoreOlder: false,
           loadingOlder: false,
           trajectoryHasMore: false,
@@ -604,7 +599,7 @@ export class SessionViewService extends Service {
         return
       }
       this.replace({
-        sessionId: body.id,
+        sessionId: body.id || sessionId,
         events,
         nodes,
         project: body.project,
@@ -630,8 +625,7 @@ export class SessionViewService extends Service {
       view,
       focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
       error: undefined,
-      pending: false,
-      agentStatus: 'idle',
+      ...this.busyFlagsFor(sessionId),
       hasMoreOlder: cached.hasMoreOlder,
       loadingOlder: false,
       trajectoryHasMore: false,
@@ -830,8 +824,11 @@ export class SessionViewService extends Service {
     const wasActive = this.value.sessionId === id
     // 乐观更新：先从侧栏拿掉，避免等网络才「卡一下消失」
     this.dropCache(id)
+    const busySessions = { ...this.value.busySessions }
+    delete busySessions[id]
     this.replace({
       sessions: prevSessions.filter((item) => item.id !== id),
+      busySessions,
       ...(wasActive
         ? {
             sessionId: null,

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -23,6 +23,8 @@ export interface SessionListItem {
   eventCount: number
   updatedAt: number
   type?: 'chat' | 'live'
+  /** host 列表快照：该 session 的 agent 是否在跑 */
+  busy?: boolean
   project?: { name: string; path?: string; boundAt: number }
   mascot?: { shape: string; color: string }
 }
@@ -47,6 +49,8 @@ export interface SessionViewState {
   agentStatus: 'idle' | 'running'
   agentStep?: number
   pending: boolean
+  /** 任意 session 的 busy（含 Live 派工的 worker）；侧栏 mascot 用 */
+  busySessions: Record<string, true>
   approvalMode: ApprovalMode
   approvals: ApprovalItem[]
   project?: { name: string; path?: string; boundAt: number }
@@ -71,6 +75,7 @@ const empty: SessionViewState = {
   view: 'chat',
   agentStatus: 'idle',
   pending: false,
+  busySessions: {},
   approvalMode: 'auto',
   approvals: [],
   hasMoreOlder: false,
@@ -122,6 +127,7 @@ function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
       left.project?.name !== right.project?.name ||
       left.mascot?.shape !== right.mascot?.shape ||
       left.mascot?.color !== right.mascot?.color ||
+      Boolean(left.busy) !== Boolean(right.busy) ||
       (left.type ?? 'chat') !== (right.type ?? 'chat')
     ) {
       return false
@@ -287,12 +293,53 @@ export class SessionViewService extends Service {
     for (const fn of this.listeners) fn()
   }
 
-  setAgentStatus(status: 'idle' | 'running', step?: number) {
-    if (status === 'running') {
-      this.replace({ agentStatus: 'running', agentStep: step, pending: true })
+  setAgentStatus(status: 'idle' | 'running', step?: number, sessionId?: string) {
+    const id = sessionId ?? this.value.sessionId
+    const busySessions = { ...this.value.busySessions }
+    if (id) {
+      if (status === 'running') busySessions[id] = true
+      else delete busySessions[id]
+    }
+    const currentId = this.value.sessionId
+    const affectsCurrent = Boolean(id) && id === currentId
+    if (affectsCurrent) {
+      if (status === 'running') {
+        this.replace({ busySessions, agentStatus: 'running', agentStep: step, pending: true })
+        return
+      }
+      this.replace({ busySessions, agentStatus: 'idle', agentStep: step, pending: false })
       return
     }
-    this.replace({ agentStatus: 'idle', agentStep: step, pending: false })
+    this.replace({ busySessions })
+  }
+
+  /** 切会话时按 busySessions 恢复当前栏 pending/agentStatus */
+  private busyFlagsFor(sessionId: string | null | undefined) {
+    const running = Boolean(sessionId && this.value.busySessions[sessionId])
+    return {
+      pending: running,
+      agentStatus: (running ? 'running' : 'idle') as 'idle' | 'running',
+    }
+  }
+
+  private syncBusyFromSessions(sessions: SessionListItem[]) {
+    const busySessions = { ...this.value.busySessions }
+    let changed = false
+    const currentId = this.value.sessionId
+    for (const item of sessions) {
+      if (item.busy) {
+        if (!busySessions[item.id]) {
+          busySessions[item.id] = true
+          changed = true
+        }
+      } else if (busySessions[item.id]) {
+        // 当前会话正在 pending 时别被列表抖动清掉（send 乐观更新早于 isBusy）
+        if (item.id === currentId && this.value.pending) continue
+        delete busySessions[item.id]
+        changed = true
+      }
+    }
+    return changed ? busySessions : null
   }
 
   upsertApproval(item: ApprovalItem) {
@@ -310,9 +357,21 @@ export class SessionViewService extends Service {
       if (!res.ok) return
       const body = (await res.json()) as { sessions?: SessionListItem[] }
       const next = Array.isArray(body.sessions) ? body.sessions : []
-      // 列表引用每次都新会打穿 Shell；无变化则跳过
-      if (sessionsEqual(this.value.sessions, next)) return
-      this.replace({ sessions: next })
+      const busySessions = this.syncBusyFromSessions(next)
+      const sessionsChanged = !sessionsEqual(this.value.sessions, next)
+      if (!sessionsChanged && !busySessions) return
+      const patch: Partial<SessionViewState> = {}
+      if (sessionsChanged) patch.sessions = next
+      if (busySessions) {
+        patch.busySessions = busySessions
+        const currentId = this.value.sessionId
+        if (currentId) {
+          const running = Boolean(busySessions[currentId])
+          patch.agentStatus = running ? 'running' : 'idle'
+          patch.pending = running
+        }
+      }
+      this.replace(patch)
     } catch {
       /* host 未就绪时忽略 */
     }
@@ -853,7 +912,8 @@ export class SessionViewService extends Service {
       }
       return
     }
-    this.replace({ pending: true, agentStatus: 'running', error: undefined })
+    this.setAgentStatus('running', undefined, sessionId)
+    this.replace({ error: undefined })
     try {
       const res = await fetch(`/api/sessions/${sessionId}/messages`, {
         method: 'POST',
@@ -876,7 +936,8 @@ export class SessionViewService extends Service {
       } catch {
         /* 加载失败时仍展示下方 error */
       }
-      this.replace({ error: String(error), pending: false, agentStatus: 'idle' })
+      this.setAgentStatus('idle', undefined, sessionId)
+      this.replace({ error: String(error) })
       throw error
     }
     // 成功后不要在 finally 里强行 idle：agent 仍在跑，状态交给 WS agent/status
@@ -886,7 +947,7 @@ export class SessionViewService extends Service {
     const sessionId = this.value.sessionId
     if (!sessionId) return
     await fetch(`/api/sessions/${sessionId}/cancel`, { method: 'POST' })
-    this.replace({ pending: false, agentStatus: 'idle' })
+    this.setAgentStatus('idle', undefined, sessionId)
   }
 
   async decideApproval(id: string, allow: boolean) {

--- a/src/plugins/infrastructure/snapshot.ts
+++ b/src/plugins/infrastructure/snapshot.ts
@@ -105,11 +105,21 @@ export class SnapshotService extends Service {
           view?.upsertApproval(item)
         }
         if (parsed.type === 'agent') {
-          const status = parsed.payload as { status: 'idle' | 'running'; step?: number }
+          const status = parsed.payload as {
+            sessionId?: string
+            status: 'idle' | 'running'
+            step?: number
+          }
           const view = this.ctx.get('sessionView') as
-            | { setAgentStatus: (status: 'idle' | 'running', step?: number) => void }
+            | {
+                setAgentStatus: (
+                  status: 'idle' | 'running',
+                  step?: number,
+                  sessionId?: string,
+                ) => void
+              }
             | undefined
-          view?.setAgentStatus(status.status, status.step)
+          view?.setAgentStatus(status.status, status.step, status.sessionId)
         }
       }
       ws.onclose = () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
Live 指挥其它 Agent 时，worker 侧栏头像不播放 busy 动画。根因是：
1. `agent/status` WS 未带 `sessionId`，状态被当成「当前打开会话」
2. 侧栏仅对 `item.id === routeSessionId && agentBusy` 开动画

## 改动
- `agent/status` 携带 `sessionId`；`agents.send` 入队开跑时立即广播
- `SessionView` 维护 `busySessions`，切会话时按表恢复 pending
- 侧栏：任意 busy session 都播 mascot 动画
- Live 检查器 worker 行加 `SidebarMascot`，`running` 时动画
- `GET /api/sessions` 增加 `busy` 字段便于列表水合

## 验证
- `session-view` / `agents` 单测已通过
- 本地：Live wake worker 后，侧栏该行与检查器头像应动画
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

