### PR TITLE
fix: 修复 hmr-dev Dashboard 启动崩溃与类型错误

### DIFF
--- a/host/plugins/core/session-heal.test.ts
+++ b/host/plugins/core/session-heal.test.ts
@@ -7,10 +7,10 @@ import {
   INTERRUPTED_TOOL_DETAIL,
   rebuildHealedEvents,
 } from './session-heal.ts'
-import type { SessionEvent } from './session-types.ts'
+import type { SessionEvent, SessionEventBody } from './session-types.ts'
 import { deriveMessages } from './sessions.ts'
 
-function ev(partial: Omit<SessionEvent, 'seq' | 'ts'> & { seq?: number; ts?: number }): SessionEvent {
+function ev(partial: SessionEventBody & { seq?: number; ts?: number }): SessionEvent {
   return { seq: partial.seq ?? 0, ts: partial.ts ?? 1, ...partial } as SessionEvent
 }
 

--- a/host/plugins/seams/context.ts
+++ b/host/plugins/seams/context.ts
@@ -305,7 +305,8 @@ export function lastUsageBeforeCompact(events: SessionEvent[]): {
   cacheReadTokens: number
   found: boolean
 } {
-  let last: (typeof events)[number]['usage'] & { totalTokens?: number } | undefined
+  type AssistantUsage = NonNullable<Extract<SessionEvent, { type: 'assistant/message' }>['usage']>
+  let last: AssistantUsage | undefined
   for (const ev of events) {
     if (
       ev.type === 'tool/call' &&

--- a/host/plugins/seams/live-dispatched-usage.test.ts
+++ b/host/plugins/seams/live-dispatched-usage.test.ts
@@ -5,9 +5,9 @@ import {
   collectLiveDispatchedUsage,
   listLiveWakes,
 } from './live-dispatched-usage.ts'
-import type { SessionEvent } from '../core/session-types.ts'
+import type { SessionEvent, SessionEventBody } from '../core/session-types.ts'
 
-function ev(partial: Omit<SessionEvent, 'seq' | 'ts'> & { seq?: number; ts?: number }): SessionEvent {
+function ev(partial: SessionEventBody & { seq?: number; ts?: number }): SessionEvent {
   return { seq: partial.seq ?? 0, ts: partial.ts ?? 1, ...partial } as SessionEvent
 }
 

--- a/packages/channel-host/src/index.ts
+++ b/packages/channel-host/src/index.ts
@@ -6,7 +6,6 @@ import { Service, type Context } from 'cordis'
 const require = createRequire(import.meta.url)
 
 type DatabaseSync = import('node:sqlite').DatabaseSync
-type SQLInputValue = import('node:sqlite').SQLInputValue
 
 export type ChannelRole = 'owner' | 'member'
 
@@ -148,9 +147,15 @@ export class ChannelService extends Service {
   }
 
   listChannels(): Channel[] {
-    return this.db
+    const rows = this.db
       .prepare('SELECT id, name, owner, created_at FROM channels ORDER BY created_at DESC')
-      .all() as Array<Record<string, unknown>> as unknown as Channel[]
+      .all() as Array<Record<string, unknown>>
+    return rows.map((row) => ({
+      id: row.id as string,
+      name: row.name as string,
+      owner: row.owner as string,
+      createdAt: row.created_at as number,
+    }))
   }
 
   getChannel(id: string): Channel | undefined {

--- a/packages/tasks-ui/src/index.tsx
+++ b/packages/tasks-ui/src/index.tsx
@@ -1212,7 +1212,7 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
           <div className="tasks-filter-btn-wrap" ref={filterRef}>
             <button
               type="button"
-              className={`tasks-refresh tasks-rbar-btn${filterOpen ? ' is-active' : ''}${projectFilter || tagFilter ? ' is-active' : ''}`}
+              className={`tasks-refresh tasks-rbar-btn${filterOpen ? ' is-active' : ''}${projectFilter || tagFilter.length ? ' is-active' : ''}`}
               aria-label="筛选任务"
               title="筛选"
               aria-haspopup="menu"
@@ -1220,7 +1220,7 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
               onClick={() => setFilterOpen((v) => !v)}
             >
               <LuSlidersHorizontal size={14} aria-hidden />
-              {(projectFilter || tagFilter) ? <span className="tasks-filter-dot" aria-hidden /> : null}
+              {(projectFilter || tagFilter.length) ? <span className="tasks-filter-dot" aria-hidden /> : null}
             </button>
             {filterOpen ? (
               <div className="tasks-filter-menu" role="menu">
@@ -1245,8 +1245,8 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
                   <select
                     className="tasks-filter"
                     aria-label="按标签筛选"
-                    value={tagFilter}
-                    onChange={(e) => setTagFilter(e.target.value)}
+                    value={tagFilter[0] ?? ''}
+                    onChange={(e) => setTagFilter(e.target.value ? [e.target.value] : [])}
                   >
                     <option value="">全部标签</option>
                     {allTags.map((t) => (
@@ -1256,11 +1256,11 @@ function TasksWorkspace({ compact = false }: { compact?: boolean }) {
                     ))}
                   </select>
                 </label>
-                {(projectFilter || tagFilter) ? (
+                {(projectFilter || tagFilter.length) ? (
                   <button
                     type="button"
                     className="tasks-filter-clear"
-                    onClick={() => { setProjectFilter(''); setTagFilter(''); }}
+                    onClick={() => { setProjectFilter(''); setTagFilter([]); }}
                   >
                     清除筛选
                   </button>

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -14,7 +14,7 @@ test('boots into #app', async () => {
   await act(async () => {
     await import('./main.tsx')
   })
-  assert.match(document.body.innerHTML, /deepseek/i)
-  assert.match(document.body.innerHTML, /HARNESS/)
-  assert.match(document.body.innerHTML, /Settings|New Session/)
+  assert.match(document.body.innerHTML, /Activity bar/)
+  assert.match(document.body.innerHTML, /Agent/)
+  assert.match(document.body.innerHTML, /Settings/)
 })

--- a/src/plugins/contributors/chat/sticky-user.test.tsx
+++ b/src/plugins/contributors/chat/sticky-user.test.tsx
@@ -81,7 +81,7 @@ describe('sticky user message markers', () => {
 
     const bar = document.querySelector('[data-node-id="u-1"] [data-testid="user-turn-bar"]')
     const end = bar?.querySelector('[data-testid="user-turn-bar-end"]')
-    const kids = end ? [...end.children] : []
+    const kids = end ? Array.from(end.children) : []
     const senderIdx = kids.findIndex((el) => el.getAttribute('data-testid') === 'user-sender-human')
     const timeIdx = kids.findIndex((el) => el.getAttribute('data-testid') === 'user-sent-at')
     expect(senderIdx).toBeGreaterThanOrEqual(0)

--- a/src/plugins/contributors/dashboard-module.tsx
+++ b/src/plugins/contributors/dashboard-module.tsx
@@ -28,6 +28,27 @@ type StatsOverview = {
   projects: ProjectStat[]
 }
 
+function emptyTotals(): UsageTotals {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, turns: 0 }
+}
+
+/** fetch 可能拿到非 overview 的 JSON（测试 mock / 旧接口），缺字段时不能直接 .map */
+function normalizeOverview(raw: unknown): StatsOverview | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Partial<StatsOverview>
+  const totals = o.totals
+  const today = o.today ?? emptyTotals()
+  if (!totals || typeof totals.sessions !== 'number') return null
+  return {
+    generatedAt: typeof o.generatedAt === 'number' ? o.generatedAt : 0,
+    totals,
+    today,
+    hourly: Array.isArray(o.hourly) ? o.hourly : [],
+    daily: Array.isArray(o.daily) ? o.daily : [],
+    projects: Array.isArray(o.projects) ? o.projects : [],
+  }
+}
+
 function formatTok(n: number) {
   return n.toLocaleString('en-US')
 }
@@ -60,7 +81,7 @@ export function DashboardModule() {
       })
       .then((next) => {
         if (cancelled) return
-        setData(next)
+        setData(normalizeOverview(next))
         setError('')
       })
       .catch((err) => {
@@ -75,8 +96,10 @@ export function DashboardModule() {
     }
   }, [])
 
-  const hourlyMax = Math.max(1, ...(data?.hourly.map((item) => item.inputTokens + item.outputTokens) ?? [1]))
-  const dailyMax = Math.max(1, ...(data?.daily.map((item) => item.inputTokens + item.outputTokens) ?? [1]))
+  const hourly = data?.hourly ?? []
+  const daily = data?.daily ?? []
+  const hourlyMax = Math.max(1, ...hourly.map((item) => item.inputTokens + item.outputTokens), 1)
+  const dailyMax = Math.max(1, ...daily.map((item) => item.inputTokens + item.outputTokens), 1)
 
   return (
     <div className="dash-root">
@@ -118,10 +141,10 @@ export function DashboardModule() {
             <section className="dash-panel">
               <h2 className="dash-panel-title">近 24 小时用量</h2>
               <div className="dash-bars">
-                {data.hourly.length === 0 ? (
+                {hourly.length === 0 ? (
                   <p className="dash-muted">暂无小时数据</p>
                 ) : (
-                  data.hourly.map((item) => (
+                  hourly.map((item) => (
                     <BarRow
                       key={item.key}
                       label={item.label}
@@ -136,10 +159,10 @@ export function DashboardModule() {
             <section className="dash-panel">
               <h2 className="dash-panel-title">近 7 天用量</h2>
               <div className="dash-bars">
-                {data.daily.length === 0 ? (
+                {daily.length === 0 ? (
                   <p className="dash-muted">暂无日数据</p>
                 ) : (
-                  data.daily.map((item) => (
+                  daily.map((item) => (
                     <BarRow
                       key={item.key}
                       label={item.label.slice(5)}

--- a/src/plugins/contributors/session-inspector.tsx
+++ b/src/plugins/contributors/session-inspector.tsx
@@ -174,7 +174,7 @@ export const SessionInspector = memo(function SessionInspector({
       >
         {tab === 'traj' ? (
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid="inspector-trajectory">
-            <TrajectoryView useSessionView={useSessionView} sessionView={sessionView} />
+            <TrajectoryView useSessionView={useSessionView} sessionView={sessionView} renderSlot={() => null} />
           </div>
         ) : null}
 

--- a/src/plugins/infrastructure/session-view.test.ts
+++ b/src/plugins/infrastructure/session-view.test.ts
@@ -130,7 +130,7 @@ test('inspectCall switches to trajectory with focus', async () => {
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
   view.inspectCall('c1')
-  assert.equal(view.get().view, 'debug')
+  assert.equal(view.get().view, 'chat')
   assert.equal(view.get().focusCallId, 'c1')
 })
 

--- a/src/plugins/infrastructure/session-view.ts
+++ b/src/plugins/infrastructure/session-view.ts
@@ -207,7 +207,7 @@ export class SessionViewService extends Service {
     super(ctx, 'sessionView')
     void this.refreshSessions()
     void this.refreshApprovals()
-    this.ctx.on('dispose', () => this.stopDispatchedPoll())
+    this.ctx.effect(() => () => this.stopDispatchedPoll())
   }
 
   private buildNodes(events: SessionEvent[], byTurn = this.value.dispatchedUsageByTurn) {

--- a/src/plugins/orchestration/ui-hub.test.ts
+++ b/src/plugins/orchestration/ui-hub.test.ts
@@ -38,6 +38,7 @@ test('ui-hub mounts configured ui packages and builtin chat', async () => {
       dock: { kind: 'list' },
       project: { kind: 'single' },
       composer: { kind: 'single' },
+      models: { kind: 'single' },
       settings: { kind: 'list' },
     },
   })
@@ -53,5 +54,5 @@ test('ui-hub mounts configured ui packages and builtin chat', async () => {
   await new Promise((resolve) => setTimeout(resolve, 80))
   assert.equal(ctx.slots.list('demos').length >= 1, true)
   assert.equal(ctx.slots.list('composer').some((item) => item.id === 'chat'), true)
-  assert.equal(ctx.slots.list('settings').some((item) => item.id === 'chat-config'), true)
+  assert.equal(ctx.slots.list('models').some((item) => item.id === 'chat-config'), true)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
基于 `hmr-dev` 修启动报错与当前测试/类型不一致。

## 原因
- Dashboard 始终挂在 Shell 里。`/api/stats/overview` 返回不完整 JSON（或缺 `hourly`）时，`data?.hourly.map` 会在 `hourly === undefined` 时抛错，整页白屏。
- `inspectCall` 已改为只设 `focusCallId`、不再切 `debug` 主区，测试仍断言旧行为。
- 任务筛选 `tagFilter` 是 `string[]`，select 仍当字符串写。
- `SessionEvent` 判别联合上直接取 `usage`，以及 `ctx.on('dispose')` 不在 Events 里。

## 改动
- 规范化 overview 缺省字段，缺数据时不再 `.map` undefined。
- 检查器给 `TrajectoryView` 补 `renderSlot`；`sessionView` 用 `ctx.effect` 清理轮询。
- 对齐相关单测；频道列表 `created_at` 映射为 `createdAt`。

`vitest` 242 通过，`tsc --noEmit` 通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

