### PR TITLE
feat: 天生驾驶者 slogan + 统一入口多模型（URL / 中转站）

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 <p align="center"><b>一切即插件的 Agent Harness</b></p>
 <p align="center">多 Agent 不依赖群聊轮流发言，而是通过任务看板协作。</p>
+<p align="center">
+  <img src="public/f1.svg" width="22" height="22" alt="F1" valign="middle" />
+  &nbsp;<b>天生驾驶者</b>
+</p>
 
 <div align="center">
 

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -4,9 +4,10 @@ import { Service, type Context } from 'cordis'
 import type { ChatMessage } from './chat-types.ts'
 import type { AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
-import { LLM_MODEL_CATALOG, describeProvider, defaultModelFor, CHAT_PROVIDERS } from './model-catalog.ts'
-import type { ChatProvider, LlmModelDef } from './model-catalog.ts'
-export type { ChatProvider, LlmModelDef } from './model-catalog.ts'
+import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl } from './model-catalog.ts'
+import type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
+export type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
+export { LLM_ENDPOINT_PRESETS, LLM_MODEL_CATALOG } from './model-catalog.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import type { SessionConfig, SessionEvent } from '@biu/type-session'
 import { DEFAULT_TAIL_TURNS, sliceBeforeTurns, sliceTailTurns } from '@biu/host-sessions/window'
@@ -28,11 +29,25 @@ export type { ChatMessage }
 export type { AgentToolMode }
 
 const DEFAULT_PROVIDER: ChatProvider = 'deepseek'
+/** 当前选中入口 id；内置三家与 preset id 对齐，自定义入口为 custom-*。 */
+type EndpointId = string
 
 interface ChatConfig {
+  /** 入口 id（官方 / 中转 / 自定义）；兼容旧值 deepseek|openai|anthropic。 */
+  endpointId: EndpointId
+  /**
+   * 协议分流用的 provider（deepseek|openai|anthropic）。
+   * 由入口决定；保留字段以兼容旧持久化与会话覆盖。
+   */
   provider: ChatProvider
-  /** 每个 provider 独立存一份 apiKey；未配置的为空串。 */
-  apiKeys: Record<ChatProvider, string>
+  /** 每个入口独立存一份 apiKey。 */
+  apiKeys: Record<string, string>
+  /** 用户覆盖的 baseUrl（未覆盖则用 preset / customEndpoints 默认）。 */
+  baseUrls: Record<string, string>
+  /** 用户自定义入口（中转站自建 URL 等）。 */
+  customEndpoints: LlmEndpointDef[]
+  /** 用户在某入口下追加的模型名。 */
+  customModels: LlmModelDef[]
   model: string
   systemPrompt: string
   agentMode: AgentToolMode
@@ -44,7 +59,7 @@ function configPath() {
   return join(process.cwd(), '.cordis', 'chat-config.json')
 }
 
-function emptyKeys(): Record<ChatProvider, string> {
+function emptyKeys(): Record<string, string> {
   return { deepseek: '', openai: '', anthropic: '' }
 }
 
@@ -58,8 +73,12 @@ function defaults(): ChatConfig {
   const anthropic = Boolean(envKeys.anthropic)
   const provider: ChatProvider = deepseek ? 'deepseek' : openai ? 'openai' : anthropic ? 'anthropic' : 'deepseek'
   return {
+    endpointId: provider,
     provider,
     apiKeys: envKeys,
+    baseUrls: {},
+    customEndpoints: [],
+    customModels: [],
     model:
       process.env.CHAT_MODEL ||
       (provider === 'openai' ? 'gpt-4o-mini' : provider === 'anthropic' ? 'claude-3-5-sonnet-20241022' : 'deepseek-chat'),
@@ -90,12 +109,16 @@ function writePersisted(config: ChatConfig) {
     configPath(),
     `${JSON.stringify(
       {
+        endpointId: config.endpointId,
         provider: config.provider,
         model: config.model,
         systemPrompt: config.systemPrompt,
         agentMode: config.agentMode,
         extraTools: config.extraTools,
         apiKeys: config.apiKeys,
+        baseUrls: config.baseUrls,
+        customEndpoints: config.customEndpoints,
+        customModels: config.customModels,
       },
       null,
       2,
@@ -112,17 +135,21 @@ function parseProvider(value: unknown): ChatProvider | null {
   return CHAT_PROVIDERS.includes(value as ChatProvider) ? (value as ChatProvider) : null
 }
 
-/** 取某个 provider 的持久化 key；环境变量始终优先（不会被磁盘文件覆盖 UI 清空）。 */
-function keyFor(provider: ChatProvider, saved: Partial<ChatConfig> | null): string {
-  const envMap: Record<ChatProvider, string | undefined> = {
+function isLocalEndpoint(endpoint: LlmEndpointDef): boolean {
+  return endpoint.group === 'local'
+}
+
+/** 取某个入口的持久化 key；环境变量始终优先（不会被磁盘文件覆盖 UI 清空）。 */
+function keyFor(endpointId: string, saved: Partial<ChatConfig> | null): string {
+  const envMap: Record<string, string | undefined> = {
     deepseek: process.env.DEEPSEEK_API_KEY,
     openai: process.env.OPENAI_API_KEY,
     anthropic: process.env.ANTHROPIC_API_KEY,
   }
-  if (envMap[provider]) return envMap[provider]
+  if (envMap[endpointId]) return envMap[endpointId]!
   const savedKeys = saved?.apiKeys
-  if (savedKeys && typeof savedKeys === 'object' && typeof (savedKeys as Record<string, unknown>)[provider] === 'string') {
-    const key = (savedKeys as Record<string, string>)[provider] || ''
+  if (savedKeys && typeof savedKeys === 'object' && typeof savedKeys[endpointId] === 'string') {
+    const key = savedKeys[endpointId] || ''
     if (key.trim()) return key.trim()
   }
   // 老格式：单一 apiKey 迁移到 deepseek（或默认 provider 所在）
@@ -132,18 +159,107 @@ function keyFor(provider: ChatProvider, saved: Partial<ChatConfig> | null): stri
       legacy.provider && CHAT_PROVIDERS.includes(legacy.provider as ChatProvider)
         ? (legacy.provider as ChatProvider)
         : DEFAULT_PROVIDER
-    if (provider === owner) return legacy.apiKey.trim()
+    if (endpointId === owner) return legacy.apiKey.trim()
   }
   return ''
 }
 
+function mergeCustomEndpoints(saved: Partial<ChatConfig> | null): LlmEndpointDef[] {
+  if (!Array.isArray(saved?.customEndpoints)) return []
+  const out: LlmEndpointDef[] = []
+  for (const raw of saved.customEndpoints) {
+    if (!raw || typeof raw !== 'object') continue
+    const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+    const label = typeof raw.label === 'string' ? raw.label.trim() : ''
+    const baseUrl = typeof raw.baseUrl === 'string' ? normalizeBaseUrl(raw.baseUrl) : ''
+    if (!id || !label || !baseUrl) continue
+    const protocol = raw.protocol === 'anthropic' ? 'anthropic' : 'openai-compat'
+    const provider: ChatProvider =
+      raw.provider === 'deepseek' || raw.provider === 'anthropic' || raw.provider === 'openai'
+        ? raw.provider
+        : protocol === 'anthropic'
+          ? 'anthropic'
+          : 'openai'
+    out.push({
+      id,
+      label,
+      group: 'custom',
+      protocol,
+      baseUrl,
+      provider,
+      note: typeof raw.note === 'string' ? raw.note : undefined,
+      placeholder: typeof raw.placeholder === 'string' ? raw.placeholder : 'sk-…',
+      builtin: false,
+    })
+  }
+  return out
+}
+
+function mergeCustomModels(saved: Partial<ChatConfig> | null): LlmModelDef[] {
+  if (!Array.isArray(saved?.customModels)) return []
+  const out: LlmModelDef[] = []
+  for (const raw of saved.customModels) {
+    if (!raw || typeof raw !== 'object') continue
+    const id = typeof raw.id === 'string' ? raw.id.trim() : ''
+    const model = typeof raw.model === 'string' ? raw.model.trim() : ''
+    const endpointId = typeof raw.endpointId === 'string' ? raw.endpointId.trim() : ''
+    if (!id || !model || !endpointId) continue
+    const provider: ChatProvider =
+      raw.provider === 'deepseek' || raw.provider === 'openai' || raw.provider === 'anthropic'
+        ? raw.provider
+        : 'openai'
+    out.push({
+      id,
+      label: typeof raw.label === 'string' && raw.label.trim() ? raw.label.trim() : model,
+      endpointId,
+      provider,
+      model,
+      category: typeof raw.category === 'string' ? raw.category : 'custom',
+      note: typeof raw.note === 'string' ? raw.note : undefined,
+      builtin: false,
+    })
+  }
+  return out
+}
+
 function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): ChatConfig {
   if (!saved) return base
-  const apiKeys = emptyKeys()
-  for (const provider of CHAT_PROVIDERS) apiKeys[provider] = keyFor(provider, saved)
+  const customEndpoints = mergeCustomEndpoints(saved)
+  const customModels = mergeCustomModels(saved)
+  const apiKeys: Record<string, string> = { ...emptyKeys() }
+  // 合并所有已知入口的 key
+  const allEndpointIds = new Set<string>([
+    ...CHAT_PROVIDERS,
+    ...LLM_ENDPOINT_PRESETS.map((e) => e.id),
+    ...customEndpoints.map((e) => e.id),
+    ...(saved.apiKeys && typeof saved.apiKeys === 'object' ? Object.keys(saved.apiKeys) : []),
+  ])
+  for (const id of allEndpointIds) apiKeys[id] = keyFor(id, saved)
+
+  const baseUrls: Record<string, string> = {}
+  if (saved.baseUrls && typeof saved.baseUrls === 'object') {
+    for (const [id, url] of Object.entries(saved.baseUrls)) {
+      if (typeof url === 'string' && url.trim()) baseUrls[id] = normalizeBaseUrl(url)
+    }
+  }
+
+  const endpointId =
+    typeof saved.endpointId === 'string' && saved.endpointId.trim()
+      ? saved.endpointId.trim()
+      : parseProvider(saved.provider) ?? base.endpointId
+
+  const endpoint =
+    findEndpointPreset(endpointId) ??
+    customEndpoints.find((e) => e.id === endpointId) ??
+    findEndpointPreset(base.endpointId)
+
   return {
-    provider: parseProvider(saved.provider) ?? (base.provider in apiKeys && apiKeys[base.provider] ? base.provider : DEFAULT_PROVIDER),
+    endpointId,
+    provider: endpoint?.provider ?? parseProvider(saved.provider) ?? base.provider,
     apiKeys,
+    baseUrls,
+    customEndpoints,
+    customModels,
     model: !process.env.CHAT_MODEL && typeof saved.model === 'string' && saved.model.trim() ? saved.model.trim() : base.model,
     systemPrompt: typeof saved.systemPrompt === 'string' ? saved.systemPrompt : base.systemPrompt,
     agentMode: parseAgentMode(saved.agentMode, base.agentMode),
@@ -153,13 +269,36 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
   }
 }
 
-/** 返回某 provider 是否已配置 key（用于前端「只有配了 token 的模型可选」）。 */
-function providerConfigured(keys: Record<ChatProvider, string>): Record<ChatProvider, boolean> {
-  return {
-    deepseek: Boolean(keys.deepseek.trim()),
-    openai: Boolean(keys.openai.trim()),
-    anthropic: Boolean(keys.anthropic.trim()),
-  }
+function allEndpoints(config: ChatConfig): LlmEndpointDef[] {
+  const customIds = new Set(config.customEndpoints.map((e) => e.id))
+  return [
+    ...LLM_ENDPOINT_PRESETS.filter((e) => !customIds.has(e.id)),
+    ...config.customEndpoints,
+  ]
+}
+
+function allModels(config: ChatConfig): LlmModelDef[] {
+  const customIds = new Set(config.customModels.map((m) => m.id))
+  return [
+    ...LLM_MODEL_CATALOG.filter((m) => !customIds.has(m.id)),
+    ...config.customModels,
+  ]
+}
+
+function resolveEndpoint(config: ChatConfig, endpointId: string): LlmEndpointDef | undefined {
+  return allEndpoints(config).find((e) => e.id === endpointId)
+}
+
+function effectiveBaseUrl(config: ChatConfig, endpoint: LlmEndpointDef): string {
+  const override = config.baseUrls[endpoint.id]
+  return override?.trim() ? normalizeBaseUrl(override) : endpoint.baseUrl
+}
+
+/** 入口是否已配置：有 Key，或本地入口（允许空 Key）。 */
+function endpointConfigured(config: ChatConfig, endpoint: LlmEndpointDef): boolean {
+  const key = (config.apiKeys[endpoint.id] ?? '').trim()
+  if (key) return true
+  return isLocalEndpoint(endpoint)
 }
 
 export class ChatService extends Service {
@@ -180,22 +319,67 @@ export class ChatService extends Service {
   }
 
   publicView() {
-    const configured = providerConfigured(this.config.apiKeys)
+    const endpoints = allEndpoints(this.config)
+    const models = allModels(this.config)
+    const current = resolveEndpoint(this.config, this.config.endpointId)
+    const providers: Record<string, { label: string; configured: boolean; hint: string; baseUrl: string; group: string; protocol: string }> = {}
+    for (const ep of endpoints) {
+      providers[ep.id] = {
+        label: ep.label,
+        configured: endpointConfigured(this.config, ep),
+        hint: hint(this.config.apiKeys[ep.id] ?? ''),
+        baseUrl: effectiveBaseUrl(this.config, ep),
+        group: ep.group,
+        protocol: ep.protocol,
+      }
+    }
+    // 兼容旧前端：三家协议维度也暴露
+    for (const p of CHAT_PROVIDERS) {
+      if (!providers[p]) {
+        providers[p] = {
+          label: describeProvider(p),
+          configured: Boolean((this.config.apiKeys[p] ?? '').trim()),
+          hint: hint(this.config.apiKeys[p] ?? ''),
+          baseUrl: findEndpointPreset(p)?.baseUrl ?? '',
+          group: 'official',
+          protocol: p === 'anthropic' ? 'anthropic' : 'openai-compat',
+        }
+      }
+    }
     return {
+      endpointId: this.config.endpointId,
       provider: this.config.provider,
       model: this.config.model,
       systemPrompt: this.config.systemPrompt,
       agentMode: this.config.agentMode,
-      /** 当前默认 provider 是否已配置（兼容旧语义，供 banner 等使用）。 */
-      configured: configured[this.config.provider],
-      hint: hint(this.config.apiKeys[this.config.provider]),
-      /** 各 provider 是否已配置 key。 */
-      providers: {
-        deepseek: { label: describeProvider('deepseek'), configured: configured.deepseek, hint: hint(this.config.apiKeys.deepseek) },
-        openai: { label: describeProvider('openai'), configured: configured.openai, hint: hint(this.config.apiKeys.openai) },
-        anthropic: { label: describeProvider('anthropic'), configured: configured.anthropic, hint: hint(this.config.apiKeys.anthropic) },
-      },
-      modelCatalog: LLM_MODEL_CATALOG,
+      /** 当前默认入口是否已配置（兼容旧语义，供 banner 等使用）。 */
+      configured: current ? endpointConfigured(this.config, current) : Boolean((this.config.apiKeys[this.config.provider] ?? '').trim()),
+      hint: hint(this.config.apiKeys[this.config.endpointId] ?? this.config.apiKeys[this.config.provider] ?? ''),
+      baseUrl: current ? effectiveBaseUrl(this.config, current) : '',
+      /** 各入口是否已配置 key + baseUrl。 */
+      providers,
+      endpoints: endpoints.map((ep) => ({
+        id: ep.id,
+        label: ep.label,
+        group: ep.group,
+        protocol: ep.protocol,
+        provider: ep.provider,
+        baseUrl: effectiveBaseUrl(this.config, ep),
+        defaultBaseUrl: ep.baseUrl,
+        configured: endpointConfigured(this.config, ep),
+        hint: hint(this.config.apiKeys[ep.id] ?? ''),
+        placeholder: ep.placeholder ?? 'sk-…',
+        note: ep.note,
+        builtin: ep.builtin !== false && ep.group !== 'custom',
+      })),
+      modelCatalog: models.map((m) => ({
+        ...m,
+        // 方便前端按入口过滤
+        endpointConfigured: (() => {
+          const ep = resolveEndpoint(this.config, m.endpointId)
+          return ep ? endpointConfigured(this.config, ep) : false
+        })(),
+      })),
       tools: this.ctx.tools.names(),
       toolCatalog: this.ctx.tools.catalog(),
       extraTools: this.config.extraTools,
@@ -205,6 +389,7 @@ export class ChatService extends Service {
   /** 全局默认 + 会话覆盖（不含 apiKey）。 */
   resolveEffective(sessionId?: string | null) {
     const defaultsView = {
+      endpointId: this.config.endpointId,
       provider: this.config.provider,
       model: this.config.model,
       systemPrompt: this.config.systemPrompt,
@@ -213,9 +398,19 @@ export class ChatService extends Service {
     }
     if (!sessionId) return { defaults: defaultsView, config: undefined as SessionConfig | undefined, effective: defaultsView }
     const config = this.ctx.sessions.peek(sessionId)?.config
+    // 会话仍可覆盖 provider/model；endpoint 跟随模型所属入口或全局
+    const provider = (config?.provider as ChatProvider | undefined) ?? defaultsView.provider
+    const model = config?.model ?? defaultsView.model
+    let endpointId = defaultsView.endpointId
+    const matched = allModels(this.config).find((m) => m.model === model && m.provider === provider)
+    if (matched) endpointId = matched.endpointId
+    else if (config?.provider && CHAT_PROVIDERS.includes(config.provider as ChatProvider)) {
+      endpointId = config.provider as string
+    }
     const effective = {
-      provider: config?.provider ?? defaultsView.provider,
-      model: config?.model ?? defaultsView.model,
+      endpointId,
+      provider,
+      model,
       systemPrompt:
         typeof config?.systemPrompt === 'string' ? config.systemPrompt : defaultsView.systemPrompt,
       agentMode: config?.agentMode ?? defaultsView.agentMode,
@@ -226,54 +421,172 @@ export class ChatService extends Service {
   }
 
   resolverKey(provider: ChatProvider): string {
-    return this.config.apiKeys[provider]
+    return this.config.apiKeys[provider] ?? ''
   }
 
-  /** 根据有效 provider 取对应 apiKey；未配置则返回空（LLM 层会因鉴权失败抛错，友好提示）。 */
+  /** 根据有效入口取对应 apiKey + baseUrl。 */
   resolveLlm(sessionId?: string | null): LlmConfig {
     const { effective } = this.resolveEffective(sessionId)
+    const endpointId = (effective as { endpointId?: string }).endpointId ?? this.config.endpointId
+    const endpoint = resolveEndpoint(this.config, endpointId) ?? resolveEndpoint(this.config, effective.provider)
+    const provider: ChatProvider = endpoint?.provider ?? effective.provider
+    const apiKey =
+      (endpoint ? this.config.apiKeys[endpoint.id] : undefined) ??
+      this.config.apiKeys[provider] ??
+      ''
+    // 本地入口允许空 Key：上游常不校验，填占位避免部分网关拒空 Authorization
+    const key = apiKey.trim() || (endpoint && isLocalEndpoint(endpoint) ? 'local' : '')
     return {
-      provider: effective.provider,
-      apiKey: this.config.apiKeys[effective.provider] ?? '',
+      provider,
+      apiKey: key,
       model: effective.model,
+      ...(endpoint ? { baseUrl: effectiveBaseUrl(this.config, endpoint) } : {}),
     }
   }
 
   /**
-   * 更新配置。provider/model/systemPrompt/agentMode/extraTools 直接覆盖；
-   * setApiKey(provider, key) 按 provider 独立写入 key；空串表示保留原值，仅非空时更新。
+   * 更新配置。endpointId/provider/model/systemPrompt/agentMode/extraTools 直接覆盖；
+   * setApiKey / setBaseUrl 按入口写入；空串表示保留原值，仅非空时更新。
+   * addEndpoint / addModel / removeCustom* 管理自定义入口与模型。
    */
   patch(
     next: Partial<{
+      endpointId: string
       provider: ChatProvider
       apiKey: string
       model: string
+      baseUrl: string
       systemPrompt: string
       agentMode: AgentToolMode
       extraTools: string[]
-      /** 按 provider 更新 key：{ deepseek?: '…', openai?: '…', anthropic?: '…' } */
-      setApiKey: Partial<Record<ChatProvider, string>>
+      /** 按入口更新 key */
+      setApiKey: Partial<Record<string, string>>
+      /** 按入口覆盖 baseUrl；空串清除覆盖、回到 preset 默认 */
+      setBaseUrl: Partial<Record<string, string | null>>
+      /** 追加自定义入口 */
+      addEndpoint: { id?: string; label: string; baseUrl: string; protocol?: 'openai-compat' | 'anthropic'; provider?: ChatProvider; note?: string }
+      /** 追加模型到某入口 */
+      addModel: { endpointId: string; model: string; label?: string; note?: string }
+      removeCustomEndpoint: string
+      removeCustomModel: string
     }>,
     opts?: { persist?: boolean },
   ) {
-    if (next.provider) {
+    if (typeof next.endpointId === 'string' && next.endpointId.trim()) {
+      const id = next.endpointId.trim()
+      const ep = resolveEndpoint(this.config, id)
+      this.config.endpointId = id
+      if (ep) this.config.provider = ep.provider
+      // 未指定 model 时，切到该入口第一个模型
+      if (typeof next.model !== 'string' || !next.model.trim()) {
+        const first = allModels(this.config).find((m) => m.endpointId === id)
+        if (first) this.config.model = first.model
+        else if (ep) this.config.model = defaultModelFor(ep.provider)
+      }
+    } else if (next.provider) {
       this.config.provider = next.provider
-      // 未指定 model 时，默认模型跟随 provider 的默认模型
+      this.config.endpointId = next.provider
       if (typeof next.model !== 'string' || !next.model.trim()) {
         this.config.model = defaultModelFor(next.provider)
       }
     }
     if (typeof next.model === 'string' && next.model.trim()) this.config.model = next.model.trim()
     if (typeof next.systemPrompt === 'string') this.config.systemPrompt = next.systemPrompt
+    if (typeof next.baseUrl === 'string' && next.baseUrl.trim()) {
+      this.config.baseUrls[this.config.endpointId] = normalizeBaseUrl(next.baseUrl)
+    }
     if (next.setApiKey && typeof next.setApiKey === 'object') {
-      for (const provider of CHAT_PROVIDERS) {
-        const key = next.setApiKey[provider]
-        if (typeof key === 'string' && key.trim()) this.config.apiKeys[provider] = key.trim()
+      for (const [id, key] of Object.entries(next.setApiKey)) {
+        if (typeof key === 'string' && key.trim()) this.config.apiKeys[id] = key.trim()
       }
     }
-    // 兼容旧调用：单一 apiKey 写入当前 provider
+    if (next.setBaseUrl && typeof next.setBaseUrl === 'object') {
+      for (const [id, url] of Object.entries(next.setBaseUrl)) {
+        if (url === null || url === '') {
+          delete this.config.baseUrls[id]
+        } else if (typeof url === 'string' && url.trim()) {
+          this.config.baseUrls[id] = normalizeBaseUrl(url)
+        }
+      }
+    }
+    // 兼容旧调用：单一 apiKey 写入当前入口
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) {
-      this.config.apiKeys[this.config.provider] = next.apiKey.trim()
+      this.config.apiKeys[this.config.endpointId] = next.apiKey.trim()
+    }
+    if (next.addEndpoint && typeof next.addEndpoint === 'object') {
+      const label = String(next.addEndpoint.label ?? '').trim()
+      const baseUrl = normalizeBaseUrl(String(next.addEndpoint.baseUrl ?? ''))
+      if (label && baseUrl) {
+        const protocol = next.addEndpoint.protocol === 'anthropic' ? 'anthropic' : 'openai-compat'
+        const provider: ChatProvider =
+          next.addEndpoint.provider === 'deepseek' ||
+          next.addEndpoint.provider === 'anthropic' ||
+          next.addEndpoint.provider === 'openai'
+            ? next.addEndpoint.provider
+            : protocol === 'anthropic'
+              ? 'anthropic'
+              : 'openai'
+        const id =
+          (typeof next.addEndpoint.id === 'string' && next.addEndpoint.id.trim()) ||
+          `custom-${Date.now().toString(36)}`
+        const existing = this.config.customEndpoints.findIndex((e) => e.id === id)
+        const def: LlmEndpointDef = {
+          id,
+          label,
+          group: 'custom',
+          protocol,
+          baseUrl,
+          provider,
+          note: next.addEndpoint.note,
+          placeholder: 'sk-…',
+          builtin: false,
+        }
+        if (existing >= 0) this.config.customEndpoints[existing] = def
+        else this.config.customEndpoints.push(def)
+        this.config.endpointId = id
+        this.config.provider = provider
+      }
+    }
+    if (next.addModel && typeof next.addModel === 'object') {
+      const endpointId = String(next.addModel.endpointId ?? '').trim()
+      const model = String(next.addModel.model ?? '').trim()
+      if (endpointId && model) {
+        const ep = resolveEndpoint(this.config, endpointId)
+        const provider = ep?.provider ?? 'openai'
+        const id = `custom-model-${endpointId}-${model}`.replace(/[^a-zA-Z0-9._:-]+/g, '-')
+        const def: LlmModelDef = {
+          id,
+          label: (next.addModel.label ?? model).trim() || model,
+          endpointId,
+          provider,
+          model,
+          category: 'custom',
+          note: next.addModel.note,
+          builtin: false,
+        }
+        const existing = this.config.customModels.findIndex((m) => m.id === id || (m.endpointId === endpointId && m.model === model))
+        if (existing >= 0) this.config.customModels[existing] = def
+        else this.config.customModels.push(def)
+        this.config.endpointId = endpointId
+        this.config.provider = provider
+        this.config.model = model
+      }
+    }
+    if (typeof next.removeCustomEndpoint === 'string' && next.removeCustomEndpoint.trim()) {
+      const id = next.removeCustomEndpoint.trim()
+      this.config.customEndpoints = this.config.customEndpoints.filter((e) => e.id !== id)
+      this.config.customModels = this.config.customModels.filter((m) => m.endpointId !== id)
+      delete this.config.apiKeys[id]
+      delete this.config.baseUrls[id]
+      if (this.config.endpointId === id) {
+        this.config.endpointId = DEFAULT_PROVIDER
+        this.config.provider = DEFAULT_PROVIDER
+        this.config.model = defaultModelFor(DEFAULT_PROVIDER)
+      }
+    }
+    if (typeof next.removeCustomModel === 'string' && next.removeCustomModel.trim()) {
+      const id = next.removeCustomModel.trim()
+      this.config.customModels = this.config.customModels.filter((m) => m.id !== id)
     }
     if (next.agentMode === 'standard' || next.agentMode === 'minimal') this.config.agentMode = next.agentMode
     if (Array.isArray(next.extraTools)) {
@@ -406,13 +719,20 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/chat/config', async (route) => {
     const payload = (await route.json()) as Partial<{
+      endpointId: string
       provider: ChatProvider
       apiKey: string
       model: string
+      baseUrl: string
       systemPrompt: string
       agentMode: AgentToolMode
       extraTools: string[]
-      setApiKey: Partial<Record<ChatProvider, string>>
+      setApiKey: Partial<Record<string, string>>
+      setBaseUrl: Partial<Record<string, string | null>>
+      addEndpoint: { id?: string; label: string; baseUrl: string; protocol?: 'openai-compat' | 'anthropic'; provider?: ChatProvider; note?: string }
+      addModel: { endpointId: string; model: string; label?: string; note?: string }
+      removeCustomEndpoint: string
+      removeCustomModel: string
     }>
     route.send(200, chat.patch(payload ?? {}))
   })

--- a/packages/cap-chat/src/host/model-catalog.test.ts
+++ b/packages/cap-chat/src/host/model-catalog.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { resolveChatCompletionsUrl, resolveAnthropicMessagesUrl } from '@biu/host-llm'
+import {
+  LLM_ENDPOINT_PRESETS,
+  LLM_MODEL_CATALOG,
+  findEndpointPreset,
+  normalizeBaseUrl,
+} from './model-catalog.ts'
+
+test('resolveChatCompletionsUrl uses defaults when baseUrl missing', () => {
+  assert.equal(resolveChatCompletionsUrl(undefined, 'deepseek'), 'https://api.deepseek.com/chat/completions')
+  assert.equal(resolveChatCompletionsUrl(undefined, 'openai'), 'https://api.openai.com/v1/chat/completions')
+})
+
+test('resolveChatCompletionsUrl appends path and accepts full URL', () => {
+  assert.equal(
+    resolveChatCompletionsUrl('https://api.closeai-asia.com/v1', 'openai'),
+    'https://api.closeai-asia.com/v1/chat/completions',
+  )
+  assert.equal(
+    resolveChatCompletionsUrl('https://gate.example.com/v1/chat/completions/', 'openai'),
+    'https://gate.example.com/v1/chat/completions',
+  )
+})
+
+test('resolveAnthropicMessagesUrl supports custom base', () => {
+  assert.equal(resolveAnthropicMessagesUrl(undefined), 'https://api.anthropic.com/v1/messages')
+  assert.equal(
+    resolveAnthropicMessagesUrl('https://proxy.example.com/anthropic/v1'),
+    'https://proxy.example.com/anthropic/v1/messages',
+  )
+})
+
+test('endpoint presets cover official + relay + local groups', () => {
+  const groups = new Set(LLM_ENDPOINT_PRESETS.map((e) => e.group))
+  assert.ok(groups.has('official'))
+  assert.ok(groups.has('relay'))
+  assert.ok(groups.has('local'))
+  assert.ok(LLM_ENDPOINT_PRESETS.length >= 30)
+  assert.ok(findEndpointPreset('deepseek'))
+  assert.ok(findEndpointPreset('openrouter'))
+  assert.ok(findEndpointPreset('closeai'))
+  assert.ok(findEndpointPreset('ollama'))
+})
+
+test('builtin models reference known endpoints', () => {
+  const ids = new Set(LLM_ENDPOINT_PRESETS.map((e) => e.id))
+  for (const m of LLM_MODEL_CATALOG) {
+    assert.ok(ids.has(m.endpointId), `model ${m.id} endpoint ${m.endpointId}`)
+  }
+})
+
+test('normalizeBaseUrl strips trailing slash', () => {
+  assert.equal(normalizeBaseUrl(' https://a.com/v1/ '), 'https://a.com/v1')
+})

--- a/packages/cap-chat/src/host/model-catalog.ts
+++ b/packages/cap-chat/src/host/model-catalog.ts
@@ -1,31 +1,565 @@
+/**
+ * 模型入口目录：官方 API + 常见中转站 / 聚合网关 + 本地运行时。
+ * 同一入口（endpoint）共用一把 Key、一个 baseUrl，下面可挂多个模型名（统一入口多模型）。
+ */
+
 export type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
-export const CHAT_PROVIDERS: ChatProvider[] = ['deepseek', 'openai', 'anthropic']
+/** 请求协议：决定走 OpenAI 兼容 chat.completions 还是 Anthropic messages。 */
+export type LlmProtocol = 'openai-compat' | 'anthropic'
+
+export type EndpointGroup = 'official' | 'relay' | 'local' | 'custom'
+
+export interface LlmEndpointDef {
+  id: string
+  label: string
+  group: EndpointGroup
+  protocol: LlmProtocol
+  /**
+   * API 根地址（不含 /chat/completions 或 /messages）。
+   * openai-compat 示例：https://api.openai.com/v1
+   * anthropic 示例：https://api.anthropic.com/v1
+   */
+  baseUrl: string
+  /**
+   * 映射到现有 LLM 客户端分流：
+   * - deepseek：OpenAI 兼容 + 视觉模型自动路由
+   * - openai：OpenAI 兼容
+   * - anthropic：Anthropic Messages
+   */
+  provider: ChatProvider
+  placeholder?: string
+  note?: string
+  /** 是否内置（不可删除；baseUrl 可被用户覆盖） */
+  builtin?: boolean
+}
 
 export interface LlmModelDef {
   id: string
-  /** 展示名（如「DeepSeek Flash」） */
+  /** 展示名 */
   label: string
+  /** 所属入口 id（官方 / 中转站 / 自定义） */
+  endpointId: string
+  /**
+   * 兼容旧语义：与所属入口的 provider 一致（deepseek | openai | anthropic）。
+   * 会话 / composer 仍用它做协议分流；真正发请求时用 endpoint.baseUrl。
+   */
   provider: ChatProvider
   /** 传给上游 API 的 model id */
   model: string
-  category: 'flash' | 'pro' | 'claude' | 'gpt' | 'other'
+  category: string
   note?: string
+  builtin?: boolean
 }
 
-/** 模型目录：deepseek(flash/pro)、claude、gpt；每项归属 provider，只有对应 provider 配了 token 才可选。 */
-export const LLM_MODEL_CATALOG: LlmModelDef[] = [
-  // DeepSeek（OpenAI 兼容，endpoint https://api.deepseek.com/chat/completions）
-  { id: 'deepseek-flash', label: 'DeepSeek Flash', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '通用对话 / 快速' },
-  { id: 'deepseek-pro', label: 'DeepSeek Pro', provider: 'deepseek', model: 'deepseek-v4-pro', category: 'pro', note: '深度推理' },
-  { id: 'deepseek-flash-vision', label: 'DeepSeek Flash Vision', provider: 'deepseek', model: 'deepseek-v4-flash-vision-exp', category: 'flash', note: '多模态视觉（图片识别）' },
-  // Anthropic Claude（endpoint https://api.anthropic.com/v1/messages）
-  { id: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet', provider: 'anthropic', model: 'claude-3-5-sonnet-20241022', category: 'claude', note: '智能均衡' },
-  { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku', provider: 'anthropic', model: 'claude-3-5-haiku-20241022', category: 'claude', note: '轻量快速' },
-  // OpenAI GPT
-  { id: 'gpt-4o', label: 'GPT-4o', provider: 'openai', model: 'gpt-4o', category: 'gpt', note: '通用旗舰' },
-  { id: 'gpt-4o-mini', label: 'GPT-4o mini', provider: 'openai', model: 'gpt-4o-mini', category: 'gpt', note: '轻量快速' },
+/** 内置入口：官方 + 常见中转站 / 聚合 + 本地。越全越好，URL 可按需在 UI 覆盖。 */
+export const LLM_ENDPOINT_PRESETS: LlmEndpointDef[] = [
+  // ── 官方 ──
+  {
+    id: 'deepseek',
+    label: 'DeepSeek',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.deepseek.com',
+    provider: 'deepseek',
+    placeholder: 'sk-…',
+    note: '官方 · OpenAI 兼容',
+    builtin: true,
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.openai.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '官方 · GPT',
+    builtin: true,
+  },
+  {
+    id: 'anthropic',
+    label: 'Anthropic',
+    group: 'official',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.anthropic.com/v1',
+    provider: 'anthropic',
+    placeholder: 'sk-ant-…',
+    note: '官方 · Claude Messages',
+    builtin: true,
+  },
+  {
+    id: 'moonshot',
+    label: 'Moonshot（Kimi）',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.moonshot.cn/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '月之暗面官方',
+    builtin: true,
+  },
+  {
+    id: 'zhipu',
+    label: '智谱 GLM',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
+    provider: 'openai',
+    placeholder: '…',
+    note: '智谱 AI 官方',
+    builtin: true,
+  },
+  {
+    id: 'dashscope',
+    label: '通义千问（DashScope）',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '阿里云兼容模式',
+    builtin: true,
+  },
+  {
+    id: 'qianfan',
+    label: '百度千帆',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://qianfan.baidubce.com/v2',
+    provider: 'openai',
+    placeholder: 'bce-v3/…',
+    note: '文心 / 千帆 OpenAI 兼容',
+    builtin: true,
+  },
+  {
+    id: 'volcengine',
+    label: '火山方舟（豆包）',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    provider: 'openai',
+    placeholder: '…',
+    note: '字节跳动方舟',
+    builtin: true,
+  },
+  {
+    id: 'minimax',
+    label: 'MiniMax',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.minimax.chat/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: 'MiniMax 官方',
+    builtin: true,
+  },
+  {
+    id: 'yi',
+    label: '零一万物 Yi',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.lingyiwanwu.com/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: 'Yi 官方',
+    builtin: true,
+  },
+  {
+    id: 'stepfun',
+    label: '阶跃星辰 StepFun',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.stepfun.com/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: 'Step 系列',
+    builtin: true,
+  },
+  {
+    id: 'baichuan',
+    label: '百川 Baichuan',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.baichuan-ai.com/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: '百川智能',
+    builtin: true,
+  },
+  {
+    id: 'siliconflow',
+    label: '硅基流动 SiliconFlow',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.siliconflow.cn/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '聚合多模型 · 国内常用',
+    builtin: true,
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://openrouter.ai/api/v1',
+    provider: 'openai',
+    placeholder: 'sk-or-…',
+    note: '全球模型聚合',
+    builtin: true,
+  },
+  {
+    id: 'groq',
+    label: 'Groq',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.groq.com/openai/v1',
+    provider: 'openai',
+    placeholder: 'gsk_…',
+    note: '高速推理',
+    builtin: true,
+  },
+  {
+    id: 'together',
+    label: 'Together AI',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.together.xyz/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: '开源模型托管',
+    builtin: true,
+  },
+  {
+    id: 'fireworks',
+    label: 'Fireworks AI',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.fireworks.ai/inference/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: '开源模型推理',
+    builtin: true,
+  },
+  {
+    id: 'deepinfra',
+    label: 'DeepInfra',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.deepinfra.com/v1/openai',
+    provider: 'openai',
+    placeholder: '…',
+    note: '开源模型',
+    builtin: true,
+  },
+  {
+    id: 'mistral',
+    label: 'Mistral',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.mistral.ai/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: 'Mistral 官方',
+    builtin: true,
+  },
+  {
+    id: 'xai',
+    label: 'xAI Grok',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.x.ai/v1',
+    provider: 'openai',
+    placeholder: 'xai-…',
+    note: 'Grok 官方',
+    builtin: true,
+  },
+  {
+    id: 'gemini-openai',
+    label: 'Google Gemini（OpenAI 兼容）',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai',
+    provider: 'openai',
+    placeholder: 'AIza…',
+    note: 'Gemini OpenAI 兼容层',
+    builtin: true,
+  },
+  {
+    id: 'nvidia',
+    label: 'NVIDIA NIM',
+    group: 'official',
+    protocol: 'openai-compat',
+    baseUrl: 'https://integrate.api.nvidia.com/v1',
+    provider: 'openai',
+    placeholder: 'nvapi-…',
+    note: 'NVIDIA 托管推理',
+    builtin: true,
+  },
+
+  // ── 中转站 / 国内常见代理（统一 OpenAI 兼容入口，一把 Key 多模型）──
+  {
+    id: 'closeai',
+    label: 'CloseAI',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.closeai-asia.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站 · GPT/Claude/Gemini 等',
+    builtin: true,
+  },
+  {
+    id: 'api2d',
+    label: 'API2D',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://oa.api2d.net/v1',
+    provider: 'openai',
+    placeholder: 'fk…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'ohmygpt',
+    label: 'OhMyGPT',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.ohmygpt.com/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'chatanywhere',
+    label: 'ChatAnywhere',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.chatanywhere.tech/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站 · 国内直连',
+    builtin: true,
+  },
+  {
+    id: 'openai-sb',
+    label: 'OpenAI-SB',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.openai-sb.com/v1',
+    provider: 'openai',
+    placeholder: 'sb-…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'aiproxy',
+    label: 'AIProxy',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.aiproxy.io/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'poloapi',
+    label: 'PoloAPI',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.poloapi.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'yunwu',
+    label: '云雾 Yunwu',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.yunwu.ai/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站 · 多模型',
+    builtin: true,
+  },
+  {
+    id: 'apiyi',
+    label: 'API易',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.apiyi.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'gptgod',
+    label: 'GPTGod',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.gptgod.online/v1',
+    provider: 'openai',
+    placeholder: '…',
+    note: '中转站',
+    builtin: true,
+  },
+  {
+    id: 'aihubmix',
+    label: 'AiHubMix',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://aihubmix.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '中转站 · 聚合',
+    builtin: true,
+  },
+  {
+    id: 'opencs',
+    label: 'OpenCS / OneAPI 风格',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.openai.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '自建 OneAPI/NewAPI 时请改 URL',
+    builtin: true,
+  },
+  {
+    id: 'relay-claude-compat',
+    label: 'Claude 中转（OpenAI 兼容）',
+    group: 'relay',
+    protocol: 'openai-compat',
+    baseUrl: 'https://api.closeai-asia.com/v1',
+    provider: 'openai',
+    placeholder: 'sk-…',
+    note: '多数中转站用 OpenAI 格式调 Claude',
+    builtin: true,
+  },
+
+  // ── 本地 ──
+  {
+    id: 'ollama',
+    label: 'Ollama',
+    group: 'local',
+    protocol: 'openai-compat',
+    baseUrl: 'http://127.0.0.1:11434/v1',
+    provider: 'openai',
+    placeholder: 'ollama（可空）',
+    note: '本地 · ollama serve',
+    builtin: true,
+  },
+  {
+    id: 'lmstudio',
+    label: 'LM Studio',
+    group: 'local',
+    protocol: 'openai-compat',
+    baseUrl: 'http://127.0.0.1:1234/v1',
+    provider: 'openai',
+    placeholder: 'lm-studio（可空）',
+    note: '本地 · LM Studio Server',
+    builtin: true,
+  },
+  {
+    id: 'vllm',
+    label: 'vLLM',
+    group: 'local',
+    protocol: 'openai-compat',
+    baseUrl: 'http://127.0.0.1:8000/v1',
+    provider: 'openai',
+    placeholder: '（可空）',
+    note: '本地 / 自建 vLLM',
+    builtin: true,
+  },
 ]
+
+/** 旧三家 + 各入口常见默认模型；中转站只给代表性模型名，用户可自行追加。 */
+export const LLM_MODEL_CATALOG: LlmModelDef[] = [
+  // DeepSeek
+  { id: 'deepseek-flash', label: 'DeepSeek Flash', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '通用对话 / 快速', builtin: true },
+  { id: 'deepseek-pro', label: 'DeepSeek Pro', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-pro', category: 'pro', note: '深度推理', builtin: true },
+  { id: 'deepseek-flash-vision', label: 'DeepSeek Flash Vision', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash-vision-exp', category: 'flash', note: '多模态视觉', builtin: true },
+  { id: 'deepseek-chat', label: 'DeepSeek Chat', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-chat', category: 'flash', note: '经典对话', builtin: true },
+  { id: 'deepseek-reasoner', label: 'DeepSeek Reasoner', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-reasoner', category: 'pro', note: 'R1 推理', builtin: true },
+
+  // OpenAI
+  { id: 'gpt-4o', label: 'GPT-4o', endpointId: 'openai', provider: 'openai', model: 'gpt-4o', category: 'gpt', note: '通用旗舰', builtin: true },
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4o-mini', category: 'gpt', note: '轻量快速', builtin: true },
+  { id: 'gpt-4.1', label: 'GPT-4.1', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1', category: 'gpt', note: '编码增强', builtin: true },
+  { id: 'gpt-4.1-mini', label: 'GPT-4.1 mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1-mini', category: 'gpt', note: '轻量', builtin: true },
+  { id: 'o3-mini', label: 'o3-mini', endpointId: 'openai', provider: 'openai', model: 'o3-mini', category: 'gpt', note: '推理', builtin: true },
+  { id: 'o4-mini', label: 'o4-mini', endpointId: 'openai', provider: 'openai', model: 'o4-mini', category: 'gpt', note: '推理', builtin: true },
+
+  // Anthropic
+  { id: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-sonnet-20241022', category: 'claude', note: '智能均衡', builtin: true },
+  { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-haiku-20241022', category: 'claude', note: '轻量快速', builtin: true },
+  { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-sonnet-4-20250514', category: 'claude', note: '新一代', builtin: true },
+  { id: 'claude-opus-4-20250514', label: 'Claude Opus 4', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-opus-4-20250514', category: 'claude', note: '旗舰', builtin: true },
+
+  // Moonshot
+  { id: 'moonshot-v1-auto', label: 'Kimi', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-auto', category: 'other', note: '自动路由', builtin: true },
+  { id: 'kimi-k2', label: 'Kimi K2', endpointId: 'moonshot', provider: 'openai', model: 'kimi-k2-0711-preview', category: 'other', note: 'K2', builtin: true },
+
+  // 智谱
+  { id: 'glm-4-plus', label: 'GLM-4-Plus', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-plus', category: 'other', builtin: true },
+  { id: 'glm-4-flash', label: 'GLM-4-Flash', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-flash', category: 'other', note: '免费高速', builtin: true },
+  { id: 'glm-z1-air', label: 'GLM-Z1-Air', endpointId: 'zhipu', provider: 'openai', model: 'glm-z1-air', category: 'other', note: '推理', builtin: true },
+
+  // 通义
+  { id: 'qwen-max', label: 'Qwen-Max', endpointId: 'dashscope', provider: 'openai', model: 'qwen-max', category: 'other', builtin: true },
+  { id: 'qwen-plus', label: 'Qwen-Plus', endpointId: 'dashscope', provider: 'openai', model: 'qwen-plus', category: 'other', builtin: true },
+  { id: 'qwen-turbo', label: 'Qwen-Turbo', endpointId: 'dashscope', provider: 'openai', model: 'qwen-turbo', category: 'other', builtin: true },
+  { id: 'qwq-plus', label: 'QwQ-Plus', endpointId: 'dashscope', provider: 'openai', model: 'qwq-plus', category: 'other', note: '推理', builtin: true },
+
+  // 硅基流动（统一入口多模型示例）
+  { id: 'sf-deepseek-v3', label: 'DeepSeek-V3', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-V3', category: 'other', note: '硅基流动', builtin: true },
+  { id: 'sf-deepseek-r1', label: 'DeepSeek-R1', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-R1', category: 'other', note: '硅基流动', builtin: true },
+  { id: 'sf-qwen3-235b', label: 'Qwen3-235B', endpointId: 'siliconflow', provider: 'openai', model: 'Qwen/Qwen3-235B-A22B', category: 'other', note: '硅基流动', builtin: true },
+
+  // OpenRouter（统一入口）
+  { id: 'or-gpt-4o', label: 'GPT-4o', endpointId: 'openrouter', provider: 'openai', model: 'openai/gpt-4o', category: 'other', note: 'OpenRouter', builtin: true },
+  { id: 'or-claude-sonnet', label: 'Claude Sonnet', endpointId: 'openrouter', provider: 'openai', model: 'anthropic/claude-sonnet-4', category: 'other', note: 'OpenRouter', builtin: true },
+  { id: 'or-gemini-pro', label: 'Gemini Pro', endpointId: 'openrouter', provider: 'openai', model: 'google/gemini-2.5-pro', category: 'other', note: 'OpenRouter', builtin: true },
+
+  // Groq
+  { id: 'groq-llama-70b', label: 'Llama 3.3 70B', endpointId: 'groq', provider: 'openai', model: 'llama-3.3-70b-versatile', category: 'other', builtin: true },
+  { id: 'groq-qwen3-32b', label: 'Qwen3 32B', endpointId: 'groq', provider: 'openai', model: 'qwen/qwen3-32b', category: 'other', builtin: true },
+
+  // xAI
+  { id: 'grok-3', label: 'Grok 3', endpointId: 'xai', provider: 'openai', model: 'grok-3', category: 'other', builtin: true },
+  { id: 'grok-3-mini', label: 'Grok 3 Mini', endpointId: 'xai', provider: 'openai', model: 'grok-3-mini', category: 'other', builtin: true },
+
+  // Gemini OpenAI compat
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.5-pro', category: 'other', builtin: true },
+  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.5-flash', category: 'other', builtin: true },
+
+  // 中转站：同一入口挂多模型（名称按站内习惯，可改）
+  { id: 'closeai-gpt-4o', label: 'GPT-4o', endpointId: 'closeai', provider: 'openai', model: 'gpt-4o', category: 'relay', note: 'CloseAI', builtin: true },
+  { id: 'closeai-claude', label: 'Claude Sonnet', endpointId: 'closeai', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', note: 'CloseAI · OpenAI 格式', builtin: true },
+  { id: 'closeai-gemini', label: 'Gemini', endpointId: 'closeai', provider: 'openai', model: 'gemini-2.5-pro', category: 'relay', note: 'CloseAI', builtin: true },
+  { id: 'chatanywhere-gpt-4o', label: 'GPT-4o', endpointId: 'chatanywhere', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
+  { id: 'chatanywhere-gpt-4o-mini', label: 'GPT-4o mini', endpointId: 'chatanywhere', provider: 'openai', model: 'gpt-4o-mini', category: 'relay', builtin: true },
+  { id: 'yunwu-gpt-4o', label: 'GPT-4o', endpointId: 'yunwu', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
+  { id: 'yunwu-claude', label: 'Claude', endpointId: 'yunwu', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', builtin: true },
+  { id: 'aihubmix-gpt-4o', label: 'GPT-4o', endpointId: 'aihubmix', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
+  { id: 'aihubmix-claude', label: 'Claude', endpointId: 'aihubmix', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', builtin: true },
+  { id: 'relay-claude-sonnet', label: 'Claude Sonnet（兼容）', endpointId: 'relay-claude-compat', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', note: '改 URL 指向你的中转', builtin: true },
+  { id: 'relay-claude-opus', label: 'Claude Opus（兼容）', endpointId: 'relay-claude-compat', provider: 'openai', model: 'claude-opus-4-20250514', category: 'relay', note: '改 URL 指向你的中转', builtin: true },
+
+  // 本地
+  { id: 'ollama-llama', label: 'llama3.2', endpointId: 'ollama', provider: 'openai', model: 'llama3.2', category: 'local', builtin: true },
+  { id: 'ollama-qwen', label: 'qwen2.5', endpointId: 'ollama', provider: 'openai', model: 'qwen2.5', category: 'local', builtin: true },
+  { id: 'lmstudio-local', label: '当前加载模型', endpointId: 'lmstudio', provider: 'openai', model: 'local-model', category: 'local', note: '按 LM Studio 实际模型名改', builtin: true },
+]
+
+/** 兼容旧代码：仅 deepseek / openai / anthropic。 */
+export const CHAT_PROVIDERS: ChatProvider[] = ['deepseek', 'openai', 'anthropic']
 
 export function describeProvider(provider: ChatProvider): string {
   switch (provider) {
@@ -40,7 +574,35 @@ export function describeProvider(provider: ChatProvider): string {
   }
 }
 
+export function describeEndpointGroup(group: EndpointGroup): string {
+  switch (group) {
+    case 'official':
+      return '官方'
+    case 'relay':
+      return '中转站'
+    case 'local':
+      return '本地'
+    case 'custom':
+      return '自定义'
+    default:
+      return group
+  }
+}
+
 export function defaultModelFor(provider: ChatProvider): string {
   const first = LLM_MODEL_CATALOG.find((m) => m.provider === provider)
   return first?.model ?? 'deepseek-v4-flash'
+}
+
+export function findEndpointPreset(id: string): LlmEndpointDef | undefined {
+  return LLM_ENDPOINT_PRESETS.find((e) => e.id === id)
+}
+
+export function endpointProtocolProvider(endpoint: LlmEndpointDef): ChatProvider {
+  return endpoint.provider
+}
+
+/** 规范化用户输入的 baseUrl（去尾斜杠）。 */
+export function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '')
 }

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -57,6 +57,7 @@ type ModelOption = {
   id: string
   label: string
   provider: ChatProvider
+  endpointId: string
   model: string
   note?: string
 }
@@ -84,6 +85,7 @@ function matchModelOption(catalog: ModelOption[], provider: string, model: strin
       id: `${provider}:${model}`,
       label: model,
       provider: (provider as ChatProvider) ?? 'deepseek',
+      endpointId: provider || 'deepseek',
       model,
     }
   )
@@ -105,12 +107,13 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     id: 'deepseek-flash',
     label: 'DeepSeek Flash',
     provider: 'deepseek',
+    endpointId: 'deepseek',
     model: 'deepseek-chat',
   })
   const [modelBusy, setModelBusy] = useState(false)
-  /** 全部目录模型（含未配置的），用于下拉只展示已配置 provider，但当前选中可能来自任一。 */
+  /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
-  /** 各 provider 是否已配置 token。 */
+  /** 各入口是否已配置 token（key = endpointId）。 */
   const [modelProviders, setModelProviders] = useState<Record<string, boolean> | null>(null)
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
@@ -164,9 +167,19 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         (data: {
           toolCatalog?: ToolCatalogItem[]
           provider?: string
+          endpointId?: string
           model?: string
           providers?: Record<string, { configured?: boolean }>
-          modelCatalog?: Array<{ id: string; label: string; provider: string; model: string; note?: string }>
+          endpoints?: Array<{ id: string; configured?: boolean }>
+          modelCatalog?: Array<{
+            id: string
+            label: string
+            provider: string
+            endpointId?: string
+            model: string
+            note?: string
+            endpointConfigured?: boolean
+          }>
         }) => {
           if (cancelled) return
           const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
@@ -176,6 +189,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               id: m.id,
               label: m.label,
               provider: m.provider as ChatProvider,
+              endpointId: m.endpointId || m.provider,
               model: m.model,
               ...(m.note ? { note: m.note } : {}),
             }))
@@ -185,11 +199,14 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           } else if (data.provider && data.model) {
             setModelOption(matchModelOption([], data.provider, data.model))
           }
-          if (data.providers) {
-            const cfg: Record<string, boolean> = {}
-            for (const [k, v] of Object.entries(data.providers)) cfg[k] = Boolean(v?.configured)
-            setModelProviders(cfg)
+          const cfg: Record<string, boolean> = {}
+          if (Array.isArray(data.endpoints)) {
+            for (const ep of data.endpoints) cfg[ep.id] = Boolean(ep?.configured)
           }
+          if (data.providers) {
+            for (const [k, v] of Object.entries(data.providers)) cfg[k] = Boolean(v?.configured)
+          }
+          if (Object.keys(cfg).length) setModelProviders(cfg)
         },
       )
       .catch(() => {
@@ -357,7 +374,11 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       const res = await fetch('/api/chat/config', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ provider: option.provider, model: option.model }),
+        body: JSON.stringify({
+          endpointId: option.endpointId,
+          provider: option.provider,
+          model: option.model,
+        }),
       })
       if (!res.ok) return
       const data = (await res.json()) as { provider?: string; model?: string }
@@ -566,7 +587,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             {modelOpen ? (
               <div className="composer-model-menu" role="listbox" aria-label="模型">
                 {allModels
-                  .filter((m) => modelProviders?.[m.provider])
+                  .filter((m) => modelProviders?.[m.endpointId] || modelProviders?.[m.provider])
                   .map((option) => (
                     <button
                       key={option.id}
@@ -581,7 +602,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                     </button>
                   ))}
                 {allModels.length === 0 ||
-                !allModels.some((m) => modelProviders?.[m.provider]) ? (
+                !allModels.some((m) => modelProviders?.[m.endpointId] || modelProviders?.[m.provider]) ? (
                   <div className="composer-model-empty">请在 Settings → 模型与 Token 配置 API Key 后选择模型</div>
                 ) : null}
               </div>

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -1,108 +1,255 @@
-import { useEffect, useState, type FormEvent } from 'react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import type { SlotProps } from '@biu/web-slots'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
+type EndpointGroup = 'official' | 'relay' | 'local' | 'custom'
 
 interface ModelDef {
   id: string
   label: string
   provider: ChatProvider
+  endpointId: string
   model: string
   category: string
   note?: string
+  builtin?: boolean
+  endpointConfigured?: boolean
+}
+
+interface EndpointView {
+  id: string
+  label: string
+  group: EndpointGroup
+  protocol: string
+  provider: ChatProvider
+  baseUrl: string
+  defaultBaseUrl: string
+  configured: boolean
+  hint: string
+  placeholder: string
+  note?: string
+  builtin: boolean
 }
 
 interface ProviderView {
   label: string
   configured: boolean
   hint: string
+  baseUrl?: string
+  group?: string
 }
 
 interface ChatPublicConfig {
+  endpointId?: string
   provider: ChatProvider
   model: string
   configured: boolean
   hint: string
-  providers?: Record<ChatProvider, ProviderView>
+  baseUrl?: string
+  providers?: Record<string, ProviderView>
+  endpoints?: EndpointView[]
   modelCatalog?: ModelDef[]
 }
 
-const PROVIDERS: { key: ChatProvider; label: string; placeholder: string }[] = [
-  { key: 'deepseek', label: 'DeepSeek（Flash / Pro）', placeholder: 'sk-…' },
-  { key: 'anthropic', label: 'Claude', placeholder: 'sk-ant-…' },
-  { key: 'openai', label: 'GPT', placeholder: 'sk-…' },
-]
-
-const PROVIDER_ORDER: ChatProvider[] = ['deepseek', 'anthropic', 'openai']
+const GROUP_ORDER: EndpointGroup[] = ['official', 'relay', 'local', 'custom']
+const GROUP_LABEL: Record<EndpointGroup, string> = {
+  official: '官方',
+  relay: '中转站',
+  local: '本地',
+  custom: '自定义',
+}
 
 export function ChatConfig(_props: SlotProps) {
-  const [provider, setProvider] = useState<ChatProvider>('deepseek')
+  const [endpointId, setEndpointId] = useState('deepseek')
   const [model, setModel] = useState('deepseek-chat')
-  const [apiKeys, setApiKeys] = useState<Record<ChatProvider, string>>({
-    deepseek: '',
-    openai: '',
-    anthropic: '',
-  })
-  const [providers, setProviders] = useState<Record<ChatProvider, ProviderView> | null>(null)
+  const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
-  const [hint, setHint] = useState('')
+  const [apiKeyDraft, setApiKeyDraft] = useState('')
+  const [baseUrlDraft, setBaseUrlDraft] = useState('')
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
+
+  // 追加模型
+  const [newModelName, setNewModelName] = useState('')
+  const [newModelLabel, setNewModelLabel] = useState('')
+
+  // 追加自定义入口
+  const [showAddEndpoint, setShowAddEndpoint] = useState(false)
+  const [newEpLabel, setNewEpLabel] = useState('')
+  const [newEpUrl, setNewEpUrl] = useState('')
+  const [newEpProtocol, setNewEpProtocol] = useState<'openai-compat' | 'anthropic'>('openai-compat')
 
   async function load() {
     const res = await fetch('/api/chat/config')
     const data = (await res.json()) as ChatPublicConfig
-    setProvider(data.provider)
-    setModel(data.model)
-    setHint(data.hint ?? '')
+    const eps = Array.isArray(data.endpoints) ? data.endpoints : []
+    setEndpoints(eps)
     const cats = Array.isArray(data.modelCatalog) ? data.modelCatalog : []
     setModelCatalog(cats)
-    if (data.providers) setProviders(data.providers)
+    const eid = data.endpointId || data.provider || 'deepseek'
+    setEndpointId(eid)
+    setModel(data.model)
+    const ep = eps.find((e) => e.id === eid)
+    setBaseUrlDraft(ep?.baseUrl || data.baseUrl || '')
+    setApiKeyDraft('')
   }
 
   useEffect(() => {
     void load()
   }, [])
 
-  const availableModels = modelCatalog.filter((m) => m.provider === provider && providers?.[m.provider]?.configured)
-  const currentModelInCatalog = modelCatalog.find((m) => m.model === model)
-  const currentProviderConfigured = providers?.[provider]?.configured ?? false
+  const current = endpoints.find((e) => e.id === endpointId)
+  const availableModels = useMemo(
+    () => modelCatalog.filter((m) => m.endpointId === endpointId),
+    [modelCatalog, endpointId],
+  )
+  const currentModelInCatalog = availableModels.find((m) => m.model === model) ?? modelCatalog.find((m) => m.model === model)
+  const configured = current?.configured ?? false
+
+  const endpointsByGroup = useMemo(() => {
+    const map = new Map<EndpointGroup, EndpointView[]>()
+    for (const g of GROUP_ORDER) map.set(g, [])
+    for (const ep of endpoints) {
+      const g = (GROUP_ORDER.includes(ep.group) ? ep.group : 'custom') as EndpointGroup
+      map.get(g)!.push(ep)
+    }
+    return map
+  }, [endpoints])
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault()
     setError('')
     setStatus('')
-    const filled = PROVIDERS.some((p) => apiKeys[p.key].trim())
-    const hasAnyConfigured = providers
-      ? PROVIDER_ORDER.some((p) => providers[p]?.configured || apiKeys[p].trim())
-      : false
-    if (!filled && !hasAnyConfigured) {
-      setError('请至少为一个模型提供商填写 API Key，否则发消息只会本地回声，不会调用模型。')
+    if (!configured && !apiKeyDraft.trim() && current?.group !== 'local') {
+      setError('请填写 API Key，或选择本地入口（Ollama / LM Studio 等）。')
       return
     }
-    const nullIfEmpty = (v: string) => (v.trim() ? v.trim() : undefined)
+    const body: Record<string, unknown> = {
+      endpointId,
+      model,
+    }
+    if (apiKeyDraft.trim()) {
+      body.setApiKey = { [endpointId]: apiKeyDraft.trim() }
+    }
+    if (baseUrlDraft.trim() && baseUrlDraft.trim() !== (current?.defaultBaseUrl ?? '')) {
+      body.setBaseUrl = { [endpointId]: baseUrlDraft.trim() }
+    } else if (baseUrlDraft.trim() === (current?.defaultBaseUrl ?? '') && current?.baseUrl !== current?.defaultBaseUrl) {
+      // 用户把 URL 改回默认 → 清除覆盖
+      body.setBaseUrl = { [endpointId]: null }
+    }
     const res = await fetch('/api/chat/config', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        provider,
-        model,
-        setApiKey: {
-          deepseek: nullIfEmpty(apiKeys.deepseek),
-          openai: nullIfEmpty(apiKeys.openai),
-          anthropic: nullIfEmpty(apiKeys.anthropic),
-        },
-      }),
+      body: JSON.stringify(body),
     })
     if (!res.ok) {
       setError(`保存失败：HTTP ${res.status}`)
       return
     }
     const data = (await res.json()) as ChatPublicConfig
-    setHint(data.hint ?? '')
-    if (data.providers) setProviders(data.providers)
-    setApiKeys({ deepseek: '', openai: '', anthropic: '' })
-    setStatus('已保存。配置刷新后立即生效，重启后仍生效（.cordis/chat-config.json）。')
+    applyPublic(data)
+    setApiKeyDraft('')
+    setStatus('已保存。配置立即生效，重启后仍生效（.cordis/chat-config.json）。')
+  }
+
+  function applyPublic(data: ChatPublicConfig) {
+    const eps = Array.isArray(data.endpoints) ? data.endpoints : []
+    setEndpoints(eps)
+    setModelCatalog(Array.isArray(data.modelCatalog) ? data.modelCatalog : [])
+    const eid = data.endpointId || data.provider || endpointId
+    setEndpointId(eid)
+    setModel(data.model)
+    const ep = eps.find((e) => e.id === eid)
+    setBaseUrlDraft(ep?.baseUrl || data.baseUrl || '')
+  }
+
+  async function onAddModel() {
+    setError('')
+    setStatus('')
+    const modelName = newModelName.trim()
+    if (!modelName) {
+      setError('请填写模型名称（上游 API 的 model id）。')
+      return
+    }
+    const res = await fetch('/api/chat/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        addModel: {
+          endpointId,
+          model: modelName,
+          label: newModelLabel.trim() || modelName,
+        },
+      }),
+    })
+    if (!res.ok) {
+      setError(`添加模型失败：HTTP ${res.status}`)
+      return
+    }
+    applyPublic((await res.json()) as ChatPublicConfig)
+    setNewModelName('')
+    setNewModelLabel('')
+    setStatus(`已在「${current?.label ?? endpointId}」下添加模型 ${modelName}`)
+  }
+
+  async function onRemoveModel(id: string) {
+    setError('')
+    const res = await fetch('/api/chat/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ removeCustomModel: id }),
+    })
+    if (!res.ok) {
+      setError(`删除失败：HTTP ${res.status}`)
+      return
+    }
+    applyPublic((await res.json()) as ChatPublicConfig)
+    setStatus('已删除自定义模型')
+  }
+
+  async function onAddEndpoint() {
+    setError('')
+    setStatus('')
+    if (!newEpLabel.trim() || !newEpUrl.trim()) {
+      setError('请填写入口名称和模型 URL（baseUrl）。')
+      return
+    }
+    const res = await fetch('/api/chat/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        addEndpoint: {
+          label: newEpLabel.trim(),
+          baseUrl: newEpUrl.trim(),
+          protocol: newEpProtocol,
+        },
+      }),
+    })
+    if (!res.ok) {
+      setError(`添加入口失败：HTTP ${res.status}`)
+      return
+    }
+    applyPublic((await res.json()) as ChatPublicConfig)
+    setShowAddEndpoint(false)
+    setNewEpLabel('')
+    setNewEpUrl('')
+    setNewEpProtocol('openai-compat')
+    setStatus('已添加自定义入口，请填写 Key 并添加模型名。')
+  }
+
+  async function onRemoveEndpoint(id: string) {
+    setError('')
+    const res = await fetch('/api/chat/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ removeCustomEndpoint: id }),
+    })
+    if (!res.ok) {
+      setError(`删除失败：HTTP ${res.status}`)
+      return
+    }
+    applyPublic((await res.json()) as ChatPublicConfig)
+    setStatus('已删除自定义入口')
   }
 
   const inputCls = [
@@ -111,6 +258,11 @@ export function ChatConfig(_props: SlotProps) {
     'transition-colors',
   ].join(' ')
   const labelCls = 'text-[11px] font-semibold text-[var(--dsw-label-3)]'
+  const btnSecondary = [
+    'rounded-[8px] px-2.5 py-[6px] text-[12px] font-medium',
+    'border border-[var(--dsw-border)] text-[var(--dsw-label)]',
+    'hover:bg-[color-mix(in_srgb,var(--dsw-muted-fill)_50%,transparent)]',
+  ].join(' ')
 
   return (
     <form
@@ -118,87 +270,203 @@ export function ChatConfig(_props: SlotProps) {
       data-testid="assistant-config"
       onSubmit={onSubmit}
     >
-      {/* API Key：每个 provider 独立 */}
-      <section className="flex flex-col gap-2.5">
-        <span className={labelCls}>API Key</span>
-        {PROVIDERS.map((p) => {
-          const view = providers?.[p.key]
-          return (
-            <label key={p.key} className="flex flex-col gap-1">
-              <span className="flex items-center gap-1.5 text-[12px] font-medium text-[var(--dsw-label)]">
-                <span
-                  className={`inline-block size-1.5 rounded-full ${
-                    view?.configured ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-40'
-                  }`}
-                />
-                {p.label}
-              </span>
-              <input
-                className={inputCls}
-                type="password"
-                autoComplete="off"
-                placeholder={view?.configured ? `已配置 · 输入可覆盖 (${view.hint})` : p.placeholder}
-                value={apiKeys[p.key]}
-                onChange={(e) => setApiKeys((prev) => ({ ...prev, [p.key]: e.target.value }))}
-              />
-            </label>
-          )
-        })}
-      </section>
+      <p className="text-[11px] leading-relaxed text-[var(--dsw-label-2)]">
+        统一入口多模型：选一个官方 / 中转站 / 本地入口，共用一把 Key 与一个 URL，下面可挂多个模型名。也可添加自定义中转 URL。
+      </p>
 
-      {/* 模型选择：只列已验证 provider 的模型 */}
+      {/* 入口选择 */}
       <section className="flex flex-col gap-2.5">
-        <span className={labelCls}>Model</span>
-        <div className="flex gap-3">
-          <label className="flex w-1/3 flex-col gap-1">
-            <select
-              className={inputCls}
-              value={provider}
-              data-testid="provider"
-              onChange={(event) => {
-                const next = event.target.value as ChatProvider
-                setProvider(next)
-                const def = modelCatalog.find((m) => m.provider === next)
-                if (def) setModel(def.model)
-              }}
-            >
-              {PROVIDER_ORDER.map((key) => (
-                <option key={key} value={key}>
-                  {providers?.[key]?.label ?? key} {providers?.[key]?.configured ? '（已配置）' : '（未配置）'}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex w-2/3 flex-col gap-1">
-            {availableModels.length > 0 ? (
-              <select
-                className={inputCls}
-                value={currentModelInCatalog?.id ?? model}
-                data-testid="model"
-                onChange={(event) => {
-                  const def = modelCatalog.find((m) => m.id === event.target.value)
-                  if (def) setModel(def.model)
-                }}
-              >
-                {availableModels.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.label}
-                    {m.note ? ` — ${m.note}` : ''}
+        <span className={labelCls}>模型入口</span>
+        <select
+          className={inputCls}
+          value={endpointId}
+          data-testid="endpoint"
+          onChange={(event) => {
+            const next = event.target.value
+            setEndpointId(next)
+            const ep = endpoints.find((e) => e.id === next)
+            setBaseUrlDraft(ep?.baseUrl ?? '')
+            setApiKeyDraft('')
+            const def = modelCatalog.find((m) => m.endpointId === next)
+            if (def) setModel(def.model)
+          }}
+        >
+          {GROUP_ORDER.map((g) => {
+            const list = endpointsByGroup.get(g) ?? []
+            if (!list.length) return null
+            return (
+              <optgroup key={g} label={GROUP_LABEL[g]}>
+                {list.map((ep) => (
+                  <option key={ep.id} value={ep.id}>
+                    {ep.label}
+                    {ep.configured ? '（已配置）' : '（未配置）'}
+                    {ep.note ? ` · ${ep.note}` : ''}
                   </option>
                 ))}
-              </select>
-            ) : (
-              <div className="rounded-[8px] bg-[color-mix(in_srgb,var(--dsw-muted-fill)_40%,transparent)] px-2.5 py-2 text-[11px] text-[var(--dsw-label-2)]">
-                当前提供商尚未配置 API Key，配置后即可选择其模型。
-              </div>
-            )}
-          </label>
-        </div>
-        {!currentProviderConfigured ? (
+              </optgroup>
+            )
+          })}
+        </select>
+
+        <label className="flex flex-col gap-1">
+          <span className="flex items-center gap-1.5 text-[12px] font-medium text-[var(--dsw-label)]">
+            <span
+              className={`inline-block size-1.5 rounded-full ${
+                configured ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-40'
+              }`}
+            />
+            API Key
+            {current?.hint ? (
+              <span className="font-normal text-[var(--dsw-label-3)]">· {current.hint}</span>
+            ) : null}
+          </span>
+          <input
+            className={inputCls}
+            type="password"
+            autoComplete="off"
+            placeholder={
+              configured
+                ? `已配置 · 输入可覆盖 (${current?.placeholder ?? 'sk-…'})`
+                : current?.placeholder ?? 'sk-…'
+            }
+            value={apiKeyDraft}
+            onChange={(e) => setApiKeyDraft(e.target.value)}
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[12px] font-medium text-[var(--dsw-label)]">模型 URL（baseUrl）</span>
+          <input
+            className={inputCls}
+            type="url"
+            autoComplete="off"
+            data-testid="base-url"
+            placeholder="https://api.example.com/v1"
+            value={baseUrlDraft}
+            onChange={(e) => setBaseUrlDraft(e.target.value)}
+          />
+          <span className="text-[10px] text-[var(--dsw-label-3)]">
+            不含 /chat/completions；中转站填站方文档中的根地址。默认：{current?.defaultBaseUrl || '—'}
+          </span>
+        </label>
+
+        {current && !current.builtin ? (
+          <button type="button" className={btnSecondary} onClick={() => void onRemoveEndpoint(current.id)}>
+            删除此自定义入口
+          </button>
+        ) : null}
+      </section>
+
+      {/* 模型选择 + 追加 */}
+      <section className="flex flex-col gap-2.5">
+        <span className={labelCls}>模型名称</span>
+        {availableModels.length > 0 ? (
+          <select
+            className={inputCls}
+            value={currentModelInCatalog?.id ?? model}
+            data-testid="model"
+            onChange={(event) => {
+              const def = modelCatalog.find((m) => m.id === event.target.value)
+              if (def) setModel(def.model)
+              else setModel(event.target.value)
+            }}
+          >
+            {availableModels.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label} ({m.model})
+                {m.note ? ` — ${m.note}` : ''}
+              </option>
+            ))}
+          </select>
+        ) : (
           <div className="rounded-[8px] bg-[color-mix(in_srgb,var(--dsw-muted-fill)_40%,transparent)] px-2.5 py-2 text-[11px] text-[var(--dsw-label-2)]">
-            当前选中的提供商未配置 Key：发消息会本地回声，不会调用模型。
+            当前入口尚无模型，请在下方添加模型名称。
+          </div>
+        )}
+
+        <div className="flex flex-col gap-1.5 rounded-[8px] border border-dashed border-[var(--dsw-border)] p-2.5">
+          <span className="text-[11px] font-medium text-[var(--dsw-label)]">在此入口追加模型</span>
+          <div className="flex gap-2">
+            <input
+              className={inputCls}
+              placeholder="模型名称 model id，如 gpt-4o"
+              value={newModelName}
+              onChange={(e) => setNewModelName(e.target.value)}
+            />
+            <input
+              className={`${inputCls} max-w-[140px]`}
+              placeholder="展示名（可选）"
+              value={newModelLabel}
+              onChange={(e) => setNewModelLabel(e.target.value)}
+            />
+            <button type="button" className={btnSecondary} onClick={() => void onAddModel()}>
+              添加
+            </button>
+          </div>
+          {availableModels.some((m) => m.builtin === false) ? (
+            <ul className="mt-1 flex flex-col gap-1">
+              {availableModels
+                .filter((m) => m.builtin === false)
+                .map((m) => (
+                  <li key={m.id} className="flex items-center justify-between text-[11px] text-[var(--dsw-label-2)]">
+                    <span>
+                      {m.label} <code className="text-[10px]">{m.model}</code>
+                    </span>
+                    <button type="button" className="text-[var(--dsw-danger,#b42318)]" onClick={() => void onRemoveModel(m.id)}>
+                      删除
+                    </button>
+                  </li>
+                ))}
+            </ul>
+          ) : null}
+        </div>
+
+        {!configured && current?.group !== 'local' ? (
+          <div className="rounded-[8px] bg-[color-mix(in_srgb,var(--dsw-muted-fill)_40%,transparent)] px-2.5 py-2 text-[11px] text-[var(--dsw-label-2)]">
+            当前入口未配置 Key：发消息会本地回声，不会调用模型。
           </div>
         ) : null}
+      </section>
+
+      {/* 自定义入口 */}
+      <section className="flex flex-col gap-2">
+        {!showAddEndpoint ? (
+          <button type="button" className={btnSecondary} onClick={() => setShowAddEndpoint(true)}>
+            + 添加自定义中转 / URL
+          </button>
+        ) : (
+          <div className="flex flex-col gap-2 rounded-[8px] border border-[var(--dsw-border)] p-2.5">
+            <span className={labelCls}>自定义入口</span>
+            <input
+              className={inputCls}
+              placeholder="名称，如 我的 OneAPI"
+              value={newEpLabel}
+              onChange={(e) => setNewEpLabel(e.target.value)}
+            />
+            <input
+              className={inputCls}
+              placeholder="模型 URL，如 https://gate.example.com/v1"
+              value={newEpUrl}
+              onChange={(e) => setNewEpUrl(e.target.value)}
+            />
+            <select
+              className={inputCls}
+              value={newEpProtocol}
+              onChange={(e) => setNewEpProtocol(e.target.value as 'openai-compat' | 'anthropic')}
+            >
+              <option value="openai-compat">OpenAI 兼容（chat/completions）</option>
+              <option value="anthropic">Anthropic Messages</option>
+            </select>
+            <div className="flex gap-2">
+              <button type="button" className={btnSecondary} onClick={() => void onAddEndpoint()}>
+                确认添加
+              </button>
+              <button type="button" className={btnSecondary} onClick={() => setShowAddEndpoint(false)}>
+                取消
+              </button>
+            </div>
+          </div>
+        )}
       </section>
 
       <div className="flex flex-1 items-end justify-end gap-2">

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -6,6 +6,34 @@ export interface LlmConfig {
   provider: ChatProvider
   apiKey: string
   model: string
+  /**
+   * 可选自定义 API 根地址（官方 / 中转站 / 本地）。
+   * openai-compat：拼 `/chat/completions`；anthropic：拼 `/messages`。
+   * 也可直接传入已含后缀的完整 URL。
+   */
+  baseUrl?: string
+}
+
+/** 把用户配置的 baseUrl 解析成 chat.completions 完整地址。 */
+export function resolveChatCompletionsUrl(baseUrl: string | undefined, provider: ChatProvider): string {
+  if (baseUrl?.trim()) {
+    const trimmed = baseUrl.trim().replace(/\/+$/, '')
+    if (/\/chat\/completions$/i.test(trimmed)) return trimmed
+    return `${trimmed}/chat/completions`
+  }
+  return provider === 'deepseek'
+    ? 'https://api.deepseek.com/chat/completions'
+    : 'https://api.openai.com/v1/chat/completions'
+}
+
+/** 把用户配置的 baseUrl 解析成 Anthropic messages 完整地址。 */
+export function resolveAnthropicMessagesUrl(baseUrl: string | undefined): string {
+  if (baseUrl?.trim()) {
+    const trimmed = baseUrl.trim().replace(/\/+$/, '')
+    if (/\/messages$/i.test(trimmed)) return trimmed
+    return `${trimmed}/messages`
+  }
+  return 'https://api.anthropic.com/v1/messages'
 }
 
 /** DeepSeek 视觉模型：检测到图片输入时自动路由到它。 */
@@ -218,10 +246,7 @@ export class OpenAiCompatLlm implements LlmClient {
     signal?: AbortSignal,
     options?: ChatOptions,
   ): Promise<AssistantReply> {
-    const url =
-      this.config.provider === 'deepseek'
-        ? 'https://api.deepseek.com/chat/completions'
-        : 'https://api.openai.com/v1/chat/completions'
+    const url = resolveChatCompletionsUrl(this.config.baseUrl, this.config.provider)
     // 仅 deepseek provider 支持自动路由到视觉模型；openai/anthropic 保持配置原状。
     const hasImage = messages.some((m) => hasImageContent(m.content))
     const model =
@@ -271,8 +296,6 @@ export class OpenAiCompatLlm implements LlmClient {
  *  - 结束由 `message_stop` 标志，无 `[DONE]`。
  */
 export class AnthropicLlm implements LlmClient {
-  private endpoint = 'https://api.anthropic.com/v1/messages'
-
   constructor(private config: LlmConfig) {}
 
   async chat(
@@ -281,6 +304,7 @@ export class AnthropicLlm implements LlmClient {
     signal?: AbortSignal,
     options?: ChatOptions,
   ): Promise<AssistantReply> {
+    const endpoint = resolveAnthropicMessagesUrl(this.config.baseUrl)
     const system = messages
       .filter((m) => m.role === 'system')
       .map((m) => m.content ?? '')
@@ -326,7 +350,7 @@ export class AnthropicLlm implements LlmClient {
         }
       })
     }
-    const res = await fetch(this.endpoint, {
+    const res = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'x-api-key': this.config.apiKey,

--- a/public/f1.svg
+++ b/public/f1.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" fill="none">
+  <!-- F1-inspired racing mark: checkered + speed stripe -->
+  <rect width="64" height="64" rx="12" fill="#111"/>
+  <g fill="#fff">
+    <rect x="8" y="10" width="8" height="8"/>
+    <rect x="24" y="10" width="8" height="8"/>
+    <rect x="16" y="18" width="8" height="8"/>
+    <rect x="32" y="18" width="8" height="8"/>
+    <rect x="8" y="26" width="8" height="8"/>
+    <rect x="24" y="26" width="8" height="8"/>
+  </g>
+  <g fill="#e10600">
+    <path d="M28 38h28l-6 8H22l6-8z"/>
+    <path d="M22 46h26l-4 6H18l4-6z"/>
+  </g>
+  <circle cx="18" cy="52" r="4" fill="#ddd"/>
+  <circle cx="42" cy="52" r="4" fill="#ddd"/>
+  <circle cx="18" cy="52" r="1.6" fill="#111"/>
+  <circle cx="42" cy="52" r="1.6" fill="#111"/>
+</svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

1. **README**：增加 slogan「天生驾驶者」，并配 F1 图标（`public/f1.svg`）。
2. **模型配置**：
   - 支持配置 **模型 URL（baseUrl）** 与 **模型名称**
   - **统一入口多模型**：同一入口（一把 Key + 一个 URL）下可挂多个模型名
   - 内置官方入口（DeepSeek / OpenAI / Anthropic / Moonshot / 智谱 / 通义 / 硅基流动 / OpenRouter / Groq / xAI 等）
   - 内置常见 **中转站**（CloseAI、API2D、OhMyGPT、ChatAnywhere、Yunwu、AiHubMix 等）与本地（Ollama / LM Studio / vLLM）
   - Settings 可覆盖 URL、追加模型名、添加自定义中转入口

## 实现要点

- `LlmConfig.baseUrl` → OpenAI 兼容与 Anthropic 客户端均支持自定义根地址
- `chat-config.json` 持久化 `endpointId` / `baseUrls` / `customEndpoints` / `customModels`
- 模型选择器按入口是否已配置 Key 过滤

## 测试

- `model-catalog` / URL 解析单测
- `tsc --noEmit` 通过

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bc2719a-7efb-45af-8aa8-91cbc5d70ce8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bc2719a-7efb-45af-8aa8-91cbc5d70ce8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

