### PR TITLE
refactor: 壳和 type 不再绑 cap，加载器下沉

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ npm run dev:web    # Vite :5173，/api 和 /ws 代理到 host
 
 ```
 BIU
-├── host/                 # host 加载器 + cordis 解析
+├── host/                 # host 加载器
 ├── web/                  # 前端加载器（main.tsx / 样式）
 ├── packages/
 │   ├── type-*            # 共享契约（不是插件，不进 json）
-│   ├── host-*            # host 内核  → src/host/
+│   ├── host-*            # host 内核  → src/host/（含 host-plugin-loader）
 │   ├── web-*             # web 内核   → src/web/
 │   └── cap-*             # 能力插件   → src/host + src/web
 ├── cordis.plugins.json   # 唯一插件清单

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npm run dev:web    # Vite :5173，/api 和 /ws 代理到 host
 |----|--------|------|
 | `host` | `host/index.ts` | HTTP、sessions、tools、llm、hub … |
 | `web` | `web/main.tsx` | slots、app-shell、ui-hub … |
-| `plugins` | `@biu/host-hub` + `@biu/web-ui-hub` | 可热插拔能力；`ui` 指向 `@biu/cap-*/web` |
+| `plugins` | `@biu/host-hub` + `@biu/web-ui-hub` | 可热插拔能力；`web` 指向 `@biu/cap-*/web` |
 
 壳不认识具体 cap 插件。json 的 `id` 用短名（`chat`、`http`）；包名一律 `@biu/<prefix>-<id>`。
 
@@ -138,7 +138,7 @@ BIU
 {
   "id": "greeter",
   "package": "@biu/cap-greeter/host",
-  "ui": "@biu/cap-greeter/web",
+  "web": "@biu/cap-greeter/web",
   "togglable": true,
   "enabled": true
 }

--- a/cordis.plugins.json
+++ b/cordis.plugins.json
@@ -42,7 +42,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-chat/host + @biu/cap-chat/web。会话与 composer。",
       "package": "@biu/cap-chat/host",
-      "ui": "@biu/cap-chat/web",
+      "web": "@biu/cap-chat/web",
       "togglable": true,
       "enabled": true
     },
@@ -61,7 +61,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-clock/host + @biu/cap-clock/web。",
       "package": "@biu/cap-clock/host",
-      "ui": "@biu/cap-clock/web",
+      "web": "@biu/cap-clock/web",
       "togglable": true,
       "enabled": true
     },
@@ -80,7 +80,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-greeter/host + @biu/cap-greeter/web。",
       "package": "@biu/cap-greeter/host",
-      "ui": "@biu/cap-greeter/web",
+      "web": "@biu/cap-greeter/web",
       "togglable": true,
       "enabled": true
     },
@@ -108,7 +108,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-dashboard。用量概览。",
       "package": "@biu/cap-dashboard/host",
-      "ui": "@biu/cap-dashboard/web",
+      "web": "@biu/cap-dashboard/web",
       "togglable": true,
       "enabled": true
     },
@@ -118,7 +118,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-tasks。",
       "package": "@biu/cap-tasks/host",
-      "ui": "@biu/cap-tasks/web",
+      "web": "@biu/cap-tasks/web",
       "togglable": true,
       "enabled": true
     },
@@ -128,7 +128,7 @@
       "layer": "capability",
       "blurb": "@biu/cap-channels。",
       "package": "@biu/cap-channels/host",
-      "ui": "@biu/cap-channels/web",
+      "web": "@biu/cap-channels/web",
       "togglable": true,
       "enabled": true
     }

--- a/docs/plugin-packages.md
+++ b/docs/plugin-packages.md
@@ -2,7 +2,7 @@
 
 主仓 **`host/` / `web/` 只留加载器**：读 `cordis.plugins.json`，按包名动态 import。插件源码在 `packages/`，包名一律 `@biu/<prefix>-<id>`。
 
-`host/index.ts` 只做：建 Context、读 `host` 表、`plugin()`。`hub` 是 `@biu/host-hub`，写在 `host` 表最后一项（它再去挂 `plugins` 表）。
+`host/index.ts` 只做：建 Context、读 `host` 表、`plugin()`。json 解析在 `@biu/host-plugin-loader`。`hub` 是 `@biu/host-hub`，写在 `host` 表最后一项（它再去挂 `plugins` 表）。
 
 插件包内部源码一律 `src/host/` 与/或 `src/web/`（`type-*` 仍用 `src/`，它们不是插件）。
 
@@ -12,7 +12,7 @@
 |---|---|---|
 | `host` | `host/index.ts` | 内核（`host-http` / `host-sessions` / `host-tools` …），按数组顺序 `await plugin` |
 | `web` | `web/main.tsx` ← `virtual:cordis-web-runtime` | 壳（`web-slots` / `web-app-shell` / `web-ui-hub` …） |
-| `plugins` | `@biu/host-hub` + `@biu/web-ui-hub` | 可热插拔能力；json 的 `ui` 字段指向 `@biu/cap-*/web` |
+| `plugins` | `@biu/host-hub` + `@biu/web-ui-hub` | 可热插拔能力；json 的 `web` 字段指向 `@biu/cap-*/web` |
 
 ## `packages/` 前缀
 
@@ -21,6 +21,6 @@
 - **`type-*`**：会被很多包直接 `import` 的契约（纯类型 + 纯函数）。例如 `@biu/type-session`、`@biu/type-agent-loop`、`@biu/type-http`、`@biu/type-slots`。不是插件，不进 json。`currentSessionId` / `runWithSession` 是 ALS 运行时，在 `@biu/host-sessions/scope`。
 - **`host-*`**：host 内核插件（无浏览器入口）。源码在 `src/host/`。
 - **`web-*`**：web 内核插件；`web-mascot` 是共享库，不必进 json。源码在 `src/web/`。
-- **`cap-*`**：能力插件，同一目录，**`exports` 必须把 `./host` 与 `./web` 分开**（禁止一个入口同时带 Node + React）。json 写 `"package": "@biu/cap-chat/host", "ui": "@biu/cap-chat/web"`。
+- **`cap-*`**：能力插件，同一目录，**`exports` 必须把 `./host` 与 `./web` 分开**（禁止一个入口同时带 Node + React）。json 写 `"package": "@biu/cap-chat/host", "web": "@biu/cap-chat/web"`。
 
 json 里的 `id` 仍用短名 `chat` / `http`。命令行缝是 `host-shell`，应用壳是 `web-app-shell`。

--- a/host/index.ts
+++ b/host/index.ts
@@ -1,13 +1,8 @@
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
 import { Context } from 'cordis'
-import { importConfiguredPackage, readCordisConfig, rootDirFrom } from './cordis-plugins.ts'
+import { importConfiguredPackage, readCordisConfig, findRepoRoot } from '@biu/host-plugin-loader'
 import './types.ts'
 
-const publicDir = join(dirname(fileURLToPath(import.meta.url)), '../public')
-const port = Number(process.env.PORT ?? 3141)
-const host = process.env.HTTP_HOST ?? '127.0.0.1'
-const rootDir = rootDirFrom(import.meta.url)
+const rootDir = findRepoRoot()
 
 const ctx = new Context()
 ctx.logger.exporter({
@@ -26,8 +21,7 @@ async function boot() {
   for (const item of config.host ?? []) {
     if (!item.package || item.enabled === false) continue
     const mod = await importConfiguredPackage(rootDir, item.package)
-    const extra = item.id === 'http' ? { port, host, publicDir } : item.config
-    await ctx.plugin(mod, extra)
+    await ctx.plugin(mod, item.config)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -572,6 +572,10 @@
       "resolved": "packages/host-mcp",
       "link": true
     },
+    "node_modules/@biu/host-plugin-loader": {
+      "resolved": "packages/host-plugin-loader",
+      "link": true
+    },
     "node_modules/@biu/host-sandbox": {
       "resolved": "packages/host-sandbox",
       "link": true
@@ -846,7 +850,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,7 +1660,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1671,7 +1673,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2176,14 +2177,13 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "26.2.0",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-26.2.0.tgz",
       "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -2974,7 +2974,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3076,7 +3076,6 @@
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3152,7 +3151,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3168,7 +3166,6 @@
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3264,7 +3261,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -3367,7 +3364,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -3400,7 +3397,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3421,7 +3417,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3442,7 +3437,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3463,7 +3457,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3484,7 +3477,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3505,7 +3497,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3526,7 +3517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3547,7 +3537,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3568,7 +3557,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3589,7 +3577,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3610,7 +3597,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3691,7 +3677,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.18",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3752,12 +3737,10 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3768,7 +3751,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.26",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3944,7 +3926,6 @@
     },
     "node_modules/rollup": {
       "version": "4.62.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.9"
@@ -4068,7 +4049,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4200,7 +4180,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -4288,7 +4267,7 @@
     },
     "node_modules/tsx": {
       "version": "4.23.12",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4329,7 +4308,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4374,7 +4353,6 @@
     },
     "node_modules/vite": {
       "version": "7.3.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
@@ -4940,6 +4918,13 @@
       "version": "0.1.0",
       "peerDependencies": {
         "cordis": "4.0.0-rc.8"
+      }
+    },
+    "packages/host-plugin-loader": {
+      "name": "@biu/host-plugin-loader",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "vite": "^7.1.2"
       }
     },
     "packages/host-sandbox": {

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -384,6 +384,12 @@ export function computeTurnStats(events: SessionEvent[], targetTurn?: number): R
 export const name = 'chat'
 export const inject = ['http', 'hub', 'agents', 'sessions', 'systemPrompt', 'tools']
 
+declare module 'cordis' {
+  interface Context {
+    chat: ChatService
+  }
+}
+
 export function apply(ctx: Context) {
   const chat = new ChatService(ctx)
   ctx.hub.register({

--- a/packages/cap-chat/src/web/index.test.ts
+++ b/packages/cap-chat/src/web/index.test.ts
@@ -26,4 +26,6 @@ test('one plugin fills thread, trajectory, composer, approvals dock and models',
   assert.equal(ctx.slots.list('project').length, 0)
   assert.equal(ctx.slots.list('dock').some((item) => item.id === 'approvals'), true)
   assert.equal(ctx.slots.list('models')[0]?.id, 'chat-config')
+  assert.equal(ctx.slots.list('inspector-panels').some((item) => item.id === 'chat-traj'), true)
+  assert.equal(ctx.slots.list('inspector-panels').some((item) => item.id === 'chat-usage'), true)
 })

--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -1,20 +1,42 @@
+import { createElement } from 'react'
 import type { Context } from 'cordis'
+import { LuActivity, LuListTree } from 'react-icons/lu'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+import type { SlotProps } from '@biu/web-slots'
 import { ApprovalsRail } from './approvals.tsx'
 import { ChatComposer } from './composer.tsx'
 import { ChatConfig } from './config.tsx'
 import { ChatConfigBanner } from './config-banner.tsx'
 import { ChatThread } from './thread.tsx'
 import { TrajectoryView } from './trajectory.tsx'
+import { UsagePanel } from './usage-panel.tsx'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 
 export const name = 'chat-ui'
 export const inject = ['slots', 'sessionView', 'projectView']
 
+function InspectorTrajectory(props: SlotProps) {
+  return createElement(
+    'div',
+    { className: 'flex min-h-0 flex-1 flex-col overflow-hidden', 'data-testid': 'inspector-trajectory' },
+    createElement(TrajectoryView, props),
+  )
+}
+
+function InspectorUsage(props: SlotProps) {
+  return createElement(
+    'div',
+    { className: 'min-h-0 flex-1 overflow-y-auto p-2.5', 'data-testid': 'inspector-usage' },
+    createElement(UsagePanel, {
+      useSessionView: props.useSessionView as ReturnType<typeof bindSessionView>,
+      sessionView: props.sessionView as SessionViewService,
+    }),
+  )
+}
+
 export function apply(ctx: Context) {
   const view = ctx.sessionView as SessionViewService
   const project = ctx.projectView as ProjectViewService
-  // 稳定 props：避免 Shell 重绘时 bind* 新函数打穿 memo（重 Markdown 切换卡顿）
   const slotProps = {
     useSessionView: bindSessionView(view),
     sessionView: view,
@@ -24,9 +46,25 @@ export function apply(ctx: Context) {
   const props = () => slotProps
   ctx.slots.place('stage', ChatThread, { key: 'chat-thread', order: 1, props })
   ctx.slots.place('trajectory', TrajectoryView, { key: 'trajectory', order: 1, props })
-  // project 胶囊嵌在 dock ApprovalsRail 胶囊行，不再单独占顶栏
   ctx.slots.place('composer', ChatComposer, { key: 'chat', order: 10, props })
   ctx.slots.place('dock', ChatConfigBanner, { key: 'chat-config-banner', order: 1 })
   ctx.slots.place('dock', ApprovalsRail, { key: 'approvals', order: 5, props })
   ctx.slots.place('models', ChatConfig, { key: 'chat-config', order: 10 })
+  ctx.slots.place('inspector-panels', InspectorTrajectory, {
+    key: 'chat-traj',
+    order: 1,
+    props: () => ({
+      ...slotProps,
+      tabId: 'traj',
+      tabLabel: '轨迹',
+      tabIcon: LuListTree,
+      ensureTrajectory: true,
+      focusOnCall: true,
+    }),
+  })
+  ctx.slots.place('inspector-panels', InspectorUsage, {
+    key: 'chat-usage',
+    order: 2,
+    props: () => ({ ...slotProps, tabId: 'usage', tabLabel: '用量', tabIcon: LuActivity }),
+  })
 }

--- a/packages/cap-clock/src/host/index.ts
+++ b/packages/cap-clock/src/host/index.ts
@@ -1,5 +1,11 @@
 import type { Context } from 'cordis'
 
+declare module 'cordis' {
+  interface Events {
+    'clock/tick'(iso: string): void
+  }
+}
+
 export const name = 'clock'
 export const inject = ['http', 'hub', 'tools']
 

--- a/packages/cap-greeter/src/host/index.ts
+++ b/packages/cap-greeter/src/host/index.ts
@@ -29,6 +29,12 @@ type HostCtx = Context & {
   waterfall: (name: string, value: string, fallback: () => string) => string
 }
 
+declare module 'cordis' {
+  interface Events {
+    'greet/transform'(text: string, next: () => string): string
+  }
+}
+
 export class GreetService extends Service {
   constructor(ctx: Context) {
     super(ctx, 'greet')

--- a/packages/cap-uppercase/src/host/index.ts
+++ b/packages/cap-uppercase/src/host/index.ts
@@ -1,5 +1,11 @@
 import type { Context } from 'cordis'
 
+declare module 'cordis' {
+  interface Events {
+    'greet/transform'(text: string, next: () => string): string
+  }
+}
+
 export const name = 'uppercase'
 export const inject = ['greet']
 

--- a/packages/host-http/src/host/index.ts
+++ b/packages/host-http/src/host/index.ts
@@ -51,11 +51,25 @@ function parseBody(req: IncomingMessage): Promise<unknown> {
   })
 }
 
+export type HttpListenConfig = {
+  port?: number
+  host?: string
+  publicDir?: string
+}
+
+function resolveListenConfig(config?: HttpListenConfig) {
+  return {
+    port: Number(config?.port ?? process.env.PORT ?? 3141),
+    host: config?.host ?? process.env.HTTP_HOST ?? '127.0.0.1',
+    publicDir: config?.publicDir ?? join(process.cwd(), 'public'),
+  }
+}
+
 export class HttpService extends Service {
   private routes: Route[] = []
   private sockets = new Set<WebSocket>()
 
-  constructor(ctx: Context, public config: { port: number; host?: string; publicDir: string }) {
+  constructor(ctx: Context, public config: { port: number; host: string; publicDir: string }) {
     super(ctx, 'http')
     ctx.effect(() => {
       const server = createServer((req, res) => {
@@ -198,6 +212,6 @@ export class HttpService extends Service {
 export const name = 'http'
 export const inject = [] as const
 
-export function apply(ctx: Context, config: { port: number; host?: string; publicDir: string }) {
-  new HttpService(ctx, config)
+export function apply(ctx: Context, config?: HttpListenConfig) {
+  new HttpService(ctx, resolveListenConfig(config))
 }

--- a/packages/host-hub/src/host/catalog.ts
+++ b/packages/host-hub/src/host/catalog.ts
@@ -10,9 +10,6 @@ export interface CatalogEntry {
   togglable: boolean
   enabled: boolean
   config?: unknown
-  ui?: string
+  web?: string
   packageName?: string
 }
-
-/** 能力插件只来自 cordis.plugins.json；此文件不再静态 import 任何插件。 */
-export const builtinCatalog: CatalogEntry[] = []

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -73,7 +73,7 @@ export class HubService extends Service {
       togglable: entry.togglable,
       enabled: Boolean(fiber && fiber.uid !== null),
       state: fiber ? STATE[fiber.state] ?? String(fiber.state) : 'off',
-      ...(entry.ui ? { ui: entry.ui } : {}),
+      ...(entry.web ? { web: entry.web } : {}),
       ...(entry.packageName ? { packageName: entry.packageName } : {}),
     }))
     return {

--- a/packages/host-hub/src/host/resolve-catalog.test.ts
+++ b/packages/host-hub/src/host/resolve-catalog.test.ts
@@ -3,19 +3,19 @@ import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { resolveCatalog } from './resolve-catalog.ts'
-import { rootDirFrom } from '../../../../host/cordis-plugins.ts'
+import { findRepoRoot, pluginWebSpecifier } from '@biu/host-plugin-loader'
 
 test('resolveCatalog loads only packages declared in cordis.plugins.json', async () => {
-  const root = rootDirFrom()
+  const root = findRepoRoot()
   const raw = JSON.parse(await readFile(join(root, 'cordis.plugins.json'), 'utf8')) as {
-    plugins: Array<{ id: string; package: string; ui?: string }>
+    plugins: Array<{ id: string; package: string; web?: string; ui?: string }>
   }
   const catalog = await resolveCatalog()
   for (const item of raw.plugins) {
     const entry = catalog.find((row) => row.id === item.id)
     assert.ok(entry, `missing ${item.id}`)
     assert.equal(entry?.packageName, item.package)
-    assert.equal(entry?.ui, item.ui)
+    assert.equal(entry?.web, pluginWebSpecifier(item))
     assert.equal(typeof entry?.plugin, 'object')
   }
 })

--- a/packages/host-hub/src/host/resolve-catalog.ts
+++ b/packages/host-hub/src/host/resolve-catalog.ts
@@ -1,18 +1,19 @@
 import type { Plugin } from 'cordis'
-import { builtinCatalog, type CatalogEntry } from './catalog.ts'
+import type { CatalogEntry } from './catalog.ts'
 import {
+  findRepoRoot,
   importConfiguredPackage,
+  pluginWebSpecifier,
   readCordisPlugins,
-  rootDirFrom,
   type CordisPluginEntry,
-} from '../../../../host/cordis-plugins.ts'
+} from '@biu/host-plugin-loader'
 
-const rootDir = rootDirFrom()
+const rootDir = findRepoRoot()
 
-/** 内置 catalog + cordis.plugins.json（主仓代码不出现具体外部包名）。 */
+/** 只读 cordis.plugins.json 的 plugins 表。 */
 export async function resolveCatalog(): Promise<CatalogEntry[]> {
   const external = readCordisPlugins(rootDir)
-  const externalEntries: CatalogEntry[] = []
+  const entries: CatalogEntry[] = []
   const seen = new Set<string>()
 
   for (const item of external) {
@@ -23,18 +24,11 @@ export async function resolveCatalog(): Promise<CatalogEntry[]> {
       throw new Error(`duplicate plugin id in cordis.plugins.json: ${item.id}`)
     }
     const mod = (await importConfiguredPackage(rootDir, item.package)) as Plugin & { inject?: string[] }
-    externalEntries.push(toCatalogEntry(item, mod))
+    entries.push(toCatalogEntry(item, mod))
     seen.add(item.id)
   }
 
-  for (const item of builtinCatalog) {
-    if (seen.has(item.id)) {
-      throw new Error(`duplicate plugin id with cordis.plugins.json: ${item.id}`)
-    }
-    seen.add(item.id)
-  }
-
-  return [...externalEntries, ...builtinCatalog]
+  return entries
 }
 
 function toCatalogEntry(item: CordisPluginEntry, mod: Plugin & { inject?: string[] }): CatalogEntry {
@@ -48,7 +42,7 @@ function toCatalogEntry(item: CordisPluginEntry, mod: Plugin & { inject?: string
     togglable: item.togglable !== false,
     enabled: item.enabled !== false,
     config: item.config,
-    ui: item.ui,
+    web: pluginWebSpecifier(item),
     packageName: item.package,
   }
 }

--- a/packages/host-plugin-loader/package.json
+++ b/packages/host-plugin-loader/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@biu/host-plugin-loader",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "读 cordis.plugins.json、解析 workspace 包、Vite virtual 模块",
+  "exports": {
+    ".": "./src/host/index.ts"
+  },
+  "peerDependencies": {
+    "vite": "^7.1.2"
+  }
+}

--- a/packages/host-plugin-loader/src/host/index.ts
+++ b/packages/host-plugin-loader/src/host/index.ts
@@ -7,6 +7,9 @@ export interface CordisPluginEntry {
   id: string
   name?: string
   package?: string
+  /** 前端入口 specifier，如 @biu/cap-chat/web */
+  web?: string
+  /** @deprecated 用 web */
   ui?: string
   layer?: string
   blurb?: string
@@ -26,8 +29,25 @@ const RESOLVED_UI = `\0${VIRTUAL_UI}`
 const VIRTUAL_WEB = 'virtual:cordis-web-runtime'
 const RESOLVED_WEB = `\0${VIRTUAL_WEB}`
 
-export function rootDirFrom(metaUrl = import.meta.url) {
-  return join(dirname(fileURLToPath(metaUrl)), '..')
+/** 能力插件的前端 specifier（json 的 `web`，兼容旧字段 `ui`）。 */
+export function pluginWebSpecifier(item: CordisPluginEntry): string | undefined {
+  return item.web || item.ui
+}
+
+export function findRepoRoot(start = fileURLToPath(import.meta.url)): string {
+  let dir = dirname(start)
+  for (let i = 0; i < 10; i++) {
+    if (existsSync(join(dir, 'cordis.plugins.json'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return process.cwd()
+}
+
+/** @deprecated 用 findRepoRoot */
+export function rootDirFrom(_metaUrl?: string) {
+  return findRepoRoot()
 }
 
 export function splitPackageRef(specifier: string): { name: string; subpath: string } {
@@ -52,7 +72,6 @@ export function readCordisConfig(root: string): CordisConfig {
   }
 }
 
-/** 可热插拔能力插件（hub / ui-hub）。 */
 export function readCordisPlugins(root: string): CordisPluginEntry[] {
   return readCordisConfig(root).plugins ?? []
 }
@@ -62,7 +81,6 @@ export function allConfiguredEntries(root: string): CordisPluginEntry[] {
   return [...(config.host ?? []), ...(config.web ?? []), ...(config.plugins ?? [])]
 }
 
-/** 按 package.json name 在 packages/* 里找目录；主仓不写死任何插件包名。 */
 export function findWorkspacePackageDir(root: string, packageName: string): string | null {
   const { name } = splitPackageRef(packageName)
   const base = join(root, 'packages')
@@ -113,7 +131,8 @@ export function linkConfiguredPackages(root: string) {
   const names = new Set<string>()
   for (const item of allConfiguredEntries(root)) {
     if (item.package) names.add(splitPackageRef(item.package).name)
-    if (item.ui) names.add(splitPackageRef(item.ui).name)
+    const web = pluginWebSpecifier(item)
+    if (web) names.add(splitPackageRef(web).name)
   }
   for (const name of names) {
     const dir = findWorkspacePackageDir(root, name)
@@ -139,7 +158,7 @@ function posix(path: string) {
   return path.replace(/\\/g, '/')
 }
 
-/** Vite：能力 UI loaders + web 内核加载列表。主仓源码不出现具体包名。 */
+/** Vite：能力 web loaders + web 内核加载列表。主仓源码不出现具体包名。 */
 export function cordisPluginsVite(root = process.cwd()): VitePlugin {
   return {
     name: 'cordis-plugins',
@@ -151,14 +170,15 @@ export function cordisPluginsVite(root = process.cwd()): VitePlugin {
       if (id === RESOLVED_UI) {
         const lines: string[] = []
         for (const item of readCordisPlugins(root)) {
-          if (!item.ui) continue
-          const dir = findWorkspacePackageDir(root, item.ui)
+          const web = pluginWebSpecifier(item)
+          if (!web) continue
+          const dir = findWorkspacePackageDir(root, web)
           if (!dir) {
-            console.warn(`[cordis-plugins] ui package missing: ${item.ui}`)
+            console.warn(`[cordis-plugins] web package missing: ${web}`)
             continue
           }
-          const entry = posix(packageEntryFile(dir, item.ui))
-          lines.push(`  ${JSON.stringify(item.ui)}: () => import(${JSON.stringify(entry)}),`)
+          const entry = posix(packageEntryFile(dir, web))
+          lines.push(`  ${JSON.stringify(web)}: () => import(${JSON.stringify(entry)}),`)
         }
         return `export const uiPackageLoaders = {\n${lines.join('\n')}\n}\n`
       }

--- a/packages/type-host-context/src/index.ts
+++ b/packages/type-host-context/src/index.ts
@@ -6,7 +6,6 @@ import type { AgentLoopService } from '@biu/host-agent-loop'
 import type { PreStepReq } from '@biu/type-agent-loop'
 import type { AgentsService } from '@biu/host-agents'
 import type { ApprovalsService } from '@biu/host-approvals'
-import type { ChatService } from '@biu/cap-chat/host'
 import type { SessionsService } from '@biu/host-sessions'
 import type { SessionEvent } from '@biu/type-session'
 import type { SessionStoreService } from '@biu/host-session-store'
@@ -37,7 +36,6 @@ declare module 'cordis' {
     agentLoop: AgentLoopService
     agents: AgentsService
     approvals: ApprovalsService
-    chat: ChatService
     sessionStore: SessionStoreService
     sessions: SessionsService
     systemPrompt: SystemPromptService
@@ -75,7 +73,5 @@ declare module 'cordis' {
     'fs/write'(path: string): void
     'fs/list'(path: string): void
     'sandbox/wrap'(payload: { argv: string[]; cwd: string }): void
-    'clock/tick'(iso: string): void
-    'greet/transform'(text: string, next: () => string): string
   }
 }

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -1,15 +1,11 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type ComponentType, type ReactNode } from 'react'
-import { LuActivity, LuLayoutGrid, LuListTree, LuPanelRightClose } from 'react-icons/lu'
+import { LuLayoutGrid, LuPanelRightClose } from 'react-icons/lu'
 import {
   bindSessionView,
   type SessionViewService,
 } from '@biu/web-session-view'
-import { TrajectoryView } from '@biu/cap-chat/web/trajectory'
-import { UsagePanel } from '@biu/cap-chat/web/usage-panel'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
-
-const BUILTIN_TABS = ['traj', 'usage'] as const
 
 export type SessionInspectorProps = {
   open: boolean
@@ -64,13 +60,16 @@ export const SessionInspector = memo(function SessionInspector({
             id: String(extra.tabId ?? entry.id),
             label: String(extra.tabLabel ?? '插件'),
             Icon: extra.tabIcon as ComponentType<{ className?: string }> | undefined,
+            ensureTrajectory: Boolean(extra.ensureTrajectory),
+            focusOnCall: Boolean(extra.focusOnCall),
           }
         }),
     [extras],
   )
-  const allowedTabs = useMemo(() => [...extraTabs.map((item) => item.id), ...BUILTIN_TABS], [extraTabs])
+  const allowedTabs = useMemo(() => extraTabs.map((item) => item.id), [extraTabs])
+  const defaultTab = extraTabs[0]?.id ?? ''
 
-  const [tab, setTabState] = useState(() => inspectorStoredTab(sessionId, allowedTabs) ?? extraTabs[0]?.id ?? 'traj')
+  const [tab, setTabState] = useState(() => inspectorStoredTab(sessionId, allowedTabs) ?? defaultTab)
   const setTab = useCallback(
     (next: string) => {
       setTabState(next)
@@ -87,16 +86,18 @@ export const SessionInspector = memo(function SessionInspector({
 
   useEffect(() => {
     if (focusCallId) {
-      setTab('traj')
+      const focus = extraTabs.find((item) => item.focusOnCall)
+      if (focus) setTab(focus.id)
       return
     }
-    setTabState(inspectorStoredTab(sessionId, allowedTabs) ?? extraTabs[0]?.id ?? 'traj')
-  }, [sessionId, focusCallId, allowedTabs.join('|'), extraTabs[0]?.id, setTab])
+    setTabState(inspectorStoredTab(sessionId, allowedTabs) ?? defaultTab)
+  }, [sessionId, focusCallId, allowedTabs.join('|'), defaultTab, setTab, extraTabs])
 
   useEffect(() => {
-    if (!open || tab !== 'traj') return
-    void sessionView.ensureTrajectory()
-  }, [open, tab, sessionId, sessionView])
+    if (!open) return
+    const current = extraTabs.find((item) => item.id === tab)
+    if (current?.ensureTrajectory) void sessionView.ensureTrajectory()
+  }, [open, tab, sessionId, sessionView, extraTabs])
 
   useEffect(() => {
     const onMove = (event: PointerEvent) => {
@@ -157,28 +158,6 @@ export const SessionInspector = memo(function SessionInspector({
               {item.label}
             </button>
           ))}
-          <button
-            type="button"
-            role="tab"
-            aria-selected={tab === 'traj'}
-            className={tabClass(tab === 'traj')}
-            onClick={() => setTab('traj')}
-            data-testid="inspector-tab-traj"
-          >
-            <LuListTree className="size-3.5" />
-            轨迹
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={tab === 'usage'}
-            className={tabClass(tab === 'usage')}
-            onClick={() => setTab('usage')}
-            data-testid="inspector-tab-usage"
-          >
-            <LuActivity className="size-3.5" />
-            用量
-          </button>
         </div>
         <button
           type="button"
@@ -191,26 +170,10 @@ export const SessionInspector = memo(function SessionInspector({
         </button>
       </div>
 
-      <div
-        className={`min-h-0 flex-1 ${
-          tab === 'traj' || extraActive ? 'flex flex-col overflow-hidden' : 'overflow-auto p-2.5'
-        }`}
-      >
-        {tab === 'traj' ? (
-          <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid="inspector-trajectory">
-            <TrajectoryView useSessionView={useSessionView} sessionView={sessionView} renderSlot={() => null} />
-          </div>
-        ) : null}
-
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {extraActive && ExtraComponent ? (
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid={`inspector-${extraActive.id}`}>
             <ExtraComponent {...(extraActive.entry.props?.() ?? {})} renderSlot={renderSlot} />
-          </div>
-        ) : null}
-
-        {tab === 'usage' ? (
-          <div className="min-h-0 flex-1 overflow-y-auto p-2.5" data-testid="inspector-usage">
-            <UsagePanel useSessionView={useSessionView} sessionView={sessionView} />
           </div>
         ) : null}
       </div>

--- a/packages/web-snapshot/src/web/index.ts
+++ b/packages/web-snapshot/src/web/index.ts
@@ -11,8 +11,8 @@ export interface PluginRow {
   togglable: boolean
   enabled: boolean
   state: string
-  /** cordis.plugins.json 声明的前端包名 */
-  ui?: string
+  /** cordis.plugins.json 的 web 入口 */
+  web?: string
   packageName?: string
 }
 

--- a/packages/web-ui-hub/src/web/index.test.ts
+++ b/packages/web-ui-hub/src/web/index.test.ts
@@ -11,7 +11,7 @@ import { uiPackageLoaders } from 'virtual:cordis-ui-loaders'
 
 const Dummy = () => null
 
-function plugin(id: string, enabled: boolean, ui?: string) {
+function plugin(id: string, enabled: boolean, web?: string) {
   return {
     id,
     name: id,
@@ -21,7 +21,7 @@ function plugin(id: string, enabled: boolean, ui?: string) {
     togglable: true,
     enabled,
     state: enabled ? 'active' : 'off',
-    ...(ui ? { ui } : {}),
+    ...(web ? { web } : {}),
   }
 }
 

--- a/packages/web-ui-hub/src/web/index.ts
+++ b/packages/web-ui-hub/src/web/index.ts
@@ -9,9 +9,9 @@ export function apply(ctx: Context) {
   let pending = false
   let running = false
 
-  async function resolvePlugin(_id: string, ui?: string): Promise<Plugin | undefined> {
-    if (!ui) return undefined
-    const loader = uiPackageLoaders[ui]
+  async function resolvePlugin(_id: string, web?: string): Promise<Plugin | undefined> {
+    if (!web) return undefined
+    const loader = uiPackageLoaders[web]
     if (loader) return loader()
     return undefined
   }
@@ -25,7 +25,7 @@ export function apply(ctx: Context) {
     try {
       const rows = ctx.snapshot.get().plugins
       const enabledRows = rows.filter((plugin) => {
-        if (!plugin.ui) return false
+        if (!plugin.web) return false
         if (plugin.enabled) return true
         return plugin.state === 'pending' || plugin.state === 'loading' || plugin.state === 'active'
       })
@@ -33,7 +33,7 @@ export function apply(ctx: Context) {
 
       for (const row of enabledRows) {
         if (forks.has(row.id)) continue
-        const loaded = await resolvePlugin(row.id, row.ui)
+        const loaded = await resolvePlugin(row.id, row.web)
         if (!loaded) continue
         const plugin =
           loaded && typeof loaded === 'object' && 'default' in loaded && (loaded as { default?: Plugin }).default

--- a/scripts/link-cordis-plugins.mjs
+++ b/scripts/link-cordis-plugins.mjs
@@ -29,6 +29,7 @@ function allConfiguredNames() {
     if (!Array.isArray(list)) continue
     for (const item of list) {
       if (item.package) names.add(splitPackageRef(item.package).name)
+      if (item.web) names.add(splitPackageRef(item.web).name)
       if (item.ui) names.add(splitPackageRef(item.ui).name)
     }
   }

--- a/test-delete-validation.txt
+++ b/test-delete-validation.txt
@@ -1,1 +1,0 @@
-delete-test

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { cordisPluginsVite, linkConfiguredPackages } from './host/cordis-plugins.ts'
+import { cordisPluginsVite, linkConfiguredPackages } from './packages/host-plugin-loader/src/host/index.ts'
 
 const root = dirname(fileURLToPath(import.meta.url))
 linkConfiguredPackages(root)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
按上次结构债清单收口：

- **壳不认识 cap**：`web-app-shell` 的检查器只渲染 `inspector-panels` 插槽；轨迹 / 用量由 `@biu/cap-chat` 自己 `place`。
- **type 不 import cap**：`@biu/type-host-context` 去掉 `ChatService` 和演示事件；augmentation 写在 `cap-chat` / `cap-clock` / `cap-greeter` / `cap-uppercase`。
- **加载器下沉**：`host/cordis-plugins.ts` 迁到 `@biu/host-plugin-loader`；hub 不再相对翻仓库根。
- **http 自配置**：加载器不再特判 `id === 'http'`；端口 / 静态目录由 `@biu/host-http` 读 env。
- json 前端字段从 `ui` 改为 `web`（读配置仍兼容旧 `ui`）。
- 删掉空的 `builtinCatalog` 和根目录 `test-delete-validation.txt`。

本地：`npx tsc --noEmit`、`npx vitest run` 242 通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

