### PR TITLE
Settings 插件面板展示 Host / Web / 能力全部条目

### DIFF
--- a/packages/host-hub/src/host/catalog.ts
+++ b/packages/host-hub/src/host/catalog.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'cordis'
 export interface CatalogEntry {
   id: string
   name: string
-  layer: 'web' | 'capability'
+  layer: 'host' | 'web' | 'capability'
   blurb: string
   plugin: Plugin
   inject?: string[]

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -1,5 +1,7 @@
 import { Service, type Context, type Fiber, type Plugin } from 'cordis'
+import { findRepoRoot, readCordisConfig } from '@biu/host-plugin-loader'
 import type { CatalogEntry } from './catalog.ts'
+import { kernelCatalogRows } from './kernel-rows.ts'
 import { resolveCatalog } from './resolve-catalog.ts'
 import type { PageSpec } from '@biu/type-http'
 import { HUB_CHANGE, HUB_CHANNEL_EVENT, HUB_CHANNEL_SNAPSHOT } from '@biu/type-http'
@@ -64,18 +66,23 @@ export class HubService extends Service {
   }
 
   snapshot() {
-    const plugins = [...this.forks.values()].map(({ entry, fiber }) => ({
-      id: entry.id,
-      name: entry.name,
-      layer: entry.layer,
-      blurb: entry.blurb,
-      inject: entry.inject ?? [],
-      togglable: entry.togglable,
-      enabled: Boolean(fiber && fiber.uid !== null),
-      state: fiber ? STATE[fiber.state] ?? String(fiber.state) : 'off',
-      ...(entry.web ? { web: entry.web } : {}),
-      ...(entry.packageName ? { packageName: entry.packageName } : {}),
-    }))
+    const config = readCordisConfig(findRepoRoot())
+    const plugins = [
+      ...kernelCatalogRows(config.host ?? [], 'host'),
+      ...kernelCatalogRows(config.web ?? [], 'web'),
+      ...[...this.forks.values()].map(({ entry, fiber }) => ({
+        id: entry.id,
+        name: entry.name,
+        layer: entry.layer,
+        blurb: entry.blurb,
+        inject: entry.inject ?? [],
+        togglable: entry.togglable,
+        enabled: Boolean(fiber && fiber.uid !== null),
+        state: fiber ? STATE[fiber.state] ?? String(fiber.state) : 'off',
+        ...(entry.web ? { web: entry.web } : {}),
+        ...(entry.packageName ? { packageName: entry.packageName } : {}),
+      })),
+    ]
     return {
       seq: ++this.seq,
       plugins,

--- a/packages/host-hub/src/host/kernel-rows.test.ts
+++ b/packages/host-hub/src/host/kernel-rows.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { findRepoRoot, readCordisConfig } from '@biu/host-plugin-loader'
+import { kernelCatalogRows } from './kernel-rows.ts'
+import { resolveCatalog } from './resolve-catalog.ts'
+
+test('kernel rows cover host and web tables without overlapping catalog forks', async () => {
+  const root = findRepoRoot()
+  const raw = JSON.parse(await readFile(join(root, 'cordis.plugins.json'), 'utf8')) as {
+    host: Array<{ id: string }>
+    web: Array<{ id: string }>
+    plugins: Array<{ id: string }>
+  }
+  const config = readCordisConfig(root)
+  const hostRows = kernelCatalogRows(config.host ?? [], 'host')
+  const webRows = kernelCatalogRows(config.web ?? [], 'web')
+  const catalog = await resolveCatalog()
+
+  assert.equal(hostRows.length, raw.host.length)
+  assert.equal(webRows.length, raw.web.length)
+  assert.ok(hostRows.every((row) => row.layer === 'host' && row.togglable === false && row.enabled === true))
+  assert.ok(webRows.every((row) => row.layer === 'web' && row.togglable === false && row.enabled === true))
+  assert.ok(hostRows.some((row) => row.id === 'shell'))
+  assert.ok(webRows.some((row) => row.id === 'shell'))
+  assert.equal(catalog.length, raw.plugins.length)
+  assert.ok(catalog.every((row) => row.layer === 'capability'))
+})

--- a/packages/host-hub/src/host/kernel-rows.ts
+++ b/packages/host-hub/src/host/kernel-rows.ts
@@ -1,0 +1,15 @@
+import type { CordisPluginEntry } from '@biu/host-plugin-loader'
+
+export function kernelCatalogRows(entries: CordisPluginEntry[], layer: 'host' | 'web') {
+  return entries.map((item) => ({
+    id: item.id,
+    name: item.name || item.id,
+    layer,
+    blurb: item.blurb || item.package || '',
+    inject: [] as string[],
+    togglable: false,
+    enabled: true,
+    state: 'active',
+    ...(item.package ? { packageName: item.package } : {}),
+  }))
+}

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -179,7 +179,9 @@ function Shell(props: SlotProps) {
   const slots = props.slots as SlotsService
   const navigate = useNavigate()
   const location = useLocation()
-  const live = useSnapshot((state: Snapshot) => state.plugins.some((plugin) => plugin.enabled))
+  const live = useSnapshot((state: Snapshot) =>
+    state.plugins.some((plugin) => plugin.layer === 'capability' && plugin.enabled),
+  )
   const modules = useAppModules()
   const pluginModules = modules.filter((item) => item.id !== 'agent')
   const sessionId = useSessionView((state) => state.sessionId)

--- a/packages/web-plugin-tree/src/web/index.tsx
+++ b/packages/web-plugin-tree/src/web/index.tsx
@@ -5,33 +5,54 @@ import { bindSnapshot, type Snapshot } from '@biu/web-snapshot'
 export const name = 'plugin-tree'
 export const inject = ['slots', 'snapshot']
 
+const SECTIONS = [
+  { layer: 'host', title: '内核 · Host' },
+  { layer: 'web', title: '内核 · Web' },
+  { layer: 'capability', title: '能力插件' },
+] as const
+
 function PluginTree(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const setEnabled = props.setEnabled as (id: string, enabled: boolean) => Promise<void>
   const snap = useSnapshot((state: Snapshot) => state.plugins)
   return (
-    <ul className="m-0 list-none space-y-2 p-0">
-      {snap.map((plugin) => (
-        <li className="rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3" key={plugin.id}>
-          <div className="flex items-start justify-between gap-3">
-            <div>
-              <h3 className="m-0 text-sm font-medium">{plugin.name}</h3>
-              <div className="mt-0.5 text-xs text-[var(--dsw-label-3)]">
-                {plugin.layer} · {plugin.state}
-              </div>
-            </div>
-            <button
-              className="toggle"
-              type="button"
-              aria-checked={plugin.enabled}
-              disabled={!plugin.togglable}
-              onClick={() => void setEnabled(plugin.id, !plugin.enabled)}
-            />
-          </div>
-          <p className="mt-2 mb-0 text-sm leading-5 text-[var(--dsw-label-3)]">{plugin.blurb}</p>
-        </li>
-      ))}
-    </ul>
+    <div className="space-y-5">
+      {SECTIONS.map((section) => {
+        const rows = snap.filter((plugin) => plugin.layer === section.layer)
+        if (!rows.length) return null
+        return (
+          <section key={section.layer}>
+            <h2 className="m-0 mb-2 text-xs font-medium tracking-wide text-[var(--dsw-label-3)]">{section.title}</h2>
+            <ul className="m-0 list-none space-y-2 p-0">
+              {rows.map((plugin) => (
+                <li
+                  className="rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-3 py-3"
+                  key={`${plugin.layer}:${plugin.id}`}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="m-0 text-sm font-medium">{plugin.name}</h3>
+                      <div className="mt-0.5 text-xs text-[var(--dsw-label-3)]">
+                        {plugin.id} · {plugin.state}
+                        {!plugin.togglable ? ' · 不可卸载' : ''}
+                      </div>
+                    </div>
+                    <button
+                      className="toggle"
+                      type="button"
+                      aria-checked={plugin.enabled}
+                      disabled={!plugin.togglable}
+                      onClick={() => void setEnabled(plugin.id, !plugin.enabled)}
+                    />
+                  </div>
+                  <p className="mt-2 mb-0 text-sm leading-5 text-[var(--dsw-label-3)]">{plugin.blurb}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )
+      })}
+    </div>
   )
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Settings 的插件树原先只画 hub 里 fork 的 `plugins` 表。现在 snapshot 会把 `cordis.plugins.json` 的 host、web 表合成只读行，面板按三组展示。

- 仍只 fork / 热插拔能力插件；内核开关禁用
- React key 用 `layer:id`，避免 host/web 都叫 `shell`
- Live 指示灯只看能力插件，避免内核永远 enabled 把状态钉死

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

