### PR TITLE
收藏黄星、板块计数，去掉开合三角

### DIFF
--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -19,9 +19,9 @@ import {
   LuChevronDown,
   LuChevronRight,
   LuPanelLeftClose,
-  LuPin,
   LuPlus,
   LuRadio,
+  LuStar,
   LuTrash2,
 } from 'react-icons/lu'
 
@@ -81,17 +81,17 @@ const SessionRow = memo(function SessionRow({
       <div className="side-page-tools">
         <button
           type="button"
-          className={`side-tool${pinned ? ' is-on' : ''}`}
+          className={`side-tool is-star${pinned ? ' is-on' : ''}`}
           aria-pressed={pinned}
-          aria-label={pinned ? `取消置顶 ${item.title}` : `置顶 ${item.title}`}
-          title={pinned ? '取消置顶' : '置顶'}
+          aria-label={pinned ? `取消收藏 ${item.title}` : `收藏 ${item.title}`}
+          title={pinned ? '取消收藏' : '收藏'}
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
             onPin(item)
           }}
         >
-          <LuPin />
+          <LuStar />
         </button>
         <button
           type="button"
@@ -117,6 +117,15 @@ export type ChatSidebarProps = {
   useSessionView: ReturnType<typeof bindSessionView>
   sessionView: SessionViewService
   onCollapse: () => void
+}
+
+function sectionCount(section: { sessions?: SessionListItem[]; groups?: { sessions: SessionListItem[] }[] }) {
+  if (section.sessions) return section.sessions.length
+  const ids = new Set<string>()
+  for (const group of section.groups ?? []) {
+    for (const row of group.sessions) ids.add(row.id)
+  }
+  return ids.size
 }
 
 export const ChatSidebar = memo(function ChatSidebar({
@@ -239,10 +248,8 @@ export const ChatSidebar = memo(function ChatSidebar({
                   aria-expanded={!sectionCollapsed}
                   onClick={() => toggleSection(section.kind)}
                 >
-                  <span className="side-sec-chev" aria-hidden>
-                    {sectionCollapsed ? <LuChevronRight /> : <LuChevronDown />}
-                  </span>
-                  {section.label}
+                  <span className="side-sec-name">{section.label}</span>
+                  <span className="side-count">{sectionCount(section)}</span>
                 </button>
                 {sectionCollapsed ? null : section.sessions ? (
                   <div className="side-sec-body">
@@ -285,6 +292,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                                 <FolderGlyph className="side-group-icon" />
                               )}
                               <span className="side-group-name">{group.label}</span>
+                              <span className="side-count">{group.sessions.length}</span>
                             </button>
                             {canAddHere ? (
                               <button

--- a/packages/web-session-view/src/web/session-groups.ts
+++ b/packages/web-session-view/src/web/session-groups.ts
@@ -103,7 +103,7 @@ export function buildSidebarGroups(sessions: SessionListItem[], groupBy: Sidebar
   return [
     {
       key: PINNED_GROUP_KEY,
-      label: '置顶',
+      label: '收藏',
       sessions: pinned,
       updatedAt: pinned[0]?.updatedAt ?? 0,
       kind: 'pinned',
@@ -137,7 +137,7 @@ export function buildSidebarSections(sessions: SessionListItem[]): SidebarSectio
   if (pinned.length) {
     sections.push({
       kind: 'pinned',
-      label: '置顶',
+      label: '收藏',
       sessions: pinned,
     })
   }

--- a/web/style.css
+++ b/web/style.css
@@ -379,10 +379,10 @@ body {
 .side-sec-label {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: 8px;
   width: 100%;
   height: 24px;
-  padding: 0 6px 0 4px;
+  padding: 0 8px 0 8px;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -390,33 +390,36 @@ body {
   font: inherit;
   font-size: 11px;
   font-weight: 500;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
   text-align: left;
   cursor: pointer;
 }
 
 .side-sec-label:hover {
-  background: var(--dsw-hover);
+  color: var(--dsw-label-2);
 }
 
-.side-sec-chev {
-  display: grid;
-  width: 16px;
-  height: 16px;
+.side-sec-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.side-count {
+  margin-left: auto;
   flex: none;
-  place-items: center;
-  opacity: 0;
   color: var(--dsw-label-3);
+  font-size: 10px;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  opacity: 0.7;
+  line-height: 1;
 }
 
-.side-sec-label:hover .side-sec-chev,
-.side-sec-label:focus-visible .side-sec-chev {
-  opacity: 1;
-}
-
-.side-sec-chev svg {
-  width: 12px;
-  height: 12px;
+.side-group-toggle .side-count {
+  padding-right: 2px;
 }
 
 .side-sec-body {
@@ -551,8 +554,17 @@ body {
   color: var(--dsw-label);
 }
 
-.side-tool.is-on {
-  color: var(--dsw-label);
+.side-tool.is-star.is-on {
+  color: #efc454;
+}
+
+.side-tool.is-star.is-on svg {
+  fill: currentColor;
+}
+
+.side-tool.is-star.is-on:hover {
+  color: #f3d06a;
+  background: color-mix(in srgb, #efc454 16%, transparent);
 }
 
 .side-tool.is-danger:hover {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏「置顶」改为「收藏」：星星点亮为黄色实心。收藏 / 项目 / 标签仍可点击开合，但不再画展开三角。计数用小号等宽数字贴在标题右侧，项目下的文件夹同样带数量。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

