### PR TITLE
feat(chat): 空回车 abort 并立刻 claim 队列

### DIFF
--- a/host/plugins/contributors/chat.ts
+++ b/host/plugins/contributors/chat.ts
@@ -479,6 +479,22 @@ export function apply(ctx: Context) {
     ctx.agents.get(route.params.id)?.cancel()
     route.send(200, { ok: true })
   })
+  ctx.http.route('POST', '/api/sessions/:id/inbox/flush', async (route) => {
+    const id = route.params.id
+    if (!(await ctx.sessions.get(id))) return route.send(404, { error: 'unknown session' })
+    const agent = await ctx.agents.create(id)
+    chat.patch({}, { persist: false })
+    try {
+      const result = await agent.flush({ wait: false })
+      route.send(200, {
+        sessionId: id,
+        flushed: result.flushed,
+        inbox: ctx.agents.listInbox(id),
+      })
+    } catch (error) {
+      route.send(500, { error: String(error) })
+    }
+  })
   ctx.http.route('POST', '/api/chat', async (route) => {
     const payload = (await route.json()) as { messages?: ChatMessage[]; sessionId?: string; text?: string }
     const messages = Array.isArray(payload?.messages)

--- a/host/plugins/orchestration/agents.test.ts
+++ b/host/plugins/orchestration/agents.test.ts
@@ -134,3 +134,61 @@ test('busy second send becomes inject alongside queued wake', async () => {
   assert.ok(users.includes('steer'))
   assert.ok(users.includes('follow-up wake'))
 })
+
+test('flush aborts current turn and claims queued wake+inject', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  ctx.agents.configure({ provider: 'deepseek', apiKey: '', model: 'x' })
+  const agent = await ctx.agents.create()
+
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  let runs = 0
+  const originalCreate = ctx.agentLoop.create.bind(ctx.agentLoop)
+  ctx.agentLoop.create = ((config, sessionId, signal) => {
+    const runner = originalCreate(config, sessionId, signal)
+    const originalRun = runner.run.bind(runner)
+    runner.run = async (claimed) => {
+      runs += 1
+      if (runs === 1) {
+        await gate
+        if (signal.aborted) throw new Error('cancelled')
+      }
+      return originalRun(claimed)
+    }
+    return runner
+  }) as typeof ctx.agentLoop.create
+
+  void agent.send('running-now', { wait: false })
+  for (let i = 0; i < 20 && !ctx.agents.isBusy(agent.sessionId); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  await agent.send('queued-wake', { wait: false })
+  await agent.send('queued-inject', { wait: false })
+  assert.equal(ctx.agents.listInbox(agent.sessionId).length, 2)
+
+  const flushPromise = agent.flush({ wait: false })
+  // 让 abort 生效后再放行第一回合
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  release()
+  const flushed = await flushPromise
+  assert.equal(flushed.flushed, true)
+
+  for (let i = 0; i < 80 && ctx.agents.isBusy(agent.sessionId); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  assert.equal(ctx.agents.listInbox(agent.sessionId).length, 0)
+  const users = (await ctx.sessions.require(agent.sessionId)).events
+    .filter((item) => item.type === 'user/message')
+    .map((item) => ('text' in item ? item.text : ''))
+  assert.ok(users.includes('queued-inject'))
+  assert.ok(users.includes('queued-wake'))
+})

--- a/host/plugins/orchestration/agents.ts
+++ b/host/plugins/orchestration/agents.ts
@@ -18,6 +18,8 @@ export interface AgentHandle {
   sessionId: string
   send(text: string, opts?: AgentSendOptions): Promise<AgentTurn>
   inject(text: string, opts?: AgentSendOptions): void
+  /** 空回车：abort 当前回合，立刻 kick/claim 队列（需至少一条 wake） */
+  flush(opts?: { wait?: boolean }): Promise<{ flushed: boolean }>
   cancel(): void
   dispose(): void
 }
@@ -100,6 +102,30 @@ export class AgentsService extends Service {
       return last
     }
 
+    const startKick = (wait: boolean): Promise<AgentTurn> => {
+      live.abort = new AbortController()
+      let result: AgentTurn = { text: '', steps: [] }
+      const running = kick()
+        .then((turn) => {
+          result = turn
+        })
+        .finally(() => {
+          if (live.running === running) live.running = undefined
+        })
+      live.running = running
+      this.ctx.emit('agent/status', { sessionId: id, status: 'running', step: 0 })
+      if (!wait) {
+        void running.catch(() => undefined)
+        return Promise.resolve({ text: '', steps: [] })
+      }
+      return running.then(() => result).catch((error) => {
+        if (/cancelled|AbortError|aborted/i.test(String(error))) {
+          return { text: '', steps: [] }
+        }
+        throw error
+      })
+    }
+
     const handle: AgentHandle = {
       sessionId: id,
       send: async (text: string, opts?: AgentSendOptions) => {
@@ -126,27 +152,9 @@ export class AgentsService extends Service {
 
         if (live.running) {
           if (!wait) return { text: '', steps: [] }
-          await live.running
+          await live.running.catch(() => undefined)
         }
-        live.abort = new AbortController()
-        let result: AgentTurn = { text: '', steps: [] }
-        const running = kick().then((turn) => {
-          result = turn
-        })
-        live.running = running
-        this.ctx.emit('agent/status', { sessionId: id, status: 'running', step: 0 })
-        if (!wait) {
-          void running.finally(() => {
-            if (live.running === running) live.running = undefined
-          })
-          return { text: '', steps: [] }
-        }
-        try {
-          await running
-          return result
-        } finally {
-          if (live.running === running) live.running = undefined
-        }
+        return startKick(wait)
       },
       inject: (text: string, opts?: AgentSendOptions) => {
         const trimmed = text.trim()
@@ -160,6 +168,19 @@ export class AgentsService extends Service {
           ...(opts?.sender ? { sender: opts.sender } : {}),
         })
         this.emitInbox(id)
+      },
+      flush: async (opts?: { wait?: boolean }) => {
+        const wait = opts?.wait !== false
+        // claim 需要 wake；队列里没有 wake 时空回车无意义
+        if (!live.inbox.some((item) => item.kind === 'wake')) {
+          return { flushed: false }
+        }
+        live.abort.abort()
+        if (live.running) {
+          await live.running.catch(() => undefined)
+        }
+        await startKick(wait)
+        return { flushed: true }
       },
       cancel: () => live.abort.abort(),
       dispose: () => {

--- a/src/plugins/contributors/chat/composer.tsx
+++ b/src/plugins/contributors/chat/composer.tsx
@@ -274,7 +274,17 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       debounceRef.current = null
     }
     const content = (textareaRef.current?.value ?? '').trim()
-    if (!content && !picked.length) return
+    // 空回车 + 队列有 wake：abort 当前回合并立刻 claim
+    if (!content && !picked.length) {
+      if (inbox.some((item) => item.kind === 'wake')) {
+        try {
+          await sessionView.flushInbox()
+        } catch {
+          /* error 已写入 sessionView */
+        }
+      }
+      return
+    }
     const tools = [...picked]
     const text = content || (tools.length ? `请使用工具：${tools.join(', ')}` : '')
     clearInput()

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -1186,6 +1186,31 @@ export class SessionViewService extends Service {
     this.setAgentStatus('idle', undefined, sessionId)
   }
 
+  /** 空回车：abort 当前回合并立刻 claim 队列（需队列里有 wake） */
+  async flushInbox() {
+    const sessionId = this.value.sessionId
+    if (!sessionId) return false
+    if (!this.value.inbox.some((item) => item.kind === 'wake')) return false
+    this.setAgentStatus('running', undefined, sessionId)
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/inbox/flush`, { method: 'POST' })
+      const data = (await res.json()) as {
+        error?: string
+        flushed?: boolean
+        inbox?: InboxQueueItem[]
+      }
+      if (!res.ok) {
+        this.replace({ error: data.error || `冲刷队列失败：${res.status}` })
+        return false
+      }
+      if (Array.isArray(data.inbox)) this.setInbox(data.inbox, sessionId)
+      return Boolean(data.flushed)
+    } catch (error) {
+      this.replace({ error: String(error) })
+      return false
+    }
+  }
+
   async decideApproval(id: string, allow: boolean) {
     await fetch(`/api/approvals/${id}`, {
       method: 'POST',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 行为
输入框**为空**且队列里**至少有一条 wake** 时，按回车：

1. **Abort** 当前回合  
2. 立刻 **kick/claim** 排队中的 wake + inject  

与「停止」不同：停止只 abort、队列仍挂着；空回车会马上消费队列。

## 接口
- `POST /api/sessions/:id/inbox/flush`
- `agent.flush({ wait: false })`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

