### PR TITLE
任务面板增强 + Live 创建/配置可绑定文件夹

### DIFF
--- a/host/plugins/seams/live-sessions.test.ts
+++ b/host/plugins/seams/live-sessions.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Context } from 'cordis'
 import '../../types.ts'
 import * as sessionStore from '../storage/session-store.ts'
@@ -213,4 +216,52 @@ test('wait=false wake: queues worker and does not append note to live', async ()
     ),
     false,
   )
+})
+
+test('session_create / session_configure bind and rebind project folder', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  await ctx.plugin(llm)
+  await ctx.plugin(agentLoop)
+  await ctx.plugin(agents)
+  await ctx.plugin(liveSessions)
+
+  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  const dirA = await mkdtemp(join(tmpdir(), 'proj-a-'))
+  const dirB = await mkdtemp(join(tmpdir(), 'proj-b-'))
+  try {
+    const created = (await runWithSession(live.id, () =>
+      ctx.tools.invoke(
+        'session_create',
+        { title: 'worker-folder', project: dirA },
+        new AbortController().signal,
+      ),
+    )) as { id: string; project: { path: string; name: string } | null }
+    assert.ok(created.id)
+    assert.equal(created.project?.path, dirA)
+
+    const configured = (await runWithSession(live.id, () =>
+      ctx.tools.invoke(
+        'session_configure',
+        { sessionId: created.id, project: dirB },
+        new AbortController().signal,
+      ),
+    )) as { project: { path: string } | null }
+    assert.equal(configured.project?.path, dirB)
+
+    const cleared = (await runWithSession(live.id, () =>
+      ctx.tools.invoke(
+        'session_configure',
+        { sessionId: created.id, project: '' },
+        new AbortController().signal,
+      ),
+    )) as { project: unknown }
+    assert.equal(cleared.project, null)
+  } finally {
+    await rm(dirA, { recursive: true, force: true })
+    await rm(dirB, { recursive: true, force: true })
+  }
 })

--- a/host/plugins/seams/live-sessions.ts
+++ b/host/plugins/seams/live-sessions.ts
@@ -15,7 +15,7 @@ export const LIVE_TOOL_NAMES = [
 ] as const
 
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
-工作流：session_list / session_inspect 了解现场 → 需要时可 session_create 新建、session_rename / session_configure 调整目标 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。
+工作流：session_list / session_inspect 了解现场 → 需要时可 session_create（可带 project 绑定文件夹）新建、session_rename / session_configure（可改 project）调整目标 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。
 异步派工后不要等待对方完成：完成态在目标 session 自己的 turn 里，需要时再 inspect / progress。
 向用户汇报要克制：只在关键节点、明显卡住、或用户追问时说明，不要刷屏。
 回答简洁：说明调度了谁、当前状态、下一步。`
@@ -332,12 +332,17 @@ export function apply(ctx: Context) {
 
   ctx.tools.register({
     name: 'session_create',
-    description: '创建新的 chat session（可带标题与初始配置）。Live 指挥席专用。',
+    description:
+      '创建新的 chat session（可带标题、初始配置、绑定工作区文件夹）。Live 指挥席专用。',
     parameters: {
       type: 'object',
       properties: {
         title: { type: 'string', description: '会话显示名' },
         type: { type: 'string', description: "默认 'chat'；一般不要创建 live" },
+        project: {
+          type: 'string',
+          description: '绑定的主机绝对路径文件夹；创建后也可再改',
+        },
         model: { type: 'string' },
         provider: { type: 'string', enum: ['deepseek', 'openai'] },
         systemPrompt: { type: 'string' },
@@ -348,7 +353,7 @@ export function apply(ctx: Context) {
     execute: async (args) => {
       await requireLiveCaller(ctx)
       const type = args.type === 'live' ? 'live' : 'chat'
-      const record = await ctx.sessions.create(undefined, {
+      let record = await ctx.sessions.create(undefined, {
         type,
         ...(typeof args.title === 'string' ? { title: args.title } : {}),
         config: {
@@ -363,11 +368,16 @@ export function apply(ctx: Context) {
             : {}),
         },
       })
+      if (typeof args.project === 'string' && args.project.trim()) {
+        await ctx.sessions.setProject(record.id, { path: args.project.trim() })
+        record = await ctx.sessions.require(record.id)
+      }
       return {
         id: record.id,
         type: normalizeSessionType(record.type),
         title: record.config?.title ?? record.id.slice(0, 8),
         config: record.config ?? null,
+        project: record.project ?? null,
       }
     },
   })
@@ -397,12 +407,16 @@ export function apply(ctx: Context) {
   ctx.tools.register({
     name: 'session_configure',
     description:
-      '修改目标 session 的配置覆盖（model/provider/systemPrompt/agentMode/extraTools）。未传字段保持不变；systemPrompt 传空串可清回默认。',
+      '修改目标 session 的配置（title/model/provider/systemPrompt/agentMode/extraTools/project）。未传字段保持不变；systemPrompt 传空串可清回默认；project 传空串可解绑文件夹。',
     parameters: {
       type: 'object',
       properties: {
         sessionId: { type: 'string' },
         title: { type: 'string' },
+        project: {
+          type: 'string',
+          description: '绑定文件夹的绝对路径；传空串解绑；可重复修改',
+        },
         model: { type: 'string' },
         provider: { type: 'string', enum: ['deepseek', 'openai'] },
         systemPrompt: { type: 'string' },
@@ -415,7 +429,7 @@ export function apply(ctx: Context) {
       await requireLiveCaller(ctx)
       const targetId = String(args.sessionId || '').trim()
       if (!targetId) throw new Error('sessionId required')
-      const record = await ctx.sessions.patchConfig(targetId, {
+      let record = await ctx.sessions.patchConfig(targetId, {
         ...(typeof args.title === 'string' ? { title: args.title } : {}),
         ...(typeof args.model === 'string' ? { model: args.model } : {}),
         ...(args.provider === 'deepseek' || args.provider === 'openai' ? { provider: args.provider } : {}),
@@ -427,7 +441,16 @@ export function apply(ctx: Context) {
           ? { extraTools: args.extraTools.map((name) => String(name)) }
           : {}),
       })
-      return { id: record.id, config: record.config ?? null }
+      if (typeof args.project === 'string') {
+        const path = args.project.trim()
+        await ctx.sessions.setProject(targetId, path ? { path } : null)
+        record = await ctx.sessions.require(targetId)
+      }
+      return {
+        id: record.id,
+        config: record.config ?? null,
+        project: record.project ?? null,
+      }
     },
   })
 }

--- a/host/plugins/storage/session-store.ts
+++ b/host/plugins/storage/session-store.ts
@@ -11,13 +11,13 @@ import {
   sessionDisplayTitle,
 } from '../core/session-types.ts'
 
-function toSummary(record: SessionRecord): SessionSummary {
+function toSummary(record: SessionRecord, updatedAt?: number): SessionSummary {
   return {
     id: record.id,
     version: record.version,
     eventCount: record.events.length,
     title: sessionDisplayTitle(record),
-    updatedAt: record.events.at(-1)?.ts ?? 0,
+    updatedAt: updatedAt ?? record.events.at(-1)?.ts ?? 0,
     type: normalizeSessionType(record.type),
     ...(record.project ? { project: record.project } : {}),
     ...(record.mascot ? { mascot: record.mascot } : {}),
@@ -27,6 +27,7 @@ function toSummary(record: SessionRecord): SessionSummary {
 
 export class MemorySessionStore implements SessionStore {
   private records = new Map<string, SessionRecord>()
+  private touched = new Map<string, number>()
 
   async load(id: string) {
     return this.records.get(id)
@@ -34,6 +35,7 @@ export class MemorySessionStore implements SessionStore {
 
   async save(record: SessionRecord) {
     this.records.set(record.id, { ...record, events: [...record.events] })
+    this.touched.set(record.id, Date.now())
   }
 
   async list() {
@@ -41,10 +43,13 @@ export class MemorySessionStore implements SessionStore {
   }
 
   async listSummaries() {
-    return [...this.records.values()].map(toSummary).sort((a, b) => b.updatedAt - a.updatedAt)
+    return [...this.records.values()]
+      .map((record) => toSummary(record, this.touched.get(record.id)))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
   }
 
   async delete(id: string) {
+    this.touched.delete(id)
     return this.records.delete(id)
   }
 }

--- a/host/plugins/storage/sqlite-session-store.ts
+++ b/host/plugins/storage/sqlite-session-store.ts
@@ -140,7 +140,7 @@ export class SqliteSessionStore implements SessionStore {
       throw new Error(`unsupported session version ${record.version}`)
     }
     const title = sessionDisplayTitle(record)
-    const updatedAt = record.events.at(-1)?.ts ?? Date.now()
+    const updatedAt = Date.now()
     const projectJson = record.project ? JSON.stringify(record.project) : null
     const mascotJson = record.mascot ? JSON.stringify(record.mascot) : null
     const configJson = record.config ? JSON.stringify(record.config) : null

--- a/packages/tasks-host/src/index.test.ts
+++ b/packages/tasks-host/src/index.test.ts
@@ -12,14 +12,29 @@ test('tasks sqlite crud and status move', async () => {
   try {
     const ctx = new Context()
     const tasks = new TasksService(ctx, path).open()
-    const a = tasks.create({ title: '写需求' })
+    const a = tasks.create({
+      title: '写需求',
+      creator: { kind: 'user', name: '用户' },
+    })
     assert.equal(a.status, 'todo')
-    const b = tasks.update(a.id, { status: 'doing', priority: 'high' })
+    assert.equal(a.creator.name, '用户')
+    assert.equal(a.assignee, null)
+    assert.equal(a.assignedAt, null)
+
+    const b = tasks.update(a.id, {
+      status: 'doing',
+      priority: 'high',
+      assignee: { kind: 'agent', sessionId: 'sess-1', name: 'Worker-A', mascot: { shape: 'blob', color: 'cyan' } },
+    })
     assert.equal(b.status, 'doing')
     assert.equal(b.priority, 'high')
+    assert.equal(b.assignee?.sessionId, 'sess-1')
+    assert.ok(b.assignedAt && b.assignedAt > 0)
+
     const listed = tasks.list({ status: 'doing' })
     assert.equal(listed.length, 1)
     assert.equal(listed[0]?.id, a.id)
+    assert.equal(listed[0]?.creator.name, '用户')
     assert.equal(tasks.delete(a.id), true)
     assert.equal(tasks.list().length, 0)
   } finally {

--- a/packages/tasks-host/src/index.ts
+++ b/packages/tasks-host/src/index.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { Service, type Context } from 'cordis'
+import { currentSessionId } from '../../../host/plugins/core/session-scope.ts'
 
 type DatabaseSync = import('node:sqlite').DatabaseSync
 
@@ -9,34 +10,57 @@ const require = createRequire(import.meta.url)
 
 export type TaskStatus = 'todo' | 'doing' | 'done'
 export type TaskPriority = 'low' | 'med' | 'high'
+export type TaskActorKind = 'user' | 'agent'
+
+export type TaskActor = {
+  kind: TaskActorKind
+  sessionId?: string
+  name: string
+  mascot?: { shape: string; color: string; eye?: number }
+}
+
+export type TaskExecution = {
+  status: 'idle' | 'running' | 'unassigned'
+  reason?: string
+  turn: number | null
+  assistantText: string
+  updatedAt: number
+}
 
 export type TaskRow = {
   id: string
   title: string
   status: TaskStatus
   priority: TaskPriority
-  assignee: string
   dueAt: number | null
   notes: string
   sort: number
   createdAt: number
   updatedAt: number
+  creator: TaskActor
+  assignee: TaskActor | null
+  assignedAt: number | null
+  /** 列表接口按需附带：从 assignee session 事件推导 */
+  execution?: TaskExecution
 }
 
 export type TaskCreateInput = {
   title: string
   status?: TaskStatus
   priority?: TaskPriority
-  assignee?: string
+  assignee?: TaskActor | null
+  assigneeSessionId?: string
   dueAt?: number | null
   notes?: string
+  creator?: TaskActor
 }
 
 export type TaskUpdateInput = Partial<{
   title: string
   status: TaskStatus
   priority: TaskPriority
-  assignee: string
+  assignee: TaskActor | null
+  assigneeSessionId: string | null
   dueAt: number | null
   notes: string
   sort: number
@@ -45,6 +69,22 @@ export type TaskUpdateInput = Partial<{
 export type TaskListFilter = {
   status?: TaskStatus
   q?: string
+}
+
+type SessionEventLite = {
+  type: string
+  text?: string
+  seq?: number
+  turn?: number
+  reason?: string
+  ts?: number
+}
+
+type SessionPeek = {
+  id: string
+  config?: { title?: string }
+  mascot?: { shape: string; color: string; eye?: number }
+  events?: SessionEventLite[]
 }
 
 type HostCtx = Context & {
@@ -78,6 +118,13 @@ type HostCtx = Context & {
       execute: (args: Record<string, unknown>) => unknown
     }) => unknown
   }
+  sessions?: {
+    peek: (id: string) => SessionPeek | undefined
+    get?: (id: string) => Promise<SessionPeek | undefined>
+  }
+  agents?: {
+    isBusy?: (id: string) => boolean
+  }
 }
 
 const STATUSES = new Set<TaskStatus>(['todo', 'doing', 'done'])
@@ -101,19 +148,193 @@ function asPriority(value: unknown, fallback: TaskPriority = 'med'): TaskPriorit
   return PRIORITIES.has(raw as TaskPriority) ? (raw as TaskPriority) : fallback
 }
 
+function normalizeActor(value: unknown, fallbackName = '用户'): TaskActor | null {
+  if (value == null) return null
+  if (typeof value === 'string') {
+    const name = value.trim()
+    return name ? { kind: 'user', name: name.slice(0, 80) } : null
+  }
+  if (typeof value !== 'object') return null
+  const raw = value as Record<string, unknown>
+  const kind: TaskActorKind = raw.kind === 'agent' ? 'agent' : 'user'
+  const name =
+    typeof raw.name === 'string' && raw.name.trim()
+      ? raw.name.trim().slice(0, 80)
+      : kind === 'agent'
+        ? 'Agent'
+        : fallbackName
+  const sessionId =
+    typeof raw.sessionId === 'string' && raw.sessionId.trim() ? raw.sessionId.trim() : undefined
+  let mascot: TaskActor['mascot']
+  if (raw.mascot && typeof raw.mascot === 'object') {
+    const m = raw.mascot as Record<string, unknown>
+    if (typeof m.shape === 'string' && typeof m.color === 'string') {
+      mascot = {
+        shape: m.shape,
+        color: m.color,
+        ...(typeof m.eye === 'number' ? { eye: m.eye } : {}),
+      }
+    }
+  }
+  return {
+    kind,
+    name,
+    ...(sessionId ? { sessionId } : {}),
+    ...(mascot ? { mascot } : {}),
+  }
+}
+
+function actorFromSession(record: SessionPeek): TaskActor {
+  let name = record.config?.title?.trim() ?? ''
+  if (!name && Array.isArray(record.events)) {
+    for (let i = record.events.length - 1; i >= 0; i -= 1) {
+      const event = record.events[i]
+      if (event?.type === 'user/message' && typeof event.text === 'string' && event.text.trim()) {
+        name = event.text.trim().slice(0, 48)
+        break
+      }
+    }
+  }
+  if (!name) name = record.id.slice(0, 8)
+  return {
+    kind: 'agent',
+    sessionId: record.id,
+    name,
+    ...(record.mascot ? { mascot: record.mascot } : {}),
+  }
+}
+
+async function resolveCreator(host: HostCtx, explicit?: TaskActor): Promise<TaskActor> {
+  if (explicit) return normalizeActor(explicit, '用户') ?? { kind: 'user', name: '用户' }
+  const sessionId = currentSessionId()
+  if (sessionId && host.sessions) {
+    const peeked = host.sessions.peek(sessionId) ?? (await host.sessions.get?.(sessionId))
+    if (peeked) return actorFromSession(peeked)
+    return { kind: 'agent', sessionId, name: sessionId.slice(0, 8) }
+  }
+  return { kind: 'user', name: '用户' }
+}
+
+async function resolveAssignee(
+  host: HostCtx,
+  input: { assignee?: TaskActor | null; assigneeSessionId?: string | null },
+): Promise<{ assignee: TaskActor | null; touchAssignedAt: boolean }> {
+  if ('assigneeSessionId' in input) {
+    const sid = input.assigneeSessionId?.trim()
+    if (!sid) return { assignee: null, touchAssignedAt: true }
+    if (host.sessions) {
+      const peeked = host.sessions.peek(sid) ?? (await host.sessions.get?.(sid))
+      if (peeked) return { assignee: actorFromSession(peeked), touchAssignedAt: true }
+    }
+    return { assignee: { kind: 'agent', sessionId: sid, name: sid.slice(0, 8) }, touchAssignedAt: true }
+  }
+  if ('assignee' in input) {
+    return { assignee: normalizeActor(input.assignee), touchAssignedAt: true }
+  }
+  return { assignee: null, touchAssignedAt: false }
+}
+
+function actorsEqual(a: TaskActor | null, b: TaskActor | null): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.kind === b.kind && a.name === b.name && (a.sessionId ?? '') === (b.sessionId ?? '')
+}
+
 function mapRow(row: Record<string, unknown>): TaskRow {
+  let creator: TaskActor = { kind: 'user', name: '用户' }
+  if (typeof row.creator_json === 'string' && row.creator_json) {
+    try {
+      creator = normalizeActor(JSON.parse(row.creator_json), '用户') ?? creator
+    } catch {
+      /* ignore */
+    }
+  }
+
+  let assignee: TaskActor | null = null
+  if (typeof row.assignee_json === 'string' && row.assignee_json) {
+    try {
+      assignee = normalizeActor(JSON.parse(row.assignee_json))
+    } catch {
+      /* ignore */
+    }
+  } else if (typeof row.assignee === 'string' && row.assignee.trim()) {
+    assignee = { kind: 'user', name: row.assignee.trim() }
+  }
+
+  const assignedAt =
+    row.assigned_at == null || row.assigned_at === ''
+      ? assignee
+        ? Number(row.created_at ?? 0) || null
+        : null
+      : Number(row.assigned_at)
+
   return {
     id: String(row.id),
     title: String(row.title ?? ''),
     status: asStatus(row.status),
     priority: asPriority(row.priority),
-    assignee: String(row.assignee ?? ''),
     dueAt: row.due_at == null ? null : Number(row.due_at),
     notes: String(row.notes ?? ''),
     sort: Number(row.sort ?? 0),
     createdAt: Number(row.created_at ?? 0),
     updatedAt: Number(row.updated_at ?? 0),
+    creator,
+    assignee,
+    assignedAt: assignee ? assignedAt : null,
   }
+}
+
+/** 从 assignee session 的 turn 事件推导执行情况（对齐 request/response 成对回合）。 */
+function deriveExecution(
+  events: SessionEventLite[] | undefined,
+  busy: boolean,
+): TaskExecution {
+  if (!events?.length) {
+    return { status: busy ? 'running' : 'idle', turn: null, assistantText: '', updatedAt: 0 }
+  }
+  let turn: number | null = null
+  let openTurn = false
+  let reason: string | undefined
+  let assistantText = ''
+  const chunks: string[] = []
+  for (const event of events) {
+    if (event.type === 'turn/start') {
+      turn = typeof event.turn === 'number' ? event.turn : turn
+      openTurn = true
+      reason = undefined
+      assistantText = ''
+      chunks.length = 0
+    } else if (event.type === 'turn/end') {
+      turn = typeof event.turn === 'number' ? event.turn : turn
+      reason = typeof event.reason === 'string' ? event.reason : undefined
+      openTurn = false
+    } else if (event.type === 'assistant/message' && typeof event.text === 'string' && event.text.trim()) {
+      assistantText = event.text
+      chunks.length = 0
+    } else if (event.type === 'assistant/chunk' && typeof event.text === 'string') {
+      chunks.push(event.text)
+    }
+  }
+  if (!assistantText && chunks.length) assistantText = chunks.join('')
+  if (assistantText.length > 240) assistantText = `${assistantText.slice(0, 240)}…`
+  const newest = events.at(-1)
+  return {
+    status: busy || openTurn ? 'running' : 'idle',
+    ...(reason ? { reason } : {}),
+    turn,
+    assistantText,
+    updatedAt: typeof newest?.ts === 'number' ? newest.ts : 0,
+  }
+}
+
+async function enrichExecution(host: HostCtx, task: TaskRow): Promise<TaskRow> {
+  const sid = task.assignee?.sessionId
+  if (!sid) {
+    return { ...task, execution: { status: 'unassigned', turn: null, assistantText: '', updatedAt: 0 } }
+  }
+  const record = host.sessions?.peek(sid) ?? (await host.sessions?.get?.(sid))
+  const busy = Boolean(host.agents?.isBusy?.(sid))
+  return { ...task, execution: deriveExecution(record?.events, busy) }
 }
 
 export class TasksService extends Service {
@@ -140,10 +361,24 @@ export class TasksService extends Service {
         notes TEXT NOT NULL DEFAULT '',
         sort REAL NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
+        updated_at INTEGER NOT NULL,
+        creator_json TEXT,
+        assignee_json TEXT,
+        assigned_at INTEGER
       );
       CREATE INDEX IF NOT EXISTS tasks_status_sort ON tasks(status, sort, updated_at DESC);
     `)
+    for (const sql of [
+      'ALTER TABLE tasks ADD COLUMN creator_json TEXT',
+      'ALTER TABLE tasks ADD COLUMN assignee_json TEXT',
+      'ALTER TABLE tasks ADD COLUMN assigned_at INTEGER',
+    ]) {
+      try {
+        this.db.exec(sql)
+      } catch {
+        /* already exists */
+      }
+    }
     return this
   }
 
@@ -164,9 +399,11 @@ export class TasksService extends Service {
       params.push(filter.status)
     }
     if (filter.q?.trim()) {
-      clauses.push('(title LIKE ? OR notes LIKE ? OR assignee LIKE ?)')
+      clauses.push(
+        '(title LIKE ? OR notes LIKE ? OR assignee LIKE ? OR creator_json LIKE ? OR assignee_json LIKE ?)',
+      )
       const like = `%${filter.q.trim()}%`
-      params.push(like, like, like)
+      params.push(like, like, like, like, like)
     }
     const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : ''
     const rows = this.db
@@ -186,38 +423,56 @@ export class TasksService extends Service {
     return row ? mapRow(row) : undefined
   }
 
-  create(input: TaskCreateInput): TaskRow {
+  create(input: TaskCreateInput & { creator: TaskActor; assignee?: TaskActor | null; assignedAt?: number | null }): TaskRow {
     const title = String(input.title ?? '').trim()
     if (!title) throw new Error('title required')
     const id = nextId()
     const ts = now()
     const status = asStatus(input.status)
     const priority = asPriority(input.priority)
-    const assignee = String(input.assignee ?? '').trim()
     const dueAt = input.dueAt == null || Number.isNaN(Number(input.dueAt)) ? null : Number(input.dueAt)
     const notes = String(input.notes ?? '')
+    const creator = normalizeActor(input.creator, '用户') ?? { kind: 'user', name: '用户' }
+    const assignee = input.assignee ? normalizeActor(input.assignee) : null
+    const assignedAt = assignee ? (input.assignedAt ?? ts) : null
+    const assigneeLabel = assignee?.name ?? ''
     const maxSort = this.db
       .prepare('SELECT COALESCE(MAX(sort), 0) AS m FROM tasks WHERE status = ?')
       .get(status) as { m: number }
     const sort = Number(maxSort?.m ?? 0) + 1
     this.db
       .prepare(
-        `INSERT INTO tasks (id, title, status, priority, assignee, due_at, notes, sort, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO tasks (
+          id, title, status, priority, assignee, due_at, notes, sort,
+          created_at, updated_at, creator_json, assignee_json, assigned_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(id, title, status, priority, assignee, dueAt, notes, sort, ts, ts)
+      .run(
+        id,
+        title,
+        status,
+        priority,
+        assigneeLabel,
+        dueAt,
+        notes,
+        sort,
+        ts,
+        ts,
+        JSON.stringify(creator),
+        assignee ? JSON.stringify(assignee) : null,
+        assignedAt,
+      )
     this.emitChange()
     return this.get(id)!
   }
 
-  update(id: string, patch: TaskUpdateInput): TaskRow {
+  update(id: string, patch: TaskUpdateInput & { assignee?: TaskActor | null; assignedAt?: number | null }): TaskRow {
     const current = this.get(id)
     if (!current) throw new Error('unknown task')
     const title = patch.title != null ? String(patch.title).trim() : current.title
     if (!title) throw new Error('title required')
     const status = patch.status != null ? asStatus(patch.status) : current.status
     const priority = patch.priority != null ? asPriority(patch.priority) : current.priority
-    const assignee = patch.assignee != null ? String(patch.assignee).trim() : current.assignee
     const dueAt =
       patch.dueAt === undefined
         ? current.dueAt
@@ -232,13 +487,37 @@ export class TasksService extends Service {
         .get(status) as { m: number }
       sort = Number(maxSort?.m ?? 0) + 1
     }
+
+    let assignee = current.assignee
+    let assignedAt = current.assignedAt
+    if ('assignee' in patch) {
+      assignee = patch.assignee ? normalizeActor(patch.assignee) : null
+      if (!actorsEqual(assignee, current.assignee)) {
+        assignedAt = assignee ? (patch.assignedAt ?? now()) : null
+      }
+    }
+
     const ts = now()
     this.db
       .prepare(
-        `UPDATE tasks SET title = ?, status = ?, priority = ?, assignee = ?, due_at = ?, notes = ?, sort = ?, updated_at = ?
+        `UPDATE tasks SET
+          title = ?, status = ?, priority = ?, assignee = ?, due_at = ?, notes = ?, sort = ?,
+          updated_at = ?, assignee_json = ?, assigned_at = ?
          WHERE id = ?`,
       )
-      .run(title, status, priority, assignee, dueAt, notes, sort, ts, id)
+      .run(
+        title,
+        status,
+        priority,
+        assignee?.name ?? '',
+        dueAt,
+        notes,
+        sort,
+        ts,
+        assignee ? JSON.stringify(assignee) : null,
+        assignedAt,
+        id,
+      )
     this.emitChange()
     return this.get(id)!
   }
@@ -251,12 +530,20 @@ export class TasksService extends Service {
 }
 
 export const name = 'tasks'
-export const inject = ['http', 'hub', 'tools']
+export const inject = ['http', 'hub', 'tools', 'sessions']
 
 export function apply(ctx: Context) {
   const host = ctx as HostCtx
   const dbPath = join(process.cwd(), '.cordis', 'tasks.sqlite')
   const tasks = new TasksService(ctx, dbPath).open()
+
+  async function present(row: TaskRow): Promise<TaskRow> {
+    return enrichExecution(host, row)
+  }
+
+  async function presentMany(rows: TaskRow[]): Promise<TaskRow[]> {
+    return Promise.all(rows.map((row) => present(row)))
+  }
 
   host.hub.register({
     id: 'tasks',
@@ -268,65 +555,79 @@ export function apply(ctx: Context) {
 
   host.tools.register({
     name: 'tasks_list',
-    description: '列出任务（可按 status / 关键词筛选）',
+    description: '列出任务（含创建人、分配人、执行情况；可按 status / 关键词筛选）',
     parameters: {
       type: 'object',
       properties: {
         status: { type: 'string', enum: ['todo', 'doing', 'done'], description: '状态筛选' },
-        q: { type: 'string', description: '标题/备注/负责人关键词' },
+        q: { type: 'string', description: '标题/备注/负责人/创建人关键词' },
       },
     },
-    execute: (args) =>
-      tasks.list({
-        ...(args.status ? { status: asStatus(args.status) } : {}),
-        ...(args.q ? { q: String(args.q) } : {}),
-      }),
+    execute: async (args) =>
+      presentMany(
+        tasks.list({
+          ...(args.status ? { status: asStatus(args.status) } : {}),
+          ...(args.q ? { q: String(args.q) } : {}),
+        }),
+      ),
   })
 
   host.tools.register({
     name: 'tasks_get',
-    description: '按 id 获取任务详情',
+    description: '按 id 获取任务详情（含执行情况）',
     parameters: {
       type: 'object',
       properties: { id: { type: 'string', description: '任务 id' } },
       required: ['id'],
     },
-    execute: (args) => {
+    execute: async (args) => {
       const row = tasks.get(String(args.id ?? ''))
       if (!row) throw new Error('unknown task')
-      return row
+      return present(row)
     },
   })
 
   host.tools.register({
     name: 'tasks_create',
-    description: '创建任务',
+    description: '创建任务（自动记录创建 Agent；可用 assigneeSessionId 分配给某 session）',
     parameters: {
       type: 'object',
       properties: {
         title: { type: 'string' },
         status: { type: 'string', enum: ['todo', 'doing', 'done'] },
         priority: { type: 'string', enum: ['low', 'med', 'high'] },
-        assignee: { type: 'string' },
+        assigneeSessionId: { type: 'string', description: '分配给的 session id（Agent）' },
+        assignee: { type: 'string', description: '分配给人名（非 Agent 时）' },
         dueAt: { type: 'number', description: '截止时间戳 ms' },
         notes: { type: 'string' },
       },
       required: ['title'],
     },
-    execute: (args) =>
-      tasks.create({
+    execute: async (args) => {
+      const creator = await resolveCreator(host)
+      let assignee: TaskActor | null = null
+      if (typeof args.assigneeSessionId === 'string' && args.assigneeSessionId.trim()) {
+        const resolved = await resolveAssignee(host, { assigneeSessionId: String(args.assigneeSessionId) })
+        assignee = resolved.assignee
+      } else if (typeof args.assignee === 'string' && args.assignee.trim()) {
+        assignee = { kind: 'user', name: String(args.assignee).trim() }
+      }
+      const row = tasks.create({
         title: String(args.title ?? ''),
         ...(args.status != null ? { status: asStatus(args.status) } : {}),
         ...(args.priority != null ? { priority: asPriority(args.priority) } : {}),
-        ...(args.assignee != null ? { assignee: String(args.assignee) } : {}),
         ...(args.dueAt != null ? { dueAt: Number(args.dueAt) } : {}),
         ...(args.notes != null ? { notes: String(args.notes) } : {}),
-      }),
+        creator,
+        assignee,
+      })
+      return present(row)
+    },
   })
 
   host.tools.register({
     name: 'tasks_update',
-    description: '更新任务字段（改 status 即换看板列）',
+    description: '更新任务字段（可改分配人 assigneeSessionId / assignee；改 status 即换看板列）',
     parameters: {
       type: 'object',
       properties: {
@@ -334,24 +635,35 @@ export function apply(ctx: Context) {
         title: { type: 'string' },
         status: { type: 'string', enum: ['todo', 'doing', 'done'] },
         priority: { type: 'string', enum: ['low', 'med', 'high'] },
-        assignee: { type: 'string' },
+        assigneeSessionId: { type: ['string', 'null'], description: '分配 session；null 清空' },
+        assignee: { type: ['string', 'null'], description: '分配人名；null 清空' },
         dueAt: { type: ['number', 'null'] },
         notes: { type: 'string' },
         sort: { type: 'number' },
       },
       required: ['id'],
     },
-    execute: (args) => {
+    execute: async (args) => {
       const id = String(args.id ?? '')
-      const patch: TaskUpdateInput = {}
+      const patch: TaskUpdateInput & { assignee?: TaskActor | null } = {}
       if (args.title != null) patch.title = String(args.title)
       if (args.status != null) patch.status = asStatus(args.status)
       if (args.priority != null) patch.priority = asPriority(args.priority)
-      if (args.assignee != null) patch.assignee = String(args.assignee)
       if (args.dueAt !== undefined) patch.dueAt = args.dueAt == null ? null : Number(args.dueAt)
       if (args.notes != null) patch.notes = String(args.notes)
       if (args.sort != null) patch.sort = Number(args.sort)
-      return tasks.update(id, patch)
+      if (args.assigneeSessionId !== undefined) {
+        const resolved = await resolveAssignee(host, {
+          assigneeSessionId: args.assigneeSessionId == null ? null : String(args.assigneeSessionId),
+        })
+        patch.assignee = resolved.assignee
+      } else if (args.assignee !== undefined) {
+        patch.assignee =
+          args.assignee == null || !String(args.assignee).trim()
+            ? null
+            : { kind: 'user', name: String(args.assignee).trim() }
+      }
+      return present(tasks.update(id, patch))
     },
   })
 
@@ -370,34 +682,52 @@ export function apply(ctx: Context) {
     },
   })
 
-  host.http.route('GET', '/api/tasks', (route) => {
+  host.http.route('GET', '/api/tasks', async (route) => {
     const statusRaw = route.query.get('status')
     const q = route.query.get('q') ?? undefined
     const status = statusRaw && STATUSES.has(statusRaw as TaskStatus) ? (statusRaw as TaskStatus) : undefined
-    route.send(200, { tasks: tasks.list({ ...(status ? { status } : {}), ...(q ? { q } : {}) }) })
+    const rows = await presentMany(tasks.list({ ...(status ? { status } : {}), ...(q ? { q } : {}) }))
+    route.send(200, { tasks: rows })
   })
 
   host.http.route('POST', '/api/tasks', async (route) => {
     try {
       const body = (await route.json()) as TaskCreateInput
-      const row = tasks.create(body)
-      route.send(201, { task: row })
+      const creator = await resolveCreator(host, body.creator)
+      const resolved = await resolveAssignee(host, {
+        ...(body.assigneeSessionId !== undefined ? { assigneeSessionId: body.assigneeSessionId } : {}),
+        ...(body.assignee !== undefined ? { assignee: body.assignee } : {}),
+      })
+      const row = tasks.create({
+        ...body,
+        creator,
+        assignee: resolved.touchAssignedAt ? resolved.assignee : body.assignee ?? null,
+      })
+      route.send(201, { task: await present(row) })
     } catch (error) {
       route.send(400, { error: String(error) })
     }
   })
 
-  host.http.route('GET', '/api/tasks/:id', (route) => {
+  host.http.route('GET', '/api/tasks/:id', async (route) => {
     const row = tasks.get(route.params.id)
     if (!row) return route.send(404, { error: 'unknown task' })
-    route.send(200, { task: row })
+    route.send(200, { task: await present(row) })
   })
 
   host.http.route('PATCH', '/api/tasks/:id', async (route) => {
     try {
       const body = (await route.json()) as TaskUpdateInput
-      const row = tasks.update(route.params.id, body)
-      route.send(200, { task: row })
+      const patch: TaskUpdateInput & { assignee?: TaskActor | null } = { ...body }
+      if (body.assigneeSessionId !== undefined || body.assignee !== undefined) {
+        const resolved = await resolveAssignee(host, {
+          ...(body.assigneeSessionId !== undefined ? { assigneeSessionId: body.assigneeSessionId } : {}),
+          ...(body.assignee !== undefined ? { assignee: body.assignee } : {}),
+        })
+        if (resolved.touchAssignedAt) patch.assignee = resolved.assignee
+      }
+      const row = tasks.update(route.params.id, patch)
+      route.send(200, { task: await present(row) })
     } catch (error) {
       const message = String(error)
       route.send(message.includes('unknown') ? 404 : 400, { error: message })

--- a/packages/tasks-host/src/index.ts
+++ b/packages/tasks-host/src/index.ts
@@ -548,7 +548,7 @@ export function apply(ctx: Context) {
   host.hub.register({
     id: 'tasks',
     title: '任务',
-    subtitle: 'Table / Board · SQLite · Agent tools',
+    subtitle: '',
     plugin: 'tasks',
     kind: 'tasks',
   })

--- a/packages/tasks-ui/package.json
+++ b/packages/tasks-ui/package.json
@@ -9,6 +9,7 @@
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",
-    "react": "^19.1.1"
+    "react": "^19.1.1",
+    "react-icons": "^5.7.0"
   }
 }

--- a/packages/tasks-ui/src/index.tsx
+++ b/packages/tasks-ui/src/index.tsx
@@ -1,5 +1,23 @@
-import { useCallback, useEffect, useMemo, useState, type DragEvent, type FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, type DragEvent, type FormEvent, type ReactNode } from 'react'
 import type { Context } from 'cordis'
+import {
+  LuActivity,
+  LuBot,
+  LuCalendarClock,
+  LuCircleCheck,
+  LuCircleDashed,
+  LuClock,
+  LuColumns3,
+  LuFlag,
+  LuListChecks,
+  LuLoaderCircle,
+  LuPlus,
+  LuSearch,
+  LuStickyNote,
+  LuTable2,
+  LuTrash2,
+  LuUserRound,
+} from 'react-icons/lu'
 
 export type SlotProps = Record<string, unknown> & {
   renderSlot?: (name: string) => unknown
@@ -45,10 +63,10 @@ export type Task = {
 
 type ViewMode = 'table' | 'board'
 
-const STATUS_META: Array<{ id: TaskStatus; label: string }> = [
-  { id: 'todo', label: '待办' },
-  { id: 'doing', label: '进行中' },
-  { id: 'done', label: '已完成' },
+const STATUS_META: Array<{ id: TaskStatus; label: string; icon: ReactNode }> = [
+  { id: 'todo', label: '待办', icon: <LuCircleDashed size={13} aria-hidden /> },
+  { id: 'doing', label: '进行中', icon: <LuLoaderCircle size={13} aria-hidden /> },
+  { id: 'done', label: '已完成', icon: <LuCircleCheck size={13} aria-hidden /> },
 ]
 
 const PRIORITY_LABEL: Record<TaskPriority, string> = {
@@ -162,16 +180,45 @@ function useTasks(pollMs = 2500) {
   return { tasks, setTasks, error, loading, refresh, query, setQuery }
 }
 
+function TimeLabel({ ts, empty = '—' }: { ts: number | null | undefined; empty?: string }) {
+  if (!ts) {
+    return (
+      <span className="tasks-time is-empty">
+        <LuClock size={12} aria-hidden />
+        {empty}
+      </span>
+    )
+  }
+  return (
+    <span className="tasks-time" title={new Date(ts).toLocaleString()}>
+      <LuClock size={12} aria-hidden />
+      {formatWhen(ts)}
+    </span>
+  )
+}
+
 function ActorChip({ actor, empty = '未分配' }: { actor: TaskActor | null | undefined; empty?: string }) {
   if (!actor) {
-    return <span className="tasks-actor is-empty">{empty}</span>
+    return (
+      <span className="tasks-actor is-empty">
+        <LuUserRound size={13} aria-hidden />
+        {empty}
+      </span>
+    )
   }
-  const color = actor.mascot?.color ? MASCOT_COLOR[actor.mascot.color] ?? '#7a7f87' : actor.kind === 'agent' ? '#3b6fd9' : '#7a7f87'
+  const color = actor.mascot?.color
+    ? (MASCOT_COLOR[actor.mascot.color] ?? '#7a7f87')
+    : actor.kind === 'agent'
+      ? '#3b6fd9'
+      : '#7a7f87'
   const initial = (actor.name || '?').trim().slice(0, 1).toUpperCase()
   return (
-    <span className="tasks-actor" title={actor.sessionId ? `${actor.name} · ${actor.sessionId.slice(0, 8)}` : actor.name}>
+    <span
+      className="tasks-actor"
+      title={actor.sessionId ? `${actor.name} · ${actor.sessionId.slice(0, 8)}` : actor.name}
+    >
       <span className="tasks-avatar" style={{ background: color }} aria-hidden>
-        {initial}
+        {actor.kind === 'agent' ? <LuBot size={11} /> : initial}
       </span>
       <span className="tasks-actor-name">{actor.name}</span>
       {actor.kind === 'agent' ? <span className="tasks-actor-kind">Agent</span> : null}
@@ -181,11 +228,17 @@ function ActorChip({ actor, empty = '未分配' }: { actor: TaskActor | null | u
 
 function ExecBadge({ execution }: { execution?: TaskExecution }) {
   if (!execution || execution.status === 'unassigned') {
-    return <span className="tasks-exec is-muted">未派工</span>
+    return (
+      <span className="tasks-exec is-muted">
+        <LuCircleDashed size={12} aria-hidden />
+        未派工
+      </span>
+    )
   }
   if (execution.status === 'running') {
     return (
       <span className="tasks-exec is-running" title={execution.assistantText || execution.reason || ''}>
+        <LuLoaderCircle size={12} className="tasks-spin" aria-hidden />
         执行中{execution.turn != null ? ` · T${execution.turn}` : ''}
       </span>
     )
@@ -196,6 +249,7 @@ function ExecBadge({ execution }: { execution?: TaskExecution }) {
       className={`tasks-exec ${doneHint ? 'is-idle' : 'is-muted'}`}
       title={execution.assistantText || execution.reason || ''}
     >
+      {doneHint ? <LuCircleCheck size={12} aria-hidden /> : <LuActivity size={12} aria-hidden />}
       {doneHint ? '已响应' : '空闲'}
       {execution.turn != null ? ` · T${execution.turn}` : ''}
     </span>
@@ -205,12 +259,15 @@ function ExecBadge({ execution }: { execution?: TaskExecution }) {
 function PriorityMark({ value }: { value: TaskPriority }) {
   return (
     <span className={`tasks-priority is-${value}`} title={`优先级 ${PRIORITY_LABEL[value]}`}>
-      <i />
-      <i />
-      <i />
+      <LuFlag size={12} aria-hidden />
       <span>{PRIORITY_LABEL[value]}</span>
     </span>
   )
+}
+
+function StatusIcon({ status }: { status: TaskStatus }) {
+  const meta = STATUS_META.find((item) => item.id === status)
+  return <span className={`tasks-status-icon is-${status}`}>{meta?.icon}</span>
 }
 
 function TasksWorkspace({ compact = false }: { compact?: boolean }) {
@@ -280,12 +337,23 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
     <div className={`tasks-root${compact ? ' is-compact' : ''}`}>
       <header className="tasks-head">
         <div className="tasks-head-left">
-          <h1 className="tasks-title">任务</h1>
+          <h1 className="tasks-title">
+            <LuListChecks size={compact ? 16 : 22} aria-hidden />
+            任务
+          </h1>
           <div className="tasks-stats" aria-label="任务统计">
-            <span>{counts.total} 项</span>
-            <span className="is-todo">{counts.todo} 待办</span>
-            <span className="is-doing">{counts.doing} 进行</span>
-            <span className="is-done">{counts.done} 完成</span>
+            <span className="is-todo">
+              <LuCircleDashed size={12} aria-hidden />
+              {counts.todo} 待办
+            </span>
+            <span className="is-doing">
+              <LuLoaderCircle size={12} aria-hidden />
+              {counts.doing} 进行
+            </span>
+            <span className="is-done">
+              <LuCircleCheck size={12} aria-hidden />
+              {counts.done} 完成
+            </span>
           </div>
         </div>
         <div className="tasks-view-switch" role="tablist" aria-label="视图">
@@ -296,6 +364,7 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
             className={`tasks-view-btn${view === 'table' ? ' is-active' : ''}`}
             onClick={() => setView('table')}
           >
+            <LuTable2 size={13} aria-hidden />
             表格
           </button>
           <button
@@ -305,6 +374,7 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
             className={`tasks-view-btn${view === 'board' ? ' is-active' : ''}`}
             onClick={() => setView('board')}
           >
+            <LuColumns3 size={13} aria-hidden />
             看板
           </button>
         </div>
@@ -320,16 +390,20 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
             onChange={(event) => setDraft(event.target.value)}
           />
           <button type="submit" className="tasks-create-btn" disabled={busy || !draft.trim()}>
+            <LuPlus size={14} aria-hidden />
             添加
           </button>
         </form>
-        <input
-          className="tasks-search"
-          value={query}
-          placeholder="搜索标题 / 人 / 备注"
-          aria-label="搜索任务"
-          onChange={(event) => setQuery(event.target.value)}
-        />
+        <label className="tasks-search-wrap">
+          <LuSearch size={14} aria-hidden />
+          <input
+            className="tasks-search"
+            value={query}
+            placeholder="搜索标题 / 人 / 备注"
+            aria-label="搜索任务"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </label>
       </div>
 
       {error ? <div className="tasks-error">{error}</div> : null}
@@ -341,6 +415,17 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
         <TasksBoard columns={byStatus} onDropStatus={onDropStatus} onUpdate={onUpdate} onDelete={onDelete} />
       )}
     </div>
+  )
+}
+
+function ThIcon({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+  return (
+    <th>
+      <span className="tasks-th">
+        {icon}
+        {children}
+      </span>
+    </th>
   )
 }
 
@@ -363,14 +448,14 @@ function TasksTable({
       <table className="tasks-table">
         <thead>
           <tr>
-            <th>标题</th>
-            <th>状态</th>
-            <th>优先级</th>
-            {!compact ? <th>创建人</th> : null}
-            {!compact ? <th>创建时间</th> : null}
-            <th>分配人</th>
-            {!compact ? <th>分配时间</th> : null}
-            <th>执行</th>
+            <ThIcon icon={<LuStickyNote size={12} aria-hidden />}>标题</ThIcon>
+            <ThIcon icon={<LuCircleDashed size={12} aria-hidden />}>状态</ThIcon>
+            <ThIcon icon={<LuFlag size={12} aria-hidden />}>优先级</ThIcon>
+            {!compact ? <ThIcon icon={<LuUserRound size={12} aria-hidden />}>创建人</ThIcon> : null}
+            {!compact ? <ThIcon icon={<LuClock size={12} aria-hidden />}>创建时间</ThIcon> : null}
+            <ThIcon icon={<LuBot size={12} aria-hidden />}>分配人</ThIcon>
+            {!compact ? <ThIcon icon={<LuClock size={12} aria-hidden />}>分配时间</ThIcon> : null}
+            <ThIcon icon={<LuActivity size={12} aria-hidden />}>执行</ThIcon>
             <th aria-label="操作" />
           </tr>
         </thead>
@@ -389,44 +474,64 @@ function TasksTable({
                       if (title && title !== task.title) void onUpdate(task.id, { title })
                     }}
                   />
-                  {task.notes ? <div className="tasks-notes-preview">{task.notes}</div> : null}
-                  {task.dueAt ? <div className="tasks-due">截止 {formatDue(task.dueAt)}</div> : null}
+                  {task.notes ? (
+                    <div className="tasks-notes-preview">
+                      <LuStickyNote size={11} aria-hidden />
+                      {task.notes}
+                    </div>
+                  ) : null}
+                  {task.dueAt ? (
+                    <div className="tasks-due">
+                      <LuCalendarClock size={11} aria-hidden />
+                      截止 {formatDue(task.dueAt)}
+                    </div>
+                  ) : null}
                 </div>
               </td>
               <td>
-                <select
-                  className="tasks-cell-select"
-                  value={task.status}
-                  aria-label="状态"
-                  onChange={(event) => void onUpdate(task.id, { status: event.target.value as TaskStatus })}
-                >
-                  {STATUS_META.map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.label}
-                    </option>
-                  ))}
-                </select>
+                <div className="tasks-status-cell">
+                  <StatusIcon status={task.status} />
+                  <select
+                    className="tasks-cell-select"
+                    value={task.status}
+                    aria-label="状态"
+                    onChange={(event) => void onUpdate(task.id, { status: event.target.value as TaskStatus })}
+                  >
+                    {STATUS_META.map((item) => (
+                      <option key={item.id} value={item.id}>
+                        {item.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </td>
               <td>
-                <select
-                  className="tasks-cell-select"
-                  value={task.priority}
-                  aria-label="优先级"
-                  onChange={(event) => void onUpdate(task.id, { priority: event.target.value as TaskPriority })}
-                >
-                  {(Object.keys(PRIORITY_LABEL) as TaskPriority[]).map((key) => (
-                    <option key={key} value={key}>
-                      {PRIORITY_LABEL[key]}
-                    </option>
-                  ))}
-                </select>
+                <div className="tasks-status-cell">
+                  <PriorityMark value={task.priority} />
+                  <select
+                    className="tasks-cell-select tasks-priority-select"
+                    value={task.priority}
+                    aria-label="优先级"
+                    onChange={(event) => void onUpdate(task.id, { priority: event.target.value as TaskPriority })}
+                  >
+                    {(Object.keys(PRIORITY_LABEL) as TaskPriority[]).map((key) => (
+                      <option key={key} value={key}>
+                        {PRIORITY_LABEL[key]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
               </td>
               {!compact ? (
                 <td>
                   <ActorChip actor={task.creator} empty="—" />
                 </td>
               ) : null}
-              {!compact ? <td className="tasks-time">{formatWhen(task.createdAt)}</td> : null}
+              {!compact ? (
+                <td>
+                  <TimeLabel ts={task.createdAt} />
+                </td>
+              ) : null}
               <td>
                 <div className="tasks-assignee-cell">
                   <ActorChip actor={task.assignee} />
@@ -453,13 +558,17 @@ function TasksTable({
                   />
                 </div>
               </td>
-              {!compact ? <td className="tasks-time">{formatWhen(task.assignedAt)}</td> : null}
+              {!compact ? (
+                <td>
+                  <TimeLabel ts={task.assignedAt} />
+                </td>
+              ) : null}
               <td>
                 <ExecBadge execution={task.execution} />
               </td>
               <td>
                 <button type="button" className="tasks-icon-btn" title="删除" onClick={() => void onDelete(task.id)}>
-                  ×
+                  <LuTrash2 size={14} aria-hidden />
                 </button>
               </td>
             </tr>
@@ -505,7 +614,10 @@ function TasksBoard({
           }}
         >
           <header className="tasks-column-head">
-            <span>{column.label}</span>
+            <span className="tasks-column-title">
+              <StatusIcon status={column.id} />
+              {column.label}
+            </span>
             <span className="tasks-column-count">{columns[column.id].length}</span>
           </header>
           <ul className="tasks-column-list">
@@ -520,7 +632,7 @@ function TasksBoard({
                   <PriorityMark value={task.priority} />
                   <ExecBadge execution={task.execution} />
                   <button type="button" className="tasks-icon-btn" title="删除" onClick={() => void onDelete(task.id)}>
-                    ×
+                    <LuTrash2 size={13} aria-hidden />
                   </button>
                 </div>
                 <input
@@ -533,17 +645,34 @@ function TasksBoard({
                     if (title && title !== task.title) void onUpdate(task.id, { title })
                   }}
                 />
-                {task.notes ? <p className="tasks-card-notes">{task.notes}</p> : null}
+                {task.notes ? (
+                  <p className="tasks-card-notes">
+                    <LuStickyNote size={11} aria-hidden />
+                    {task.notes}
+                  </p>
+                ) : null}
+                {task.dueAt ? (
+                  <div className="tasks-due">
+                    <LuCalendarClock size={11} aria-hidden />
+                    截止 {formatDue(task.dueAt)}
+                  </div>
+                ) : null}
                 <div className="tasks-card-people">
                   <div className="tasks-card-person">
-                    <span className="tasks-card-label">创建</span>
+                    <span className="tasks-card-label">
+                      <LuUserRound size={11} aria-hidden />
+                      创建
+                    </span>
                     <ActorChip actor={task.creator} empty="—" />
-                    <span className="tasks-time">{formatWhen(task.createdAt)}</span>
+                    <TimeLabel ts={task.createdAt} />
                   </div>
                   <div className="tasks-card-person">
-                    <span className="tasks-card-label">分配</span>
+                    <span className="tasks-card-label">
+                      <LuBot size={11} aria-hidden />
+                      分配
+                    </span>
                     <ActorChip actor={task.assignee} />
-                    <span className="tasks-time">{formatWhen(task.assignedAt)}</span>
+                    <TimeLabel ts={task.assignedAt} />
                   </div>
                 </div>
               </li>
@@ -594,38 +723,49 @@ if (typeof document !== 'undefined') {
 .tasks-root { display:flex; min-height:0; flex:1; flex-direction:column; gap:14px; padding:18px 20px 22px; overflow:auto; }
 .tasks-root.is-compact { padding:10px 12px 14px; gap:8px; }
 .tasks-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
-.tasks-title { margin:0; font-size:22px; font-weight:700; letter-spacing:-0.03em; }
-.tasks-root.is-compact .tasks-title { font-size:14px; }
-.tasks-stats { display:flex; flex-wrap:wrap; gap:8px; margin-top:6px; color:var(--dsw-label-3); font-size:11px; font-variant-numeric:tabular-nums; }
+.tasks-title { margin:0; display:inline-flex; align-items:center; gap:8px; font-size:22px; font-weight:700; letter-spacing:-0.03em; }
+.tasks-root.is-compact .tasks-title { font-size:14px; gap:6px; }
+.tasks-stats { display:flex; flex-wrap:wrap; gap:10px; margin-top:8px; color:var(--dsw-label-3); font-size:11px; font-variant-numeric:tabular-nums; }
+.tasks-stats > span { display:inline-flex; align-items:center; gap:4px; }
 .tasks-stats .is-todo { color:var(--dsw-label-2); }
 .tasks-stats .is-doing { color:var(--dsw-business); }
 .tasks-stats .is-done { color:color-mix(in srgb, #3d9a5f 80%, var(--dsw-label-3)); }
 .tasks-view-switch { display:inline-flex; gap:2px; padding:2px; border:1px solid var(--dsw-border); border-radius:8px; background:var(--dsw-muted-fill); }
-.tasks-view-btn { border:0; border-radius:6px; padding:4px 10px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; font-size:12px; font-weight:600; }
+.tasks-view-btn { border:0; border-radius:6px; padding:4px 10px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; font-size:12px; font-weight:600; display:inline-flex; align-items:center; gap:5px; }
 .tasks-view-btn.is-active { background:var(--dsw-surface); color:var(--dsw-label); box-shadow:0 1px 0 color-mix(in srgb, var(--dsw-label) 6%, transparent); }
 .tasks-toolbar { display:flex; gap:8px; align-items:stretch; flex-wrap:wrap; }
 .tasks-create { display:flex; gap:8px; flex:1 1 280px; min-width:0; }
 .tasks-create-input, .tasks-search { min-width:0; border:1px solid var(--dsw-border); border-radius:10px; padding:8px 10px; background:var(--dsw-input); color:var(--dsw-label); font:inherit; font-size:13px; outline:none; }
 .tasks-create-input { flex:1; }
-.tasks-search { flex:0 1 220px; }
-.tasks-create-btn { border:0; border-radius:10px; padding:8px 12px; background:var(--dsw-business); color:var(--dsw-bg); cursor:pointer; font:inherit; font-size:12px; font-weight:650; }
+.tasks-search-wrap { flex:0 1 240px; display:flex; align-items:center; gap:8px; border:1px solid var(--dsw-border); border-radius:10px; padding:0 10px; background:var(--dsw-input); color:var(--dsw-label-3); min-width:0; }
+.tasks-search-wrap .tasks-search { flex:1; border:0; padding-left:0; background:transparent; }
+.tasks-create-btn { border:0; border-radius:10px; padding:8px 12px; background:var(--dsw-business); color:var(--dsw-bg); cursor:pointer; font:inherit; font-size:12px; font-weight:650; display:inline-flex; align-items:center; gap:5px; }
 .tasks-create-btn:disabled { opacity:.35; cursor:default; }
 .tasks-error { border-radius:8px; padding:8px 10px; background:var(--dsw-danger-soft); color:var(--dsw-danger); font-size:12px; }
 .tasks-empty { color:var(--dsw-label-3); font-size:12px; line-height:1.5; }
 .tasks-table-wrap { overflow:auto; border:1px solid var(--dsw-border); border-radius:14px; background:color-mix(in srgb, var(--dsw-surface) 92%, transparent); backdrop-filter:blur(6px); }
 .tasks-table { width:100%; border-collapse:collapse; font-size:12px; }
 .tasks-table th { padding:10px 10px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-3); font-weight:600; text-align:left; white-space:nowrap; position:sticky; top:0; background:var(--dsw-surface); z-index:1; }
-.tasks-table td { padding:8px 8px; border-bottom:1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent); vertical-align:top; }
+.tasks-th { display:inline-flex; align-items:center; gap:5px; }
+.tasks-table td { padding:8px 8px; border-bottom:1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent); vertical-align:middle; }
 .tasks-table tr:last-child td { border-bottom:0; }
 .tasks-table tr:hover td { background:color-mix(in srgb, var(--dsw-hover) 70%, transparent); }
-.tasks-title-cell { display:flex; flex-direction:column; gap:3px; min-width:160px; }
-.tasks-notes-preview, .tasks-card-notes { margin:0; color:var(--dsw-label-3); font-size:11px; line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
-.tasks-due { color:var(--dsw-label-3); font-size:10px; }
+.tasks-title-cell { display:flex; flex-direction:column; gap:4px; min-width:160px; }
+.tasks-notes-preview, .tasks-card-notes, .tasks-due { margin:0; color:var(--dsw-label-3); font-size:11px; line-height:1.4; display:inline-flex; align-items:flex-start; gap:5px; }
+.tasks-notes-preview, .tasks-card-notes { display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.tasks-notes-preview svg, .tasks-card-notes svg, .tasks-due svg { flex:none; margin-top:1px; }
 .tasks-cell-input, .tasks-cell-select, .tasks-card-title { width:100%; border:0; border-radius:6px; padding:4px 6px; background:transparent; color:var(--dsw-label); font:inherit; outline:none; }
 .tasks-cell-input:focus, .tasks-cell-select:focus, .tasks-card-title:focus { background:var(--dsw-hover); }
+.tasks-status-cell { display:flex; align-items:center; gap:6px; min-width:0; }
+.tasks-status-cell .tasks-cell-select { flex:1; min-width:0; }
+.tasks-priority-select { max-width:4.5rem; }
+.tasks-status-icon { display:inline-flex; color:var(--dsw-label-3); }
+.tasks-status-icon.is-doing { color:var(--dsw-business); }
+.tasks-status-icon.is-done { color:#2f7d4c; }
 .tasks-assignee-cell { display:flex; flex-direction:column; gap:4px; min-width:120px; }
 .tasks-assignee-edit { font-size:11px; color:var(--dsw-label-3); }
-.tasks-time { color:var(--dsw-label-3); font-size:11px; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.tasks-time { display:inline-flex; align-items:center; gap:4px; color:var(--dsw-label-3); font-size:11px; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.tasks-time.is-empty { opacity:.7; }
 .tasks-actor { display:inline-flex; align-items:center; gap:6px; min-width:0; max-width:160px; }
 .tasks-actor.is-empty { color:var(--dsw-label-3); }
 .tasks-avatar { width:18px; height:18px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:700; flex:none; box-shadow:inset 0 0 0 1px color-mix(in srgb, #000 18%, transparent); }
@@ -635,17 +775,18 @@ if (typeof document !== 'undefined') {
 .tasks-exec.is-running { background:color-mix(in srgb, var(--dsw-business) 16%, transparent); color:var(--dsw-business); }
 .tasks-exec.is-idle { background:color-mix(in srgb, #3d9a5f 14%, transparent); color:#2f7d4c; }
 .tasks-exec.is-muted { background:var(--dsw-muted-fill); color:var(--dsw-label-3); }
-.tasks-priority { display:inline-flex; align-items:center; gap:3px; color:var(--dsw-label-3); font-size:10px; font-weight:650; }
-.tasks-priority i { width:3px; height:8px; border-radius:1px; background:color-mix(in srgb, var(--dsw-label-3) 35%, transparent); display:inline-block; }
-.tasks-priority.is-med i:nth-child(-n+2), .tasks-priority.is-high i { background:currentColor; }
+.tasks-spin { animation: tasks-spin 1s linear infinite; }
+@keyframes tasks-spin { to { transform: rotate(360deg); } }
+.tasks-priority { display:inline-flex; align-items:center; gap:4px; color:var(--dsw-label-3); font-size:10px; font-weight:650; }
 .tasks-priority.is-med { color:#c48a2a; }
 .tasks-priority.is-high { color:#d64545; }
-.tasks-icon-btn { border:0; border-radius:6px; padding:2px 6px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; }
+.tasks-icon-btn { border:0; border-radius:6px; padding:4px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; display:inline-flex; align-items:center; justify-content:center; }
 .tasks-icon-btn:hover { background:var(--dsw-hover); color:var(--dsw-label); }
 .tasks-board { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:12px; min-height:280px; align-items:start; }
 .tasks-root.is-compact .tasks-board { grid-template-columns:1fr; }
 .tasks-column { display:flex; min-height:0; flex-direction:column; border:1px solid var(--dsw-border); border-radius:14px; background:color-mix(in srgb, var(--dsw-surface) 88%, transparent); overflow:hidden; }
 .tasks-column-head { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:10px 12px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-2); font-size:12px; font-weight:650; }
+.tasks-column-title { display:inline-flex; align-items:center; gap:6px; }
 .tasks-column-count { min-width:1.5em; text-align:center; border-radius:999px; padding:1px 6px; background:var(--dsw-muted-fill); color:var(--dsw-label-3); font-variant-numeric:tabular-nums; }
 .tasks-column-list { display:flex; flex:1; flex-direction:column; gap:8px; margin:0; padding:10px; list-style:none; overflow:auto; min-height:120px; }
 .tasks-card { border:1px solid color-mix(in srgb, var(--dsw-border) 90%, transparent); border-radius:12px; padding:10px; background:var(--dsw-muted-fill); cursor:grab; display:flex; flex-direction:column; gap:8px; transition:border-color .15s ease, transform .15s ease; }
@@ -655,8 +796,8 @@ if (typeof document !== 'undefined') {
 .tasks-card-top .tasks-icon-btn { margin-left:auto; }
 .tasks-card-title { font-size:13px; font-weight:650; padding:0; }
 .tasks-card-people { display:flex; flex-direction:column; gap:6px; }
-.tasks-card-person { display:grid; grid-template-columns:36px minmax(0,1fr) auto; gap:6px; align-items:center; }
-.tasks-card-label { color:var(--dsw-label-3); font-size:10px; }
+.tasks-card-person { display:grid; grid-template-columns:52px minmax(0,1fr) auto; gap:6px; align-items:center; }
+.tasks-card-label { display:inline-flex; align-items:center; gap:3px; color:var(--dsw-label-3); font-size:10px; }
 `
   if (!style.parentNode) document.head.appendChild(style)
 }

--- a/packages/tasks-ui/src/index.tsx
+++ b/packages/tasks-ui/src/index.tsx
@@ -12,25 +12,43 @@ type SlotsService = {
 export type TaskStatus = 'todo' | 'doing' | 'done'
 export type TaskPriority = 'low' | 'med' | 'high'
 
+export type TaskActor = {
+  kind: 'user' | 'agent'
+  sessionId?: string
+  name: string
+  mascot?: { shape: string; color: string; eye?: number }
+}
+
+export type TaskExecution = {
+  status: 'idle' | 'running' | 'unassigned'
+  reason?: string
+  turn: number | null
+  assistantText: string
+  updatedAt: number
+}
+
 export type Task = {
   id: string
   title: string
   status: TaskStatus
   priority: TaskPriority
-  assignee: string
   dueAt: number | null
   notes: string
   sort: number
   createdAt: number
   updatedAt: number
+  creator: TaskActor
+  assignee: TaskActor | null
+  assignedAt: number | null
+  execution?: TaskExecution
 }
 
 type ViewMode = 'table' | 'board'
 
 const STATUS_META: Array<{ id: TaskStatus; label: string }> = [
-  { id: 'todo', label: 'Todo' },
-  { id: 'doing', label: 'Doing' },
-  { id: 'done', label: 'Done' },
+  { id: 'todo', label: '待办' },
+  { id: 'doing', label: '进行中' },
+  { id: 'done', label: '已完成' },
 ]
 
 const PRIORITY_LABEL: Record<TaskPriority, string> = {
@@ -39,8 +57,23 @@ const PRIORITY_LABEL: Record<TaskPriority, string> = {
   high: '高',
 }
 
-async function fetchTasks(): Promise<Task[]> {
-  const res = await fetch('/api/tasks')
+const MASCOT_COLOR: Record<string, string> = {
+  black: '#2a2a2a',
+  brown: '#8b5a2b',
+  red: '#d64545',
+  orange: '#e07a2f',
+  yellow: '#d4a017',
+  green: '#3d9a5f',
+  cyan: '#2a9f9a',
+  blue: '#3b6fd9',
+  violet: '#7a5ccf',
+  magenta: '#c44f9a',
+  gray: '#7a7f87',
+}
+
+async function fetchTasks(q = ''): Promise<Task[]> {
+  const url = q.trim() ? `/api/tasks?q=${encodeURIComponent(q.trim())}` : '/api/tasks'
+  const res = await fetch(url)
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
   const body = (await res.json()) as { tasks?: Task[] }
   return Array.isArray(body.tasks) ? body.tasks : []
@@ -57,7 +90,7 @@ async function createTask(title: string): Promise<Task> {
   return body.task
 }
 
-async function patchTask(id: string, patch: Partial<Task>): Promise<Task> {
+async function patchTask(id: string, patch: Record<string, unknown>): Promise<Task> {
   const res = await fetch(`/api/tasks/${id}`, {
     method: 'PATCH',
     headers: { 'content-type': 'application/json' },
@@ -76,14 +109,39 @@ async function removeTask(id: string): Promise<void> {
   }
 }
 
+function formatWhen(ts: number | null | undefined): string {
+  if (!ts) return '—'
+  const date = new Date(ts)
+  if (Number.isNaN(date.getTime())) return '—'
+  const diff = Date.now() - ts
+  if (diff < 60_000) return '刚刚'
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)} 分钟前`
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)} 小时前`
+  if (diff < 7 * 86_400_000) return `${Math.floor(diff / 86_400_000)} 天前`
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatDue(ts: number | null): string {
+  if (!ts) return ''
+  const date = new Date(ts)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
 function useTasks(pollMs = 2500) {
   const [tasks, setTasks] = useState<Task[]>([])
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
+  const [query, setQuery] = useState('')
 
   const refresh = useCallback(async () => {
     try {
-      const next = await fetchTasks()
+      const next = await fetchTasks(query)
       setTasks(next)
       setError('')
     } catch (err) {
@@ -91,7 +149,7 @@ function useTasks(pollMs = 2500) {
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [query])
 
   useEffect(() => {
     void refresh()
@@ -101,14 +159,71 @@ function useTasks(pollMs = 2500) {
     return () => window.clearInterval(timer)
   }, [refresh, pollMs])
 
-  return { tasks, setTasks, error, loading, refresh }
+  return { tasks, setTasks, error, loading, refresh, query, setQuery }
+}
+
+function ActorChip({ actor, empty = '未分配' }: { actor: TaskActor | null | undefined; empty?: string }) {
+  if (!actor) {
+    return <span className="tasks-actor is-empty">{empty}</span>
+  }
+  const color = actor.mascot?.color ? MASCOT_COLOR[actor.mascot.color] ?? '#7a7f87' : actor.kind === 'agent' ? '#3b6fd9' : '#7a7f87'
+  const initial = (actor.name || '?').trim().slice(0, 1).toUpperCase()
+  return (
+    <span className="tasks-actor" title={actor.sessionId ? `${actor.name} · ${actor.sessionId.slice(0, 8)}` : actor.name}>
+      <span className="tasks-avatar" style={{ background: color }} aria-hidden>
+        {initial}
+      </span>
+      <span className="tasks-actor-name">{actor.name}</span>
+      {actor.kind === 'agent' ? <span className="tasks-actor-kind">Agent</span> : null}
+    </span>
+  )
+}
+
+function ExecBadge({ execution }: { execution?: TaskExecution }) {
+  if (!execution || execution.status === 'unassigned') {
+    return <span className="tasks-exec is-muted">未派工</span>
+  }
+  if (execution.status === 'running') {
+    return (
+      <span className="tasks-exec is-running" title={execution.assistantText || execution.reason || ''}>
+        执行中{execution.turn != null ? ` · T${execution.turn}` : ''}
+      </span>
+    )
+  }
+  const doneHint = execution.reason === 'stop' || execution.reason === 'end' || Boolean(execution.assistantText)
+  return (
+    <span
+      className={`tasks-exec ${doneHint ? 'is-idle' : 'is-muted'}`}
+      title={execution.assistantText || execution.reason || ''}
+    >
+      {doneHint ? '已响应' : '空闲'}
+      {execution.turn != null ? ` · T${execution.turn}` : ''}
+    </span>
+  )
+}
+
+function PriorityMark({ value }: { value: TaskPriority }) {
+  return (
+    <span className={`tasks-priority is-${value}`} title={`优先级 ${PRIORITY_LABEL[value]}`}>
+      <i />
+      <i />
+      <i />
+      <span>{PRIORITY_LABEL[value]}</span>
+    </span>
+  )
 }
 
 function TasksWorkspace({ compact = false }: { compact?: boolean }) {
-  const { tasks, setTasks, error, loading, refresh } = useTasks(compact ? 3000 : 2500)
-  const [view, setView] = useState<ViewMode>('table')
+  const { tasks, setTasks, error, loading, refresh, query, setQuery } = useTasks(compact ? 3000 : 2500)
+  const [view, setView] = useState<ViewMode>(compact ? 'board' : 'table')
   const [draft, setDraft] = useState('')
   const [busy, setBusy] = useState(false)
+
+  const counts = useMemo(() => {
+    const map = { todo: 0, doing: 0, done: 0, total: tasks.length }
+    for (const task of tasks) map[task.status] += 1
+    return map
+  }, [tasks])
 
   const byStatus = useMemo(() => {
     const map: Record<TaskStatus, Task[]> = { todo: [], doing: [], done: [] }
@@ -129,7 +244,6 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
       setTasks((prev) => [task, ...prev.filter((item) => item.id !== task.id)])
       setDraft('')
     } catch (err) {
-      setTasks((prev) => prev)
       console.error(err)
     } finally {
       setBusy(false)
@@ -137,8 +251,8 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
     }
   }
 
-  async function onUpdate(id: string, patch: Partial<Task>) {
-    setTasks((prev) => prev.map((item) => (item.id === id ? { ...item, ...patch } : item)))
+  async function onUpdate(id: string, patch: Record<string, unknown>) {
+    setTasks((prev) => prev.map((item) => (item.id === id ? ({ ...item, ...patch } as Task) : item)))
     try {
       const task = await patchTask(id, patch)
       setTasks((prev) => prev.map((item) => (item.id === id ? task : item)))
@@ -167,7 +281,12 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
       <header className="tasks-head">
         <div className="tasks-head-left">
           <h1 className="tasks-title">任务</h1>
-          {!compact ? <p className="tasks-sub">Table / Board · Agent 可用 tools · SQLite</p> : null}
+          <div className="tasks-stats" aria-label="任务统计">
+            <span>{counts.total} 项</span>
+            <span className="is-todo">{counts.todo} 待办</span>
+            <span className="is-doing">{counts.doing} 进行</span>
+            <span className="is-done">{counts.done} 完成</span>
+          </div>
         </div>
         <div className="tasks-view-switch" role="tablist" aria-label="视图">
           <button
@@ -191,18 +310,27 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
         </div>
       </header>
 
-      <form className="tasks-create" onSubmit={onCreate}>
+      <div className="tasks-toolbar">
+        <form className="tasks-create" onSubmit={onCreate}>
+          <input
+            className="tasks-create-input"
+            value={draft}
+            placeholder="新建任务，回车添加"
+            aria-label="新建任务"
+            onChange={(event) => setDraft(event.target.value)}
+          />
+          <button type="submit" className="tasks-create-btn" disabled={busy || !draft.trim()}>
+            添加
+          </button>
+        </form>
         <input
-          className="tasks-create-input"
-          value={draft}
-          placeholder="新建任务，回车添加"
-          aria-label="新建任务"
-          onChange={(event) => setDraft(event.target.value)}
+          className="tasks-search"
+          value={query}
+          placeholder="搜索标题 / 人 / 备注"
+          aria-label="搜索任务"
+          onChange={(event) => setQuery(event.target.value)}
         />
-        <button type="submit" className="tasks-create-btn" disabled={busy || !draft.trim()}>
-          添加
-        </button>
-      </form>
+      </div>
 
       {error ? <div className="tasks-error">{error}</div> : null}
       {loading && tasks.length === 0 ? <div className="tasks-empty">加载中…</div> : null}
@@ -223,7 +351,7 @@ function TasksTable({
   compact,
 }: {
   tasks: Task[]
-  onUpdate: (id: string, patch: Partial<Task>) => Promise<void>
+  onUpdate: (id: string, patch: Record<string, unknown>) => Promise<void>
   onDelete: (id: string) => Promise<void>
   compact: boolean
 }) {
@@ -237,8 +365,12 @@ function TasksTable({
           <tr>
             <th>标题</th>
             <th>状态</th>
-            {!compact ? <th>优先级</th> : null}
-            {!compact ? <th>负责人</th> : null}
+            <th>优先级</th>
+            {!compact ? <th>创建人</th> : null}
+            {!compact ? <th>创建时间</th> : null}
+            <th>分配人</th>
+            {!compact ? <th>分配时间</th> : null}
+            <th>执行</th>
             <th aria-label="操作" />
           </tr>
         </thead>
@@ -246,16 +378,20 @@ function TasksTable({
           {tasks.map((task) => (
             <tr key={task.id}>
               <td>
-                <input
-                  className="tasks-cell-input"
-                  defaultValue={task.title}
-                  key={`${task.id}-${task.updatedAt}-title`}
-                  aria-label="标题"
-                  onBlur={(event) => {
-                    const title = event.target.value.trim()
-                    if (title && title !== task.title) void onUpdate(task.id, { title })
-                  }}
-                />
+                <div className="tasks-title-cell">
+                  <input
+                    className="tasks-cell-input"
+                    defaultValue={task.title}
+                    key={`${task.id}-${task.updatedAt}-title`}
+                    aria-label="标题"
+                    onBlur={(event) => {
+                      const title = event.target.value.trim()
+                      if (title && title !== task.title) void onUpdate(task.id, { title })
+                    }}
+                  />
+                  {task.notes ? <div className="tasks-notes-preview">{task.notes}</div> : null}
+                  {task.dueAt ? <div className="tasks-due">截止 {formatDue(task.dueAt)}</div> : null}
+                </div>
               </td>
               <td>
                 <select
@@ -271,39 +407,56 @@ function TasksTable({
                   ))}
                 </select>
               </td>
+              <td>
+                <select
+                  className="tasks-cell-select"
+                  value={task.priority}
+                  aria-label="优先级"
+                  onChange={(event) => void onUpdate(task.id, { priority: event.target.value as TaskPriority })}
+                >
+                  {(Object.keys(PRIORITY_LABEL) as TaskPriority[]).map((key) => (
+                    <option key={key} value={key}>
+                      {PRIORITY_LABEL[key]}
+                    </option>
+                  ))}
+                </select>
+              </td>
               {!compact ? (
                 <td>
-                  <select
-                    className="tasks-cell-select"
-                    value={task.priority}
-                    aria-label="优先级"
-                    onChange={(event) =>
-                      void onUpdate(task.id, { priority: event.target.value as TaskPriority })
-                    }
-                  >
-                    {(Object.keys(PRIORITY_LABEL) as TaskPriority[]).map((key) => (
-                      <option key={key} value={key}>
-                        {PRIORITY_LABEL[key]}
-                      </option>
-                    ))}
-                  </select>
+                  <ActorChip actor={task.creator} empty="—" />
                 </td>
               ) : null}
-              {!compact ? (
-                <td>
+              {!compact ? <td className="tasks-time">{formatWhen(task.createdAt)}</td> : null}
+              <td>
+                <div className="tasks-assignee-cell">
+                  <ActorChip actor={task.assignee} />
                   <input
-                    className="tasks-cell-input"
-                    defaultValue={task.assignee}
+                    className="tasks-cell-input tasks-assignee-edit"
+                    defaultValue={task.assignee?.sessionId || task.assignee?.name || ''}
                     key={`${task.id}-${task.updatedAt}-assignee`}
-                    placeholder="—"
-                    aria-label="负责人"
+                    placeholder="sessionId 或人名"
+                    aria-label="分配人"
                     onBlur={(event) => {
-                      const assignee = event.target.value.trim()
-                      if (assignee !== task.assignee) void onUpdate(task.id, { assignee })
+                      const raw = event.target.value.trim()
+                      const prev = task.assignee?.sessionId || task.assignee?.name || ''
+                      if (raw === prev) return
+                      if (!raw) {
+                        void onUpdate(task.id, { assignee: null })
+                        return
+                      }
+                      if (/^[0-9a-f-]{8,}$/i.test(raw) || raw.length >= 20) {
+                        void onUpdate(task.id, { assigneeSessionId: raw })
+                      } else {
+                        void onUpdate(task.id, { assignee: raw })
+                      }
                     }}
                   />
-                </td>
-              ) : null}
+                </div>
+              </td>
+              {!compact ? <td className="tasks-time">{formatWhen(task.assignedAt)}</td> : null}
+              <td>
+                <ExecBadge execution={task.execution} />
+              </td>
               <td>
                 <button type="button" className="tasks-icon-btn" title="删除" onClick={() => void onDelete(task.id)}>
                   ×
@@ -325,7 +478,7 @@ function TasksBoard({
 }: {
   columns: Record<TaskStatus, Task[]>
   onDropStatus: (taskId: string, status: TaskStatus) => Promise<void>
-  onUpdate: (id: string, patch: Partial<Task>) => Promise<void>
+  onUpdate: (id: string, patch: Record<string, unknown>) => Promise<void>
   onDelete: (id: string) => Promise<void>
 }) {
   function onDragStart(event: DragEvent, id: string) {
@@ -363,6 +516,13 @@ function TasksBoard({
                 draggable
                 onDragStart={(event) => onDragStart(event, task.id)}
               >
+                <div className="tasks-card-top">
+                  <PriorityMark value={task.priority} />
+                  <ExecBadge execution={task.execution} />
+                  <button type="button" className="tasks-icon-btn" title="删除" onClick={() => void onDelete(task.id)}>
+                    ×
+                  </button>
+                </div>
                 <input
                   className="tasks-card-title"
                   defaultValue={task.title}
@@ -373,12 +533,18 @@ function TasksBoard({
                     if (title && title !== task.title) void onUpdate(task.id, { title })
                   }}
                 />
-                <div className="tasks-card-meta">
-                  <span>{PRIORITY_LABEL[task.priority]}</span>
-                  {task.assignee ? <span>{task.assignee}</span> : null}
-                  <button type="button" className="tasks-icon-btn" title="删除" onClick={() => void onDelete(task.id)}>
-                    ×
-                  </button>
+                {task.notes ? <p className="tasks-card-notes">{task.notes}</p> : null}
+                <div className="tasks-card-people">
+                  <div className="tasks-card-person">
+                    <span className="tasks-card-label">创建</span>
+                    <ActorChip actor={task.creator} empty="—" />
+                    <span className="tasks-time">{formatWhen(task.createdAt)}</span>
+                  </div>
+                  <div className="tasks-card-person">
+                    <span className="tasks-card-label">分配</span>
+                    <ActorChip actor={task.assignee} />
+                    <span className="tasks-time">{formatWhen(task.assignedAt)}</span>
+                  </div>
                 </div>
               </li>
             ))}
@@ -415,50 +581,82 @@ export function apply(ctx: Context) {
   slots.place('inspector-tasks', TasksInspectorPanel, { key: 'tasks-inspector', order: 10 })
 }
 
-/** 注入一点插件样式（挂在 document，避免改主仓 css）。 */
 if (typeof document !== 'undefined') {
   const id = 'hmr-tasks-ui-style'
-  if (!document.getElementById(id)) {
-    const style = document.createElement('style')
-    style.id = id
-    style.textContent = `
-.tasks-module-page { display:flex; flex:1; min-height:0; flex-direction:column; overflow:hidden; background:var(--dsw-bg); color:var(--dsw-label); }
+  const style = document.getElementById(id) ?? document.createElement('style')
+  style.id = id
+  style.textContent = `
+.tasks-module-page { display:flex; flex:1; min-height:0; flex-direction:column; overflow:hidden; background:
+  radial-gradient(1200px 480px at 12% -10%, color-mix(in srgb, var(--dsw-business) 10%, transparent), transparent 60%),
+  linear-gradient(180deg, color-mix(in srgb, var(--dsw-surface) 70%, var(--dsw-bg)), var(--dsw-bg));
+  color:var(--dsw-label); }
 .tasks-inspector-panel { display:flex; min-height:0; flex:1; flex-direction:column; overflow:hidden; }
-.tasks-root { display:flex; min-height:0; flex:1; flex-direction:column; gap:12px; padding:16px 18px 20px; overflow:auto; }
+.tasks-root { display:flex; min-height:0; flex:1; flex-direction:column; gap:14px; padding:18px 20px 22px; overflow:auto; }
 .tasks-root.is-compact { padding:10px 12px 14px; gap:8px; }
 .tasks-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
-.tasks-title { margin:0; font-size:18px; font-weight:650; letter-spacing:-0.02em; }
+.tasks-title { margin:0; font-size:22px; font-weight:700; letter-spacing:-0.03em; }
 .tasks-root.is-compact .tasks-title { font-size:14px; }
-.tasks-sub { margin:4px 0 0; color:var(--dsw-label-3); font-size:12px; }
+.tasks-stats { display:flex; flex-wrap:wrap; gap:8px; margin-top:6px; color:var(--dsw-label-3); font-size:11px; font-variant-numeric:tabular-nums; }
+.tasks-stats .is-todo { color:var(--dsw-label-2); }
+.tasks-stats .is-doing { color:var(--dsw-business); }
+.tasks-stats .is-done { color:color-mix(in srgb, #3d9a5f 80%, var(--dsw-label-3)); }
 .tasks-view-switch { display:inline-flex; gap:2px; padding:2px; border:1px solid var(--dsw-border); border-radius:8px; background:var(--dsw-muted-fill); }
 .tasks-view-btn { border:0; border-radius:6px; padding:4px 10px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; font-size:12px; font-weight:600; }
-.tasks-view-btn.is-active { background:var(--dsw-surface); color:var(--dsw-label); }
-.tasks-create { display:flex; gap:8px; }
-.tasks-create-input { flex:1; min-width:0; border:1px solid var(--dsw-border); border-radius:10px; padding:8px 10px; background:var(--dsw-input); color:var(--dsw-label); font:inherit; font-size:13px; outline:none; }
+.tasks-view-btn.is-active { background:var(--dsw-surface); color:var(--dsw-label); box-shadow:0 1px 0 color-mix(in srgb, var(--dsw-label) 6%, transparent); }
+.tasks-toolbar { display:flex; gap:8px; align-items:stretch; flex-wrap:wrap; }
+.tasks-create { display:flex; gap:8px; flex:1 1 280px; min-width:0; }
+.tasks-create-input, .tasks-search { min-width:0; border:1px solid var(--dsw-border); border-radius:10px; padding:8px 10px; background:var(--dsw-input); color:var(--dsw-label); font:inherit; font-size:13px; outline:none; }
+.tasks-create-input { flex:1; }
+.tasks-search { flex:0 1 220px; }
 .tasks-create-btn { border:0; border-radius:10px; padding:8px 12px; background:var(--dsw-business); color:var(--dsw-bg); cursor:pointer; font:inherit; font-size:12px; font-weight:650; }
 .tasks-create-btn:disabled { opacity:.35; cursor:default; }
 .tasks-error { border-radius:8px; padding:8px 10px; background:var(--dsw-danger-soft); color:var(--dsw-danger); font-size:12px; }
 .tasks-empty { color:var(--dsw-label-3); font-size:12px; line-height:1.5; }
-.tasks-table-wrap { overflow:auto; border:1px solid var(--dsw-border); border-radius:12px; background:var(--dsw-surface); }
+.tasks-table-wrap { overflow:auto; border:1px solid var(--dsw-border); border-radius:14px; background:color-mix(in srgb, var(--dsw-surface) 92%, transparent); backdrop-filter:blur(6px); }
 .tasks-table { width:100%; border-collapse:collapse; font-size:12px; }
-.tasks-table th { padding:8px 10px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-3); font-weight:600; text-align:left; }
-.tasks-table td { padding:6px 8px; border-bottom:1px solid var(--dsw-border); vertical-align:middle; }
+.tasks-table th { padding:10px 10px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-3); font-weight:600; text-align:left; white-space:nowrap; position:sticky; top:0; background:var(--dsw-surface); z-index:1; }
+.tasks-table td { padding:8px 8px; border-bottom:1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent); vertical-align:top; }
 .tasks-table tr:last-child td { border-bottom:0; }
+.tasks-table tr:hover td { background:color-mix(in srgb, var(--dsw-hover) 70%, transparent); }
+.tasks-title-cell { display:flex; flex-direction:column; gap:3px; min-width:160px; }
+.tasks-notes-preview, .tasks-card-notes { margin:0; color:var(--dsw-label-3); font-size:11px; line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.tasks-due { color:var(--dsw-label-3); font-size:10px; }
 .tasks-cell-input, .tasks-cell-select, .tasks-card-title { width:100%; border:0; border-radius:6px; padding:4px 6px; background:transparent; color:var(--dsw-label); font:inherit; outline:none; }
 .tasks-cell-input:focus, .tasks-cell-select:focus, .tasks-card-title:focus { background:var(--dsw-hover); }
+.tasks-assignee-cell { display:flex; flex-direction:column; gap:4px; min-width:120px; }
+.tasks-assignee-edit { font-size:11px; color:var(--dsw-label-3); }
+.tasks-time { color:var(--dsw-label-3); font-size:11px; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.tasks-actor { display:inline-flex; align-items:center; gap:6px; min-width:0; max-width:160px; }
+.tasks-actor.is-empty { color:var(--dsw-label-3); }
+.tasks-avatar { width:18px; height:18px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; color:#fff; font-size:10px; font-weight:700; flex:none; box-shadow:inset 0 0 0 1px color-mix(in srgb, #000 18%, transparent); }
+.tasks-actor-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:600; color:var(--dsw-label-2); }
+.tasks-actor-kind { font-size:9px; color:var(--dsw-label-3); border:1px solid var(--dsw-border); border-radius:4px; padding:0 4px; line-height:1.4; }
+.tasks-exec { display:inline-flex; align-items:center; gap:4px; border-radius:999px; padding:2px 8px; font-size:10px; font-weight:650; white-space:nowrap; }
+.tasks-exec.is-running { background:color-mix(in srgb, var(--dsw-business) 16%, transparent); color:var(--dsw-business); }
+.tasks-exec.is-idle { background:color-mix(in srgb, #3d9a5f 14%, transparent); color:#2f7d4c; }
+.tasks-exec.is-muted { background:var(--dsw-muted-fill); color:var(--dsw-label-3); }
+.tasks-priority { display:inline-flex; align-items:center; gap:3px; color:var(--dsw-label-3); font-size:10px; font-weight:650; }
+.tasks-priority i { width:3px; height:8px; border-radius:1px; background:color-mix(in srgb, var(--dsw-label-3) 35%, transparent); display:inline-block; }
+.tasks-priority.is-med i:nth-child(-n+2), .tasks-priority.is-high i { background:currentColor; }
+.tasks-priority.is-med { color:#c48a2a; }
+.tasks-priority.is-high { color:#d64545; }
 .tasks-icon-btn { border:0; border-radius:6px; padding:2px 6px; background:transparent; color:var(--dsw-label-3); cursor:pointer; font:inherit; }
 .tasks-icon-btn:hover { background:var(--dsw-hover); color:var(--dsw-label); }
-.tasks-board { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:10px; min-height:280px; }
+.tasks-board { display:grid; grid-template-columns:repeat(3, minmax(0, 1fr)); gap:12px; min-height:280px; align-items:start; }
 .tasks-root.is-compact .tasks-board { grid-template-columns:1fr; }
-.tasks-column { display:flex; min-height:0; flex-direction:column; border:1px solid var(--dsw-border); border-radius:12px; background:var(--dsw-surface); overflow:hidden; }
-.tasks-column-head { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:8px 10px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-2); font-size:12px; font-weight:650; }
-.tasks-column-count { color:var(--dsw-label-3); font-variant-numeric:tabular-nums; }
-.tasks-column-list { display:flex; flex:1; flex-direction:column; gap:8px; margin:0; padding:8px; list-style:none; overflow:auto; min-height:120px; }
-.tasks-card { border:1px solid var(--dsw-border); border-radius:10px; padding:8px; background:var(--dsw-muted-fill); cursor:grab; }
-.tasks-card:active { cursor:grabbing; }
-.tasks-card-meta { display:flex; align-items:center; gap:8px; margin-top:6px; color:var(--dsw-label-3); font-size:11px; }
-.tasks-card-meta .tasks-icon-btn { margin-left:auto; }
+.tasks-column { display:flex; min-height:0; flex-direction:column; border:1px solid var(--dsw-border); border-radius:14px; background:color-mix(in srgb, var(--dsw-surface) 88%, transparent); overflow:hidden; }
+.tasks-column-head { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:10px 12px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-2); font-size:12px; font-weight:650; }
+.tasks-column-count { min-width:1.5em; text-align:center; border-radius:999px; padding:1px 6px; background:var(--dsw-muted-fill); color:var(--dsw-label-3); font-variant-numeric:tabular-nums; }
+.tasks-column-list { display:flex; flex:1; flex-direction:column; gap:8px; margin:0; padding:10px; list-style:none; overflow:auto; min-height:120px; }
+.tasks-card { border:1px solid color-mix(in srgb, var(--dsw-border) 90%, transparent); border-radius:12px; padding:10px; background:var(--dsw-muted-fill); cursor:grab; display:flex; flex-direction:column; gap:8px; transition:border-color .15s ease, transform .15s ease; }
+.tasks-card:hover { border-color:color-mix(in srgb, var(--dsw-business) 35%, var(--dsw-border)); }
+.tasks-card:active { cursor:grabbing; transform:scale(.995); }
+.tasks-card-top { display:flex; align-items:center; gap:6px; }
+.tasks-card-top .tasks-icon-btn { margin-left:auto; }
+.tasks-card-title { font-size:13px; font-weight:650; padding:0; }
+.tasks-card-people { display:flex; flex-direction:column; gap:6px; }
+.tasks-card-person { display:grid; grid-template-columns:36px minmax(0,1fr) auto; gap:6px; align-items:center; }
+.tasks-card-label { color:var(--dsw-label-3); font-size:10px; }
 `
-    document.head.appendChild(style)
-  }
+  if (!style.parentNode) document.head.appendChild(style)
 }

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -85,6 +85,8 @@ export const SessionInspector = memo(function SessionInspector({
   const [busy, setBusy] = useState(false)
   const [titleDraft, setTitleDraft] = useState('')
   const [promptDraft, setPromptDraft] = useState('')
+  const titleFocusedRef = useRef(false)
+  const promptFocusedRef = useRef(false)
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
 
   useEffect(() => {
@@ -107,12 +109,15 @@ export const SessionInspector = memo(function SessionInspector({
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const body = (await res.json()) as InspectorPayload
       setData(body)
-      setTitleDraft(body.config?.title ?? '')
-      setPromptDraft(
-        typeof body.config?.systemPrompt === 'string'
-          ? body.config.systemPrompt
-          : (body.defaults?.systemPrompt ?? ''),
-      )
+      // 编辑中勿被轮询覆盖，否则 blur 会把半成品写回或看起来像「改不了」
+      if (!titleFocusedRef.current) setTitleDraft(body.config?.title ?? '')
+      if (!promptFocusedRef.current) {
+        setPromptDraft(
+          typeof body.config?.systemPrompt === 'string'
+            ? body.config.systemPrompt
+            : (body.defaults?.systemPrompt ?? ''),
+        )
+      }
       setError('')
     } catch (err) {
       setError(String(err))
@@ -279,11 +284,20 @@ export const SessionInspector = memo(function SessionInspector({
                     disabled={busy}
                     data-testid="inspector-session-title"
                     onChange={(event) => setTitleDraft(event.target.value)}
+                    onFocus={() => {
+                      titleFocusedRef.current = true
+                    }}
                     onBlur={() => {
+                      titleFocusedRef.current = false
                       const next = titleDraft.trim()
                       const prev = data?.config?.title ?? ''
                       if (next === prev) return
                       void patchSessionConfig({ title: next || null })
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== 'Enter') return
+                      event.preventDefault()
+                      ;(event.target as HTMLInputElement).blur()
                     }}
                   />
                 </label>
@@ -343,7 +357,11 @@ export const SessionInspector = memo(function SessionInspector({
                     disabled={busy}
                     data-testid="inspector-system-prompt"
                     onChange={(event) => setPromptDraft(event.target.value)}
+                    onFocus={() => {
+                      promptFocusedRef.current = true
+                    }}
                     onBlur={() => {
+                      promptFocusedRef.current = false
                       const prev =
                         typeof data?.config?.systemPrompt === 'string'
                           ? data.config.systemPrompt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 任务面板
- 展示创建人（Agent 带头像色块 + 名称）、创建时间
- 展示分配人、分配时间（分配 session 时记录 `assignedAt`）
- 执行情况：从分配人 session 的 turn 事件推导（执行中 / 已响应 / 空闲 / 未派工）
- 表格与看板视觉加强；支持搜索
- 去掉「Table / Board · Agent 可用 tools · SQLite」说明文案

## Live tools
- `session_create` / `session_configure` 增加 `project` 参数，可绑定/改绑/解绑工作区文件夹

## 修复
- 配置面板改名：编辑中不被 2s 轮询覆盖 draft

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d19d26b5-98b8-4cc0-9c3f-35b1bee5e9cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

