### PR TITLE
feat(chat): 输入框上方展示 wake/inject 排队

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -435,6 +435,7 @@ export function apply(ctx: Context) {
     const payload = (await route.json()) as {
       text?: string
       kind?: 'wake' | 'inject'
+      wait?: boolean
       extraTools?: string[]
     }
     const agent = await ctx.agents.create(route.params.id)
@@ -443,17 +444,36 @@ export function apply(ctx: Context) {
     const extraTools = Array.isArray(payload.extraTools)
       ? [...new Set(payload.extraTools.map((name) => String(name).trim()).filter(Boolean))]
       : []
-    const sendOpts = extraTools.length ? { extraTools } : undefined
+    const sendOpts = {
+      ...(extraTools.length ? { extraTools } : {}),
+      ...(payload.wait === false ? { wait: false as const } : {}),
+    }
     if (payload.kind === 'inject') {
       agent.inject(payload.text ?? '', sendOpts)
-      return route.send(200, { sessionId: agent.sessionId, queued: true })
+      return route.send(200, {
+        sessionId: agent.sessionId,
+        queued: true,
+        inbox: ctx.agents.listInbox(agent.sessionId),
+      })
     }
     try {
       const turn = await agent.send(payload.text ?? '', sendOpts)
-      route.send(200, { sessionId: agent.sessionId, text: turn.text, steps: turn.steps })
+      route.send(200, {
+        sessionId: agent.sessionId,
+        text: turn.text,
+        steps: turn.steps,
+        queued: Boolean(sendOpts.wait === false || ctx.agents.isBusy(agent.sessionId)),
+        inbox: ctx.agents.listInbox(agent.sessionId),
+      })
     } catch (error) {
       route.send(500, { error: String(error) })
     }
+  })
+  ctx.http.route('GET', '/api/sessions/:id/inbox', async (route) => {
+    const id = route.params.id
+    if (!(await ctx.sessions.get(id))) return route.send(404, { error: 'unknown session' })
+    await ctx.agents.create(id)
+    route.send(200, { sessionId: id, inbox: ctx.agents.listInbox(id) })
   })
   ctx.http.route('POST', '/api/sessions/:id/cancel', (route) => {
     ctx.agents.get(route.params.id)?.cancel()

--- a/host/plugins/orchestration/agent-loop.ts
+++ b/host/plugins/orchestration/agent-loop.ts
@@ -15,6 +15,8 @@ export interface AgentTurn {
 export interface ClaimedInput {
   kind: InboxKind
   text: string
+  /** 前端排队展示用；写入 session 日志前可丢弃 */
+  id?: string
   /** slash 为本回合临时放开的额外工具（极简模式） */
   extraTools?: string[]
   /** 写入 user/message 的来源；缺省为真人用户 */

--- a/host/plugins/orchestration/agents.test.ts
+++ b/host/plugins/orchestration/agents.test.ts
@@ -73,3 +73,64 @@ test('send wait:false returns immediately; isBusy clears when done', async () =>
     true,
   )
 })
+
+test('busy second send becomes inject alongside queued wake', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  ctx.agents.configure({ provider: 'deepseek', apiKey: '', model: 'x' })
+  const agent = await ctx.agents.create()
+
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const originalCreate = ctx.agentLoop.create.bind(ctx.agentLoop)
+  ctx.agentLoop.create = ((config, sessionId, signal) => {
+    const runner = originalCreate(config, sessionId, signal)
+    const originalRun = runner.run.bind(runner)
+    runner.run = async (claimed) => {
+      await gate
+      return originalRun(claimed)
+    }
+    return runner
+  }) as typeof ctx.agentLoop.create
+
+  void agent.send('first', { wait: false })
+  for (let i = 0; i < 20 && !ctx.agents.isBusy(agent.sessionId); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  assert.equal(ctx.agents.isBusy(agent.sessionId), true)
+
+  await agent.send('follow-up wake', { wait: false })
+  let inbox = ctx.agents.listInbox(agent.sessionId)
+  assert.equal(inbox.length, 1)
+  assert.equal(inbox[0]?.kind, 'wake')
+  assert.equal(inbox[0]?.text, 'follow-up wake')
+
+  await agent.send('steer', { wait: false })
+  inbox = ctx.agents.listInbox(agent.sessionId)
+  assert.equal(inbox.length, 2)
+  assert.deepEqual(
+    inbox.map((item) => item.kind),
+    ['wake', 'inject'],
+  )
+  assert.equal(inbox[1]?.text, 'steer')
+
+  release()
+  for (let i = 0; i < 80 && ctx.agents.isBusy(agent.sessionId); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  assert.equal(ctx.agents.listInbox(agent.sessionId).length, 0)
+  const users = (await ctx.sessions.require(agent.sessionId)).events
+    .filter((item) => item.type === 'user/message')
+    .map((item) => ('text' in item ? item.text : ''))
+  assert.ok(users.includes('first'))
+  assert.ok(users.includes('steer'))
+  assert.ok(users.includes('follow-up wake'))
+})

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -22,11 +22,23 @@ export interface AgentHandle {
   dispose(): void
 }
 
+export type InboxRow = {
+  id: string
+  kind: 'wake' | 'inject'
+  text: string
+}
+
 interface LiveAgent {
   handle: AgentHandle
   inbox: ClaimedInput[]
   running?: Promise<void>
   abort: AbortController
+}
+
+let inboxSeq = 0
+function nextInboxId() {
+  inboxSeq += 1
+  return `inq-${Date.now().toString(36)}-${inboxSeq}`
 }
 
 export class AgentsService extends Service {
@@ -50,6 +62,21 @@ export class AgentsService extends Service {
     return this.lives.get(sessionId)?.inbox.length ?? 0
   }
 
+  /** 当前尚未 claim 的排队消息（wake / inject）。 */
+  listInbox(sessionId: string): InboxRow[] {
+    const live = this.lives.get(sessionId)
+    if (!live) return []
+    return live.inbox.map((item) => ({
+      id: item.id ?? nextInboxId(),
+      kind: item.kind,
+      text: item.text,
+    }))
+  }
+
+  private emitInbox(sessionId: string) {
+    this.ctx.emit('agent/inbox', { sessionId, inbox: this.listInbox(sessionId) })
+  }
+
   async create(sessionId?: string): Promise<AgentHandle> {
     const id = sessionId ?? (await this.ctx.sessions.create()).id
     if (!(await this.ctx.sessions.get(id))) await this.ctx.sessions.create(id)
@@ -66,6 +93,7 @@ export class AgentsService extends Service {
       let last: AgentTurn = { text: '', steps: [] }
       while (true) {
         const claimed = claim(live.inbox)
+        this.emitInbox(id)
         if (!claimed) break
         last = await this.ctx.agentLoop.create(this.llm, id, live.abort.signal).run(claimed)
       }
@@ -79,12 +107,23 @@ export class AgentsService extends Service {
         if (!trimmed) return { text: '请先输入内容。', steps: [] }
         const extraTools = sanitizeExtraTools(opts?.extraTools)
         const wait = opts?.wait !== false
-        live.inbox.push({
-          kind: 'wake',
+        const entry = {
           text: trimmed,
+          id: nextInboxId(),
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
-        })
+        }
+
+        // Cursor 同款：忙碌且已有 wake 排队时，再发送 → inject（并入该 wake 的下一回合）
+        if (live.running && live.inbox.some((item) => item.kind === 'wake')) {
+          live.inbox.push({ kind: 'inject', ...entry })
+          this.emitInbox(id)
+          return { text: '', steps: [] }
+        }
+
+        live.inbox.push({ kind: 'wake', ...entry })
+        this.emitInbox(id)
+
         if (live.running) {
           if (!wait) return { text: '', steps: [] }
           await live.running
@@ -116,14 +155,17 @@ export class AgentsService extends Service {
         live.inbox.push({
           kind: 'inject',
           text: trimmed,
+          id: nextInboxId(),
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
         })
+        this.emitInbox(id)
       },
       cancel: () => live.abort.abort(),
       dispose: () => {
         live.abort.abort()
         this.lives.delete(id)
+        this.ctx.emit('agent/inbox', { sessionId: id, inbox: [] })
       },
     }
     live.handle = handle

--- a/host/plugins/registry/http.ts
+++ b/host/plugins/registry/http.ts
@@ -69,6 +69,7 @@ export class HttpService extends Service {
       })
       ctx.on('session/event', (payload) => this.broadcast('session', payload))
       ctx.on('agent/status', (payload) => this.broadcast('agent', payload))
+      ctx.on('agent/inbox', (payload) => this.broadcast('inbox', payload))
       server.on('error', (error: NodeJS.ErrnoException) => {
         if (error.code === 'EADDRINUSE') {
           ctx.logger('http').error(

--- a/host/types.ts
+++ b/host/types.ts
@@ -72,6 +72,10 @@ declare module 'cordis' {
     'http/ready'(info: { port: number }): void
     'hub/change'(): void
     'agent/status'(payload: { sessionId: string; status: 'idle' | 'running'; step?: number }): void
+    'agent/inbox'(payload: {
+      sessionId: string
+      inbox: Array<{ id: string; kind: 'wake' | 'inject'; text: string }>
+    }): void
     'agent/pre-step'(req: PreStepReq, next: () => PreStepReq): PreStepReq
     'session/event'(payload: { sessionId: string; event: SessionEvent }): void
     'tools/pre-execute'(req: ToolRequest, next: () => ToolRequest): ToolRequest

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -67,6 +67,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const [modelBusy, setModelBusy] = useState(false)
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
+  const inbox = useSessionView((state) => state.inbox)
   const sessionView = props.sessionView as SessionViewService
   const navigate = useNavigate()
   const location = useLocation()
@@ -263,7 +264,6 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
-    if (pending) return
     if (slash?.open && filtered.length) {
       const item = filtered[activeIndex] ?? filtered[0]
       if (item) pickTool(item.name)
@@ -321,13 +321,31 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
     if (event.key !== 'Enter' || event.shiftKey) return
     if (event.nativeEvent.isComposing || event.keyCode === 229) return
-    if (pending) return
     event.preventDefault()
     event.currentTarget.form?.requestSubmit()
   }
 
   return (
-    <form className={`composer-pill${expanded ? ' is-expanded' : ''}`} onSubmit={onSubmit}>
+    <div className="composer-stack">
+      {inbox.length > 0 ? (
+        <div className="composer-inbox" aria-label="排队中">
+          <div className="composer-inbox-head">排队中 · {inbox.length}</div>
+          <ul className="composer-inbox-list">
+            {inbox.map((item) => (
+              <li key={item.id} className="composer-inbox-item">
+                <span className={`composer-inbox-kind composer-inbox-kind-${item.kind}`}>
+                  {item.kind}
+                </span>
+                <span className="composer-inbox-text" title={item.text}>
+                  {item.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <form className={`composer-pill${expanded ? ' is-expanded' : ''}`} onSubmit={onSubmit}>
       {slash?.open ? (
         <div className="composer-slash" role="listbox" aria-label="工具列表">
           <div className="composer-slash-head">工具 · 输入过滤 · Enter 选用</div>
@@ -392,7 +410,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           className="composer-pill-input"
           defaultValue=""
           rows={1}
-          placeholder={pending ? 'Add a follow up' : 'Add a follow up'}
+          placeholder={pending ? 'Add a follow up…' : 'Add a follow up'}
           aria-label="对话输入"
           aria-expanded={Boolean(slash?.open)}
           onChange={(event) => {
@@ -451,21 +469,21 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             >
               <span className="composer-stop-square" aria-hidden />
             </button>
-          ) : (
-            <button
-              type="submit"
-              className="composer-send"
-              disabled={!canSubmit}
-              aria-label="Send"
-              title="发送"
-            >
-              <svg viewBox="0 0 24 24" className="size-3.5" fill="currentColor" aria-hidden>
-                <path d="M3.4 20.6 21 12 3.4 3.4 3 10.3 15 12 3 13.7z" />
-              </svg>
-            </button>
-          )}
+          ) : null}
+          <button
+            type="submit"
+            className="composer-send"
+            disabled={!canSubmit}
+            aria-label={pending ? 'Queue' : 'Send'}
+            title={pending ? (inbox.some((item) => item.kind === 'wake') ? '注入排队' : '加入排队') : '发送'}
+          >
+            <svg viewBox="0 0 24 24" className="size-3.5" fill="currentColor" aria-hidden>
+              <path d="M3.4 20.6 21 12 3.4 3.4 3 10.3 15 12 3 13.7z" />
+            </svg>
+          </button>
         </div>
       </div>
     </form>
+    </div>
   )
 })

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -50,6 +50,13 @@ export type DispatchedTaskRow = {
   preview?: string
 }
 
+/** 当前 session agent inbox 中尚未 claim 的排队消息 */
+export type InboxQueueItem = {
+  id: string
+  kind: 'wake' | 'inject'
+  text: string
+}
+
 /** 与 host DEFAULT_TAIL_TURNS 对齐；仅 loadOlder 分页仍用窗口拉取 */
 export const SESSION_TAIL_TURNS = 24
 export const TRAJECTORY_TAIL_TURNS = 48
@@ -67,6 +74,8 @@ export interface SessionViewState {
   agentStatus: 'idle' | 'running'
   agentStep?: number
   pending: boolean
+  /** 忙碌时已入队、尚未开始的 wake/inject */
+  inbox: InboxQueueItem[]
   /** 任意 session 的 busy（含 Live 派工的 worker）；侧栏 mascot 用 */
   busySessions: Record<string, true>
   approvalMode: ApprovalMode
@@ -99,6 +108,7 @@ const empty: SessionViewState = {
   view: 'chat',
   agentStatus: 'idle',
   pending: false,
+  inbox: [],
   busySessions: {},
   approvalMode: 'auto',
   approvals: [],
@@ -276,6 +286,7 @@ export class SessionViewService extends Service {
         focusCallId: undefined,
         pending: false,
         agentStatus: 'idle',
+        inbox: [],
         project: undefined,
         hasMoreOlder: false,
         loadingOlder: false,
@@ -757,6 +768,7 @@ export class SessionViewService extends Service {
       })
       this.syncDispatchedPoll()
       if (view === 'debug') void this.ensureTrajectory()
+      void this.refreshInbox(sessionId)
     } catch {
       /* 静默 */
     }
@@ -772,6 +784,7 @@ export class SessionViewService extends Service {
       view,
       focusCallId: view === 'chat' ? undefined : this.value.focusCallId,
       error: undefined,
+      inbox: sessionId === this.value.sessionId ? this.value.inbox : [],
       ...this.busyFlagsFor(sessionId),
       hasMoreOlder: cached.hasMoreOlder,
       loadingOlder: false,
@@ -784,6 +797,7 @@ export class SessionViewService extends Service {
       switchingSession: false,
     })
     this.syncDispatchedPoll()
+    void this.refreshInbox(sessionId)
   }
 
   private stashCurrent() {
@@ -1052,6 +1066,7 @@ export class SessionViewService extends Service {
       approvals: [],
       pending: false,
       agentStatus: 'idle',
+      inbox: [],
       view: 'chat',
       focusCallId: undefined,
       project: undefined,
@@ -1070,23 +1085,35 @@ export class SessionViewService extends Service {
     if (!content) return
     const sessionId = await this.ensureSession()
     const tools = [...new Set(extraTools.map((name) => name.trim()).filter(Boolean))]
-    const body =
-      kind === 'inject'
-        ? { text: content, kind: 'inject' as const, ...(tools.length ? { extraTools: tools } : {}) }
-        : { text: content, ...(tools.length ? { extraTools: tools } : {}) }
-    if (kind === 'inject') {
+    const busy = this.value.pending || this.value.agentStatus === 'running'
+    const hasWake = this.value.inbox.some((item) => item.kind === 'wake')
+    // 忙碌且已有 wake：再发 → inject；否则 wake。忙碌时 wait:false 立刻返回。
+    const effectiveKind: 'wake' | 'inject' =
+      kind === 'inject' || (kind === 'wake' && busy && hasWake) ? 'inject' : 'wake'
+    const body: Record<string, unknown> =
+      effectiveKind === 'inject'
+        ? { text: content, kind: 'inject', ...(tools.length ? { extraTools: tools } : {}) }
+        : {
+            text: content,
+            ...(busy ? { wait: false } : {}),
+            ...(tools.length ? { extraTools: tools } : {}),
+          }
+
+    if (effectiveKind === 'inject') {
       const res = await fetch(`/api/sessions/${sessionId}/messages`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
-      const data = (await res.json()) as { error?: string }
+      const data = (await res.json()) as { error?: string; inbox?: InboxQueueItem[] }
       if (!res.ok) {
         this.replace({ error: data.error || `注入失败：${res.status}` })
         throw new Error(data.error || `注入失败：${res.status}`)
       }
+      if (Array.isArray(data.inbox)) this.setInbox(data.inbox, sessionId)
       return
     }
+
     this.setAgentStatus('running', undefined, sessionId)
     this.replace({ error: undefined })
     try {
@@ -1095,8 +1122,19 @@ export class SessionViewService extends Service {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       })
-      const data = (await res.json()) as { error?: string; sessionId?: string; text?: string }
+      const data = (await res.json()) as {
+        error?: string
+        sessionId?: string
+        text?: string
+        queued?: boolean
+        inbox?: InboxQueueItem[]
+      }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)
+      if (Array.isArray(data.inbox)) this.setInbox(data.inbox, data.sessionId ?? sessionId)
+      if (data.queued) {
+        // 已入队：不阻塞等回合结束，状态交给 WS
+        return
+      }
       if (data.sessionId && data.sessionId !== sessionId) {
         await this.load(data.sessionId, { view: 'chat', wait: true })
       } else {
@@ -1116,6 +1154,29 @@ export class SessionViewService extends Service {
       throw error
     }
     // 成功后不要在 finally 里强行 idle：agent 仍在跑，状态交给 WS agent/status
+  }
+
+  setInbox(inbox: InboxQueueItem[], sessionId?: string) {
+    const id = sessionId ?? this.value.sessionId
+    if (id && this.value.sessionId && id !== this.value.sessionId) return
+    const next = Array.isArray(inbox) ? inbox : []
+    if (JSON.stringify(next) === JSON.stringify(this.value.inbox)) return
+    this.replace({ inbox: next })
+  }
+
+  async refreshInbox(sessionId = this.value.sessionId) {
+    if (!sessionId) {
+      this.replace({ inbox: [] })
+      return
+    }
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/inbox`)
+      if (!res.ok || this.value.sessionId !== sessionId) return
+      const body = (await res.json()) as { inbox?: InboxQueueItem[] }
+      this.setInbox(Array.isArray(body.inbox) ? body.inbox : [], sessionId)
+    } catch {
+      /* 静默 */
+    }
   }
 
   async cancel() {

--- a/src/plugins/infrastructure/snapshot.ts
+++ b/src/plugins/infrastructure/snapshot.ts
@@ -121,6 +121,23 @@ export class SnapshotService extends Service {
             | undefined
           view?.setAgentStatus(status.status, status.step, status.sessionId)
         }
+        if (parsed.type === 'inbox') {
+          const detail = parsed.payload as {
+            sessionId?: string
+            inbox?: Array<{ id: string; kind: 'wake' | 'inject'; text: string }>
+          }
+          const view = this.ctx.get('sessionView') as
+            | {
+                setInbox: (
+                  inbox: Array<{ id: string; kind: 'wake' | 'inject'; text: string }>,
+                  sessionId?: string,
+                ) => void
+              }
+            | undefined
+          if (detail.sessionId && Array.isArray(detail.inbox)) {
+            view?.setInbox(detail.inbox, detail.sessionId)
+          }
+        }
       }
       ws.onclose = () => {
         if (import.meta.env.MODE === 'test') return

--- a/src/style.css
+++ b/src/style.css
@@ -1988,6 +1988,76 @@ body {
   position: relative;
 }
 
+.composer-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.composer-inbox {
+  border: 1px solid var(--dsw-border);
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--dsw-surface) 88%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.composer-inbox-head {
+  margin-bottom: 6px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.composer-inbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.composer-inbox-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 2px;
+}
+
+.composer-inbox-kind {
+  flex-shrink: 0;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+
+.composer-inbox-kind-wake {
+  color: var(--dsw-ok);
+  background: rgba(34, 140, 90, 0.12);
+}
+
+.composer-inbox-kind-inject {
+  color: var(--dsw-label);
+  background: var(--dsw-hover-strong);
+}
+
+.composer-inbox-text {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--dsw-label-2);
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .composer-slash {
   position: absolute;
   right: 10px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做什么
给**所有 Chat**（不限 Live）接上已有 inbox 排队的前端展示与交互：

1. **忙碌仍可发送**：内容进队列，不挡输入。
2. **输入框上方「排队中」**：列出尚未 claim 的消息，并标注 `wake` / `inject`。
3. **Cursor 同款二次发送**：回合进行中，第一条 follow-up 为 `wake`；再发一条自动变为 `inject`，与该 `wake` 一并在下一回合 claim。

## 实现要点
- `agents.listInbox` + `agent/inbox` WS；`GET /api/sessions/:id/inbox`
- `send` 在 busy 且已有 wake 时升级为 inject；busy 时 `wait:false`
- Composer：pending 也可提交；停止与发送并存

## 测试
- `host/plugins/orchestration/agents.test.ts`（含 busy 二次 send → inject）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

