### PR TITLE
feat(ui): 长消息折叠 + 检查器工具行等高 + Live 派工头像

### DIFF
--- a/host/plugins/core/session-types.ts
+++ b/host/plugins/core/session-types.ts
@@ -2,6 +2,11 @@ export const SESSION_FORMAT_VERSION = 1
 
 export type InboxKind = 'wake' | 'inject'
 
+/** 谁写入这条 user/message：真人用户，或其它 session（如 Live 派工）。缺省按 user。 */
+export type MessageSender =
+  | { type: 'user' }
+  | { type: 'session'; sessionId: string }
+
 /** 写入 append 的正文（不含 seq/ts）；与 SessionEvent 判别联合一一对应。 */
 export type SessionEventBody =
   | { type: 'session/open'; version: number }
@@ -10,7 +15,7 @@ export type SessionEventBody =
   | { type: 'step/start'; turn: number; step: number }
   | { type: 'step/end'; turn: number; step: number }
   | { type: 'system/prompt'; text: string }
-  | { type: 'user/message'; text: string; kind: InboxKind }
+  | { type: 'user/message'; text: string; kind: InboxKind; sender?: MessageSender }
   | {
       type: 'assistant/message'
       text: string

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -1,7 +1,7 @@
 import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { AssistantReply, ChatOptions, LlmClient, LlmConfig, LlmMessage } from './llm.ts'
-import type { InboxKind } from '../core/session-types.ts'
+import type { InboxKind, MessageSender } from '../core/session-types.ts'
 import { normalizeSessionType } from '../core/session-types.ts'
 import { runWithSession } from '../core/session-scope.ts'
 import { runWithExtraTools } from '../registry/tools.ts'
@@ -17,6 +17,8 @@ export interface ClaimedInput {
   text: string
   /** slash 为本回合临时放开的额外工具（极简模式） */
   extraTools?: string[]
+  /** 写入 user/message 的来源；缺省为真人用户 */
+  sender?: MessageSender
 }
 
 export interface PreStepReq {
@@ -71,7 +73,12 @@ export class AgentLoop implements AgentRunner {
     }
 
     for (const item of req.messages) {
-      await session.append(this.sessionId, { type: 'user/message', text: item.text, kind: item.kind })
+      await session.append(this.sessionId, {
+        type: 'user/message',
+        text: item.text,
+        kind: item.kind,
+        ...(item.sender ? { sender: item.sender } : {}),
+      })
     }
 
     // 分段 prompt 只在 turn 开头写入一次，避免每 step 污染权威日志；derive 取最后一条 system/prompt。

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -2,6 +2,7 @@ import { Service, type Context } from 'cordis'
 import '../../types.ts'
 import type { LlmConfig } from './llm.ts'
 import type { AgentTurn, ClaimedInput } from './agent-loop.ts'
+import type { MessageSender } from '../core/session-types.ts'
 
 export type { AgentTurn, LlmConfig }
 
@@ -9,6 +10,8 @@ export interface AgentSendOptions {
   extraTools?: string[]
   /** false：入队后立即返回，不阻塞等回合结束（Live 派工后可再 progress）。默认 true。 */
   wait?: boolean
+  /** 消息来源：Live 派工时传入 { type: 'session', sessionId } */
+  sender?: MessageSender
 }
 
 export interface AgentHandle {
@@ -80,6 +83,7 @@ export class AgentsService extends Service {
           kind: 'wake',
           text: trimmed,
           ...(extraTools.length ? { extraTools } : {}),
+          ...(opts?.sender ? { sender: opts.sender } : {}),
         })
         if (live.running) {
           if (!wait) return { text: '', steps: [] }
@@ -113,6 +117,7 @@ export class AgentsService extends Service {
           kind: 'inject',
           text: trimmed,
           ...(extraTools.length ? { extraTools } : {}),
+          ...(opts?.sender ? { sender: opts.sender } : {}),
         })
       },
       cancel: () => live.abort.abort(),

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -309,13 +309,14 @@ export function apply(ctx: Context) {
         throw new Error('cannot wake another live session; target a chat session')
       }
       const agent = await ctx.agents.create(targetId)
+      const sender = { type: 'session' as const, sessionId: selfId }
       if (!wait) {
         // 先订阅再派工，避免极快完成时丢掉 turn/end；结束后自动 dispose
         watchTurnEnd(selfId, targetId)
-        void agent.send(text, { wait: false })
+        void agent.send(text, { wait: false, sender })
         return { sessionId: targetId, queued: true, wait: false }
       }
-      const turn = await agent.send(text, { wait: true })
+      const turn = await agent.send(text, { wait: true, sender })
       return {
         sessionId: targetId,
         queued: false,
@@ -347,7 +348,7 @@ export function apply(ctx: Context) {
       const target = await ctx.sessions.require(targetId)
       watchTurnEnd(selfId, targetId)
       const agent = await ctx.agents.create(targetId)
-      agent.inject(text)
+      agent.inject(text, { sender: { type: 'session', sessionId: selfId } })
       return { sessionId: targetId, queued: true }
     },
   })

--- a/src/plugins/contributors/chat/thread.tsx
+++ b/src/plugins/contributors/chat/thread.tsx
@@ -4,6 +4,7 @@ import {
   LuCheck,
   LuChevronDown,
   LuChevronRight,
+  LuChevronUp,
   LuClock,
   LuCoins,
   LuCopy,
@@ -12,10 +13,11 @@ import {
   LuLayers,
   LuTimer,
   LuType,
+  LuUser,
   LuWrench,
 } from 'react-icons/lu'
 import type { SlotProps } from '../../registry/slots.ts'
-import { bindSessionView, type SessionViewService } from '../../infrastructure/session-view.ts'
+import { bindSessionView, type SessionListItem, type SessionViewService } from '../../infrastructure/session-view.ts'
 import {
   formatTrajectoryUsage,
   type ChatNode,
@@ -24,6 +26,7 @@ import {
   type TrajectoryUsage,
 } from '../../infrastructure/session-project.ts'
 import { SidebarMascot } from '../mascot/sidebar-mascot.tsx'
+import { StaticMascotMark } from '../mascot/static-mascot-mark.tsx'
 import { DEFAULT_SESSION_MASCOT, resolveSessionMascot } from '../mascot/session-mascot.ts'
 import type { SessionMascotIdentity } from '../mascot/grok-bot-types.ts'
 import { MarkdownBody } from './markdown.tsx'
@@ -351,11 +354,17 @@ function UserTurnBar({
   reply,
   detailsOpen,
   onToggleDetails,
+  canExpand,
+  expanded,
+  onToggleExpand,
 }: {
   user: Extract<ChatNode, { kind: 'user' }>
   reply?: Extract<ChatNode, { kind: 'reply' }>
   detailsOpen: boolean
   onToggleDetails: (replyId: string) => void
+  canExpand?: boolean
+  expanded?: boolean
+  onToggleExpand?: () => void
 }) {
   const streaming = Boolean(reply?.streaming)
   const { hasDetails } = reply && !streaming ? splitReplyForDisplay(reply) : { hasDetails: false }
@@ -369,7 +378,7 @@ function UserTurnBar({
       Boolean(reply.usage) ||
       toolCount > 0)
   const sentLabel = user.ts != null ? formatSentAt(user.ts) : ''
-  if (!hasDetails && !hasMeta && !sentLabel) return null
+  if (!hasDetails && !hasMeta && !sentLabel && !canExpand) return null
 
   return (
     <div className="chat-user-turn-bar" aria-label="回合摘要" data-testid="user-turn-bar">
@@ -417,13 +426,50 @@ function UserTurnBar({
           </div>
         ) : null}
       </div>
-      {sentLabel ? (
-        <span className="chat-user-turn-sent" title="发送时间" data-testid="user-sent-at">
-          <LuClock className="size-3" aria-hidden />
-          <span>{sentLabel}</span>
-        </span>
-      ) : null}
+      <div className="chat-user-turn-bar-end">
+        {canExpand && onToggleExpand ? (
+          <button
+            type="button"
+            className="chat-user-expand"
+            aria-expanded={Boolean(expanded)}
+            aria-label={expanded ? '收起请求全文' : '展开请求全文'}
+            data-testid="user-expand-toggle"
+            onClick={onToggleExpand}
+          >
+            {expanded ? <LuChevronUp className="size-3.5" /> : <LuChevronDown className="size-3.5" />}
+          </button>
+        ) : null}
+        {sentLabel ? (
+          <span className="chat-user-turn-sent" title="发送时间" data-testid="user-sent-at">
+            <LuClock className="size-3" aria-hidden />
+            <span>{sentLabel}</span>
+          </span>
+        ) : null}
+      </div>
     </div>
+  )
+}
+
+function UserSenderAvatar({
+  sender,
+  sessions,
+}: {
+  sender?: Extract<ChatNode, { kind: 'user' }>['sender']
+  sessions: SessionListItem[]
+}) {
+  if (sender?.type === 'session') {
+    const hit = sessions.find((item) => item.id === sender.sessionId)
+    const identity = resolveSessionMascot(sender.sessionId, hit?.mascot)
+    return (
+      <span className="chat-user-avatar" title={hit?.title || 'Live session'} data-testid="user-sender-mascot">
+        <StaticMascotMark identity={identity} size={22} title={hit?.title || identity.shape} />
+      </span>
+    )
+  }
+  return (
+    <span className="chat-user-avatar is-human" title="你" data-testid="user-sender-human" aria-hidden>
+      <LuUser className="size-3.5" />
+    </span>
   )
 }
 
@@ -445,6 +491,7 @@ function NodeView({
   onToggleDetails = noopToggleDetails,
   onInspect,
   onFork,
+  sessions = [],
 }: {
   node: ChatNode
   /** 用户消息发起的本回合回复（统计挂在用户气泡下） */
@@ -453,19 +500,45 @@ function NodeView({
   onToggleDetails?: (replyId: string) => void
   onInspect: (callId: string) => void
   onFork: () => void | Promise<void>
+  sessions?: SessionListItem[]
 }) {
+  const [expanded, setExpanded] = useState(false)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const [overflows, setOverflows] = useState(false)
+
+  useLayoutEffect(() => {
+    if (node.kind !== 'user') return
+    const el = bodyRef.current
+    if (!el) return
+    // 展开时也用 scrollHeight 对比上限，避免收起后漏掉按钮
+    const limit = Number.parseFloat(getComputedStyle(el).getPropertyValue('--chat-user-max-height')) || 160
+    setOverflows(el.scrollHeight > limit + 1)
+  }, [node.kind === 'user' ? node.text : '', expanded, node.kind])
+
   if (node.kind === 'user') {
+    const canExpand = overflows || expanded
     return (
       <div className="chat-user-row">
-        <div className="chat-user-bubble">
-          {node.kindTag === 'inject' ? <div className="chat-user-tag">inject</div> : null}
-          <MarkdownBody text={node.text} />
+        <div className={`chat-user-shell${expanded ? ' is-expanded' : ''}`}>
+          <UserSenderAvatar sender={node.sender} sessions={sessions} />
+          <div
+            ref={bodyRef}
+            className={`chat-user-bubble${expanded ? ' is-expanded' : ''}${canExpand && !expanded ? ' is-clamped' : ''}`}
+            data-testid="user-bubble"
+          >
+            {node.kindTag === 'inject' ? <div className="chat-user-tag">inject</div> : null}
+            {node.sender?.type === 'session' ? <div className="chat-user-tag">from live</div> : null}
+            <MarkdownBody text={node.text} />
+          </div>
         </div>
         <UserTurnBar
           user={node}
           reply={replyForUser}
           detailsOpen={Boolean(detailsOpen)}
           onToggleDetails={onToggleDetails}
+          canExpand={canExpand}
+          expanded={expanded}
+          onToggleExpand={() => setExpanded((value) => !value)}
         />
       </div>
     )
@@ -505,10 +578,12 @@ export function ChatNodeList({
   nodes,
   onInspect,
   onFork,
+  sessions = [],
 }: {
   nodes: ChatNode[]
   onInspect: (callId: string) => void
   onFork: () => void | Promise<void>
+  sessions?: SessionListItem[]
 }) {
   const [detailsOpenByReply, setDetailsOpenByReply] = useState<Record<string, boolean>>({})
 
@@ -536,6 +611,7 @@ export function ChatNodeList({
               onToggleDetails={onToggleDetails}
               onInspect={onInspect}
               onFork={onFork}
+              sessions={sessions}
             />
           </div>
         )
@@ -711,7 +787,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       {loadingOlder ? (
         <div className="mb-3 text-center text-[11px] text-[var(--dsw-label-3)]">加载更早消息…</div>
       ) : null}
-      <ChatNodeList nodes={nodes} onInspect={onInspect} onFork={onFork} />
+      <ChatNodeList nodes={nodes} onInspect={onInspect} onFork={onFork} sessions={sessions} />
       {error ? (
         <div className="mt-4 rounded-[12px] bg-[var(--dsw-danger-soft)] px-3 py-2 text-sm text-[var(--dsw-danger)]">{error}</div>
       ) : null}

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -216,28 +216,30 @@ export const SessionInspector = memo(function SessionInspector({
                   key={tool.name}
                   className={`session-inspector-tool${tool.active ? ' is-active' : ''}`}
                   data-tool={tool.name}
+                  title={tool.description || tool.name}
                 >
-                  <div className="session-inspector-tool-top">
-                    {tool.configurable ? (
-                      <input
-                        type="checkbox"
-                        checked={(data?.extraTools ?? []).includes(tool.name)}
-                        disabled={busy}
-                        aria-label={`启用 ${tool.name}`}
-                        onChange={(event) => toggleExtra(tool.name, event.target.checked)}
-                      />
-                    ) : (
-                      <span className="session-inspector-tool-dot" aria-hidden />
-                    )}
-                    <code>{tool.name}</code>
-                    <span className={`session-inspector-badge ${SOURCE_TONE[tool.source]}`}>
-                      {tool.source}
+                  {tool.configurable ? (
+                    <input
+                      type="checkbox"
+                      className="session-inspector-tool-check"
+                      checked={(data?.extraTools ?? []).includes(tool.name)}
+                      disabled={busy}
+                      aria-label={`启用 ${tool.name}`}
+                      onChange={(event) => toggleExtra(tool.name, event.target.checked)}
+                    />
+                  ) : (
+                    <span
+                      className={`session-inspector-tool-icon${tool.active ? ' is-on' : ''}`}
+                      aria-hidden
+                    >
+                      <LuWrench className="size-3.5" />
                     </span>
-                    <span className={`session-inspector-state${tool.active ? ' is-on' : ''}`}>
-                      {tool.active ? '可用' : '未开'}
-                    </span>
-                  </div>
-                  <p>{tool.description || '（无说明）'}</p>
+                  )}
+                  <span className="session-inspector-tool-name">{tool.name}</span>
+                  <span className="session-inspector-tool-source">{tool.source}</span>
+                  <span className={`session-inspector-state${tool.active ? ' is-on' : ''}`}>
+                    {tool.active ? '可用' : '未开'}
+                  </span>
                 </li>
               ))}
             </ul>

--- a/src/plugins/infrastructure/session-project.test.ts
+++ b/src/plugins/infrastructure/session-project.test.ts
@@ -41,6 +41,24 @@ test('projects user, streaming assistant, tool call/result from session events',
   if (user?.kind === 'user') assert.equal(user.ts, 2)
 })
 
+test('projects live sender onto user nodes', () => {
+  const nodes = projectNodes([
+    { type: 'session/open', version: 1, seq: 0, ts: 1 },
+    {
+      type: 'user/message',
+      text: 'do it',
+      kind: 'wake',
+      sender: { type: 'session', sessionId: 'live-1' },
+      seq: 1,
+      ts: 2,
+    },
+  ])
+  const user = nodes[0]
+  assert.equal(user?.kind, 'user')
+  if (user?.kind !== 'user') return
+  assert.deepEqual(user.sender, { type: 'session', sessionId: 'live-1' })
+})
+
 test('keeps reply streaming across tools until turn/end (Details stay open)', () => {
   const base: SessionEvent[] = [
     { type: 'turn/start', turn: 1, seq: 0, ts: 1 },

--- a/src/plugins/infrastructure/session-project.ts
+++ b/src/plugins/infrastructure/session-project.ts
@@ -9,7 +9,12 @@ export type SessionEvent = {
   | { type: 'step/start'; turn: number; step: number }
   | { type: 'step/end'; turn: number; step: number }
   | { type: 'system/prompt'; text: string }
-  | { type: 'user/message'; text: string; kind?: string }
+  | {
+      type: 'user/message'
+      text: string
+      kind?: string
+      sender?: { type: 'user' } | { type: 'session'; sessionId: string }
+    }
   | {
       type: 'assistant/message'
       text: string
@@ -65,7 +70,15 @@ export type ChatStepStat = {
 }
 
 export type ChatNode =
-  | { id: string; kind: 'user'; text: string; kindTag?: string; ts?: number }
+  | {
+      id: string
+      kind: 'user'
+      text: string
+      kindTag?: string
+      ts?: number
+      /** 缺省 / user = 真人；session = Live 等其它会话派工 */
+      sender?: { type: 'user' } | { type: 'session'; sessionId: string }
+    }
   | {
       id: string
       kind: 'reply'
@@ -256,6 +269,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
         text: event.text,
         kindTag: event.kind,
         ts: event.ts,
+        ...(event.sender ? { sender: event.sender } : {}),
       })
     } else if (event.type === 'assistant/chunk') {
       const r = ensureReply(event.seq)

--- a/src/style.css
+++ b/src/style.css
@@ -1413,13 +1413,46 @@ body {
   gap: 0;
 }
 
-.chat-user-bubble {
+.chat-user-shell {
+  display: flex;
   width: 100%;
   max-width: 100%;
+  align-items: flex-start;
+  gap: 8px;
   padding: 10px 12px;
   border: 0;
   border-radius: var(--dsw-radius-bubble);
   background: var(--dsw-bubble);
+  color: var(--dsw-label);
+}
+
+.chat-user-row:has(.chat-user-turn-bar) .chat-user-shell {
+  border-radius: var(--dsw-radius-bubble) var(--dsw-radius-bubble) 0 0;
+}
+
+.chat-user-avatar {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  place-items: center;
+  margin-top: 1px;
+  color: var(--dsw-label-3);
+}
+
+.chat-user-avatar.is-human {
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--dsw-label-3) 14%, transparent);
+}
+
+.chat-user-bubble {
+  --chat-user-max-height: 160px;
+  min-width: 0;
+  flex: 1;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   box-shadow: none;
   color: var(--dsw-label);
   font-size: var(--dsw-chat-font-size);
@@ -1427,9 +1460,16 @@ body {
   outline: none;
 }
 
-/* 有统计栏时：气泡上圆下方，与下面统计栏无缝贴合 */
-.chat-user-row:has(.chat-user-turn-bar) .chat-user-bubble {
-  border-radius: var(--dsw-radius-bubble) var(--dsw-radius-bubble) 0 0;
+.chat-user-bubble.is-clamped {
+  max-height: var(--chat-user-max-height);
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
+}
+
+.chat-user-bubble.is-expanded {
+  max-height: none;
+  overflow: visible;
+  mask-image: none;
 }
 
 .chat-user-tag {
@@ -1465,6 +1505,31 @@ body {
   flex: 1;
   align-items: center;
   gap: 10px;
+}
+
+.chat-user-turn-bar-end {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.chat-user-expand {
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+  padding: 0;
+}
+
+.chat-user-expand:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-label);
 }
 
 .chat-user-turn-sent {
@@ -2556,18 +2621,24 @@ body {
 .session-inspector-sources {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 1px;
 }
 
 .session-inspector-source {
   border-radius: 8px;
-  border: 1px solid var(--dsw-border);
-  padding: 8px;
+  border: 0;
+  padding: 6px 8px;
+  background: transparent;
+}
+
+.session-inspector-source:hover {
+  background: var(--dsw-hover);
 }
 
 .session-inspector-source-label {
+  color: var(--dsw-label-2);
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .session-inspector-source-desc {
@@ -2577,38 +2648,101 @@ body {
   line-height: 1.4;
 }
 
-.inspector-source-minimal {
-  border-color: color-mix(in srgb, #3b82f6 35%, var(--dsw-border));
-}
-
-.inspector-source-live {
-  border-color: color-mix(in srgb, #10b981 35%, var(--dsw-border));
-}
-
+.inspector-source-minimal,
+.inspector-source-live,
 .inspector-source-plugin {
-  border-color: color-mix(in srgb, #a855f7 35%, var(--dsw-border));
+  border-color: transparent;
 }
 
 .session-inspector-tools,
 .session-inspector-workers {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 1px;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.session-inspector-tool,
-.session-inspector-worker {
-  border: 1px solid var(--dsw-border);
-  border-radius: 10px;
-  background: var(--dsw-surface);
-  padding: 8px;
+.session-inspector-tool {
+  position: relative;
+  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 30px;
+  height: 30px;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--dsw-label-2);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.2;
+  padding: 5px 8px;
+  transition: none;
+}
+
+.session-inspector-tool:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-label);
 }
 
 .session-inspector-tool.is-active {
-  border-color: color-mix(in srgb, var(--dsw-business) 40%, var(--dsw-border));
+  color: var(--dsw-label);
+}
+
+.session-inspector-tool-check {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  margin: 0;
+  accent-color: var(--dsw-business);
+}
+
+.session-inspector-tool-icon {
+  display: grid;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  place-items: center;
+  color: var(--dsw-label-3);
+}
+
+.session-inspector-tool:hover .session-inspector-tool-icon,
+.session-inspector-tool-icon.is-on {
+  color: var(--dsw-label);
+}
+
+.session-inspector-tool-name {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.session-inspector-tool-source {
+  flex-shrink: 0;
+  color: var(--dsw-label-3);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: lowercase;
+}
+
+.session-inspector-worker {
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 6px 8px;
+}
+
+.session-inspector-worker:hover {
+  background: var(--dsw-hover);
 }
 
 .session-inspector-tool-top,
@@ -2619,22 +2753,6 @@ body {
   gap: 6px;
 }
 
-.session-inspector-tool-top code {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 11px;
-}
-
-.session-inspector-tool-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: var(--dsw-border);
-}
-
-.session-inspector-tool p,
 .session-inspector-worker-text,
 .session-inspector-hint,
 .session-inspector-empty {
@@ -2642,31 +2760,6 @@ body {
   color: var(--dsw-label-3);
   font-size: 11px;
   line-height: 1.45;
-}
-
-.session-inspector-badge {
-  flex-shrink: 0;
-  border-radius: 999px;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  padding: 2px 6px;
-  text-transform: uppercase;
-}
-
-.session-inspector-badge.inspector-source-minimal {
-  background: color-mix(in srgb, #3b82f6 18%, transparent);
-  color: #60a5fa;
-}
-
-.session-inspector-badge.inspector-source-live {
-  background: color-mix(in srgb, #10b981 18%, transparent);
-  color: #34d399;
-}
-
-.session-inspector-badge.inspector-source-plugin {
-  background: color-mix(in srgb, #a855f7 18%, transparent);
-  color: #c084fc;
 }
 
 .session-inspector-state {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 补齐此前未完成的 UI

上次只合了 worker busy 动画，这三项当时被 stash，现已补齐：

1. **长用户消息折叠**：超过约 160px 限高，状态栏右侧向下箭头展开全文
2. **右侧检查器工具行**：等高 30px 行（icon + 名称），配色对齐左侧 `--dsw-hover` / `--dsw-label-*`，去掉彩色 badge 卡片
3. **Live sender 头像**：wake/inject 写入 `sender`；气泡显示用户图标或 Live mascot

相关单测已跑过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

