### PR TITLE
fix(sessions): 按对话顺序重建孤儿 tool_calls

### DIFF
--- a/host/plugins/core/session-heal.test.ts
+++ b/host/plugins/core/session-heal.test.ts
@@ -4,6 +4,8 @@ import {
   findOpenTurnStep,
   findOrphanToolCalls,
   healInterruptedTurnBodies,
+  INTERRUPTED_TOOL_DETAIL,
+  rebuildHealedEvents,
 } from './session-heal.ts'
 import type { SessionEvent } from './session-types.ts'
 import { deriveMessages } from './sessions.ts'
@@ -37,7 +39,6 @@ test('healInterruptedTurnBodies fills orphan tool results then closes step/turn'
       type: 'assistant/message',
       text: '',
       tool_calls: [{ id: 'c1', name: 'session_wake', arguments: '{}' }],
-      seq: 2,
     }),
   ])
   assert.deepEqual(bodies, [
@@ -46,8 +47,7 @@ test('healInterruptedTurnBodies fills orphan tool results then closes step/turn'
       id: 'c1',
       name: 'session_wake',
       ok: false,
-      detail:
-        'interrupted: tool call was not completed (host restart or crash before tool/result)',
+      detail: INTERRUPTED_TOOL_DETAIL,
     },
     { type: 'step/end', turn: 3, step: 1 },
     { type: 'turn/end', turn: 3, reason: 'host-restart' },
@@ -93,4 +93,96 @@ test('deriveMessages synthesizes missing tool results before next user', () => {
   assert.equal(messages[2]?.tool_call_id, 't1')
   assert.equal(messages[3]?.role, 'user')
   assert.equal(messages[3]?.content, 'hello again')
+})
+
+test('rebuildHealedEvents inserts tool result before error assistant and drops misplaced trailing result', () => {
+  const rebuilt = rebuildHealedEvents(
+    [
+      ev({ type: 'user/message', text: 'hi', kind: 'wake', seq: 0, ts: 10 }),
+      ev({
+        type: 'assistant/message',
+        text: '',
+        tool_calls: [{ id: 'call_x', name: 'session_wake', arguments: '{}' }],
+        seq: 1,
+        ts: 11,
+      }),
+      // 模型调用失败写进日志，旧 heal 却把 tool/result 追加在更后面
+      ev({
+        type: 'assistant/message',
+        text: "模型调用失败：Error: An assistant message with 'tool_calls' must be followed by tool messages",
+        seq: 2,
+        ts: 12,
+      }),
+      ev({
+        type: 'tool/result',
+        id: 'call_x',
+        name: 'session_wake',
+        ok: false,
+        detail: INTERRUPTED_TOOL_DETAIL,
+        seq: 3,
+        ts: 13,
+      }),
+      ev({ type: 'user/message', text: '再测并发', kind: 'wake', seq: 4, ts: 14 }),
+    ],
+    99,
+  )
+  assert.ok(rebuilt)
+  const types = rebuilt!.map((e) => e.type)
+  assert.deepEqual(types, [
+    'user/message',
+    'assistant/message',
+    'tool/result',
+    'assistant/message',
+    'user/message',
+  ])
+  assert.equal(rebuilt![2]?.type, 'tool/result')
+  if (rebuilt![2]?.type === 'tool/result') {
+    assert.equal(rebuilt![2].id, 'call_x')
+    assert.equal(rebuilt![2].ok, false)
+  }
+  // 错位的那条已被丢弃，没有第二份 tool/result
+  assert.equal(rebuilt!.filter((e) => e.type === 'tool/result').length, 1)
+
+  const messages = deriveMessages(rebuilt!)
+  assert.deepEqual(
+    messages.map((m) => m.role),
+    ['user', 'assistant', 'tool', 'assistant', 'user'],
+  )
+  assert.equal(messages[2]?.tool_call_id, 'call_x')
+})
+
+test('deriveMessages skips orphan tool results after error assistant', () => {
+  const messages = deriveMessages([
+    ev({
+      type: 'assistant/message',
+      text: '',
+      tool_calls: [{ id: 'c1', name: 'bash', arguments: '{}' }],
+      seq: 0,
+    }),
+    ev({ type: 'assistant/message', text: '模型调用失败', seq: 1 }),
+    ev({ type: 'tool/result', id: 'c1', name: 'bash', ok: false, detail: 'late', seq: 2 }),
+  ])
+  assert.deepEqual(
+    messages.map((m) => m.role),
+    ['assistant', 'tool', 'assistant'],
+  )
+  assert.equal(messages[1]?.tool_call_id, 'c1')
+  assert.match(String(messages[1]?.content), /interrupted/)
+})
+
+test('rebuildHealedEvents returns null when log is already healthy', () => {
+  assert.equal(
+    rebuildHealedEvents([
+      ev({ type: 'turn/start', turn: 1, seq: 0 }),
+      ev({
+        type: 'assistant/message',
+        text: '',
+        tool_calls: [{ id: 'c1', name: 'bash', arguments: '{}' }],
+        seq: 1,
+      }),
+      ev({ type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 2 }),
+      ev({ type: 'turn/end', turn: 1, reason: 'complete', seq: 3 }),
+    ]),
+    null,
+  )
 })

--- a/host/plugins/core/session-heal.ts
+++ b/host/plugins/core/session-heal.ts
@@ -69,10 +69,91 @@ export function orphanToolResultBodies(
   }))
 }
 
+function stripSeqTs(event: SessionEvent): SessionEventBody {
+  const { seq: _seq, ts: _ts, ...body } = event
+  return body as SessionEventBody
+}
+
 /**
- * 进程崩溃 / 重启后补齐日志：
- * 1) 缺失的 tool/result（先于 step/turn 结束）
- * 2) 未闭合的 step/end、turn/end（reason=host-restart）
+ * 按对话顺序重建事件：
+ * - 在带 tool_calls 的 assistant 之后、下一条 user/assistant 之前插入缺失的 tool/result
+ * - 丢掉错位/重复的 tool/result（例如旧 heal 追加在日志末尾）
+ * - 闭合未结束的 step/turn
+ * - 重编 seq
+ *
+ * 无变更时返回 null。
+ */
+export function rebuildHealedEvents(
+  events: SessionEvent[],
+  now = Date.now(),
+): SessionEvent[] | null {
+  const out: SessionEvent[] = []
+  const pending = new Map<string, string>()
+  let changed = false
+
+  const push = (body: SessionEventBody, ts: number) => {
+    out.push({ ...body, seq: out.length, ts } as SessionEvent)
+  }
+
+  const flushPending = () => {
+    if (!pending.size) return
+    changed = true
+    for (const body of orphanToolResultBodies(
+      [...pending.entries()].map(([id, name]) => ({ id, name })),
+    )) {
+      push(body, now)
+    }
+    pending.clear()
+  }
+
+  for (const event of events) {
+    if (event.type === 'tool/result') {
+      if (!pending.has(event.id)) {
+        changed = true
+        continue
+      }
+      pending.delete(event.id)
+      push(stripSeqTs(event), event.ts)
+      continue
+    }
+
+    if (event.type === 'user/message' || event.type === 'assistant/message') {
+      flushPending()
+      push(stripSeqTs(event), event.ts)
+      if (event.type === 'assistant/message' && event.tool_calls?.length) {
+        for (const call of event.tool_calls) {
+          pending.set(call.id, call.name)
+        }
+      }
+      continue
+    }
+
+    // chunk 可夹在 tool_calls 与 tool/result 之间；其余事件前先闭合未配对 tool
+    if (pending.size && event.type !== 'assistant/chunk') {
+      flushPending()
+    }
+    push(stripSeqTs(event), event.ts)
+  }
+
+  flushPending()
+
+  const { openTurn, openStep } = findOpenTurnStep(out)
+  if (openStep) {
+    changed = true
+    push({ type: 'step/end', turn: openStep.turn, step: openStep.step }, now)
+  }
+  if (openTurn != null) {
+    changed = true
+    push({ type: 'turn/end', turn: openTurn, reason: 'host-restart' }, now)
+  }
+
+  if (!changed) return null
+  return out.map((event, i) => ({ ...event, seq: i }))
+}
+
+/**
+ * 仅计算「追加在末尾」的补丁（旧行为）。新加载路径请用 rebuildHealedEvents。
+ * 保留给单元测试与兼容导出。
  */
 export function healInterruptedTurnBodies(events: SessionEvent[]): SessionEventBody[] {
   const orphans = findOrphanToolCalls(events)

--- a/host/plugins/core/sessions.ts
+++ b/host/plugins/core/sessions.ts
@@ -19,11 +19,15 @@ import {
   pickSessionMascot,
   type SessionMascot as AssignedMascot,
 } from './session-mascot.ts'
-import { healInterruptedTurnBodies } from './session-heal.ts'
+import { rebuildHealedEvents } from './session-heal.ts'
 
 export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord, SessionMascot, SessionType }
 export { SESSION_FORMAT_VERSION, normalizeSessionType }
-export { findOpenTurnStep, healInterruptedTurnBodies } from './session-heal.ts'
+export {
+  findOpenTurnStep,
+  healInterruptedTurnBodies,
+  rebuildHealedEvents,
+} from './session-heal.ts'
 
 export function deriveMessages(events: SessionEvent[]): LlmMessage[] {
   let system = ''
@@ -69,6 +73,8 @@ export function deriveMessages(events: SessionEvent[]): LlmMessage[] {
         for (const call of event.tool_calls!) pendingToolCalls.set(call.id, call.name)
       }
     } else if (event.type === 'tool/result') {
+      // 错位/重复的 tool/result 不能进 LLM（否则报 tool 必须跟在 tool_calls 后）
+      if (!pendingToolCalls.has(event.id)) continue
       messages.push({ role: 'tool', tool_call_id: event.id, content: event.detail })
       pendingToolCalls.delete(event.id)
     }
@@ -119,22 +125,12 @@ export class SessionsService extends Service {
    * 重启后进程内 agent 已空，但日志若仍开着 turn，UI/Live 会一直显示 running，再发消息也会叠 turn。
    */
   private async healOpenTurnsOnLoad(record: SessionRecord): Promise<SessionRecord> {
-    const bodies = healInterruptedTurnBodies(record.events)
-    if (!bodies.length) return record
-    const ts = Date.now()
-    let seq = record.events.length
-    const appended: SessionEvent[] = []
-    for (const body of bodies) {
-      const event = { ...body, seq: seq++, ts } as SessionEvent
-      record.events.push(event)
-      appended.push(event)
-    }
+    const rebuilt = rebuildHealedEvents(record.events)
+    if (!rebuilt) return record
+    record.events = rebuilt
     await this.persist(record)
-    for (const event of appended) {
-      this.ctx.emit('session/event', { sessionId: record.id, event })
-    }
     this.ctx.logger('sessions').info(
-      `healed interrupted session log session=${record.id} +${appended.map((e) => e.type).join(',')}`,
+      `healed interrupted session log session=${record.id} events=${rebuilt.length}`,
     )
     return record
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
Live 会话在崩溃后留下 `assistant` + `tool_calls` 无对应 `tool/result`。先前 heal 把 synthetic `tool/result` **追加在日志末尾**，若中间已有「模型调用失败」等 assistant/user，会出现：

1. `tool_calls` 后缺少 tool messages  
2. 或错位的 `role: tool` 不跟在 `tool_calls` 后 → `Messages with role 'tool' must be a response to a preceding message with 'tool_calls'`

## 修复
- `rebuildHealedEvents`：在带 `tool_calls` 的 assistant **正后方**插入缺失 result；丢弃错位/重复的 `tool/result`；再闭合 open step/turn 并重编 `seq`
- `healOpenTurnsOnLoad` 改为整段重写 events（不再末尾 append）
- `deriveMessages` 忽略非 pending 的 `tool/result`（防御）

## 验证
`vitest`：`session-heal.test.ts` + `sessions.test.ts` 全部通过

## 使用说明
重启 host 后重新打开该 Live session（加载时会自动 heal）。历史若已被旧 heal 弄乱，本次加载会按正确顺序重建。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

