### PR TITLE
Rename Live tool session_pin → session_star

### DIFF
--- a/packages/host-live-sessions/src/host/index.test.ts
+++ b/packages/host-live-sessions/src/host/index.test.ts
@@ -333,7 +333,7 @@ test('session_tag add/set/remove/clear on chat session', async () => {
   assert.deepEqual(cleared.tags, [])
 })
 
-test('session_pin pin / unpin / toggle on chat session', async () => {
+test('session_star pin / unpin / toggle on chat session', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'memory' })
   await ctx.plugin(sessions)
@@ -351,26 +351,26 @@ test('session_pin pin / unpin / toggle on chat session', async () => {
   await assert.rejects(
     () =>
       runWithSession(chat.id, () =>
-        ctx.tools.invoke('session_pin', { sessionId: chat.id, pinned: true }, new AbortController().signal),
+        ctx.tools.invoke('session_star', { sessionId: chat.id, pinned: true }, new AbortController().signal),
       ),
     /only available in live/,
   )
 
   // 置顶
   const p1 = (await runWithSession(live.id, () =>
-    ctx.tools.invoke('session_pin', { sessionId: chat.id, pinned: true }, new AbortController().signal),
+    ctx.tools.invoke('session_star', { sessionId: chat.id, pinned: true }, new AbortController().signal),
   )) as { pinned: boolean }
   assert.equal(p1.pinned, true)
 
   // 不传 pinned → 切换为取消置顶
   const p2 = (await runWithSession(live.id, () =>
-    ctx.tools.invoke('session_pin', { sessionId: chat.id }, new AbortController().signal),
+    ctx.tools.invoke('session_star', { sessionId: chat.id }, new AbortController().signal),
   )) as { pinned: boolean }
   assert.equal(p2.pinned, false)
 
   // 显式置顶回来
   await runWithSession(live.id, () =>
-    ctx.tools.invoke('session_pin', { sessionId: chat.id, pinned: true }, new AbortController().signal),
+    ctx.tools.invoke('session_star', { sessionId: chat.id, pinned: true }, new AbortController().signal),
   )
 
   // session_list 能看到 pinned

--- a/packages/host-live-sessions/src/host/index.ts
+++ b/packages/host-live-sessions/src/host/index.ts
@@ -13,11 +13,11 @@ export const LIVE_TOOL_NAMES = [
   'session_configure',
   'session_delete',
   'session_tag',
-  'session_pin',
+  'session_star',
 ] as const
 
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
-工作流：session_list / session_inspect（含 tags / pinned）了解现场 → 需要时可 session_create（可带 project 绑定文件夹）新建、session_rename / session_configure（可改 project）调整目标，用 session_tag 打标签、session_pin 置顶 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。废弃的 session 可 session_delete 清理。
+工作流：session_list / session_inspect（含 tags / pinned）了解现场 → 需要时可 session_create（可带 project 绑定文件夹）新建、session_rename / session_configure（可改 project）调整目标，用 session_tag 打标签、session_star 收藏 → session_wake（wait=false 可先派工）或 session_inject → session_progress 抽查进度。废弃的 session 可 session_delete 清理。
 异步派工后不要等待对方完成：完成态在目标 session 自己的 turn 里，需要时再 inspect / progress。
 向用户汇报要克制：只在关键节点、明显卡住、或用户追问时说明，不要刷屏。
 回答简洁：说明调度了谁、当前状态、下一步。`
@@ -426,7 +426,7 @@ export function apply(ctx: Context) {
         systemPrompt: { type: 'string' },
         agentMode: { type: 'string', enum: ['standard', 'minimal'] },
         extraTools: { type: 'array', items: { type: 'string' } },
-        pinned: { type: 'boolean', description: 'true=置顶；false=取消置顶' },
+        pinned: { type: 'boolean', description: 'true=收藏；false=取消收藏' },
       },
       required: ['sessionId'],
     },
@@ -506,14 +506,14 @@ export function apply(ctx: Context) {
   })
 
   ctx.tools.register({
-    name: 'session_pin',
+    name: 'session_star',
     description:
-      '置顶/取消置顶目标 session（侧栏 pinned）。传 pinned=true 置顶；pinned=false 取消置顶；不传时切换。返回更新后的 pinned 状态。Live 指挥席专用。',
+      '收藏/取消收藏目标 session（侧栏星标，config.pinned）。传 pinned=true 收藏；pinned=false 取消收藏；不传时切换。返回更新后的 pinned 状态。Live 指挥席专用。',
     parameters: {
       type: 'object',
       properties: {
         sessionId: { type: 'string', description: '目标 session id' },
-        pinned: { type: 'boolean', description: 'true=置顶；false=取消置顶；不传则切换' },
+        pinned: { type: 'boolean', description: 'true=收藏；false=取消收藏；不传则切换' },
       },
       required: ['sessionId'],
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Live 指挥席工具 `session_pin` 改名为 `session_star`，与侧栏「收藏 / 星标」用语对齐。

存储字段仍是 `config.pinned`（PATCH / `session_configure` 的 `pinned` 参数不变），避免无谓的数据迁移。

- `LIVE_TOOL_NAMES` 与派工 prompt 工作流已更新
- 工具描述改为收藏/取消收藏
- 测试改为 invoke `session_star`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdf33982-e0e2-4edb-9bd8-eeef39d3f009&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

