### PR TITLE
fix(ui): 去掉指挥台、拖动条变细、轨迹夜间对比度

### DIFF
--- a/host/plugins/seams/session-inspector.ts
+++ b/host/plugins/seams/session-inspector.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'cordis'
 import '../../types.ts'
 import { MINIMAL_TOOL_NAMES, type AgentToolMode } from '../registry/tools.ts'
-import { LIVE_TOOL_NAMES, buildSessionProgress } from './live-sessions.ts'
+import { LIVE_TOOL_NAMES } from './live-sessions.ts'
 import { collectLiveDispatchedTasks } from './live-dispatched-usage.ts'
 import { normalizeSessionType, type SessionEvent, type SessionType } from '../core/session-types.ts'
 
@@ -21,21 +21,6 @@ export interface InspectorSourceInfo {
   id: ToolSourceId
   label: string
   description: string
-}
-
-export interface InspectorWorkerRow {
-  id: string
-  title: string
-  type: SessionType
-  status: 'idle' | 'running'
-  turn: number | null
-  step: number | null
-  lastTool: string | null
-  assistantText: string
-  updatedAt: number
-  inboxPending: number
-  project?: string
-  mascot?: { shape: string; color: string }
 }
 
 const SOURCE_INFO: InspectorSourceInfo[] = [
@@ -103,40 +88,6 @@ export function buildInspectorTools(
     })
 }
 
-export async function buildLiveWorkers(ctx: Context, selfId: string): Promise<InspectorWorkerRow[]> {
-  const items = await ctx.sessions.listSummaries()
-  const workers: InspectorWorkerRow[] = []
-  for (const item of items) {
-    if (item.id === selfId) continue
-    if (normalizeSessionType(item.type) === 'live') continue
-    const record = await ctx.sessions.require(item.id)
-    const progress = buildSessionProgress(record.events, {
-      busy: ctx.agents.isBusy(item.id),
-      inboxPending: ctx.agents.inboxPending(item.id),
-      textLimit: 180,
-    })
-    workers.push({
-      id: item.id,
-      title: item.title,
-      type: normalizeSessionType(item.type),
-      status: progress.status,
-      turn: progress.turn,
-      step: progress.step,
-      lastTool: progress.lastTool?.name ?? null,
-      assistantText: progress.assistantText,
-      updatedAt: progress.updatedAt || item.updatedAt,
-      inboxPending: progress.inboxPending,
-      project: item.project?.name,
-      ...(item.mascot ? { mascot: item.mascot } : {}),
-    })
-  }
-  workers.sort((a, b) => {
-    if (a.status !== b.status) return a.status === 'running' ? -1 : 1
-    return b.updatedAt - a.updatedAt
-  })
-  return workers
-}
-
 export const name = 'session-inspector'
 export const inject = ['http', 'sessions', 'agents', 'tools', 'chat']
 
@@ -162,7 +113,6 @@ export function apply(ctx: Context) {
       tools,
     }
     if (sessionType === 'live') {
-      body.workers = await buildLiveWorkers(ctx, id)
       const dispatched = await loadDispatchedUsage(ctx, id, record.events)
       const titles = new Map<string, string>()
       const mascots = new Map<string, { shape: string; color: string; eye?: number }>()

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -1,16 +1,14 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { LuListTree, LuPanelRightClose, LuRadio, LuWrench } from 'react-icons/lu'
+import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { LuListTree, LuPanelRightClose, LuWrench } from 'react-icons/lu'
 import {
   bindSessionView,
   type SessionViewService,
 } from '../infrastructure/session-view.ts'
-import { SidebarMascot } from './mascot/sidebar-mascot.tsx'
-import { resolveSessionMascot } from './mascot/session-mascot.ts'
 import { TrajectoryView } from './chat/trajectory.tsx'
 
 type ToolSourceId = 'minimal' | 'live' | 'plugin'
 type AgentMode = 'standard' | 'minimal'
-type InspectorTab = 'tools' | 'live' | 'traj'
+type InspectorTab = 'tools' | 'traj'
 
 interface InspectorTool {
   name: string
@@ -26,20 +24,6 @@ interface InspectorSource {
   description: string
 }
 
-interface InspectorWorker {
-  id: string
-  title: string
-  status: 'idle' | 'running'
-  turn: number | null
-  step: number | null
-  lastTool: string | null
-  assistantText: string
-  updatedAt: number
-  inboxPending: number
-  project?: string
-  mascot?: { shape: string; color: string; eye?: number }
-}
-
 interface InspectorPayload {
   sessionId: string
   type: 'chat' | 'live'
@@ -47,7 +31,6 @@ interface InspectorPayload {
   extraTools: string[]
   sources: InspectorSource[]
   tools: InspectorTool[]
-  workers?: InspectorWorker[]
 }
 
 export type SessionInspectorProps = {
@@ -75,12 +58,7 @@ export const SessionInspector = memo(function SessionInspector({
   sessionView,
 }: SessionInspectorProps) {
   const sessionId = useSessionView((state) => state.sessionId)
-  const sessions = useSessionView((state) => state.sessions)
   const focusCallId = useSessionView((state) => state.focusCallId)
-  const sessionType = useMemo(() => {
-    const hit = sessions.find((item) => item.id === sessionId)
-    return (hit?.type ?? 'chat') as 'chat' | 'live'
-  }, [sessionId, sessions])
 
   const [tab, setTab] = useState<InspectorTab>('tools')
   const [data, setData] = useState<InspectorPayload | null>(null)
@@ -93,8 +71,8 @@ export const SessionInspector = memo(function SessionInspector({
       setTab('traj')
       return
     }
-    setTab(sessionType === 'live' ? 'live' : 'tools')
-  }, [sessionType, sessionId, focusCallId])
+    setTab('tools')
+  }, [sessionId, focusCallId])
 
   useEffect(() => {
     if (!open || tab !== 'traj') return
@@ -175,7 +153,6 @@ export const SessionInspector = memo(function SessionInspector({
   const mode = data?.agentMode ?? 'standard'
   const sources = data?.sources ?? []
   const tools = data?.tools ?? []
-  const workers = data?.workers ?? []
 
   return (
     <aside
@@ -184,7 +161,7 @@ export const SessionInspector = memo(function SessionInspector({
       aria-label="会话检查器"
     >
       <div
-        className="absolute inset-y-0 left-0 z-10 w-1.5 cursor-col-resize touch-none hover:bg-[color-mix(in_srgb,var(--dsw-business)_35%,transparent)]"
+        className="absolute inset-y-0 left-0 z-10 w-1 cursor-col-resize touch-none before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent hover:before:bg-[color-mix(in_srgb,var(--dsw-business)_55%,transparent)]"
         data-testid="inspector-resize"
         title="拖动调整宽度"
         onPointerDown={(event) => {
@@ -207,18 +184,6 @@ export const SessionInspector = memo(function SessionInspector({
             <LuWrench className="size-3.5" />
             工具
           </button>
-          {sessionType === 'live' ? (
-            <button
-              type="button"
-              role="tab"
-              aria-selected={tab === 'live'}
-              className={tabClass(tab === 'live')}
-              onClick={() => setTab('live')}
-            >
-              <LuRadio className="size-3.5" />
-              指挥台
-            </button>
-          ) : null}
           <button
             type="button"
             role="tab"
@@ -321,57 +286,6 @@ export const SessionInspector = memo(function SessionInspector({
                 </li>
               ))}
             </ul>
-          </div>
-        ) : null}
-
-        {tab === 'live' ? (
-          <div className="flex flex-col gap-2.5">
-            <p className="m-0 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">
-              其它 chat session 的现场（只读，约 2s 刷新）。
-            </p>
-            {workers.length === 0 ? (
-              <div className="text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">暂无 worker session</div>
-            ) : (
-              <ul className="m-0 flex list-none flex-col gap-px p-0" data-testid="inspector-workers">
-                {workers.map((worker) => (
-                  <li key={worker.id} className="rounded-[8px] px-2 py-1.5 hover:bg-[var(--dsw-hover)]">
-                    <div className="flex min-w-0 items-center gap-1.5">
-                      <SidebarMascot
-                        size={22}
-                        sessionId={worker.id}
-                        identity={resolveSessionMascot(worker.id, worker.mascot)}
-                        busy={worker.status === 'running'}
-                        animate={false}
-                        title={worker.title}
-                      />
-                      <span className="min-w-0 flex-1 truncate text-[12px] font-semibold">{worker.title}</span>
-                      <span
-                        className={`ml-auto shrink-0 text-[10px] font-semibold ${
-                          worker.status === 'running'
-                            ? 'text-[var(--dsw-ok,#34d399)]'
-                            : 'text-[var(--dsw-label-3)]'
-                        }`}
-                      >
-                        {worker.status}
-                      </span>
-                    </div>
-                    <div className="mt-1 flex flex-wrap gap-1.5 text-[10px] text-[var(--dsw-label-3)]">
-                      {worker.project ? <span>{worker.project}</span> : null}
-                      <span>
-                        t{worker.turn ?? '—'} / s{worker.step ?? '—'}
-                      </span>
-                      {worker.lastTool ? <span>{worker.lastTool}</span> : null}
-                      {worker.inboxPending > 0 ? <span>inbox {worker.inboxPending}</span> : null}
-                    </div>
-                    {worker.assistantText ? (
-                      <p className="mt-1.5 mb-0 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">
-                        {worker.assistantText}
-                      </p>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            )}
           </div>
         ) : null}
 

--- a/src/style.css
+++ b/src/style.css
@@ -1068,7 +1068,7 @@ body {
 }
 
 .traj-usage-out {
-  color: var(--dsw-business);
+  color: var(--dsw-label);
   font-weight: 600;
 }
 
@@ -1120,7 +1120,7 @@ body {
 }
 
 .traj-usage-stat-out strong {
-  color: var(--dsw-business);
+  color: var(--dsw-label);
 }
 
 .traj-usage-stat-sub {
@@ -1166,7 +1166,7 @@ body {
   gap: 6px;
   padding: 6px 8px;
   border-bottom: 1px solid var(--dsw-border);
-  background: rgba(255, 255, 255, 0.7);
+  background: var(--dsw-muted-fill);
 }
 
 .traj-io-role {
@@ -1188,8 +1188,8 @@ body {
 }
 
 .traj-io-role-assistant {
-  color: var(--dsw-business);
-  background: var(--dsw-business-soft);
+  color: var(--dsw-label);
+  background: var(--dsw-hover-strong);
 }
 
 .traj-io-role-tool {
@@ -1208,7 +1208,7 @@ body {
   max-height: 220px;
   overflow: auto;
   padding: 8px;
-  color: var(--dsw-label);
+  color: var(--dsw-label-2);
   font-family: var(--font-mono);
   font-size: 11px;
   line-height: 1.45;
@@ -1252,8 +1252,8 @@ body {
 }
 
 .traj-tag-assistant {
-  color: var(--dsw-business);
-  background: var(--dsw-business-soft);
+  color: var(--dsw-label);
+  background: var(--dsw-hover-strong);
 }
 
 .traj-tag-tool {
@@ -1333,7 +1333,7 @@ body {
 
 .traj-detail-type {
   margin-top: 2px;
-  color: var(--dsw-business);
+  color: var(--dsw-label-2);
   font-family: var(--font-mono);
   font-size: 11px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更
- **去掉右侧检查器「指挥台」tab**：聊天里已有派工表；Live 默认回到「工具」；API 不再返回 `workers`。
- **拖动条高亮变细**：可点区域仍约 `w-1`，hover 仅 1px 竖线。
- **轨迹详情夜间可读性**：消息头去掉硬编码半透明白底；详情 type / assistant 角色等由近白 `--dsw-business` 改为更柔和的 label 色。

## 保留
- 聊天内 `LiveDispatchTable` 与 dispatched-usage API 不变。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

