### PR TITLE
重写 README：Harness、看板多 Agent、可观测性

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,153 +1,148 @@
 <p align="center">
-  <img src="public/favicon.svg" width="88" height="88" alt="Biu" />
+  <img src="public/favicon.svg" width="72" height="72" alt="Biu" />
 </p>
 
 <h1 align="center">Biu</h1>
 
 <p align="center">
-  可热插拔的本地 Agent 工作台：host 跑能力，web 只投影界面。
+  一切即插件的 Agent Harness。<br />
+  多 Agent 不靠群聊，靠任务看板协作。
 </p>
 
 <p align="center">
-  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white" />
-  <img alt="Vite" src="https://img.shields.io/badge/Vite-7-646CFF?logo=vite&logoColor=white" />
-  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=222" />
-  <img alt="Cordis" src="https://img.shields.io/badge/Cordis-plugin-111111" />
-</p>
-
-<p align="center">
+  <a href="#理念">理念</a> ·
+  <a href="#任务看板上的多-agent">多 Agent</a> ·
+  <a href="#harness-的可观测性">可观测性</a> ·
+  <a href="#设计">设计</a> ·
   <a href="#快速开始">快速开始</a> ·
-  <a href="#它做什么">它做什么</a> ·
-  <a href="#架构">架构</a> ·
-  <a href="#仓库结构">仓库结构</a> ·
-  <a href="#命令">命令</a> ·
   <a href="docs/plugin-packages.md">插件约定</a>
 </p>
 
 ---
 
-## 它做什么
+## 理念
 
-Biu 是一套 **Cordis 插件工作区**：Node host 负责会话、工具、Agent loop 和 HTTP/WS；浏览器壳只订阅 snapshot，用插槽拼出界面。主仓 **`host/`** 和 **`web/`** 只留加载器，具体能力都在 `packages/`，用 `cordis.plugins.json` 开关。
+Biu 不是「聊天窗口外挂几个 tool」。它是一套 **Agent Harness**：运行时、能力、界面都是插件；人、调度席、执行席共享同一份任务对象。
 
-- **一切皆插件** — 依赖服务键（`inject`），不绑死实现类
-- **会话是权威日志** — append-only session；对话从 `session/event` 投影，浏览器不持模型能力
-- **热插拔能力** — 改 json、开关插件，host hub 与 web ui-hub 成对装卸
-- **工具与审批** — tools 管线 + hold/auto；敏感调用进 composer dock
-- **可替换 Agent loop** — factory 可换，agents 句柄不变
-- **MCP / Terminal / LSP** — 可编排的宿主面，不是写死在壳里
-- **VS Code 式壳** — Activity Bar 只内置 Agent；Dashboard / Tasks / Channels 由 cap 插件自己注册
+**一切即插件。** HTTP、会话、工具、LLM、审批、Agent loop、壳、侧栏、对话、任务、看板——一律 Cordis 插件，靠服务键 `inject`，不绑实现类。主仓 `host/` 和 `web/` 只做加载；清单只有一份 [`cordis.plugins.json`](cordis.plugins.json)。关掉 `tasks`，看板、派工工具、心跳一起消失；壳不知道「任务」这个词，只认识插槽。
+
+**Session 是权威日志。** 每个 Agent 是一条 append-only session。模型输出、tool 调用、审批、派工，都先写成 `session/event`。浏览器只投影，不持能力。
+
+**协作对象是任务，不是另一段 prompt。** 多 Agent 交互发生在任务看板上：创建、指派到某个 session、依赖与阻塞、触发派工、`task_report` 回报。这是 Harness 的工作面，不是演示页。
+
+## 任务看板上的多 Agent
+
+常见产品把「多 Agent」做成一个窗口里轮流说话。Biu 里每个 Agent 是独立 session（可绑工作区、模型、工具集），**任务看板是它们之间的总线**。
+
+```
+人 / Live 调度席
+        │  建任务 · 指派 session · 设依赖 / 触发器
+        ▼
+   任务看板  ── task_deliver / 自动触发 ──►  执行席 session（被 wake）
+        ▲                                      │
+        └──────── task_report（doing / done）───┘
+```
+
+- **一张板，两边都能动。** 人在 UI 上建卡、改负责人、看阻塞；Agent 用 `tasks_list` / `tasks_update` / `task_deliver` / `task_report` 做同一件事。看板不是只给人看的仪表盘。
+- **执行席是 session，不是角色标签。** 指派 `assigneeSessionId` 就是把卡交给那个对话。对方收到派工消息后干活，用 `task_report` 把进度写回任务（状态、说明、当回合用量）。删掉 session，报告仍在任务上。
+- **依赖是图，不是待办列表。** `parentId` / `dependsOn` 派生阻塞链；上游 `done` 可以 `dep:done` 自动触发下游派工。回合结束 `turn:end`、cron / at 同一套 trigger 状态机：`idle → pending → delivered → done`。
+- **调度席可以不亲自干。** `live` session 用 `session_wake` / `session_inject` 指挥其他 chat session；任务看板负责「这件事归谁、卡在哪、何时再派」。Live 管现场，看板管工作项——多数产品只有前者或只有一个群聊。
+
+侧栏打开 **Tasks** 就是这块板。对话右侧检查器里也会挂同一份任务视图：一边看轨迹，一边看卡。
+
+## Harness 的可观测性
+
+Harness 要能回答：现在装了什么、Agent 做了什么、工具和路由从哪来、协作卡在哪。Biu 把这些做成运行时表面，而不是事后 grep 日志。
+
+| 你想看见的 | 从哪看 |
+|------------|--------|
+| 哪个插件在跑、能否热卸 | Settings → Plugins（`web-plugin-tree`，写回 hub） |
+| host 暴露了哪些 HTTP | Settings → Routes |
+| Cordis 刚刚 dispatch 了什么 | Settings → Events（hub 订阅 `internal/dispatch`，滤掉 stream chunk） |
+| 这一回合模型/工具逐步做了什么 | 右侧检查器 **轨迹**（事件投影，不是另存一份聊天记录） |
+| token 怎么花的 | 检查器 **用量**；任务上的 report 会固化当回合消耗 |
+| 多 Agent 谁在做哪张卡 | 任务看板 + 检查器任务页；对话里 Live 的「本回合派工」表 |
+| 工具从哪来、对当前 session 是否有效 | 会话配置 / inspector API（`/api/sessions/:id/inspector`） |
+
+原则就一条：**能进 session 日志的，就不藏在插件私有状态里。** 投影可以换，日志不能丢。插件装卸立刻反映到 snapshot（插件表、路由表、工具名），UI 只订阅，不猜测。
+
+## 设计
+
+```
+浏览器                         Node
+web/main.tsx                   host/index.ts
+  只加载 web 表                   只加载 host 表
+        │                              │
+        ▼                              ▼
+  @biu/web-*  壳                  @biu/host-*  内核
+  插槽 / 投影 / 检查器框            会话 / 工具 / loop / HTTP·WS
+        │                              │
+        └──── cordis.plugins.json ─────┘
+                    plugins 表
+              @biu/cap-*  （./host 与 ./web 分入口）
+```
+
+- **三张表：** `host` 内核不可热卸；`web` 壳；`plugins` 可热插拔能力。json 的 `id` 用短名（`chat`、`http`），包名 `@biu/<prefix>-<id>`。
+- **壳只认插槽。** `composer`、`inspector-panels`、`app-modules`、Settings 各栏……能力自己 `place`。Activity Bar 里 Dashboard / Tasks / Channels 都是 cap 自己注册的模块。
+- **Agent loop 可替换。** `agents` 句柄不变，factory 可换。
+- **审批在管线上。** 敏感 tool 进 hold，UI 在 dock，不写进壳逻辑。
+
+包前缀与入口拆分见 [docs/plugin-packages.md](docs/plugin-packages.md)。
 
 ## 快速开始
 
-需要较新的 Node.js（建议 20+）和 npm。
+需要 Node.js 20+ 与 npm。当前开发分支是 `hmr-dev`。
 
 ```bash
 git clone https://github.com/helloooooooooooooo97/BIU.git
 cd BIU
-git checkout hmr-dev   # 当前开发分支
-make                   # 安装依赖并同时启动 host + Vite
+git checkout hmr-dev
+make          # npm install + host :3141 + Vite :5173
 ```
 
-启动后：
-
-| 服务 | 地址 |
-|------|------|
+| | |
+|--|--|
 | UI | http://127.0.0.1:5173 |
 | API / WS | http://127.0.0.1:3141 |
 
-端口被占用时：
+未配模型 Key 时发消息只会本地回声。在 **Settings → Models** 填写 DeepSeek / OpenAI / Anthropic，或启动前设置环境变量：
 
 ```bash
-make stop      # 释放 3141 / 5173
-make restart   # 停干净再启
+export DEEPSEEK_API_KEY=...    # 或 OPENAI_API_KEY / ANTHROPIC_API_KEY
+export CHAT_MODEL=deepseek-chat  # 可选
 ```
 
-也可以拆开跑：
+端口占用：`make stop` 或 `make restart`。拆开跑：`npm run dev:host` 与 `npm run dev:web`。
 
-```bash
-npm install
-npm run dev:host   # tsx host/index.ts
-npm run dev:web    # Vite :5173，/api 和 /ws 代理到 host
-```
+建议先开一个 **Live** 会话当调度席，再建执行席 chat session；在 Tasks 上看板建卡并指派，或让调度席用工具派工。右侧打开检查器看轨迹和任务。
 
-## 架构
+## 仓库
 
 ```
-浏览器  web/main.tsx          host/index.ts  Node
-        │  virtual web 表              │  host 表
-        ▼                              ▼
-   @biu/web-* 壳                  @biu/host-* 内核
-        │                              │
-        │         cordis.plugins.json  │
-        └──────── plugins 表 ──────────┘
-              @biu/cap-*  （./host + ./web 分入口）
+host/   web/          加载器（不要往这里堆能力）
+packages/
+  type-*              契约，不进 json
+  host-*              Node 内核（含 live 派工、plugin-loader）
+  web-*               浏览器内核（壳、插槽、snapshot）
+  cap-*               可热插拔能力（chat / tasks / dashboard / channels …）
+cordis.plugins.json   唯一清单
 ```
 
-| 表 | 谁加载 | 内容 |
-|----|--------|------|
-| `host` | `host/index.ts` | HTTP、sessions、tools、llm、hub … |
-| `web` | `web/main.tsx` | slots、app-shell、ui-hub … |
-| `plugins` | `@biu/host-hub` + `@biu/web-ui-hub` | 可热插拔能力；`web` 指向 `@biu/cap-*/web` |
-
-壳不认识具体 cap 插件。json 的 `id` 用短名（`chat`、`http`）；包名一律 `@biu/<prefix>-<id>`。
-
-完整约定：[docs/plugin-packages.md](docs/plugin-packages.md)
-
-## 仓库结构
-
-```
-BIU
-├── host/                 # host 加载器
-├── web/                  # 前端加载器（main.tsx / 样式）
-├── packages/
-│   ├── type-*            # 共享契约（不是插件，不进 json）
-│   ├── host-*            # host 内核  → src/host/（含 host-plugin-loader）
-│   ├── web-*             # web 内核   → src/web/
-│   └── cap-*             # 能力插件   → src/host + src/web
-├── cordis.plugins.json   # 唯一插件清单
-├── public/               # 静态资源
-└── scripts/
-    └── link-cordis-plugins.mjs   # postinstall 把包链到 node_modules
-```
-
-## 命令
-
-| 命令 | 作用 |
-|------|------|
-| `make` / `make dev` | 安装依赖并同时起 host + web |
+| 命令 | |
+|------|--|
+| `make` / `make restart` | 安装并同时起两侧 / 先停再起 |
 | `make host` / `make web` | 只起一侧 |
-| `make stop` | 杀掉占用 3141 / 5173 的进程 |
-| `make restart` | 先 stop 再 dev |
 | `npm test` | Vitest |
 | `npx tsc --noEmit` | 类型检查 |
 
-环境变量（host）：
+| 环境变量 | 默认 | |
+|----------|------|--|
+| `PORT` / `HTTP_HOST` | `3141` / `127.0.0.1` | host 监听 |
+| `CORDIS_WORKSPACE` | `.workspace` | 默认工作区根 |
+| `DEEPSEEK_API_KEY` 等 | | 模型；也可只在 UI 里存 |
 
-| 变量 | 默认 | 含义 |
-|------|------|------|
-| `PORT` | `3141` | HTTP / WS 端口 |
-| `HTTP_HOST` | `127.0.0.1` | 监听地址 |
-
-## 写一个能力插件
-
-1. 在 `packages/` 建 `cap-<id>`，`exports` **分开** `./host` 和 `./web`（禁止一个入口同时带 Node + React）。
-2. 在 `cordis.plugins.json` 的 `plugins` 表登记：
-
-```json
-{
-  "id": "tasks",
-  "package": "@biu/cap-tasks/host",
-  "web": "@biu/cap-tasks/web",
-  "togglable": true,
-  "enabled": true
-}
-```
-
-3. 重启 host / Vite。侧栏关掉插件时，ui-hub 会卸掉对应卡片。
-
-`type-*` 只给别人 `import`，不要写进 json。`web-mascot` 是共享 UI 库，也不进表。
+加能力：`packages/cap-<id>`，`exports` 分开 `./host` 与 `./web`，在 json 的 `plugins` 表登记，重启。`type-*` 和 `web-mascot` 不要进表。细节仍看 [插件约定](docs/plugin-packages.md)。
 
 ## 许可
 
-本仓库暂未声明开源许可证，默认保留版权。使用或分发前请先与维护者确认。
+本仓库暂未声明开源许可证，默认保留版权。使用或分发前请与维护者确认。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
同意：别人缺的不是「再一个带 tool 的聊天框」，而是 **任务看板作为多 Agent 总线**。

README 按这个叙事重写：

1. **理念** — 一切即插件；session 是权威日志；协作对象是任务。
2. **任务看板上的多 Agent** — 独立 session 当执行席，看板建卡/指派/依赖/触发，`task_deliver` 派工、`task_report` 回报；Live 管现场、看板管工作项。
3. **Harness 可观测性** — 插件树、路由、dispatch 事件、轨迹、用量、派工表，都从运行时表面读，不藏私有状态。
4. **设计 / 怎么跑** — 三张表和插槽仍在，但不再用口号列表冒充产品说明。

包前缀细则仍在 `docs/plugin-packages.md`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

