### PR TITLE
fix: 消除 web-slots 循环导出导致的 Vite 打包报错

### DIFF
--- a/packages/web-slots/src/web/index.ts
+++ b/packages/web-slots/src/web/index.ts
@@ -1,5 +1,3 @@
-import { Service, type Context } from 'cordis'
-import type { ComponentType } from 'react'
 export type {
   SlotKind,
   SlotEvent as SlotEventName,
@@ -9,116 +7,11 @@ export type {
   SlotProps,
 } from '@biu/type-slots'
 export { SlotEvent } from '@biu/type-slots'
-import type { SlotSpec, FillOptions, SlotEntry, SlotProps, SlotKind } from '@biu/type-slots'
-import { SlotEvent } from '@biu/type-slots'
+export { SlotsService } from './service.ts'
+export { useSlotEntries } from './use-slots.ts'
 
-export class SlotsService extends Service {
-  private declared = new Map<string, SlotSpec>([['root', { kind: 'single' }]])
-  private entries = new Map<string, SlotEntry[]>()
-  private versions = new Map<string, number>()
-  private listeners = new Map<string, Map<SlotEvent, Set<() => void>>>()
-
-  constructor(ctx: Context) {
-    super(ctx, 'slots')
-  }
-
-  /** 未打开的缝会先 inject，打开后再 fill。 */
-  place(slotName: string, Component: ComponentType<SlotProps>, options: FillOptions = {}) {
-    return this.inject(slotName, () => this.fill(slotName, Component, options))
-  }
-
-  fill(slotName: string, Component: ComponentType<SlotProps>, options: FillOptions = {}) {
-    if (!this.declared.has(slotName)) {
-      throw new Error(`fill undeclared slot "${slotName}" — use ctx.slots.place`)
-    }
-    return this.ctx.effect(() => {
-      const id = options.key ?? `${slotName}:${Component.displayName ?? Component.name ?? 'anon'}`
-      const list = this.entries.get(slotName) ?? []
-      if (list.some((item) => item.id === id)) {
-        throw new Error(`slot "${slotName}" already has "${id}"`)
-      }
-      const children = Object.keys(options.children ?? {})
-      const entry: SlotEntry = {
-        id,
-        name: slotName,
-        order: options.order ?? 0,
-        Component,
-        props: options.props,
-        children,
-      }
-      list.push(entry)
-      this.entries.set(slotName, list)
-      for (const [child, spec] of Object.entries(options.children ?? {})) {
-        if (this.declared.has(child) && child !== 'root') {
-          throw new Error(`slot "${child}" already declared`)
-        }
-        this.declared.set(child, spec)
-        this.emit(child, SlotEvent.Open)
-      }
-      this.emit(slotName, SlotEvent.Entries)
-      return () => {
-        this.entries.set(slotName, (this.entries.get(slotName) ?? []).filter((item) => item !== entry))
-        for (const child of entry.children) {
-          this.declared.delete(child)
-          this.entries.delete(child)
-          this.emit(child, SlotEvent.Close)
-          this.emit(child, SlotEvent.Entries)
-        }
-        this.emit(slotName, SlotEvent.Entries)
-      }
-    }, `slots.fill ${slotName}:${options.key ?? Component.name}`)
-  }
-
-  inject(slotName: string, callback: () => (() => void) | void) {
-    return this.ctx.effect(() => {
-      let inner: (() => void) | undefined
-      const attach = () => {
-        const result = callback()
-        inner = typeof result === 'function' ? result : undefined
-      }
-      const detach = () => {
-        inner?.()
-        inner = undefined
-      }
-      if (this.declared.has(slotName)) attach()
-      const stopOpen = this.subscribe(slotName, SlotEvent.Open, attach)
-      const stopClose = this.subscribe(slotName, SlotEvent.Close, detach)
-      return () => {
-        stopOpen()
-        stopClose()
-        detach()
-      }
-    }, `slots.inject ${slotName}`)
-  }
-
-  specOf(name: string) {
-    return this.declared.get(name)
-  }
-
-  subscribe(name: string, event: SlotEvent, fn: () => void) {
-    const byEvent = this.listeners.get(name) ?? new Map<SlotEvent, Set<() => void>>()
-    const set = byEvent.get(event) ?? new Set()
-    set.add(fn)
-    byEvent.set(event, set)
-    this.listeners.set(name, byEvent)
-    return () => set.delete(fn)
-  }
-
-  getVersion(name: string) {
-    return this.versions.get(name) ?? 0
-  }
-
-  list(name: string) {
-    return [...(this.entries.get(name) ?? [])]
-  }
-
-  private emit(name: string, event: SlotEvent) {
-    if (event === SlotEvent.Entries) {
-      this.versions.set(name, (this.versions.get(name) ?? 0) + 1)
-    }
-    for (const fn of this.listeners.get(name)?.get(event) ?? []) fn()
-  }
-}
+import type { Context } from 'cordis'
+import { SlotsService } from './service.ts'
 
 export const name = 'slots'
 export const inject = [] as const
@@ -126,5 +19,3 @@ export const inject = [] as const
 export function apply(ctx: Context) {
   new SlotsService(ctx)
 }
-
-export { useSlotEntries } from './use-slots.ts'

--- a/packages/web-slots/src/web/service.ts
+++ b/packages/web-slots/src/web/service.ts
@@ -1,0 +1,112 @@
+import { Service, type Context } from 'cordis'
+import type { ComponentType } from 'react'
+import type { SlotSpec, FillOptions, SlotEntry, SlotProps } from '@biu/type-slots'
+import { SlotEvent } from '@biu/type-slots'
+
+export class SlotsService extends Service {
+  private declared = new Map<string, SlotSpec>([['root', { kind: 'single' }]])
+  private entries = new Map<string, SlotEntry[]>()
+  private versions = new Map<string, number>()
+  private listeners = new Map<string, Map<SlotEvent, Set<() => void>>>()
+
+  constructor(ctx: Context) {
+    super(ctx, 'slots')
+  }
+
+  /** 未打开的缝会先 inject，打开后再 fill。 */
+  place(slotName: string, Component: ComponentType<SlotProps>, options: FillOptions = {}) {
+    return this.inject(slotName, () => this.fill(slotName, Component, options))
+  }
+
+  fill(slotName: string, Component: ComponentType<SlotProps>, options: FillOptions = {}) {
+    if (!this.declared.has(slotName)) {
+      throw new Error(`fill undeclared slot "${slotName}" — use ctx.slots.place`)
+    }
+    return this.ctx.effect(() => {
+      const id = options.key ?? `${slotName}:${Component.displayName ?? Component.name ?? 'anon'}`
+      const list = this.entries.get(slotName) ?? []
+      if (list.some((item) => item.id === id)) {
+        throw new Error(`slot "${slotName}" already has "${id}"`)
+      }
+      const children = Object.keys(options.children ?? {})
+      const entry: SlotEntry = {
+        id,
+        name: slotName,
+        order: options.order ?? 0,
+        Component,
+        props: options.props,
+        children,
+      }
+      list.push(entry)
+      this.entries.set(slotName, list)
+      for (const [child, spec] of Object.entries(options.children ?? {})) {
+        if (this.declared.has(child) && child !== 'root') {
+          throw new Error(`slot "${child}" already declared`)
+        }
+        this.declared.set(child, spec)
+        this.emit(child, SlotEvent.Open)
+      }
+      this.emit(slotName, SlotEvent.Entries)
+      return () => {
+        this.entries.set(slotName, (this.entries.get(slotName) ?? []).filter((item) => item !== entry))
+        for (const child of entry.children) {
+          this.declared.delete(child)
+          this.entries.delete(child)
+          this.emit(child, SlotEvent.Close)
+          this.emit(child, SlotEvent.Entries)
+        }
+        this.emit(slotName, SlotEvent.Entries)
+      }
+    }, `slots.fill ${slotName}:${options.key ?? Component.name}`)
+  }
+
+  inject(slotName: string, callback: () => (() => void) | void) {
+    return this.ctx.effect(() => {
+      let inner: (() => void) | undefined
+      const attach = () => {
+        const result = callback()
+        inner = typeof result === 'function' ? result : undefined
+      }
+      const detach = () => {
+        inner?.()
+        inner = undefined
+      }
+      if (this.declared.has(slotName)) attach()
+      const stopOpen = this.subscribe(slotName, SlotEvent.Open, attach)
+      const stopClose = this.subscribe(slotName, SlotEvent.Close, detach)
+      return () => {
+        stopOpen()
+        stopClose()
+        detach()
+      }
+    }, `slots.inject ${slotName}`)
+  }
+
+  specOf(name: string) {
+    return this.declared.get(name)
+  }
+
+  subscribe(name: string, event: SlotEvent, fn: () => void) {
+    const byEvent = this.listeners.get(name) ?? new Map<SlotEvent, Set<() => void>>()
+    const set = byEvent.get(event) ?? new Set()
+    set.add(fn)
+    byEvent.set(event, set)
+    this.listeners.set(name, byEvent)
+    return () => set.delete(fn)
+  }
+
+  getVersion(name: string) {
+    return this.versions.get(name) ?? 0
+  }
+
+  list(name: string) {
+    return [...(this.entries.get(name) ?? [])]
+  }
+
+  private emit(name: string, event: SlotEvent) {
+    if (event === SlotEvent.Entries) {
+      this.versions.set(name, (this.versions.get(name) ?? 0) + 1)
+    }
+    for (const fn of this.listeners.get(name)?.get(event) ?? []) fn()
+  }
+}

--- a/packages/web-slots/src/web/use-slots.ts
+++ b/packages/web-slots/src/web/use-slots.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react'
-import { SlotEvent, type SlotEntry, type SlotsService } from './index.ts'
+import { SlotEvent, type SlotEntry } from '@biu/type-slots'
+import type { SlotsService } from './service.ts'
 
 export function useSlotEntries(slots: SlotsService, name: string): SlotEntry[] {
   useSyncExternalStore(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npx tsc --noEmit` 在 `hmr-dev` 上已经是干净的。Vite `build` 会报 `useSlotEntries` 经 `web-slots` 的 index 循环重导出，chunk 执行顺序不确定。

把 `SlotsService` 抽到 `service.ts`，`use-slots.ts` 不再从 barrel import，循环断开。`tsc` / 242 tests / `vite build` 已过（只剩体积提示，不是编译失败）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

