### PR TITLE
feat(model-config): 输入框旁配置模型弹层（暂不合并）

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ make          # 安装依赖，同时起 host 与 Vite
 | UI | http://127.0.0.1:5173 |
 | API / WS | http://127.0.0.1:3141 |
 
-未配置 Key 时，发送消息只会得到本地回声。请点击输入框旁的 **＋ 配置模型**，或：
+未配置 Key 时，发送消息只会得到本地回声。请打开模型选择菜单右上角的 **设置**，或：
 
 ```bash
 export DEEPSEEK_API_KEY=...     # 或 OPENAI_API_KEY / ANTHROPIC_API_KEY

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ make          # 安装依赖，同时起 host 与 Vite
 | UI | http://127.0.0.1:5173 |
 | API / WS | http://127.0.0.1:3141 |
 
-未配置 Key 时，发送消息只会得到本地回声。请打开 **Settings → Models**，或：
+未配置 Key 时，发送消息只会得到本地回声。请点击输入框旁的 **＋ 配置模型**，或：
 
 ```bash
 export DEEPSEEK_API_KEY=...     # 或 OPENAI_API_KEY / ANTHROPIC_API_KEY

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -49,6 +49,11 @@ interface ChatConfig {
   customEndpoints: LlmEndpointDef[]
   /** 用户在某入口下追加的模型名。 */
   customModels: LlmModelDef[]
+  /**
+   * 探测失败 / 用户主动断开的入口：强制视为未配置，
+   * 避免坏 Key（含环境变量）仍显示绿点并出现在模型下拉。
+   */
+  blockedEndpoints: string[]
   model: string
   systemPrompt: string
   agentMode: AgentToolMode
@@ -80,6 +85,7 @@ function defaults(): ChatConfig {
     baseUrls: {},
     customEndpoints: [],
     customModels: [],
+    blockedEndpoints: [],
     model:
       process.env.CHAT_MODEL ||
       (provider === 'openai' ? 'gpt-4o-mini' : provider === 'anthropic' ? 'claude-3-5-sonnet-20241022' : 'deepseek-v4-flash'),
@@ -120,6 +126,7 @@ function writePersisted(config: ChatConfig) {
         baseUrls: config.baseUrls,
         customEndpoints: config.customEndpoints,
         customModels: config.customModels,
+        blockedEndpoints: config.blockedEndpoints,
       },
       null,
       2,
@@ -261,6 +268,9 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     baseUrls,
     customEndpoints,
     customModels,
+    blockedEndpoints: Array.isArray(saved.blockedEndpoints)
+      ? [...new Set(saved.blockedEndpoints.map((id) => String(id).trim()).filter(Boolean))]
+      : [],
     model: !process.env.CHAT_MODEL && typeof saved.model === 'string' && saved.model.trim() ? saved.model.trim() : base.model,
     systemPrompt: typeof saved.systemPrompt === 'string' ? saved.systemPrompt : base.systemPrompt,
     agentMode: parseAgentMode(saved.agentMode, base.agentMode),
@@ -295,11 +305,20 @@ function effectiveBaseUrl(config: ChatConfig, endpoint: LlmEndpointDef): string 
   return override?.trim() ? normalizeBaseUrl(override) : endpoint.baseUrl
 }
 
-/** 入口是否已配置：有 Key，或本地入口（允许空 Key）。 */
+/** 入口是否已配置：有 Key（或本地入口），且未被探测失败拉黑。 */
 function endpointConfigured(config: ChatConfig, endpoint: LlmEndpointDef): boolean {
+  if (config.blockedEndpoints.includes(endpoint.id)) return false
   const key = (config.apiKeys[endpoint.id] ?? '').trim()
   if (key) return true
   return isLocalEndpoint(endpoint)
+}
+
+function unblockEndpoint(config: ChatConfig, id: string) {
+  config.blockedEndpoints = config.blockedEndpoints.filter((x) => x !== id)
+}
+
+function blockEndpoint(config: ChatConfig, id: string) {
+  if (!config.blockedEndpoints.includes(id)) config.blockedEndpoints.push(id)
 }
 
 export class ChatService extends Service {
@@ -480,6 +499,59 @@ export class ChatService extends Service {
   }
 
   /**
+   * 探测失败：拉黑入口（绿点变灰、模型下拉不可选）。
+   * 保留已存 Key 便于改 URL 后重试；若当前默认就是该入口，切到其它已配置入口。
+   */
+  invalidateEndpoint(endpointId: string, opts?: { persist?: boolean }) {
+    const id = endpointId.trim()
+    if (!id) return this.publicView()
+    blockEndpoint(this.config, id)
+    if (this.config.endpointId === id) {
+      const fallback =
+        allEndpoints(this.config).find((ep) => ep.id !== id && endpointConfigured(this.config, ep)) ??
+        findEndpointPreset(DEFAULT_PROVIDER)
+      if (fallback) {
+        this.config.endpointId = fallback.id
+        this.config.provider = fallback.provider
+        this.config.model =
+          allModels(this.config).find((m) => m.endpointId === fallback.id)?.model ??
+          defaultModelFor(fallback.provider)
+      }
+    }
+    this.syncLlm()
+    if (opts?.persist !== false) {
+      try {
+        writePersisted(this.config)
+      } catch (error) {
+        console.warn('[chat] failed to persist config', error)
+      }
+    }
+    return this.publicView()
+  }
+
+  /** 探测成功：解除拉黑（Key 仍由调用方决定是否写入）。 */
+  markEndpointReachable(endpointId: string, opts?: { persist?: boolean; apiKey?: string; baseUrl?: string }) {
+    const id = endpointId.trim()
+    if (!id) return this.publicView()
+    unblockEndpoint(this.config, id)
+    if (typeof opts?.apiKey === 'string' && opts.apiKey.trim()) {
+      this.config.apiKeys[id] = opts.apiKey.trim()
+    }
+    if (typeof opts?.baseUrl === 'string' && opts.baseUrl.trim()) {
+      this.config.baseUrls[id] = normalizeBaseUrl(opts.baseUrl)
+    }
+    this.syncLlm()
+    if (opts?.persist !== false) {
+      try {
+        writePersisted(this.config)
+      } catch (error) {
+        console.warn('[chat] failed to persist config', error)
+      }
+    }
+    return this.publicView()
+  }
+
+  /**
    * 更新配置。endpointId/provider/model/systemPrompt/agentMode/extraTools 直接覆盖；
    * setApiKey / setBaseUrl 按入口写入；空串表示保留原值，仅非空时更新。
    * addEndpoint / addModel / removeCustom* 管理自定义入口与模型。
@@ -494,8 +566,8 @@ export class ChatService extends Service {
       systemPrompt: string
       agentMode: AgentToolMode
       extraTools: string[]
-      /** 按入口更新 key */
-      setApiKey: Partial<Record<string, string>>
+      /** 按入口更新 key；空串 / null 清除 */
+      setApiKey: Partial<Record<string, string | null>>
       /** 按入口覆盖 baseUrl；空串清除覆盖、回到 preset 默认 */
       setBaseUrl: Partial<Record<string, string | null>>
       /** 追加自定义入口 */
@@ -532,7 +604,14 @@ export class ChatService extends Service {
     }
     if (next.setApiKey && typeof next.setApiKey === 'object') {
       for (const [id, key] of Object.entries(next.setApiKey)) {
-        if (typeof key === 'string' && key.trim()) this.config.apiKeys[id] = key.trim()
+        // 空串 / null：清除 Key（测试失败或断开时用）
+        if (key === null || key === '') {
+          delete this.config.apiKeys[id]
+          blockEndpoint(this.config, id)
+        } else if (typeof key === 'string' && key.trim()) {
+          this.config.apiKeys[id] = key.trim()
+          unblockEndpoint(this.config, id)
+        }
       }
     }
     if (next.setBaseUrl && typeof next.setBaseUrl === 'object') {
@@ -547,6 +626,7 @@ export class ChatService extends Service {
     // 兼容旧调用：单一 apiKey 写入当前入口
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) {
       this.config.apiKeys[this.config.endpointId] = next.apiKey.trim()
+      unblockEndpoint(this.config, this.config.endpointId)
     }
     if (next.addEndpoint && typeof next.addEndpoint === 'object') {
       const label = String(next.addEndpoint.label ?? '').trim()
@@ -640,6 +720,7 @@ export class ChatService extends Service {
       this.config.customModels = this.config.customModels.filter((m) => m.endpointId !== id)
       delete this.config.apiKeys[id]
       delete this.config.baseUrls[id]
+      unblockEndpoint(this.config, id)
       if (this.config.endpointId === id) {
         this.config.endpointId = DEFAULT_PROVIDER
         this.config.provider = DEFAULT_PROVIDER
@@ -789,7 +870,7 @@ export function apply(ctx: Context) {
       systemPrompt: string
       agentMode: AgentToolMode
       extraTools: string[]
-      setApiKey: Partial<Record<string, string>>
+      setApiKey: Partial<Record<string, string | null>>
       setBaseUrl: Partial<Record<string, string | null>>
       addEndpoint: { id?: string; label: string; baseUrl: string; protocol?: 'openai-compat' | 'anthropic'; provider?: ChatProvider; note?: string }
       addModel: { endpointId: string; model: string; label?: string; note?: string }
@@ -807,7 +888,20 @@ export function apply(ctx: Context) {
     }
     try {
       const result = await chat.testConnection(payload)
-      route.send(result.ok ? 200 : 400, result)
+      if (result.ok) {
+        const config = chat.markEndpointReachable(result.endpointId, {
+          ...(typeof payload.apiKey === 'string' && payload.apiKey.trim()
+            ? { apiKey: payload.apiKey.trim() }
+            : {}),
+          ...(typeof payload.baseUrl === 'string' && payload.baseUrl.trim()
+            ? { baseUrl: payload.baseUrl.trim() }
+            : {}),
+        })
+        route.send(200, { ...result, config })
+        return
+      }
+      const config = chat.invalidateEndpoint(result.endpointId)
+      route.send(400, { ...result, config })
     } catch (error) {
       route.send(500, { ok: false, detail: String(error) })
     }

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -4,6 +4,7 @@ import { Service, type Context } from 'cordis'
 import type { ChatMessage } from './chat-types.ts'
 import type { AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
+import { probeLlmConnection } from '@biu/host-llm'
 import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl } from './model-catalog.ts'
 import type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
 export type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
@@ -444,6 +445,40 @@ export class ChatService extends Service {
     }
   }
 
+  /** 探测指定入口连通性；可临时覆盖草稿 Key / URL / model（不落盘）。 */
+  async testConnection(opts?: {
+    endpointId?: string
+    apiKey?: string
+    baseUrl?: string
+    model?: string
+  }) {
+    const endpointId = (opts?.endpointId || this.config.endpointId || this.config.provider).trim()
+    const endpoint = resolveEndpoint(this.config, endpointId)
+    if (!endpoint) {
+      return { ok: false as const, latencyMs: 0, detail: `未知入口：${endpointId}`, endpointId }
+    }
+    const draftKey = typeof opts?.apiKey === 'string' ? opts.apiKey.trim() : ''
+    const storedKey = (this.config.apiKeys[endpointId] ?? '').trim()
+    const apiKey = draftKey || storedKey || (isLocalEndpoint(endpoint) ? 'local' : '')
+    const baseUrl =
+      typeof opts?.baseUrl === 'string' && opts.baseUrl.trim()
+        ? normalizeBaseUrl(opts.baseUrl)
+        : effectiveBaseUrl(this.config, endpoint)
+    const model =
+      (typeof opts?.model === 'string' && opts.model.trim()) ||
+      allModels(this.config).find((m) => m.endpointId === endpointId)?.model ||
+      this.config.model ||
+      defaultModelFor(endpoint.provider)
+
+    const result = await probeLlmConnection({
+      provider: endpoint.provider,
+      apiKey,
+      model,
+      baseUrl,
+    })
+    return { ...result, endpointId, baseUrl, model }
+  }
+
   /**
    * 更新配置。endpointId/provider/model/systemPrompt/agentMode/extraTools 直接覆盖；
    * setApiKey / setBaseUrl 按入口写入；空串表示保留原值，仅非空时更新。
@@ -762,6 +797,20 @@ export function apply(ctx: Context) {
       removeCustomModel: string
     }>
     route.send(200, chat.patch(payload ?? {}))
+  })
+  ctx.http.route('POST', '/api/chat/config/test', async (route) => {
+    const payload = ((await route.json().catch(() => null)) ?? {}) as {
+      endpointId?: string
+      apiKey?: string
+      baseUrl?: string
+      model?: string
+    }
+    try {
+      const result = await chat.testConnection(payload)
+      route.send(result.ok ? 200 : 400, result)
+    } catch (error) {
+      route.send(500, { ok: false, detail: String(error) })
+    }
   })
   ctx.http.route('POST', '/api/sessions', async (route) => {
     const payload = ((await route.json().catch(() => null)) ?? {}) as {

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -545,6 +545,33 @@ export class ChatService extends Service {
         else this.config.customEndpoints.push(def)
         this.config.endpointId = id
         this.config.provider = provider
+        // 自定义入口默认挂一批常用模型名，避免下拉空空如也
+        const hasModels = allModels(this.config).some((m) => m.endpointId === id)
+        if (!hasModels) {
+          const seeds = [
+            'gpt-4o',
+            'gpt-4o-mini',
+            'gpt-4.1',
+            'o3-mini',
+            'claude-sonnet-4-20250514',
+            'claude-opus-4-20250514',
+            'gemini-2.5-pro',
+            'deepseek-chat',
+            'deepseek-reasoner',
+          ]
+          for (const modelName of seeds) {
+            this.config.customModels.push({
+              id: `custom-model-${id}-${modelName}`.replace(/[^a-zA-Z0-9._:-]+/g, '-'),
+              label: modelName,
+              endpointId: id,
+              provider,
+              model: modelName,
+              category: 'custom',
+              builtin: false,
+            })
+          }
+          this.config.model = seeds[0]!
+        }
       }
     }
     if (next.addModel && typeof next.addModel === 'object') {

--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -82,7 +82,7 @@ function defaults(): ChatConfig {
     customModels: [],
     model:
       process.env.CHAT_MODEL ||
-      (provider === 'openai' ? 'gpt-4o-mini' : provider === 'anthropic' ? 'claude-3-5-sonnet-20241022' : 'deepseek-chat'),
+      (provider === 'openai' ? 'gpt-4o-mini' : provider === 'anthropic' ? 'claude-3-5-sonnet-20241022' : 'deepseek-v4-flash'),
     systemPrompt: '你是控制台里的助手。需要时调用当前已注册的 tools；插件卸载后对应 tool 会消失。回答简洁。',
     agentMode: 'standard',
     extraTools: [],

--- a/packages/cap-chat/src/host/model-catalog.test.ts
+++ b/packages/cap-chat/src/host/model-catalog.test.ts
@@ -55,7 +55,12 @@ test('official providers ship a rich model catalog', () => {
   const deepseek = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'deepseek')
   const openai = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'openai')
   const anthropic = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'anthropic')
-  assert.ok(deepseek.length >= 5, `deepseek=${deepseek.length}`)
+  assert.ok(deepseek.length >= 3, `deepseek=${deepseek.length}`)
+  assert.ok(deepseek.length <= 3, `deepseek should be flash/pro/vision only, got ${deepseek.length}`)
+  assert.deepEqual(
+    deepseek.map((m) => m.model).sort(),
+    ['deepseek-v4-flash', 'deepseek-v4-flash-vision-exp', 'deepseek-v4-pro'].sort(),
+  )
   assert.ok(openai.length >= 15, `openai=${openai.length}`)
   assert.ok(anthropic.length >= 8, `anthropic=${anthropic.length}`)
   assert.ok(LLM_MODEL_CATALOG.length >= 100, `total=${LLM_MODEL_CATALOG.length}`)

--- a/packages/cap-chat/src/host/model-catalog.test.ts
+++ b/packages/cap-chat/src/host/model-catalog.test.ts
@@ -51,6 +51,23 @@ test('builtin models reference known endpoints', () => {
   }
 })
 
+test('official providers ship a rich model catalog', () => {
+  const deepseek = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'deepseek')
+  const openai = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'openai')
+  const anthropic = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'anthropic')
+  assert.ok(deepseek.length >= 5, `deepseek=${deepseek.length}`)
+  assert.ok(openai.length >= 15, `openai=${openai.length}`)
+  assert.ok(anthropic.length >= 8, `anthropic=${anthropic.length}`)
+  assert.ok(LLM_MODEL_CATALOG.length >= 100, `total=${LLM_MODEL_CATALOG.length}`)
+})
+
+test('relay endpoints share a multi-model pack', () => {
+  const closeai = LLM_MODEL_CATALOG.filter((m) => m.endpointId === 'closeai')
+  assert.ok(closeai.length >= 15, `closeai=${closeai.length}`)
+  assert.ok(closeai.some((m) => m.model === 'gpt-4o'))
+  assert.ok(closeai.some((m) => m.model.includes('claude')))
+})
+
 test('normalizeBaseUrl strips trailing slash', () => {
   assert.equal(normalizeBaseUrl(' https://a.com/v1/ '), 'https://a.com/v1')
 })

--- a/packages/cap-chat/src/host/model-catalog.ts
+++ b/packages/cap-chat/src/host/model-catalog.ts
@@ -518,13 +518,10 @@ function relayPack(endpointId: string, note?: string): LlmModelDef[] {
 
 /** 官方三家 + 各入口内置模型（尽量全；中转站复用统一模型包）。 */
 export const LLM_MODEL_CATALOG: LlmModelDef[] = [
-  // ── DeepSeek 官方 ──
-  { id: 'deepseek-chat', label: 'DeepSeek Chat', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-chat', category: 'flash', note: 'V3 对话', builtin: true },
-  { id: 'deepseek-reasoner', label: 'DeepSeek Reasoner', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-reasoner', category: 'pro', note: 'R1 推理', builtin: true },
-  { id: 'deepseek-flash', label: 'DeepSeek Flash', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '快速', builtin: true },
+  // ── DeepSeek 官方（仅 Flash / Pro / Vision）──
+  { id: 'deepseek-flash', label: 'DeepSeek Flash', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '通用 / 快速', builtin: true },
   { id: 'deepseek-pro', label: 'DeepSeek Pro', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-pro', category: 'pro', note: '深度推理', builtin: true },
   { id: 'deepseek-flash-vision', label: 'DeepSeek Flash Vision', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash-vision-exp', category: 'flash', note: '视觉', builtin: true },
-  { id: 'deepseek-coder', label: 'DeepSeek Coder', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-coder', category: 'flash', note: '代码', builtin: true },
 
   // ── OpenAI 官方 ──
   { id: 'gpt-4o', label: 'GPT-4o', endpointId: 'openai', provider: 'openai', model: 'gpt-4o', category: 'gpt', note: '通用旗舰', builtin: true },
@@ -709,8 +706,9 @@ export function describeEndpointGroup(group: EndpointGroup): string {
 }
 
 export function defaultModelFor(provider: ChatProvider): string {
+  if (provider === 'deepseek') return 'deepseek-v4-flash'
   const first = LLM_MODEL_CATALOG.find((m) => m.provider === provider && m.endpointId === provider)
-  return first?.model ?? LLM_MODEL_CATALOG.find((m) => m.provider === provider)?.model ?? 'deepseek-chat'
+  return first?.model ?? LLM_MODEL_CATALOG.find((m) => m.provider === provider)?.model ?? 'deepseek-v4-flash'
 }
 
 export function modelsForEndpoint(endpointId: string): LlmModelDef[] {

--- a/packages/cap-chat/src/host/model-catalog.ts
+++ b/packages/cap-chat/src/host/model-catalog.ts
@@ -479,83 +479,202 @@ export const LLM_ENDPOINT_PRESETS: LlmEndpointDef[] = [
   },
 ]
 
-/** 旧三家 + 各入口常见默认模型；中转站只给代表性模型名，用户可自行追加。 */
+/** 中转站常用模型包：同一 OpenAI 兼容入口下挂多模型。 */
+const RELAY_MODEL_SEEDS: Array<{ suffix: string; label: string; model: string; note?: string }> = [
+  { suffix: 'gpt-4o', label: 'GPT-4o', model: 'gpt-4o' },
+  { suffix: 'gpt-4o-mini', label: 'GPT-4o mini', model: 'gpt-4o-mini' },
+  { suffix: 'gpt-4.1', label: 'GPT-4.1', model: 'gpt-4.1' },
+  { suffix: 'gpt-4.1-mini', label: 'GPT-4.1 mini', model: 'gpt-4.1-mini' },
+  { suffix: 'o3', label: 'o3', model: 'o3', note: '推理' },
+  { suffix: 'o3-mini', label: 'o3-mini', model: 'o3-mini', note: '推理' },
+  { suffix: 'o4-mini', label: 'o4-mini', model: 'o4-mini', note: '推理' },
+  { suffix: 'claude-sonnet-4', label: 'Claude Sonnet 4', model: 'claude-sonnet-4-20250514' },
+  { suffix: 'claude-opus-4', label: 'Claude Opus 4', model: 'claude-opus-4-20250514' },
+  { suffix: 'claude-haiku-4', label: 'Claude Haiku 4.5', model: 'claude-haiku-4-5-20251001' },
+  { suffix: 'claude-3-7-sonnet', label: 'Claude 3.7 Sonnet', model: 'claude-3-7-sonnet-20250219' },
+  { suffix: 'claude-3-5-sonnet', label: 'Claude 3.5 Sonnet', model: 'claude-3-5-sonnet-20241022' },
+  { suffix: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', model: 'gemini-2.5-pro' },
+  { suffix: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', model: 'gemini-2.5-flash' },
+  { suffix: 'deepseek-chat', label: 'DeepSeek Chat', model: 'deepseek-chat' },
+  { suffix: 'deepseek-reasoner', label: 'DeepSeek Reasoner', model: 'deepseek-reasoner' },
+  { suffix: 'deepseek-v3', label: 'DeepSeek V3', model: 'deepseek-v3' },
+  { suffix: 'qwen-max', label: 'Qwen-Max', model: 'qwen-max' },
+  { suffix: 'qwen-plus', label: 'Qwen-Plus', model: 'qwen-plus' },
+  { suffix: 'grok-3', label: 'Grok 3', model: 'grok-3' },
+]
+
+function relayPack(endpointId: string, note?: string): LlmModelDef[] {
+  return RELAY_MODEL_SEEDS.map((s) => ({
+    id: `${endpointId}-${s.suffix}`,
+    label: s.label,
+    endpointId,
+    provider: 'openai' as const,
+    model: s.model,
+    category: 'relay',
+    note: s.note ?? note,
+    builtin: true,
+  }))
+}
+
+/** 官方三家 + 各入口内置模型（尽量全；中转站复用统一模型包）。 */
 export const LLM_MODEL_CATALOG: LlmModelDef[] = [
-  // DeepSeek
-  { id: 'deepseek-flash', label: 'DeepSeek Flash', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '通用对话 / 快速', builtin: true },
-  { id: 'deepseek-pro', label: 'DeepSeek Pro', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-pro', category: 'pro', note: '深度推理', builtin: true },
-  { id: 'deepseek-flash-vision', label: 'DeepSeek Flash Vision', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash-vision-exp', category: 'flash', note: '多模态视觉', builtin: true },
-  { id: 'deepseek-chat', label: 'DeepSeek Chat', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-chat', category: 'flash', note: '经典对话', builtin: true },
+  // ── DeepSeek 官方 ──
+  { id: 'deepseek-chat', label: 'DeepSeek Chat', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-chat', category: 'flash', note: 'V3 对话', builtin: true },
   { id: 'deepseek-reasoner', label: 'DeepSeek Reasoner', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-reasoner', category: 'pro', note: 'R1 推理', builtin: true },
+  { id: 'deepseek-flash', label: 'DeepSeek Flash', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash', category: 'flash', note: '快速', builtin: true },
+  { id: 'deepseek-pro', label: 'DeepSeek Pro', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-pro', category: 'pro', note: '深度推理', builtin: true },
+  { id: 'deepseek-flash-vision', label: 'DeepSeek Flash Vision', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-v4-flash-vision-exp', category: 'flash', note: '视觉', builtin: true },
+  { id: 'deepseek-coder', label: 'DeepSeek Coder', endpointId: 'deepseek', provider: 'deepseek', model: 'deepseek-coder', category: 'flash', note: '代码', builtin: true },
 
-  // OpenAI
+  // ── OpenAI 官方 ──
   { id: 'gpt-4o', label: 'GPT-4o', endpointId: 'openai', provider: 'openai', model: 'gpt-4o', category: 'gpt', note: '通用旗舰', builtin: true },
-  { id: 'gpt-4o-mini', label: 'GPT-4o mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4o-mini', category: 'gpt', note: '轻量快速', builtin: true },
+  { id: 'gpt-4o-mini', label: 'GPT-4o mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4o-mini', category: 'gpt', note: '轻量', builtin: true },
+  { id: 'gpt-4o-2024-11-20', label: 'GPT-4o (2024-11-20)', endpointId: 'openai', provider: 'openai', model: 'gpt-4o-2024-11-20', category: 'gpt', builtin: true },
+  { id: 'chatgpt-4o-latest', label: 'ChatGPT-4o Latest', endpointId: 'openai', provider: 'openai', model: 'chatgpt-4o-latest', category: 'gpt', builtin: true },
   { id: 'gpt-4.1', label: 'GPT-4.1', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1', category: 'gpt', note: '编码增强', builtin: true },
-  { id: 'gpt-4.1-mini', label: 'GPT-4.1 mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1-mini', category: 'gpt', note: '轻量', builtin: true },
+  { id: 'gpt-4.1-mini', label: 'GPT-4.1 mini', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1-mini', category: 'gpt', builtin: true },
+  { id: 'gpt-4.1-nano', label: 'GPT-4.1 nano', endpointId: 'openai', provider: 'openai', model: 'gpt-4.1-nano', category: 'gpt', note: '极速', builtin: true },
+  { id: 'gpt-4-turbo', label: 'GPT-4 Turbo', endpointId: 'openai', provider: 'openai', model: 'gpt-4-turbo', category: 'gpt', builtin: true },
+  { id: 'gpt-4-turbo-preview', label: 'GPT-4 Turbo Preview', endpointId: 'openai', provider: 'openai', model: 'gpt-4-turbo-preview', category: 'gpt', builtin: true },
+  { id: 'gpt-3.5-turbo', label: 'GPT-3.5 Turbo', endpointId: 'openai', provider: 'openai', model: 'gpt-3.5-turbo', category: 'gpt', note: '经典', builtin: true },
+  { id: 'o1', label: 'o1', endpointId: 'openai', provider: 'openai', model: 'o1', category: 'gpt', note: '推理', builtin: true },
+  { id: 'o1-mini', label: 'o1-mini', endpointId: 'openai', provider: 'openai', model: 'o1-mini', category: 'gpt', note: '推理轻量', builtin: true },
+  { id: 'o1-pro', label: 'o1-pro', endpointId: 'openai', provider: 'openai', model: 'o1-pro', category: 'gpt', note: '推理旗舰', builtin: true },
+  { id: 'o3', label: 'o3', endpointId: 'openai', provider: 'openai', model: 'o3', category: 'gpt', note: '推理', builtin: true },
   { id: 'o3-mini', label: 'o3-mini', endpointId: 'openai', provider: 'openai', model: 'o3-mini', category: 'gpt', note: '推理', builtin: true },
+  { id: 'o3-pro', label: 'o3-pro', endpointId: 'openai', provider: 'openai', model: 'o3-pro', category: 'gpt', note: '推理旗舰', builtin: true },
   { id: 'o4-mini', label: 'o4-mini', endpointId: 'openai', provider: 'openai', model: 'o4-mini', category: 'gpt', note: '推理', builtin: true },
+  { id: 'gpt-5', label: 'GPT-5', endpointId: 'openai', provider: 'openai', model: 'gpt-5', category: 'gpt', builtin: true },
+  { id: 'gpt-5-mini', label: 'GPT-5 mini', endpointId: 'openai', provider: 'openai', model: 'gpt-5-mini', category: 'gpt', builtin: true },
+  { id: 'gpt-5-nano', label: 'GPT-5 nano', endpointId: 'openai', provider: 'openai', model: 'gpt-5-nano', category: 'gpt', builtin: true },
 
-  // Anthropic
-  { id: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-sonnet-20241022', category: 'claude', note: '智能均衡', builtin: true },
-  { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-haiku-20241022', category: 'claude', note: '轻量快速', builtin: true },
-  { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-sonnet-4-20250514', category: 'claude', note: '新一代', builtin: true },
+  // ── Anthropic 官方 ──
   { id: 'claude-opus-4-20250514', label: 'Claude Opus 4', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-opus-4-20250514', category: 'claude', note: '旗舰', builtin: true },
+  { id: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-sonnet-4-20250514', category: 'claude', note: '均衡', builtin: true },
+  { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-haiku-4-5-20251001', category: 'claude', note: '快速', builtin: true },
+  { id: 'claude-opus-4-1-20250805', label: 'Claude Opus 4.1', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-opus-4-1-20250805', category: 'claude', builtin: true },
+  { id: 'claude-3-7-sonnet-20250219', label: 'Claude 3.7 Sonnet', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-7-sonnet-20250219', category: 'claude', note: '扩展思考', builtin: true },
+  { id: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-sonnet-20241022', category: 'claude', builtin: true },
+  { id: 'claude-3-5-sonnet-20240620', label: 'Claude 3.5 Sonnet (Jun)', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-sonnet-20240620', category: 'claude', builtin: true },
+  { id: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-5-haiku-20241022', category: 'claude', note: '轻量', builtin: true },
+  { id: 'claude-3-opus-20240229', label: 'Claude 3 Opus', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-opus-20240229', category: 'claude', builtin: true },
+  { id: 'claude-3-sonnet-20240229', label: 'Claude 3 Sonnet', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-sonnet-20240229', category: 'claude', builtin: true },
+  { id: 'claude-3-haiku-20240307', label: 'Claude 3 Haiku', endpointId: 'anthropic', provider: 'anthropic', model: 'claude-3-haiku-20240307', category: 'claude', builtin: true },
 
-  // Moonshot
-  { id: 'moonshot-v1-auto', label: 'Kimi', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-auto', category: 'other', note: '自动路由', builtin: true },
-  { id: 'kimi-k2', label: 'Kimi K2', endpointId: 'moonshot', provider: 'openai', model: 'kimi-k2-0711-preview', category: 'other', note: 'K2', builtin: true },
+  // ── Moonshot / Kimi ──
+  { id: 'moonshot-v1-auto', label: 'Kimi Auto', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-auto', category: 'other', note: '自动路由', builtin: true },
+  { id: 'moonshot-v1-8k', label: 'moonshot-v1-8k', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-8k', category: 'other', builtin: true },
+  { id: 'moonshot-v1-32k', label: 'moonshot-v1-32k', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-32k', category: 'other', builtin: true },
+  { id: 'moonshot-v1-128k', label: 'moonshot-v1-128k', endpointId: 'moonshot', provider: 'openai', model: 'moonshot-v1-128k', category: 'other', builtin: true },
+  { id: 'kimi-k2', label: 'Kimi K2', endpointId: 'moonshot', provider: 'openai', model: 'kimi-k2-0711-preview', category: 'other', builtin: true },
+  { id: 'kimi-latest', label: 'Kimi Latest', endpointId: 'moonshot', provider: 'openai', model: 'kimi-latest', category: 'other', builtin: true },
 
-  // 智谱
+  // ── 智谱 ──
   { id: 'glm-4-plus', label: 'GLM-4-Plus', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-plus', category: 'other', builtin: true },
-  { id: 'glm-4-flash', label: 'GLM-4-Flash', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-flash', category: 'other', note: '免费高速', builtin: true },
+  { id: 'glm-4-air', label: 'GLM-4-Air', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-air', category: 'other', builtin: true },
+  { id: 'glm-4-airx', label: 'GLM-4-AirX', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-airx', category: 'other', builtin: true },
+  { id: 'glm-4-flash', label: 'GLM-4-Flash', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-flash', category: 'other', note: '高速', builtin: true },
+  { id: 'glm-4-long', label: 'GLM-4-Long', endpointId: 'zhipu', provider: 'openai', model: 'glm-4-long', category: 'other', builtin: true },
+  { id: 'glm-4v-plus', label: 'GLM-4V-Plus', endpointId: 'zhipu', provider: 'openai', model: 'glm-4v-plus', category: 'other', note: '视觉', builtin: true },
   { id: 'glm-z1-air', label: 'GLM-Z1-Air', endpointId: 'zhipu', provider: 'openai', model: 'glm-z1-air', category: 'other', note: '推理', builtin: true },
+  { id: 'glm-z1-airx', label: 'GLM-Z1-AirX', endpointId: 'zhipu', provider: 'openai', model: 'glm-z1-airx', category: 'other', note: '推理', builtin: true },
+  { id: 'glm-z1-flash', label: 'GLM-Z1-Flash', endpointId: 'zhipu', provider: 'openai', model: 'glm-z1-flash', category: 'other', note: '推理', builtin: true },
 
-  // 通义
+  // ── 通义 DashScope ──
   { id: 'qwen-max', label: 'Qwen-Max', endpointId: 'dashscope', provider: 'openai', model: 'qwen-max', category: 'other', builtin: true },
+  { id: 'qwen-max-latest', label: 'Qwen-Max-Latest', endpointId: 'dashscope', provider: 'openai', model: 'qwen-max-latest', category: 'other', builtin: true },
   { id: 'qwen-plus', label: 'Qwen-Plus', endpointId: 'dashscope', provider: 'openai', model: 'qwen-plus', category: 'other', builtin: true },
+  { id: 'qwen-plus-latest', label: 'Qwen-Plus-Latest', endpointId: 'dashscope', provider: 'openai', model: 'qwen-plus-latest', category: 'other', builtin: true },
   { id: 'qwen-turbo', label: 'Qwen-Turbo', endpointId: 'dashscope', provider: 'openai', model: 'qwen-turbo', category: 'other', builtin: true },
+  { id: 'qwen-turbo-latest', label: 'Qwen-Turbo-Latest', endpointId: 'dashscope', provider: 'openai', model: 'qwen-turbo-latest', category: 'other', builtin: true },
+  { id: 'qwen-long', label: 'Qwen-Long', endpointId: 'dashscope', provider: 'openai', model: 'qwen-long', category: 'other', builtin: true },
   { id: 'qwq-plus', label: 'QwQ-Plus', endpointId: 'dashscope', provider: 'openai', model: 'qwq-plus', category: 'other', note: '推理', builtin: true },
+  { id: 'qwq-32b', label: 'QwQ-32B', endpointId: 'dashscope', provider: 'openai', model: 'qwq-32b', category: 'other', note: '推理', builtin: true },
+  { id: 'qwen3-235b', label: 'Qwen3-235B', endpointId: 'dashscope', provider: 'openai', model: 'qwen3-235b-a22b', category: 'other', builtin: true },
+  { id: 'qwen3-32b', label: 'Qwen3-32B', endpointId: 'dashscope', provider: 'openai', model: 'qwen3-32b', category: 'other', builtin: true },
 
-  // 硅基流动（统一入口多模型示例）
-  { id: 'sf-deepseek-v3', label: 'DeepSeek-V3', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-V3', category: 'other', note: '硅基流动', builtin: true },
-  { id: 'sf-deepseek-r1', label: 'DeepSeek-R1', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-R1', category: 'other', note: '硅基流动', builtin: true },
-  { id: 'sf-qwen3-235b', label: 'Qwen3-235B', endpointId: 'siliconflow', provider: 'openai', model: 'Qwen/Qwen3-235B-A22B', category: 'other', note: '硅基流动', builtin: true },
+  // ── 硅基流动 ──
+  { id: 'sf-deepseek-v3', label: 'DeepSeek-V3', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-V3', category: 'other', builtin: true },
+  { id: 'sf-deepseek-v3.1', label: 'DeepSeek-V3.1', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-V3.1', category: 'other', builtin: true },
+  { id: 'sf-deepseek-r1', label: 'DeepSeek-R1', endpointId: 'siliconflow', provider: 'openai', model: 'deepseek-ai/DeepSeek-R1', category: 'other', builtin: true },
+  { id: 'sf-qwen3-235b', label: 'Qwen3-235B', endpointId: 'siliconflow', provider: 'openai', model: 'Qwen/Qwen3-235B-A22B', category: 'other', builtin: true },
+  { id: 'sf-qwen3-32b', label: 'Qwen3-32B', endpointId: 'siliconflow', provider: 'openai', model: 'Qwen/Qwen3-32B', category: 'other', builtin: true },
+  { id: 'sf-qwen2.5-72b', label: 'Qwen2.5-72B', endpointId: 'siliconflow', provider: 'openai', model: 'Qwen/Qwen2.5-72B-Instruct', category: 'other', builtin: true },
+  { id: 'sf-glm4-9b', label: 'GLM-4-9B', endpointId: 'siliconflow', provider: 'openai', model: 'THUDM/GLM-4-9B-0414', category: 'other', builtin: true },
+  { id: 'sf-llama-70b', label: 'Llama-3.3-70B', endpointId: 'siliconflow', provider: 'openai', model: 'meta-llama/Llama-3.3-70B-Instruct', category: 'other', builtin: true },
 
-  // OpenRouter（统一入口）
-  { id: 'or-gpt-4o', label: 'GPT-4o', endpointId: 'openrouter', provider: 'openai', model: 'openai/gpt-4o', category: 'other', note: 'OpenRouter', builtin: true },
-  { id: 'or-claude-sonnet', label: 'Claude Sonnet', endpointId: 'openrouter', provider: 'openai', model: 'anthropic/claude-sonnet-4', category: 'other', note: 'OpenRouter', builtin: true },
-  { id: 'or-gemini-pro', label: 'Gemini Pro', endpointId: 'openrouter', provider: 'openai', model: 'google/gemini-2.5-pro', category: 'other', note: 'OpenRouter', builtin: true },
+  // ── OpenRouter ──
+  { id: 'or-gpt-4o', label: 'GPT-4o', endpointId: 'openrouter', provider: 'openai', model: 'openai/gpt-4o', category: 'other', builtin: true },
+  { id: 'or-gpt-4.1', label: 'GPT-4.1', endpointId: 'openrouter', provider: 'openai', model: 'openai/gpt-4.1', category: 'other', builtin: true },
+  { id: 'or-o3', label: 'o3', endpointId: 'openrouter', provider: 'openai', model: 'openai/o3', category: 'other', builtin: true },
+  { id: 'or-o4-mini', label: 'o4-mini', endpointId: 'openrouter', provider: 'openai', model: 'openai/o4-mini', category: 'other', builtin: true },
+  { id: 'or-claude-opus', label: 'Claude Opus 4', endpointId: 'openrouter', provider: 'openai', model: 'anthropic/claude-opus-4', category: 'other', builtin: true },
+  { id: 'or-claude-sonnet', label: 'Claude Sonnet 4', endpointId: 'openrouter', provider: 'openai', model: 'anthropic/claude-sonnet-4', category: 'other', builtin: true },
+  { id: 'or-claude-3.7', label: 'Claude 3.7 Sonnet', endpointId: 'openrouter', provider: 'openai', model: 'anthropic/claude-3.7-sonnet', category: 'other', builtin: true },
+  { id: 'or-gemini-pro', label: 'Gemini 2.5 Pro', endpointId: 'openrouter', provider: 'openai', model: 'google/gemini-2.5-pro', category: 'other', builtin: true },
+  { id: 'or-gemini-flash', label: 'Gemini 2.5 Flash', endpointId: 'openrouter', provider: 'openai', model: 'google/gemini-2.5-flash', category: 'other', builtin: true },
+  { id: 'or-deepseek-r1', label: 'DeepSeek R1', endpointId: 'openrouter', provider: 'openai', model: 'deepseek/deepseek-r1', category: 'other', builtin: true },
+  { id: 'or-deepseek-v3', label: 'DeepSeek V3', endpointId: 'openrouter', provider: 'openai', model: 'deepseek/deepseek-chat', category: 'other', builtin: true },
+  { id: 'or-qwen3-235b', label: 'Qwen3 235B', endpointId: 'openrouter', provider: 'openai', model: 'qwen/qwen3-235b-a22b', category: 'other', builtin: true },
 
-  // Groq
+  // ── Groq ──
   { id: 'groq-llama-70b', label: 'Llama 3.3 70B', endpointId: 'groq', provider: 'openai', model: 'llama-3.3-70b-versatile', category: 'other', builtin: true },
+  { id: 'groq-llama-8b', label: 'Llama 3.1 8B', endpointId: 'groq', provider: 'openai', model: 'llama-3.1-8b-instant', category: 'other', builtin: true },
   { id: 'groq-qwen3-32b', label: 'Qwen3 32B', endpointId: 'groq', provider: 'openai', model: 'qwen/qwen3-32b', category: 'other', builtin: true },
+  { id: 'groq-gpt-oss-120b', label: 'GPT-OSS 120B', endpointId: 'groq', provider: 'openai', model: 'openai/gpt-oss-120b', category: 'other', builtin: true },
+  { id: 'groq-kimi-k2', label: 'Kimi K2', endpointId: 'groq', provider: 'openai', model: 'moonshotai/kimi-k2-instruct', category: 'other', builtin: true },
 
-  // xAI
+  // ── xAI ──
   { id: 'grok-3', label: 'Grok 3', endpointId: 'xai', provider: 'openai', model: 'grok-3', category: 'other', builtin: true },
   { id: 'grok-3-mini', label: 'Grok 3 Mini', endpointId: 'xai', provider: 'openai', model: 'grok-3-mini', category: 'other', builtin: true },
+  { id: 'grok-3-fast', label: 'Grok 3 Fast', endpointId: 'xai', provider: 'openai', model: 'grok-3-fast', category: 'other', builtin: true },
+  { id: 'grok-2', label: 'Grok 2', endpointId: 'xai', provider: 'openai', model: 'grok-2-latest', category: 'other', builtin: true },
+  { id: 'grok-4', label: 'Grok 4', endpointId: 'xai', provider: 'openai', model: 'grok-4', category: 'other', builtin: true },
 
-  // Gemini OpenAI compat
+  // ── Gemini OpenAI 兼容 ──
   { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.5-pro', category: 'other', builtin: true },
   { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.5-flash', category: 'other', builtin: true },
+  { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.5-flash-lite', category: 'other', builtin: true },
+  { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-2.0-flash', category: 'other', builtin: true },
+  { id: 'gemini-1.5-pro', label: 'Gemini 1.5 Pro', endpointId: 'gemini-openai', provider: 'openai', model: 'gemini-1.5-pro', category: 'other', builtin: true },
 
-  // 中转站：同一入口挂多模型（名称按站内习惯，可改）
-  { id: 'closeai-gpt-4o', label: 'GPT-4o', endpointId: 'closeai', provider: 'openai', model: 'gpt-4o', category: 'relay', note: 'CloseAI', builtin: true },
-  { id: 'closeai-claude', label: 'Claude Sonnet', endpointId: 'closeai', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', note: 'CloseAI · OpenAI 格式', builtin: true },
-  { id: 'closeai-gemini', label: 'Gemini', endpointId: 'closeai', provider: 'openai', model: 'gemini-2.5-pro', category: 'relay', note: 'CloseAI', builtin: true },
-  { id: 'chatanywhere-gpt-4o', label: 'GPT-4o', endpointId: 'chatanywhere', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
-  { id: 'chatanywhere-gpt-4o-mini', label: 'GPT-4o mini', endpointId: 'chatanywhere', provider: 'openai', model: 'gpt-4o-mini', category: 'relay', builtin: true },
-  { id: 'yunwu-gpt-4o', label: 'GPT-4o', endpointId: 'yunwu', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
-  { id: 'yunwu-claude', label: 'Claude', endpointId: 'yunwu', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', builtin: true },
-  { id: 'aihubmix-gpt-4o', label: 'GPT-4o', endpointId: 'aihubmix', provider: 'openai', model: 'gpt-4o', category: 'relay', builtin: true },
-  { id: 'aihubmix-claude', label: 'Claude', endpointId: 'aihubmix', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', builtin: true },
-  { id: 'relay-claude-sonnet', label: 'Claude Sonnet（兼容）', endpointId: 'relay-claude-compat', provider: 'openai', model: 'claude-sonnet-4-20250514', category: 'relay', note: '改 URL 指向你的中转', builtin: true },
-  { id: 'relay-claude-opus', label: 'Claude Opus（兼容）', endpointId: 'relay-claude-compat', provider: 'openai', model: 'claude-opus-4-20250514', category: 'relay', note: '改 URL 指向你的中转', builtin: true },
+  // ── 火山 / MiniMax / Step / 百川 / 零一 ──
+  { id: 'doubao-pro', label: 'Doubao Pro', endpointId: 'volcengine', provider: 'openai', model: 'doubao-pro-32k', category: 'other', note: '按方舟接入点 ID 改', builtin: true },
+  { id: 'doubao-lite', label: 'Doubao Lite', endpointId: 'volcengine', provider: 'openai', model: 'doubao-lite-32k', category: 'other', note: '按方舟接入点 ID 改', builtin: true },
+  { id: 'minimax-abab6.5s', label: 'abab6.5s', endpointId: 'minimax', provider: 'openai', model: 'abab6.5s-chat', category: 'other', builtin: true },
+  { id: 'minimax-m1', label: 'MiniMax-M1', endpointId: 'minimax', provider: 'openai', model: 'MiniMax-M1', category: 'other', builtin: true },
+  { id: 'step-2', label: 'Step-2', endpointId: 'stepfun', provider: 'openai', model: 'step-2-16k', category: 'other', builtin: true },
+  { id: 'step-1o', label: 'Step-1o', endpointId: 'stepfun', provider: 'openai', model: 'step-1o-turbo-vision', category: 'other', note: '视觉', builtin: true },
+  { id: 'baichuan4', label: 'Baichuan4', endpointId: 'baichuan', provider: 'openai', model: 'Baichuan4', category: 'other', builtin: true },
+  { id: 'baichuan4-turbo', label: 'Baichuan4-Turbo', endpointId: 'baichuan', provider: 'openai', model: 'Baichuan4-Turbo', category: 'other', builtin: true },
+  { id: 'yi-lightning', label: 'Yi-Lightning', endpointId: 'yi', provider: 'openai', model: 'yi-lightning', category: 'other', builtin: true },
+  { id: 'yi-large', label: 'Yi-Large', endpointId: 'yi', provider: 'openai', model: 'yi-large', category: 'other', builtin: true },
 
-  // 本地
-  { id: 'ollama-llama', label: 'llama3.2', endpointId: 'ollama', provider: 'openai', model: 'llama3.2', category: 'local', builtin: true },
-  { id: 'ollama-qwen', label: 'qwen2.5', endpointId: 'ollama', provider: 'openai', model: 'qwen2.5', category: 'local', builtin: true },
-  { id: 'lmstudio-local', label: '当前加载模型', endpointId: 'lmstudio', provider: 'openai', model: 'local-model', category: 'local', note: '按 LM Studio 实际模型名改', builtin: true },
+  // ── 中转站：统一模型包 ──
+  ...relayPack('closeai', 'CloseAI'),
+  ...relayPack('api2d', 'API2D'),
+  ...relayPack('ohmygpt', 'OhMyGPT'),
+  ...relayPack('chatanywhere', 'ChatAnywhere'),
+  ...relayPack('openai-sb', 'OpenAI-SB'),
+  ...relayPack('aiproxy', 'AIProxy'),
+  ...relayPack('poloapi', 'PoloAPI'),
+  ...relayPack('yunwu', 'Yunwu'),
+  ...relayPack('apiyi', 'API易'),
+  ...relayPack('gptgod', 'GPTGod'),
+  ...relayPack('aihubmix', 'AiHubMix'),
+  ...relayPack('opencs', 'OneAPI'),
+  ...relayPack('relay-claude-compat', 'Claude 兼容中转'),
+
+  // ── 本地 ──
+  { id: 'ollama-llama3.2', label: 'llama3.2', endpointId: 'ollama', provider: 'openai', model: 'llama3.2', category: 'local', builtin: true },
+  { id: 'ollama-llama3.1', label: 'llama3.1', endpointId: 'ollama', provider: 'openai', model: 'llama3.1', category: 'local', builtin: true },
+  { id: 'ollama-qwen2.5', label: 'qwen2.5', endpointId: 'ollama', provider: 'openai', model: 'qwen2.5', category: 'local', builtin: true },
+  { id: 'ollama-qwen3', label: 'qwen3', endpointId: 'ollama', provider: 'openai', model: 'qwen3', category: 'local', builtin: true },
+  { id: 'ollama-deepseek-r1', label: 'deepseek-r1', endpointId: 'ollama', provider: 'openai', model: 'deepseek-r1', category: 'local', builtin: true },
+  { id: 'ollama-mistral', label: 'mistral', endpointId: 'ollama', provider: 'openai', model: 'mistral', category: 'local', builtin: true },
+  { id: 'ollama-gemma3', label: 'gemma3', endpointId: 'ollama', provider: 'openai', model: 'gemma3', category: 'local', builtin: true },
+  { id: 'lmstudio-local', label: '当前加载模型', endpointId: 'lmstudio', provider: 'openai', model: 'local-model', category: 'local', note: '按 LM Studio 实际名改', builtin: true },
+  { id: 'vllm-local', label: 'vLLM 当前模型', endpointId: 'vllm', provider: 'openai', model: 'default', category: 'local', note: '按 served-model-name 改', builtin: true },
 ]
 
 /** 兼容旧代码：仅 deepseek / openai / anthropic。 */
@@ -590,8 +709,12 @@ export function describeEndpointGroup(group: EndpointGroup): string {
 }
 
 export function defaultModelFor(provider: ChatProvider): string {
-  const first = LLM_MODEL_CATALOG.find((m) => m.provider === provider)
-  return first?.model ?? 'deepseek-v4-flash'
+  const first = LLM_MODEL_CATALOG.find((m) => m.provider === provider && m.endpointId === provider)
+  return first?.model ?? LLM_MODEL_CATALOG.find((m) => m.provider === provider)?.model ?? 'deepseek-chat'
+}
+
+export function modelsForEndpoint(endpointId: string): LlmModelDef[] {
+  return LLM_MODEL_CATALOG.filter((m) => m.endpointId === endpointId)
 }
 
 export function findEndpointPreset(id: string): LlmEndpointDef | undefined {

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
-import { LuChevronDown, LuPlus } from 'react-icons/lu'
+import { LuChevronDown, LuSettings } from 'react-icons/lu'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
@@ -672,6 +672,19 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             </button>
             {modelOpen ? (
               <div className="composer-model-menu" role="listbox" aria-label="模型">
+                <div className="composer-model-menu-head">
+                  <span className="composer-model-menu-title">选择模型</span>
+                  <button
+                    type="button"
+                    className="composer-model-settings"
+                    title="模型配置"
+                    aria-label="模型配置"
+                    data-testid="open-model-config"
+                    onClick={openModelConfig}
+                  >
+                    <LuSettings className="size-3.5" />
+                  </button>
+                </div>
                 {(() => {
                   const visible = allModels.filter(
                     (m) => modelProviders?.[m.endpointId] || modelProviders?.[m.provider],
@@ -679,7 +692,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   if (!visible.length) {
                     return (
                       <div className="composer-model-empty">
-                        尚未配置可用模型。点击下方「配置模型」添加官方 Key 或第三方。
+                        尚未配置可用模型。点击右上角设置添加官方 Key 或第三方。
                       </div>
                     )
                   }
@@ -728,29 +741,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                     )
                   })
                 })()}
-                <button
-                  type="button"
-                  className="composer-model-config-entry"
-                  data-testid="open-model-config"
-                  onClick={openModelConfig}
-                >
-                  <LuPlus className="size-3.5" />
-                  配置模型
-                </button>
               </div>
             ) : null}
           </div>
-
-          <button
-            type="button"
-            className="composer-model-add"
-            title="配置模型"
-            aria-label="配置模型"
-            data-testid="composer-model-add"
-            onClick={openModelConfig}
-          >
-            <LuPlus className="size-3.5" />
-          </button>
 
           {pending ? (
             <button

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -3,6 +3,7 @@ import { LuChevronDown, LuPlus } from 'react-icons/lu'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+import { ModelConfigDialog } from './model-config-dialog.tsx'
 
 /** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
 const INPUT_DEBOUNCE_MS = 120
@@ -111,6 +112,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     model: 'deepseek-chat',
   })
   const [modelBusy, setModelBusy] = useState(false)
+  const [configOpen, setConfigOpen] = useState(false)
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
   /** 各入口是否已配置 token（key = endpointId）。 */
@@ -124,6 +126,20 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const sessionView = props.sessionView as SessionViewService
   const navigate = useNavigate()
   const location = useLocation()
+
+  useEffect(() => {
+    const open = () => {
+      setModelOpen(false)
+      setConfigOpen(true)
+    }
+    window.addEventListener('biu:open-model-config', open)
+    return () => window.removeEventListener('biu:open-model-config', open)
+  }, [])
+
+  function openModelConfig() {
+    setModelOpen(false)
+    setConfigOpen(true)
+  }
 
   function syncComposerShape(
     el: HTMLTextAreaElement | null = textareaRef.current,
@@ -163,13 +179,87 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
   useEffect(() => {
     let cancelled = false
+
+    function applyConfig(data: {
+      toolCatalog?: ToolCatalogItem[]
+      provider?: string
+      endpointId?: string
+      model?: string
+      providers?: Record<string, { configured?: boolean }>
+      endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
+      modelCatalog?: Array<{
+        id: string
+        label: string
+        provider: string
+        endpointId?: string
+        model: string
+        note?: string
+        endpointConfigured?: boolean
+      }>
+    }) {
+      if (cancelled) return
+      const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
+      setCatalog(items.filter((item) => item?.name))
+      if (Array.isArray(data.modelCatalog) && data.modelCatalog.length) {
+        const catalog = data.modelCatalog.map((m) => ({
+          id: m.id,
+          label: m.label,
+          provider: m.provider as ChatProvider,
+          endpointId: m.endpointId || m.provider,
+          model: m.model,
+          ...(m.note ? { note: m.note } : {}),
+        }))
+        setAllModels(catalog)
+        if (data.provider && data.model)
+          setModelOption(matchModelOption(catalog, data.provider, data.model))
+      } else if (data.provider && data.model) {
+        setModelOption(matchModelOption([], data.provider, data.model))
+      }
+      const cfg: Record<string, boolean> = {}
+      const labels: Record<string, string> = {
+        deepseek: 'DeepSeek',
+        anthropic: 'Claude',
+        openai: 'GPT',
+      }
+      if (Array.isArray(data.endpoints)) {
+        for (const ep of data.endpoints) {
+          cfg[ep.id] = Boolean(ep?.configured)
+          if (ep.label) labels[ep.id] = ep.label
+        }
+      }
+      if (data.providers) {
+        for (const [k, v] of Object.entries(data.providers)) cfg[k] = Boolean(v?.configured)
+      }
+      if (Object.keys(cfg).length) setModelProviders(cfg)
+      setEndpointLabels(labels)
+    }
+
+    function reload() {
+      void fetch('/api/chat/config')
+        .then((res) => res.json())
+        .then(applyConfig)
+        .catch(() => {
+          /* ignore */
+        })
+    }
+
+    reload()
+    const onConfigChanged = () => reload()
+    window.addEventListener('biu:chat-config-changed', onConfigChanged)
+    return () => {
+      cancelled = true
+      window.removeEventListener('biu:chat-config-changed', onConfigChanged)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!modelOpen) return
+    // 打开下拉时强制刷新，保证 Settings 里新加的模型立刻可见
     void fetch('/api/chat/config')
       .then((res) => res.json())
       .then(
         (data: {
-          toolCatalog?: ToolCatalogItem[]
           provider?: string
-          endpointId?: string
           model?: string
           providers?: Record<string, { configured?: boolean }>
           endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
@@ -180,12 +270,8 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             endpointId?: string
             model: string
             note?: string
-            endpointConfigured?: boolean
           }>
         }) => {
-          if (cancelled) return
-          const items = Array.isArray(data.toolCatalog) ? data.toolCatalog : []
-          setCatalog(items.filter((item) => item?.name))
           if (Array.isArray(data.modelCatalog) && data.modelCatalog.length) {
             const catalog = data.modelCatalog.map((m) => ({
               id: m.id,
@@ -198,15 +284,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             setAllModels(catalog)
             if (data.provider && data.model)
               setModelOption(matchModelOption(catalog, data.provider, data.model))
-          } else if (data.provider && data.model) {
-            setModelOption(matchModelOption([], data.provider, data.model))
           }
           const cfg: Record<string, boolean> = {}
-          const labels: Record<string, string> = {
-            deepseek: 'DeepSeek',
-            anthropic: 'Claude',
-            openai: 'GPT',
-          }
+          const labels: Record<string, string> = { ...endpointLabels }
           if (Array.isArray(data.endpoints)) {
             for (const ep of data.endpoints) {
               cfg[ep.id] = Boolean(ep?.configured)
@@ -223,13 +303,6 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       .catch(() => {
         /* ignore */
       })
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!modelOpen) return
     const onPointer = (event: MouseEvent) => {
       const target = event.target as HTMLElement | null
       if (target?.closest('.composer-model')) return
@@ -237,6 +310,8 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
     window.addEventListener('mousedown', onPointer)
     return () => window.removeEventListener('mousedown', onPointer)
+    // endpointLabels 仅作合并基础，不纳入依赖避免循环刷新
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modelOpen])
 
   const filtered = useMemo(() => {
@@ -604,7 +679,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   if (!visible.length) {
                     return (
                       <div className="composer-model-empty">
-                        请在 Settings → Models 配置官方 API Key，或接入第三方后再选模型
+                        尚未配置可用模型。点击下方「配置模型」添加官方 Key 或第三方。
                       </div>
                     )
                   }
@@ -653,9 +728,29 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                     )
                   })
                 })()}
+                <button
+                  type="button"
+                  className="composer-model-config-entry"
+                  data-testid="open-model-config"
+                  onClick={openModelConfig}
+                >
+                  <LuPlus className="size-3.5" />
+                  配置模型
+                </button>
               </div>
             ) : null}
           </div>
+
+          <button
+            type="button"
+            className="composer-model-add"
+            title="配置模型"
+            aria-label="配置模型"
+            data-testid="composer-model-add"
+            onClick={openModelConfig}
+          >
+            <LuPlus className="size-3.5" />
+          </button>
 
           {pending ? (
             <button
@@ -682,6 +777,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         </div>
       </div>
     </form>
+    <ModelConfigDialog open={configOpen} onClose={() => setConfigOpen(false)} />
     </div>
   )
 })

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -109,7 +109,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     label: 'DeepSeek Flash',
     provider: 'deepseek',
     endpointId: 'deepseek',
-    model: 'deepseek-chat',
+    model: 'deepseek-v4-flash',
   })
   const [modelBusy, setModelBusy] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)

--- a/packages/cap-chat/src/web/config-banner.tsx
+++ b/packages/cap-chat/src/web/config-banner.tsx
@@ -32,13 +32,13 @@ export function ChatConfigBanner(_props: SlotProps) {
       style={{ borderRadius: 'var(--dsw-radius-bubble)' }}
       role="status"
     >
-      尚未配置 API Key：消息会本地回声，不会调用模型。点击输入框旁的{' '}
+      尚未配置 API Key：消息会本地回声，不会调用模型。打开模型菜单右上角的{' '}
       <button
         type="button"
         className="font-medium text-[var(--dsw-business)] underline-offset-2 hover:underline"
         onClick={() => window.dispatchEvent(new CustomEvent('biu:open-model-config'))}
       >
-        ＋ 配置模型
+        设置
       </button>
       。
     </div>

--- a/packages/cap-chat/src/web/config-banner.tsx
+++ b/packages/cap-chat/src/web/config-banner.tsx
@@ -32,7 +32,15 @@ export function ChatConfigBanner(_props: SlotProps) {
       style={{ borderRadius: 'var(--dsw-radius-bubble)' }}
       role="status"
     >
-      尚未配置 API Key：消息会本地回声，不会调用模型。打开 Settings → Assistant，填写 Key 后点「Save Assistant」。
+      尚未配置 API Key：消息会本地回声，不会调用模型。点击输入框旁的{' '}
+      <button
+        type="button"
+        className="font-medium text-[var(--dsw-business)] underline-offset-2 hover:underline"
+        onClick={() => window.dispatchEvent(new CustomEvent('biu:open-model-config'))}
+      >
+        ＋ 配置模型
+      </button>
+      。
     </div>
   )
 }

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -119,6 +119,23 @@ export function ChatConfig(_props: SlotProps) {
   const currentModelInCatalog =
     availableModels.find((m) => m.model === model) ?? availableModels[0]
 
+  /** 切换入口：同步 URL 草稿，并强制落到该入口的第一个模型。 */
+  function switchEndpoint(next: string) {
+    setEndpointId(next)
+    setThirdKeyDraft('')
+    setError('')
+    setStatus('')
+    setNewModelName('')
+    const ep = endpoints.find((x) => x.id === next)
+    if (ep && !OFFICIAL_ORDER.includes(next as ChatProvider)) {
+      setThirdUrlDraft(ep.baseUrl)
+    } else {
+      setThirdUrlDraft('')
+    }
+    const models = modelCatalog.filter((m) => m.endpointId === next)
+    if (models[0]) setModel(models[0].model)
+  }
+
   function applyPublic(data: ChatPublicConfig, preferId?: string) {
     const eps = Array.isArray(data.endpoints) ? data.endpoints : []
     setEndpoints(eps)
@@ -350,7 +367,12 @@ export function ChatConfig(_props: SlotProps) {
 
       {/* ② 默认模型 —— 下拉可见目录模型 */}
       <section className="flex flex-col gap-2.5">
-        <span className={labelCls}>默认模型</span>
+        <div className="flex items-baseline justify-between">
+          <span className={labelCls}>默认模型</span>
+          <span className="text-[10px] text-[var(--dsw-label-3)]">
+            当前入口 {availableModels.length} 个模型
+          </span>
+        </div>
         <div className="flex gap-2">
           <label className="flex w-[42%] flex-col gap-1">
             <span className="text-[11px] text-[var(--dsw-label-3)]">提供商 / 入口</span>
@@ -358,17 +380,7 @@ export function ChatConfig(_props: SlotProps) {
               className={inputCls}
               value={endpointId}
               data-testid="endpoint"
-              onChange={(e) => {
-                const next = e.target.value
-                setEndpointId(next)
-                setThirdKeyDraft('')
-                const ep = endpoints.find((x) => x.id === next)
-                if (ep && !OFFICIAL_ORDER.includes(next as ChatProvider)) {
-                  setThirdUrlDraft(ep.baseUrl)
-                }
-                const def = modelCatalog.find((m) => m.endpointId === next)
-                if (def) setModel(def.model)
-              }}
+              onChange={(e) => switchEndpoint(e.target.value)}
             >
               <optgroup label="官方">
                 {OFFICIAL.map((p) => (
@@ -393,11 +405,13 @@ export function ChatConfig(_props: SlotProps) {
           <label className="flex w-[58%] flex-col gap-1">
             <span className="text-[11px] text-[var(--dsw-label-3)]">模型</span>
             <select
+              key={endpointId}
               className={inputCls}
               value={currentModelInCatalog?.id ?? ''}
               data-testid="model"
+              size={1}
               onChange={(e) => {
-                const def = modelCatalog.find((m) => m.id === e.target.value)
+                const def = availableModels.find((m) => m.id === e.target.value)
                 if (def) setModel(def.model)
               }}
             >
@@ -407,6 +421,7 @@ export function ChatConfig(_props: SlotProps) {
                 availableModels.map((m) => (
                   <option key={m.id} value={m.id}>
                     {m.label}
+                    {m.model !== m.label ? ` · ${m.model}` : ''}
                     {m.note ? ` — ${m.note}` : ''}
                   </option>
                 ))
@@ -514,12 +529,7 @@ export function ChatConfig(_props: SlotProps) {
                   <button
                     type="button"
                     className="min-w-0 flex-1 truncate text-left"
-                    onClick={() => {
-                      setEndpointId(ep.id)
-                      setThirdUrlDraft(ep.baseUrl)
-                      const def = modelCatalog.find((m) => m.endpointId === ep.id)
-                      if (def) setModel(def.model)
-                    }}
+                    onClick={() => switchEndpoint(ep.id)}
                   >
                     <span className="font-medium">{ep.label}</span>
                     <span className="mt-0.5 block truncate text-[10px] opacity-60">{ep.baseUrl}</span>

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -7,8 +7,7 @@
  * 3. 一处保存，不再拆成三块互相抢焦点
  */
 import { useEffect, useMemo, useState } from 'react'
-import { LuCheck, LuPlus, LuSearch, LuTrash2 } from 'react-icons/lu'
-import type { SlotProps } from '@biu/web-slots'
+import { LuCheck, LuLoaderCircle, LuPlus, LuSearch, LuTrash2, LuUnplug } from 'react-icons/lu'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -74,7 +73,7 @@ const inputCls = [
   'placeholder:text-[var(--dsw-label-3)] focus:border-[var(--dsw-business)]',
 ].join(' ')
 
-export function ChatConfig(_props: SlotProps) {
+export function ChatConfig() {
   const [activeId, setActiveId] = useState('deepseek')
   const [defaultEndpointId, setDefaultEndpointId] = useState('deepseek')
   const [defaultModel, setDefaultModel] = useState('deepseek-chat')
@@ -89,6 +88,8 @@ export function ChatConfig(_props: SlotProps) {
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [testHint, setTestHint] = useState('')
 
   const [adding, setAdding] = useState(false)
   const [presetId, setPresetId] = useState('')
@@ -182,6 +183,8 @@ export function ChatConfig(_props: SlotProps) {
     const ep = eps.find((e) => e.id === eid)
     setUrlDraft(ep?.baseUrl ?? data.baseUrl ?? '')
     setKeyDraft('')
+    // 通知 Composer 等刷新模型目录
+    window.dispatchEvent(new CustomEvent('biu:chat-config-changed'))
   }
 
   function selectProvider(id: string) {
@@ -189,6 +192,7 @@ export function ChatConfig(_props: SlotProps) {
     setAdding(false)
     setError('')
     setStatus('')
+    setTestHint('')
     setKeyDraft('')
     setNewModelName('')
     const ep = endpoints.find((e) => e.id === id)
@@ -281,6 +285,38 @@ export function ChatConfig(_props: SlotProps) {
       setStatus(`默认模型：${m.label}`)
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function onTestConnection() {
+    if (!active || testing) return
+    setTesting(true)
+    setTestHint('')
+    setError('')
+    try {
+      const res = await fetch('/api/chat/config/test', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          endpointId: activeId,
+          ...(keyDraft.trim() ? { apiKey: keyDraft.trim() } : {}),
+          ...(!isOfficial(activeId) && urlDraft.trim() ? { baseUrl: urlDraft.trim() } : {}),
+          ...(isDefaultProvider && defaultModel ? { model: defaultModel } : {}),
+          ...(!isDefaultProvider && activeModels[0]?.model ? { model: activeModels[0].model } : {}),
+        }),
+      })
+      const data = (await res.json()) as { ok?: boolean; detail?: string; latencyMs?: number }
+      if (data.ok) {
+        setTestHint(data.detail || '连接成功')
+        setStatus('连接正常')
+      } else {
+        setTestHint('')
+        setError(data.detail || `连接失败（HTTP ${res.status}）`)
+      }
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setTesting(false)
     }
   }
 
@@ -604,7 +640,25 @@ export function ChatConfig(_props: SlotProps) {
 
               <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-3">
                 <label className="flex flex-col gap-1.5">
-                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">API Key</span>
+                  <span className="flex items-center justify-between text-[11px] font-semibold text-[var(--dsw-label-3)]">
+                    <span>API Key</span>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded-[6px] px-1.5 py-0.5 text-[11px] font-medium text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)] disabled:opacity-50"
+                      title="测试连接"
+                      aria-label="测试连接"
+                      data-testid="test-connection"
+                      disabled={testing}
+                      onClick={() => void onTestConnection()}
+                    >
+                      {testing ? (
+                        <LuLoaderCircle className="size-3.5 animate-spin" />
+                      ) : (
+                        <LuUnplug className="size-3.5" />
+                      )}
+                      {testing ? '测试中' : '测试连接'}
+                    </button>
+                  </span>
                   <input
                     className={inputCls}
                     type="password"
@@ -620,6 +674,9 @@ export function ChatConfig(_props: SlotProps) {
                     value={keyDraft}
                     onChange={(e) => setKeyDraft(e.target.value)}
                   />
+                  {testHint ? (
+                    <span className="text-[11px] text-[var(--dsw-ok)]">{testHint}</span>
+                  ) : null}
                 </label>
 
                 {!isOfficial(active.id) ? (

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -7,7 +7,7 @@
  * 3. 一处保存，不再拆成三块互相抢焦点
  */
 import { useEffect, useMemo, useState } from 'react'
-import { LuCheck, LuLoaderCircle, LuPlus, LuSearch, LuTrash2, LuUnplug } from 'react-icons/lu'
+import { LuCheck, LuLoaderCircle, LuPlus, LuSearch, LuTrash2, LuUnplug, LuX } from 'react-icons/lu'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -73,10 +73,10 @@ const inputCls = [
   'placeholder:text-[var(--dsw-label-3)] focus:border-[var(--dsw-business)]',
 ].join(' ')
 
-export function ChatConfig() {
+export function ChatConfig(props?: { onClose?: () => void }) {
   const [activeId, setActiveId] = useState('deepseek')
   const [defaultEndpointId, setDefaultEndpointId] = useState('deepseek')
-  const [defaultModel, setDefaultModel] = useState('deepseek-chat')
+  const [defaultModel, setDefaultModel] = useState('deepseek-v4-flash')
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
   const [providers, setProviders] = useState<Record<string, ProviderView> | null>(null)
@@ -347,8 +347,12 @@ export function ChatConfig() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ removeCustomModel: id }),
     })
-    if (!res.ok) return
+    if (!res.ok) {
+      setError(`删除模型失败：HTTP ${res.status}`)
+      return
+    }
     applyPublic((await res.json()) as ChatPublicConfig, activeId)
+    setStatus('已删除模型')
   }
 
   async function onAddConnection() {
@@ -413,48 +417,105 @@ export function ChatConfig() {
   }
 
   async function onRemoveConnection(id: string) {
+    if (isOfficial(id)) return
+    setError('')
     const res = await fetch('/api/chat/config', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ removeCustomEndpoint: id }),
     })
-    if (!res.ok) return
-    applyPublic((await res.json()) as ChatPublicConfig)
-    setStatus('已删除')
+    if (!res.ok) {
+      setError(`删除失败：HTTP ${res.status}`)
+      return
+    }
+    applyPublic((await res.json()) as ChatPublicConfig, 'deepseek')
+    setAdding(false)
+    setStatus('已删除连接')
   }
 
-  function providerRow(ep: EndpointView) {
+  /** 凡能「添加」进列表的第三方连接，都可删除（含预设接入与自定义）。 */
+  function canRemoveConnection(ep: EndpointView | undefined): boolean {
+    return Boolean(ep && !isOfficial(ep.id))
+  }
+
+  function providerRow(ep: EndpointView, opts?: { removable?: boolean }) {
     const activeRow = ep.id === activeId && !adding
     const isDef = ep.id === defaultEndpointId
     const ok = ep.configured || providers?.[ep.id]?.configured
+    const removable = opts?.removable ?? canRemoveConnection(ep)
     return (
-      <button
+      <div
         key={ep.id}
-        type="button"
-        className={`flex w-full items-center gap-2 px-3 py-[8px] text-left text-[12px] transition-colors ${
+        className={`group flex w-full items-center gap-0.5 pr-1 ${
           activeRow
             ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
             : 'text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]'
         }`}
-        onClick={() => selectProvider(ep.id)}
       >
-        <span
-          className={`size-1.5 shrink-0 rounded-full ${
-            ok ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-35'
-          }`}
-        />
-        <span className="min-w-0 flex-1 truncate font-medium">{ep.label}</span>
-        {isDef ? (
-          <span className="shrink-0 text-[9px] font-semibold tracking-wide opacity-70">默认</span>
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-[8px] text-left text-[12px] transition-colors"
+          onClick={() => selectProvider(ep.id)}
+        >
+          <span
+            className={`size-1.5 shrink-0 rounded-full ${
+              ok ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-35'
+            }`}
+          />
+          <span className="min-w-0 flex-1 truncate font-medium">{ep.label}</span>
+          {isDef ? (
+            <span className="shrink-0 text-[9px] font-semibold tracking-wide opacity-70">默认</span>
+          ) : null}
+          {activeRow && !removable ? <LuCheck className="size-3 shrink-0 opacity-80" /> : null}
+        </button>
+        {removable ? (
+          <button
+            type="button"
+            className={`grid size-7 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] transition-opacity hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-danger,#b42318)] ${
+              activeRow ? 'opacity-100' : 'opacity-50 group-hover:opacity-100 focus:opacity-100'
+            }`}
+            title="删除连接"
+            aria-label={`删除 ${ep.label}`}
+            onClick={(e) => {
+              e.stopPropagation()
+              void onRemoveConnection(ep.id)
+            }}
+          >
+            <LuTrash2 className="size-3" />
+          </button>
         ) : null}
-        {activeRow ? <LuCheck className="size-3 shrink-0 opacity-80" /> : null}
-      </button>
+      </div>
     )
   }
 
   return (
-    <div className="flex h-full min-h-[460px] flex-col" data-testid="assistant-config">
-      <div className="flex min-h-0 flex-1 overflow-hidden rounded-[12px] border border-[var(--dsw-border)]">
+    <div
+      className={`flex h-full min-h-[460px] flex-col ${props?.onClose ? 'min-h-0' : ''}`}
+      data-testid="assistant-config"
+    >
+      {props?.onClose ? (
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--dsw-border)] px-4 py-3">
+          <div>
+            <h2 className="text-[14px] font-semibold text-[var(--dsw-label)]">模型配置</h2>
+            <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
+              官方 Key / 第三方 URL · 选模型 · 测试连接
+            </p>
+          </div>
+          <button
+            type="button"
+            className="grid size-8 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+            aria-label="关闭"
+            onClick={props.onClose}
+          >
+            <LuX className="size-4" />
+          </button>
+        </div>
+      ) : null}
+      <div
+        className={`flex min-h-0 flex-1 overflow-hidden ${
+          props?.onClose ? '' : 'rounded-[12px] border border-[var(--dsw-border)]'
+        }`}
+      >
         {/* 左：Provider 列表 */}
         <aside className="flex w-[200px] shrink-0 flex-col border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
           <div className="border-b border-[var(--dsw-border)] p-2.5">
@@ -474,14 +535,14 @@ export function ChatConfig() {
             <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
               官方
             </div>
-            {filteredOfficial.map(providerRow)}
+            {filteredOfficial.map((ep) => providerRow(ep, { removable: false }))}
 
             {filteredThird.length > 0 ? (
               <>
                 <div className="px-3 pt-3 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
                   第三方
                 </div>
-                {filteredThird.map(providerRow)}
+                {filteredThird.map((ep) => providerRow(ep, { removable: true }))}
               </>
             ) : null}
           </div>
@@ -733,8 +794,9 @@ export function ChatConfig() {
                                 <span
                                   role="button"
                                   tabIndex={0}
-                                  className="grid size-6 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:text-[var(--dsw-danger,#b42318)]"
-                                  title="删除"
+                                  className="grid size-6 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-danger,#b42318)]"
+                                  title="删除模型"
+                                  aria-label={`删除 ${m.label}`}
                                   onClick={(e) => {
                                     e.stopPropagation()
                                     void onRemoveModel(m.id)
@@ -785,12 +847,13 @@ export function ChatConfig() {
                   </div>
                 </div>
 
-                {!isOfficial(active.id) && (active.group === 'custom' || !active.builtin) ? (
+                {canRemoveConnection(active) ? (
                   <button
                     type="button"
-                    className="self-start text-[11px] text-[var(--dsw-danger,#b42318)] hover:underline"
+                    className="inline-flex self-start items-center gap-1 text-[11px] text-[var(--dsw-danger,#b42318)] hover:underline"
                     onClick={() => void onRemoveConnection(active.id)}
                   >
+                    <LuTrash2 className="size-3" />
                     删除此连接
                   </button>
                 ) : null}

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -1,11 +1,13 @@
 /**
- * Models 设置：
- * 1) 官方 Token：DeepSeek / Claude / GPT 独立 Key（始终可见）
- * 2) 默认模型：提供商 + 模型下拉（有目录就能看见模型）
- * 3) 第三方：自定义 Base URL + Token + 模型名（中转站 / OneAPI 等）
+ * Models 设置 UI（对齐 LobeChat / Open WebUI）
+ *
+ * 交互：
+ * 1. 左侧选 Provider（官方置顶；已接入的第三方；+ 添加）
+ * 2. 右侧只编辑当前 Provider：Key / Base URL / 模型列表 / 设为默认
+ * 3. 一处保存，不再拆成三块互相抢焦点
  */
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
-import { LuPlus, LuTrash2 } from 'react-icons/lu'
+import { useEffect, useMemo, useState } from 'react'
+import { LuCheck, LuPlus, LuSearch, LuTrash2 } from 'react-icons/lu'
 import type { SlotProps } from '@biu/web-slots'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
@@ -53,107 +55,144 @@ interface ChatPublicConfig {
   modelCatalog?: ModelDef[]
 }
 
-const OFFICIAL: { key: ChatProvider; label: string; placeholder: string }[] = [
-  { key: 'deepseek', label: 'DeepSeek', placeholder: 'sk-…' },
-  { key: 'anthropic', label: 'Claude（Anthropic）', placeholder: 'sk-ant-…' },
-  { key: 'openai', label: 'GPT（OpenAI）', placeholder: 'sk-…' },
-]
+const OFFICIAL_IDS = ['deepseek', 'anthropic', 'openai'] as const
+type OfficialId = (typeof OFFICIAL_IDS)[number]
 
-const OFFICIAL_ORDER: ChatProvider[] = ['deepseek', 'anthropic', 'openai']
+const OFFICIAL_META: Record<OfficialId, { label: string; placeholder: string }> = {
+  deepseek: { label: 'DeepSeek', placeholder: 'sk-…' },
+  anthropic: { label: 'Claude', placeholder: 'sk-ant-…' },
+  openai: { label: 'OpenAI', placeholder: 'sk-…' },
+}
+
+function isOfficial(id: string): id is OfficialId {
+  return (OFFICIAL_IDS as readonly string[]).includes(id)
+}
 
 const inputCls = [
   'w-full rounded-[8px] px-2.5 py-[7px] text-[13px] text-[var(--dsw-label)]',
   'border border-[var(--dsw-border)] bg-[var(--dsw-input)] outline-none',
   'placeholder:text-[var(--dsw-label-3)] focus:border-[var(--dsw-business)]',
 ].join(' ')
-const labelCls = 'text-[11px] font-semibold text-[var(--dsw-label-3)]'
-const ghostBtn = [
-  'inline-flex items-center gap-1 rounded-[8px] px-2.5 py-[6px] text-[12px] font-medium',
-  'border border-[var(--dsw-border)] text-[var(--dsw-label)]',
-  'hover:bg-[var(--dsw-hover)]',
-].join(' ')
 
 export function ChatConfig(_props: SlotProps) {
-  const [endpointId, setEndpointId] = useState('deepseek')
-  const [model, setModel] = useState('deepseek-chat')
+  const [activeId, setActiveId] = useState('deepseek')
+  const [defaultEndpointId, setDefaultEndpointId] = useState('deepseek')
+  const [defaultModel, setDefaultModel] = useState('deepseek-chat')
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
   const [providers, setProviders] = useState<Record<string, ProviderView> | null>(null)
-  const [officialKeys, setOfficialKeys] = useState<Record<ChatProvider, string>>({
-    deepseek: '',
-    openai: '',
-    anthropic: '',
-  })
-  const [thirdKeyDraft, setThirdKeyDraft] = useState('')
-  const [thirdUrlDraft, setThirdUrlDraft] = useState('')
+
+  const [keyDraft, setKeyDraft] = useState('')
+  const [urlDraft, setUrlDraft] = useState('')
+  const [query, setQuery] = useState('')
+  const [newModelName, setNewModelName] = useState('')
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
+  const [saving, setSaving] = useState(false)
 
-  const [newModelName, setNewModelName] = useState('')
-  const [showAddThird, setShowAddThird] = useState(false)
-  const [newEpLabel, setNewEpLabel] = useState('')
-  const [newEpUrl, setNewEpUrl] = useState('')
-  const [newEpKey, setNewEpKey] = useState('')
-  const [newEpProtocol, setNewEpProtocol] = useState<'openai-compat' | 'anthropic'>('openai-compat')
+  const [adding, setAdding] = useState(false)
   const [presetId, setPresetId] = useState('')
+  const [newLabel, setNewLabel] = useState('')
+  const [newUrl, setNewUrl] = useState('')
+  const [newKey, setNewKey] = useState('')
+  const [newProtocol, setNewProtocol] = useState<'openai-compat' | 'anthropic'>('openai-compat')
 
-  const officialEndpoints = useMemo(
-    () => endpoints.filter((e) => OFFICIAL_ORDER.includes(e.id as ChatProvider)),
-    [endpoints],
+  const active = endpoints.find((e) => e.id === activeId)
+  const activeModels = useMemo(
+    () => modelCatalog.filter((m) => m.endpointId === activeId),
+    [modelCatalog, activeId],
   )
-  const thirdEndpoints = useMemo(
-    () => endpoints.filter((e) => !OFFICIAL_ORDER.includes(e.id as ChatProvider)),
-    [endpoints],
-  )
-  const relayPresets = useMemo(
-    () => thirdEndpoints.filter((e) => e.group === 'relay' || e.group === 'local' || (e.group === 'official' && !OFFICIAL_ORDER.includes(e.id as ChatProvider))),
-    [thirdEndpoints],
+  const isDefaultProvider = defaultEndpointId === activeId
+  const configured = active?.configured ?? providers?.[activeId]?.configured ?? false
+
+  const officialList = useMemo(() => {
+    return OFFICIAL_IDS.map((id) => {
+      const found = endpoints.find((e) => e.id === id)
+      if (found) return found
+      return {
+        id,
+        label: OFFICIAL_META[id].label,
+        group: 'official',
+        protocol: id === 'anthropic' ? 'anthropic' : 'openai-compat',
+        provider: id,
+        baseUrl: '',
+        defaultBaseUrl: '',
+        configured: Boolean(providers?.[id]?.configured),
+        hint: providers?.[id]?.hint ?? '',
+        placeholder: OFFICIAL_META[id].placeholder,
+        note: '官方',
+        builtin: true,
+      } satisfies EndpointView
+    })
+  }, [endpoints, providers])
+
+  /** 已接入的第三方：配过 Key，或自定义，或当前默认 */
+  const connectedThird = useMemo(
+    () =>
+      endpoints.filter(
+        (e) =>
+          !isOfficial(e.id) &&
+          (e.configured || e.group === 'custom' || e.id === defaultEndpointId || e.id === activeId),
+      ),
+    [endpoints, defaultEndpointId, activeId],
   )
 
-  const isOfficial = OFFICIAL_ORDER.includes(endpointId as ChatProvider)
-  const current = endpoints.find((e) => e.id === endpointId)
-  const availableModels = useMemo(
-    () => modelCatalog.filter((m) => m.endpointId === endpointId),
-    [modelCatalog, endpointId],
+  const presets = useMemo(
+    () =>
+      endpoints.filter(
+        (e) =>
+          !isOfficial(e.id) &&
+          !connectedThird.some((c) => c.id === e.id) &&
+          (e.group === 'relay' || e.group === 'local' || e.group === 'official'),
+      ),
+    [endpoints, connectedThird],
   )
-  const currentModelInCatalog =
-    availableModels.find((m) => m.model === model) ?? availableModels[0]
 
-  /** 切换入口：同步 URL 草稿，并强制落到该入口的第一个模型。 */
-  function switchEndpoint(next: string) {
-    setEndpointId(next)
-    setThirdKeyDraft('')
-    setError('')
-    setStatus('')
-    setNewModelName('')
-    const ep = endpoints.find((x) => x.id === next)
-    if (ep && !OFFICIAL_ORDER.includes(next as ChatProvider)) {
-      setThirdUrlDraft(ep.baseUrl)
-    } else {
-      setThirdUrlDraft('')
-    }
-    const models = modelCatalog.filter((m) => m.endpointId === next)
-    if (models[0]) setModel(models[0].model)
-  }
+  const filteredOfficial = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return officialList
+    return officialList.filter(
+      (e) => e.label.toLowerCase().includes(q) || e.id.includes(q),
+    )
+  }, [officialList, query])
 
-  function applyPublic(data: ChatPublicConfig, preferId?: string) {
+  const filteredThird = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return connectedThird
+    return connectedThird.filter(
+      (e) =>
+        e.label.toLowerCase().includes(q) ||
+        e.id.includes(q) ||
+        e.baseUrl.toLowerCase().includes(q),
+    )
+  }, [connectedThird, query])
+
+  function applyPublic(data: ChatPublicConfig, preferActive?: string) {
     const eps = Array.isArray(data.endpoints) ? data.endpoints : []
     setEndpoints(eps)
     const cats = Array.isArray(data.modelCatalog) ? data.modelCatalog : []
     setModelCatalog(cats)
     if (data.providers) setProviders(data.providers)
-    const eid = preferId || data.endpointId || data.provider || 'deepseek'
-    setEndpointId(eid)
-    const modelsFor = cats.filter((m) => m.endpointId === eid)
-    const nextModel =
-      data.model && modelsFor.some((m) => m.model === data.model)
-        ? data.model
-        : modelsFor[0]?.model || data.model
-    setModel(nextModel)
+
+    const eid = preferActive || data.endpointId || data.provider || 'deepseek'
+    setDefaultEndpointId(data.endpointId || data.provider || eid)
+    setDefaultModel(data.model)
+    setActiveId(eid)
+
     const ep = eps.find((e) => e.id === eid)
-    setThirdUrlDraft(ep && !OFFICIAL_ORDER.includes(eid as ChatProvider) ? ep.baseUrl : '')
-    setThirdKeyDraft('')
-    setOfficialKeys({ deepseek: '', openai: '', anthropic: '' })
+    setUrlDraft(ep?.baseUrl ?? data.baseUrl ?? '')
+    setKeyDraft('')
+  }
+
+  function selectProvider(id: string) {
+    setActiveId(id)
+    setAdding(false)
+    setError('')
+    setStatus('')
+    setKeyDraft('')
+    setNewModelName('')
+    const ep = endpoints.find((e) => e.id === id)
+    setUrlDraft(ep?.baseUrl ?? '')
   }
 
   useEffect(() => {
@@ -163,67 +202,107 @@ export function ChatConfig(_props: SlotProps) {
       .catch(() => setError('加载配置失败'))
   }, [])
 
-  async function onSubmit(event: FormEvent) {
-    event.preventDefault()
+  async function saveCurrent(opts?: { makeDefault?: boolean; model?: string }) {
+    if (!active) return
+    setSaving(true)
     setError('')
     setStatus('')
+    try {
+      const body: Record<string, unknown> = {}
+      const nextModel = opts?.model ?? (isDefaultProvider ? defaultModel : activeModels[0]?.model)
+      if (opts?.makeDefault || isDefaultProvider) {
+        body.endpointId = activeId
+        if (nextModel) body.model = nextModel
+      }
+      if (keyDraft.trim()) body.setApiKey = { [activeId]: keyDraft.trim() }
+      if (!isOfficial(activeId)) {
+        const base = urlDraft.trim()
+        if (base && base !== active.defaultBaseUrl) body.setBaseUrl = { [activeId]: base }
+        else if (base === active.defaultBaseUrl && active.baseUrl !== active.defaultBaseUrl) {
+          body.setBaseUrl = { [activeId]: null }
+        }
+      }
+      // 至少要有可写内容，或设为默认
+      if (
+        !body.endpointId &&
+        !body.setApiKey &&
+        !body.setBaseUrl &&
+        !opts?.makeDefault
+      ) {
+        // 仅切换默认模型（当前已是默认入口）
+        if (isDefaultProvider && opts?.model) {
+          body.endpointId = activeId
+          body.model = opts.model
+        } else {
+          setStatus('没有需要保存的更改')
+          return
+        }
+      }
 
-    const setApiKey: Record<string, string> = {}
-    for (const p of OFFICIAL) {
-      if (officialKeys[p.key].trim()) setApiKey[p.key] = officialKeys[p.key].trim()
+      const res = await fetch('/api/chat/config', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        setError(`保存失败：HTTP ${res.status}`)
+        return
+      }
+      applyPublic((await res.json()) as ChatPublicConfig, activeId)
+      setStatus(opts?.makeDefault ? '已设为默认并保存' : '已保存')
+    } finally {
+      setSaving(false)
     }
-    if (!isOfficial && thirdKeyDraft.trim()) setApiKey[endpointId] = thirdKeyDraft.trim()
+  }
 
-    const hasOfficial =
-      OFFICIAL_ORDER.some((p) => providers?.[p]?.configured || officialKeys[p].trim())
-    const hasThird =
-      thirdEndpoints.some((e) => e.configured) || Boolean(thirdKeyDraft.trim()) || Object.keys(setApiKey).length > 0
-    if (!hasOfficial && !hasThird && current?.group !== 'local') {
-      setError('请至少填写一个官方 API Key，或配置第三方连接。')
-      return
+  async function pickDefaultModel(m: ModelDef) {
+    setDefaultModel(m.model)
+    setSaving(true)
+    setError('')
+    try {
+      const body: Record<string, unknown> = {
+        endpointId: activeId,
+        model: m.model,
+      }
+      if (keyDraft.trim()) body.setApiKey = { [activeId]: keyDraft.trim() }
+      if (!isOfficial(activeId) && urlDraft.trim()) {
+        body.setBaseUrl = { [activeId]: urlDraft.trim() }
+      }
+      const res = await fetch('/api/chat/config', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) {
+        setError(`保存失败：HTTP ${res.status}`)
+        return
+      }
+      applyPublic((await res.json()) as ChatPublicConfig, activeId)
+      setStatus(`默认模型：${m.label}`)
+    } finally {
+      setSaving(false)
     }
-
-    const body: Record<string, unknown> = {
-      endpointId,
-      model,
-      ...(Object.keys(setApiKey).length ? { setApiKey } : {}),
-    }
-    if (!isOfficial && thirdUrlDraft.trim()) {
-      body.setBaseUrl = { [endpointId]: thirdUrlDraft.trim() }
-    }
-
-    const res = await fetch('/api/chat/config', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    })
-    if (!res.ok) {
-      setError(`保存失败：HTTP ${res.status}`)
-      return
-    }
-    applyPublic((await res.json()) as ChatPublicConfig, endpointId)
-    setStatus('已保存（.cordis/chat-config.json）')
   }
 
   async function onAddModel() {
     const name = newModelName.trim()
     if (!name) {
-      setError('请填写模型名称')
+      setError('请填写模型 ID')
       return
     }
     setError('')
     const res = await fetch('/api/chat/config', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ addModel: { endpointId, model: name, label: name } }),
+      body: JSON.stringify({ addModel: { endpointId: activeId, model: name, label: name } }),
     })
     if (!res.ok) {
-      setError(`添加模型失败：HTTP ${res.status}`)
+      setError(`添加失败：HTTP ${res.status}`)
       return
     }
-    applyPublic((await res.json()) as ChatPublicConfig, endpointId)
+    applyPublic((await res.json()) as ChatPublicConfig, activeId)
     setNewModelName('')
-    setStatus(`已添加模型 ${name}`)
+    setStatus(`已添加 ${name}`)
   }
 
   async function onRemoveModel(id: string) {
@@ -233,24 +312,24 @@ export function ChatConfig(_props: SlotProps) {
       body: JSON.stringify({ removeCustomModel: id }),
     })
     if (!res.ok) return
-    applyPublic((await res.json()) as ChatPublicConfig, endpointId)
+    applyPublic((await res.json()) as ChatPublicConfig, activeId)
   }
 
-  async function onAddThird() {
+  async function onAddConnection() {
     const fromPreset = presetId ? endpoints.find((e) => e.id === presetId) : null
-    const label = newEpLabel.trim() || fromPreset?.label || ''
-    const baseUrl = newEpUrl.trim() || fromPreset?.defaultBaseUrl || fromPreset?.baseUrl || ''
+    const label = newLabel.trim() || fromPreset?.label || ''
+    const baseUrl = newUrl.trim() || fromPreset?.defaultBaseUrl || fromPreset?.baseUrl || ''
     if (!label || !baseUrl) {
-      setError('请填写第三方名称与 API URL，或选择预设中转站')
+      setError('请选择预设或填写名称与 Base URL')
       return
     }
     setError('')
-    // 预设：只切到该入口并写 Key/URL；自定义：addEndpoint
-    if (fromPreset && !newEpLabel.trim()) {
+
+    if (fromPreset && !newLabel.trim()) {
       const body: Record<string, unknown> = { endpointId: fromPreset.id }
-      if (newEpKey.trim()) body.setApiKey = { [fromPreset.id]: newEpKey.trim() }
-      if (newEpUrl.trim() && newEpUrl.trim() !== fromPreset.defaultBaseUrl) {
-        body.setBaseUrl = { [fromPreset.id]: newEpUrl.trim() }
+      if (newKey.trim()) body.setApiKey = { [fromPreset.id]: newKey.trim() }
+      if (newUrl.trim() && newUrl.trim() !== fromPreset.defaultBaseUrl) {
+        body.setBaseUrl = { [fromPreset.id]: newUrl.trim() }
       }
       const first = modelCatalog.find((m) => m.endpointId === fromPreset.id)
       if (first) body.model = first.model
@@ -269,45 +348,35 @@ export function ChatConfig(_props: SlotProps) {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          addEndpoint: {
-            label,
-            baseUrl,
-            protocol: newEpProtocol,
-          },
-          ...(newEpKey.trim()
-            ? {
-                // addEndpoint 会切到新 id；紧接着再 patch key 需二次请求
-              }
-            : {}),
+          addEndpoint: { label, baseUrl, protocol: newProtocol },
         }),
       })
       if (!res.ok) {
         setError(`添加失败：HTTP ${res.status}`)
         return
       }
-      const data = (await res.json()) as ChatPublicConfig
+      let data = (await res.json()) as ChatPublicConfig
       const newId = data.endpointId
-      if (newEpKey.trim() && newId) {
+      if (newKey.trim() && newId) {
         const res2 = await fetch('/api/chat/config', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ setApiKey: { [newId]: newEpKey.trim() }, endpointId: newId }),
+          body: JSON.stringify({ setApiKey: { [newId]: newKey.trim() }, endpointId: newId }),
         })
-        if (res2.ok) applyPublic((await res2.json()) as ChatPublicConfig, newId)
-        else applyPublic(data)
-      } else {
-        applyPublic(data)
+        if (res2.ok) data = (await res2.json()) as ChatPublicConfig
       }
+      applyPublic(data, newId)
     }
-    setShowAddThird(false)
+
+    setAdding(false)
     setPresetId('')
-    setNewEpLabel('')
-    setNewEpUrl('')
-    setNewEpKey('')
-    setStatus('第三方已接入，可在上方选择其模型')
+    setNewLabel('')
+    setNewUrl('')
+    setNewKey('')
+    setStatus('已接入')
   }
 
-  async function onRemoveThird(id: string) {
+  async function onRemoveConnection(id: string) {
     const res = await fetch('/api/chat/config', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -315,335 +384,394 @@ export function ChatConfig(_props: SlotProps) {
     })
     if (!res.ok) return
     applyPublic((await res.json()) as ChatPublicConfig)
-    setStatus('已删除第三方连接')
+    setStatus('已删除')
   }
 
-  const selectOptions = useMemo(() => {
-    const official = officialEndpoints
-    const configuredThird = thirdEndpoints.filter((e) => e.configured || e.id === endpointId)
-    return { official, third: configuredThird }
-  }, [officialEndpoints, thirdEndpoints, endpointId])
+  function providerRow(ep: EndpointView) {
+    const activeRow = ep.id === activeId && !adding
+    const isDef = ep.id === defaultEndpointId
+    const ok = ep.configured || providers?.[ep.id]?.configured
+    return (
+      <button
+        key={ep.id}
+        type="button"
+        className={`flex w-full items-center gap-2 px-3 py-[8px] text-left text-[12px] transition-colors ${
+          activeRow
+            ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
+            : 'text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]'
+        }`}
+        onClick={() => selectProvider(ep.id)}
+      >
+        <span
+          className={`size-1.5 shrink-0 rounded-full ${
+            ok ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-35'
+          }`}
+        />
+        <span className="min-w-0 flex-1 truncate font-medium">{ep.label}</span>
+        {isDef ? (
+          <span className="shrink-0 text-[9px] font-semibold tracking-wide opacity-70">默认</span>
+        ) : null}
+        {activeRow ? <LuCheck className="size-3 shrink-0 opacity-80" /> : null}
+      </button>
+    )
+  }
 
   return (
-    <form
-      className="relative flex h-full min-h-[420px] flex-col gap-5 px-1 pb-14"
-      data-testid="assistant-config"
-      onSubmit={onSubmit}
-    >
-      {/* ① 官方 Token —— 始终可见 */}
-      <section className="flex flex-col gap-2.5">
-        <div className="flex items-baseline justify-between">
-          <span className={labelCls}>官方 API Key</span>
-          <span className="text-[10px] text-[var(--dsw-label-3)]">DeepSeek / Claude / GPT</span>
-        </div>
-        {OFFICIAL.map((p) => {
-          const view = providers?.[p.key]
-          return (
-            <label key={p.key} className="flex flex-col gap-1">
-              <span className="flex items-center gap-1.5 text-[12px] font-medium text-[var(--dsw-label)]">
-                <span
-                  className={`inline-block size-1.5 rounded-full ${
-                    view?.configured ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-40'
-                  }`}
-                />
-                {p.label}
-                {view?.configured ? (
-                  <span className="font-normal text-[var(--dsw-label-3)]">· {view.hint}</span>
-                ) : null}
-              </span>
+    <div className="flex h-full min-h-[460px] flex-col" data-testid="assistant-config">
+      <div className="flex min-h-0 flex-1 overflow-hidden rounded-[12px] border border-[var(--dsw-border)]">
+        {/* 左：Provider 列表 */}
+        <aside className="flex w-[200px] shrink-0 flex-col border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
+          <div className="border-b border-[var(--dsw-border)] p-2.5">
+            <div className="relative">
+              <LuSearch className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-[var(--dsw-label-3)]" />
               <input
-                className={inputCls}
-                type="password"
-                autoComplete="off"
-                data-testid={`key-${p.key}`}
-                placeholder={view?.configured ? `已配置 · 输入可覆盖` : p.placeholder}
-                value={officialKeys[p.key]}
-                onChange={(e) => setOfficialKeys((prev) => ({ ...prev, [p.key]: e.target.value }))}
+                className={`${inputCls} pl-7`}
+                placeholder="搜索…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                aria-label="搜索 Provider"
               />
-            </label>
-          )
-        })}
-      </section>
-
-      {/* ② 默认模型 —— 下拉可见目录模型 */}
-      <section className="flex flex-col gap-2.5">
-        <div className="flex items-baseline justify-between">
-          <span className={labelCls}>默认模型</span>
-          <span className="text-[10px] text-[var(--dsw-label-3)]">
-            当前入口 {availableModels.length} 个模型
-          </span>
-        </div>
-        <div className="flex gap-2">
-          <label className="flex w-[42%] flex-col gap-1">
-            <span className="text-[11px] text-[var(--dsw-label-3)]">提供商 / 入口</span>
-            <select
-              className={inputCls}
-              value={endpointId}
-              data-testid="endpoint"
-              onChange={(e) => switchEndpoint(e.target.value)}
-            >
-              <optgroup label="官方">
-                {OFFICIAL.map((p) => (
-                  <option key={p.key} value={p.key}>
-                    {p.label}
-                    {providers?.[p.key]?.configured ? '（已配置）' : ''}
-                  </option>
-                ))}
-              </optgroup>
-              {selectOptions.third.length ? (
-                <optgroup label="第三方 / 中转">
-                  {selectOptions.third.map((ep) => (
-                    <option key={ep.id} value={ep.id}>
-                      {ep.label}
-                      {ep.configured ? '（已配置）' : ''}
-                    </option>
-                  ))}
-                </optgroup>
-              ) : null}
-            </select>
-          </label>
-          <label className="flex w-[58%] flex-col gap-1">
-            <span className="text-[11px] text-[var(--dsw-label-3)]">模型</span>
-            <select
-              key={endpointId}
-              className={inputCls}
-              value={currentModelInCatalog?.id ?? ''}
-              data-testid="model"
-              size={1}
-              onChange={(e) => {
-                const def = availableModels.find((m) => m.id === e.target.value)
-                if (def) setModel(def.model)
-              }}
-            >
-              {availableModels.length === 0 ? (
-                <option value="">暂无模型 — 可在下方添加</option>
-              ) : (
-                availableModels.map((m) => (
-                  <option key={m.id} value={m.id}>
-                    {m.label}
-                    {m.model !== m.label ? ` · ${m.model}` : ''}
-                    {m.note ? ` — ${m.note}` : ''}
-                  </option>
-                ))
-              )}
-            </select>
-          </label>
-        </div>
-
-        {/* 第三方入口：显示 URL + Key 覆盖 */}
-        {!isOfficial && current ? (
-          <div className="flex flex-col gap-2 rounded-[10px] border border-[var(--dsw-border)] p-3">
-            <div className="text-[12px] font-medium text-[var(--dsw-label)]">{current.label}</div>
-            <label className="flex flex-col gap-1">
-              <span className="text-[11px] text-[var(--dsw-label-3)]">API URL</span>
-              <input
-                className={inputCls}
-                type="url"
-                data-testid="base-url"
-                value={thirdUrlDraft}
-                placeholder={current.defaultBaseUrl}
-                onChange={(e) => setThirdUrlDraft(e.target.value)}
-              />
-            </label>
-            <label className="flex flex-col gap-1">
-              <span className="text-[11px] text-[var(--dsw-label-3)]">API Token</span>
-              <input
-                className={inputCls}
-                type="password"
-                autoComplete="off"
-                placeholder={current.configured ? `已配置 · ${current.hint}` : current.placeholder}
-                value={thirdKeyDraft}
-                onChange={(e) => setThirdKeyDraft(e.target.value)}
-              />
-            </label>
-          </div>
-        ) : null}
-
-        {/* 在当前入口追加模型名 */}
-        <div className="flex gap-2">
-          <input
-            className={inputCls}
-            placeholder="追加模型名称，如 gpt-4o / deepseek-chat"
-            value={newModelName}
-            onChange={(e) => setNewModelName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                void onAddModel()
-              }
-            }}
-          />
-          <button type="button" className={ghostBtn} onClick={() => void onAddModel()}>
-            <LuPlus className="size-3.5" />
-            添加模型
-          </button>
-        </div>
-        {availableModels.some((m) => m.builtin === false) ? (
-          <ul className="flex flex-col gap-1">
-            {availableModels
-              .filter((m) => m.builtin === false)
-              .map((m) => (
-                <li
-                  key={m.id}
-                  className="flex items-center justify-between text-[11px] text-[var(--dsw-label-2)]"
-                >
-                  <span>
-                    {m.label} <code className="text-[10px] opacity-70">{m.model}</code>
-                  </span>
-                  <button
-                    type="button"
-                    className="text-[var(--dsw-danger,#b42318)]"
-                    onClick={() => void onRemoveModel(m.id)}
-                  >
-                    删除
-                  </button>
-                </li>
-              ))}
-          </ul>
-        ) : null}
-      </section>
-
-      {/* ③ 第三方 / 中转 */}
-      <section className="flex flex-col gap-2.5">
-        <div className="flex items-center justify-between">
-          <span className={labelCls}>第三方 API</span>
-          {!showAddThird ? (
-            <button type="button" className={ghostBtn} onClick={() => setShowAddThird(true)}>
-              <LuPlus className="size-3.5" />
-              接入中转 / 自定义
-            </button>
-          ) : null}
-        </div>
-
-        {thirdEndpoints.filter((e) => e.configured || !e.builtin).length ? (
-          <ul className="flex flex-col gap-1 rounded-[10px] border border-[var(--dsw-border)] p-1.5">
-            {thirdEndpoints
-              .filter((e) => e.configured || e.group === 'custom')
-              .map((ep) => (
-                <li
-                  key={ep.id}
-                  className={`flex items-center gap-2 rounded-[8px] px-2.5 py-2 text-[12px] ${
-                    ep.id === endpointId ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]' : 'text-[var(--dsw-label)]'
-                  }`}
-                >
-                  <button
-                    type="button"
-                    className="min-w-0 flex-1 truncate text-left"
-                    onClick={() => switchEndpoint(ep.id)}
-                  >
-                    <span className="font-medium">{ep.label}</span>
-                    <span className="mt-0.5 block truncate text-[10px] opacity-60">{ep.baseUrl}</span>
-                  </button>
-                  <span
-                    className={`size-1.5 shrink-0 rounded-full ${
-                      ep.configured ? 'bg-[var(--dsw-ok)]' : 'bg-[var(--dsw-label-3)] opacity-40'
-                    }`}
-                  />
-                  {ep.group === 'custom' || !ep.builtin ? (
-                    <button
-                      type="button"
-                      className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:text-[var(--dsw-danger,#b42318)]"
-                      title="删除"
-                      onClick={() => void onRemoveThird(ep.id)}
-                    >
-                      <LuTrash2 className="size-3" />
-                    </button>
-                  ) : null}
-                </li>
-              ))}
-          </ul>
-        ) : (
-          <p className="text-[11px] text-[var(--dsw-label-3)]">
-            未接入第三方。可用官方 Key，或添加中转站 / 自定义 URL。
-          </p>
-        )}
-
-        {showAddThird ? (
-          <div className="flex flex-col gap-2 rounded-[10px] border border-[var(--dsw-border)] p-3">
-            <label className="flex flex-col gap-1">
-              <span className="text-[11px] text-[var(--dsw-label-3)]">预设中转站（可选）</span>
-              <select
-                className={inputCls}
-                value={presetId}
-                onChange={(e) => {
-                  const id = e.target.value
-                  setPresetId(id)
-                  const ep = endpoints.find((x) => x.id === id)
-                  if (ep) {
-                    setNewEpUrl(ep.defaultBaseUrl || ep.baseUrl)
-                    if (!newEpLabel) setNewEpLabel('')
-                  }
-                }}
-              >
-                <option value="">自定义…</option>
-                {relayPresets.map((ep) => (
-                  <option key={ep.id} value={ep.id}>
-                    {ep.label}
-                    {ep.note ? ` · ${ep.note}` : ''}
-                  </option>
-                ))}
-              </select>
-            </label>
-            {!presetId ? (
-              <>
-                <input
-                  className={inputCls}
-                  placeholder="名称，如 My OneAPI"
-                  value={newEpLabel}
-                  onChange={(e) => setNewEpLabel(e.target.value)}
-                />
-                <select
-                  className={inputCls}
-                  value={newEpProtocol}
-                  onChange={(e) => setNewEpProtocol(e.target.value as 'openai-compat' | 'anthropic')}
-                >
-                  <option value="openai-compat">OpenAI 兼容</option>
-                  <option value="anthropic">Anthropic Messages</option>
-                </select>
-              </>
-            ) : null}
-            <input
-              className={inputCls}
-              placeholder="API URL，如 https://api.example.com/v1"
-              value={newEpUrl}
-              onChange={(e) => setNewEpUrl(e.target.value)}
-            />
-            <input
-              className={inputCls}
-              type="password"
-              autoComplete="off"
-              placeholder="API Token"
-              value={newEpKey}
-              onChange={(e) => setNewEpKey(e.target.value)}
-            />
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className="rounded-[8px] px-3 py-[6px] text-[12px] font-medium text-[var(--dsw-bg)]"
-                style={{ background: 'var(--dsw-business)' }}
-                onClick={() => void onAddThird()}
-              >
-                确认接入
-              </button>
-              <button type="button" className={ghostBtn} onClick={() => setShowAddThird(false)}>
-                取消
-              </button>
             </div>
           </div>
-        ) : null}
-      </section>
 
-      <div className="flex flex-1 items-end justify-end gap-2">
-        {status ? <span className="text-[11px] text-[var(--dsw-ok)]">{status}</span> : null}
-        {error ? <span className="text-[11px] text-[var(--dsw-danger,#b42318)]">{error}</span> : null}
-        <button
-          className="rounded-[8px] px-3 py-[7px] text-[13px] font-medium text-[var(--dsw-bg)] transition-opacity hover:opacity-90"
-          style={{ background: 'var(--dsw-business)' }}
-          type="submit"
-        >
-          保存
-        </button>
+          <div className="min-h-0 flex-1 overflow-y-auto py-1">
+            <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
+              官方
+            </div>
+            {filteredOfficial.map(providerRow)}
+
+            {filteredThird.length > 0 ? (
+              <>
+                <div className="px-3 pt-3 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
+                  第三方
+                </div>
+                {filteredThird.map(providerRow)}
+              </>
+            ) : null}
+          </div>
+
+          <div className="border-t border-[var(--dsw-border)] p-2">
+            <button
+              type="button"
+              className={`flex w-full items-center justify-center gap-1 rounded-[8px] px-2.5 py-[7px] text-[12px] font-medium transition-colors ${
+                adding
+                  ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
+                  : 'text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]'
+              }`}
+              onClick={() => {
+                setAdding(true)
+                setError('')
+                setStatus('')
+              }}
+            >
+              <LuPlus className="size-3.5" />
+              添加连接
+            </button>
+          </div>
+        </aside>
+
+        {/* 右：详情 */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          {adding ? (
+            <>
+              <div className="border-b border-[var(--dsw-border)] px-4 py-3">
+                <h3 className="text-[14px] font-semibold text-[var(--dsw-label)]">添加连接</h3>
+                <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
+                  选中转站预设，或填自定义 Base URL + Token
+                </p>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3">
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">预设</span>
+                  <select
+                    className={inputCls}
+                    value={presetId}
+                    onChange={(e) => {
+                      const id = e.target.value
+                      setPresetId(id)
+                      const ep = endpoints.find((x) => x.id === id)
+                      if (ep) {
+                        setNewUrl(ep.defaultBaseUrl || ep.baseUrl)
+                        setNewLabel('')
+                      } else {
+                        setNewUrl('')
+                      }
+                    }}
+                  >
+                    <option value="">自定义 URL…</option>
+                    {presets.map((ep) => (
+                      <option key={ep.id} value={ep.id}>
+                        {ep.label}
+                        {ep.note ? ` · ${ep.note}` : ''}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                {!presetId ? (
+                  <>
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">名称</span>
+                      <input
+                        className={inputCls}
+                        placeholder="My OneAPI"
+                        value={newLabel}
+                        onChange={(e) => setNewLabel(e.target.value)}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1.5">
+                      <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">协议</span>
+                      <select
+                        className={inputCls}
+                        value={newProtocol}
+                        onChange={(e) => setNewProtocol(e.target.value as 'openai-compat' | 'anthropic')}
+                      >
+                        <option value="openai-compat">OpenAI 兼容</option>
+                        <option value="anthropic">Anthropic Messages</option>
+                      </select>
+                    </label>
+                  </>
+                ) : null}
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">Base URL</span>
+                  <input
+                    className={inputCls}
+                    placeholder="https://api.example.com/v1"
+                    value={newUrl}
+                    onChange={(e) => setNewUrl(e.target.value)}
+                  />
+                </label>
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">API Key</span>
+                  <input
+                    className={inputCls}
+                    type="password"
+                    autoComplete="off"
+                    placeholder="sk-…"
+                    value={newKey}
+                    onChange={(e) => setNewKey(e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="flex items-center justify-end gap-2 border-t border-[var(--dsw-border)] px-4 py-2.5">
+                {error ? (
+                  <span className="mr-auto text-[11px] text-[var(--dsw-danger,#b42318)]">{error}</span>
+                ) : null}
+                <button
+                  type="button"
+                  className="rounded-[8px] px-3 py-[6px] text-[12px] text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)]"
+                  onClick={() => setAdding(false)}
+                >
+                  取消
+                </button>
+                <button
+                  type="button"
+                  className="rounded-[8px] px-3.5 py-[7px] text-[13px] font-medium text-[var(--dsw-bg)]"
+                  style={{ background: 'var(--dsw-business)' }}
+                  onClick={() => void onAddConnection()}
+                >
+                  接入
+                </button>
+              </div>
+            </>
+          ) : active ? (
+            <>
+              <div className="flex items-start justify-between gap-3 border-b border-[var(--dsw-border)] px-4 py-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-[14px] font-semibold text-[var(--dsw-label)]">
+                    {isOfficial(active.id) ? OFFICIAL_META[active.id].label : active.label}
+                  </h3>
+                  <p className="mt-0.5 truncate text-[11px] text-[var(--dsw-label-3)]">
+                    {active.note || active.baseUrl}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <span
+                    className={`rounded-[6px] px-2 py-0.5 text-[10px] font-medium ${
+                      configured
+                        ? 'bg-[color-mix(in_srgb,var(--dsw-ok)_16%,transparent)] text-[var(--dsw-ok)]'
+                        : 'bg-[var(--dsw-hover)] text-[var(--dsw-label-3)]'
+                    }`}
+                  >
+                    {configured ? '已配置' : '未配置'}
+                  </span>
+                  {isDefaultProvider ? (
+                    <span className="rounded-[6px] bg-[var(--dsw-business-soft)] px-2 py-0.5 text-[10px] font-medium text-[var(--dsw-business)]">
+                      当前默认
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-3">
+                <label className="flex flex-col gap-1.5">
+                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">API Key</span>
+                  <input
+                    className={inputCls}
+                    type="password"
+                    autoComplete="off"
+                    data-testid={isOfficial(active.id) ? `key-${active.id}` : 'key-third'}
+                    placeholder={
+                      configured
+                        ? `已配置 · 输入新 Key 可覆盖（${active.hint || active.placeholder}）`
+                        : isOfficial(active.id)
+                          ? OFFICIAL_META[active.id].placeholder
+                          : active.placeholder
+                    }
+                    value={keyDraft}
+                    onChange={(e) => setKeyDraft(e.target.value)}
+                  />
+                </label>
+
+                {!isOfficial(active.id) ? (
+                  <label className="flex flex-col gap-1.5">
+                    <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">Base URL</span>
+                    <input
+                      className={inputCls}
+                      type="url"
+                      data-testid="base-url"
+                      value={urlDraft}
+                      placeholder={active.defaultBaseUrl}
+                      onChange={(e) => setUrlDraft(e.target.value)}
+                    />
+                  </label>
+                ) : (
+                  <p className="text-[11px] text-[var(--dsw-label-3)]">
+                    官方地址：<span className="font-mono text-[10px]">{active.defaultBaseUrl}</span>
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">
+                      模型
+                      <span className="ml-1 font-normal">· {activeModels.length}</span>
+                    </span>
+                    <span className="text-[10px] text-[var(--dsw-label-3)]">点击设为默认</span>
+                  </div>
+
+                  {activeModels.length ? (
+                    <ul className="flex max-h-[220px] flex-col gap-0.5 overflow-y-auto rounded-[8px] border border-[var(--dsw-border)] p-1">
+                      {activeModels.map((m) => {
+                        const selected = isDefaultProvider && m.model === defaultModel
+                        return (
+                          <li key={m.id}>
+                            <button
+                              type="button"
+                              data-testid={selected ? 'model-active' : undefined}
+                              className={`flex w-full items-center gap-2 rounded-[6px] px-2 py-1.5 text-left transition-colors ${
+                                selected
+                                  ? 'bg-[var(--dsw-business-soft)] text-[var(--dsw-business)]'
+                                  : 'text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]'
+                              }`}
+                              onClick={() => void pickDefaultModel(m)}
+                            >
+                              <span className="min-w-0 flex-1">
+                                <span className="block truncate text-[12px] font-medium">{m.label}</span>
+                                <span className="block truncate font-mono text-[10px] opacity-55">
+                                  {m.model}
+                                  {m.note ? ` · ${m.note}` : ''}
+                                </span>
+                              </span>
+                              {m.builtin === false ? (
+                                <span
+                                  role="button"
+                                  tabIndex={0}
+                                  className="grid size-6 shrink-0 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:text-[var(--dsw-danger,#b42318)]"
+                                  title="删除"
+                                  onClick={(e) => {
+                                    e.stopPropagation()
+                                    void onRemoveModel(m.id)
+                                  }}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                      e.preventDefault()
+                                      e.stopPropagation()
+                                      void onRemoveModel(m.id)
+                                    }
+                                  }}
+                                >
+                                  <LuTrash2 className="size-3" />
+                                </span>
+                              ) : selected ? (
+                                <LuCheck className="size-3.5 shrink-0" />
+                              ) : null}
+                            </button>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  ) : (
+                    <p className="text-[11px] text-[var(--dsw-label-3)]">暂无模型，在下方添加 model id</p>
+                  )}
+
+                  <div className="flex gap-2">
+                    <input
+                      className={inputCls}
+                      placeholder="添加模型 ID"
+                      value={newModelName}
+                      onChange={(e) => setNewModelName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault()
+                          void onAddModel()
+                        }
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="inline-flex shrink-0 items-center gap-1 rounded-[8px] border border-[var(--dsw-border)] px-2.5 py-[6px] text-[12px] text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]"
+                      onClick={() => void onAddModel()}
+                    >
+                      <LuPlus className="size-3.5" />
+                      添加
+                    </button>
+                  </div>
+                </div>
+
+                {!isOfficial(active.id) && (active.group === 'custom' || !active.builtin) ? (
+                  <button
+                    type="button"
+                    className="self-start text-[11px] text-[var(--dsw-danger,#b42318)] hover:underline"
+                    onClick={() => void onRemoveConnection(active.id)}
+                  >
+                    删除此连接
+                  </button>
+                ) : null}
+              </div>
+
+              <div className="flex items-center justify-end gap-2 border-t border-[var(--dsw-border)] px-4 py-2.5">
+                {status ? <span className="mr-auto text-[11px] text-[var(--dsw-ok)]">{status}</span> : null}
+                {error ? (
+                  <span className="mr-auto text-[11px] text-[var(--dsw-danger,#b42318)]">{error}</span>
+                ) : null}
+                {!isDefaultProvider ? (
+                  <button
+                    type="button"
+                    className="rounded-[8px] border border-[var(--dsw-border)] px-3 py-[6px] text-[12px] text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]"
+                    disabled={saving}
+                    onClick={() => void saveCurrent({ makeDefault: true })}
+                  >
+                    设为默认
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className="rounded-[8px] px-3.5 py-[7px] text-[13px] font-medium text-[var(--dsw-bg)] transition-opacity hover:opacity-90 disabled:opacity-50"
+                  style={{ background: 'var(--dsw-business)' }}
+                  disabled={saving}
+                  onClick={() => void saveCurrent()}
+                >
+                  {saving ? '保存中…' : '保存'}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="grid flex-1 place-items-center text-[12px] text-[var(--dsw-label-3)]">
+              从左侧选择 Provider
+            </div>
+          )}
+        </div>
       </div>
-    </form>
+    </div>
   )
 }

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -488,46 +488,46 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     )
   }
 
+  const asDialog = Boolean(props?.onClose)
+
   return (
     <div
-      className={`flex h-full min-h-[460px] flex-col ${props?.onClose ? 'min-h-0' : ''}`}
+      className={
+        asDialog
+          ? 'flex h-[min(640px,calc(100vh-48px))] w-[min(720px,calc(100vw-32px))] flex-col overflow-hidden rounded-[16px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] shadow-2xl'
+          : 'flex h-full min-h-[460px] flex-col overflow-hidden rounded-[12px] border border-[var(--dsw-border)]'
+      }
       data-testid="assistant-config"
+      role={asDialog ? 'dialog' : undefined}
+      aria-modal={asDialog ? true : undefined}
+      aria-label={asDialog ? '模型配置' : undefined}
+      onClick={asDialog ? (e) => e.stopPropagation() : undefined}
     >
-      {props?.onClose ? (
-        <div className="flex shrink-0 items-center justify-between border-b border-[var(--dsw-border)] px-4 py-3">
-          <div>
-            <h2 className="text-[14px] font-semibold text-[var(--dsw-label)]">模型配置</h2>
-            <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
-              官方 Key / 第三方 URL · 选模型 · 测试连接
-            </p>
-          </div>
-          <button
-            type="button"
-            className="grid size-8 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
-            aria-label="关闭"
-            onClick={props.onClose}
-          >
-            <LuX className="size-4" />
-          </button>
-        </div>
-      ) : null}
-      <div
-        className={`flex min-h-0 flex-1 overflow-hidden ${
-          props?.onClose ? '' : 'rounded-[12px] border border-[var(--dsw-border)]'
-        }`}
-      >
+      <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* 左：Provider 列表 */}
         <aside className="flex w-[200px] shrink-0 flex-col border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
           <div className="border-b border-[var(--dsw-border)] p-2.5">
-            <div className="relative">
-              <LuSearch className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-[var(--dsw-label-3)]" />
-              <input
-                className={`${inputCls} pl-7`}
-                placeholder="搜索…"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                aria-label="搜索 Provider"
-              />
+            <div className="flex items-center gap-1.5">
+              <div className="relative min-w-0 flex-1">
+                <LuSearch className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-[var(--dsw-label-3)]" />
+                <input
+                  className={`${inputCls} pl-7`}
+                  placeholder="搜索…"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  aria-label="搜索 Provider"
+                />
+              </div>
+              {asDialog ? (
+                <button
+                  type="button"
+                  className="grid size-8 shrink-0 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+                  aria-label="关闭"
+                  onClick={props?.onClose}
+                >
+                  <LuX className="size-4" />
+                </button>
+              ) : null}
             </div>
           </div>
 

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -6,8 +6,8 @@
  * 2. 右侧只编辑当前 Provider：Key / Base URL / 模型列表 / 设为默认
  * 3. 一处保存，不再拆成三块互相抢焦点
  */
-import { useEffect, useMemo, useState } from 'react'
-import { LuCheck, LuLoaderCircle, LuPlus, LuTrash2, LuUnplug, LuX } from 'react-icons/lu'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { LuCheck, LuChevronDown, LuLoaderCircle, LuPlus, LuSearch, LuTrash2, LuUnplug, LuX } from 'react-icons/lu'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -96,6 +96,10 @@ export function ChatConfig(props?: { onClose?: () => void }) {
   const [newUrl, setNewUrl] = useState('')
   const [newKey, setNewKey] = useState('')
   const [newProtocol, setNewProtocol] = useState<'openai-compat' | 'anthropic'>('openai-compat')
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [pickerQuery, setPickerQuery] = useState('')
+  const pickerRef = useRef<HTMLDivElement>(null)
+  const pickerInputRef = useRef<HTMLInputElement>(null)
 
   const active = endpoints.find((e) => e.id === activeId)
   const activeModels = useMemo(
@@ -147,6 +151,107 @@ export function ChatConfig(props?: { onClose?: () => void }) {
       ),
     [endpoints, connectedThird],
   )
+
+  const selectedPreset = useMemo(
+    () => (presetId ? presets.find((e) => e.id === presetId) ?? endpoints.find((e) => e.id === presetId) : null),
+    [presetId, presets, endpoints],
+  )
+
+  const filteredPresets = useMemo(() => {
+    const q = pickerQuery.trim().toLowerCase()
+    if (!q) return presets
+    return presets.filter(
+      (e) =>
+        e.label.toLowerCase().includes(q) ||
+        e.id.toLowerCase().includes(q) ||
+        (e.note || '').toLowerCase().includes(q) ||
+        (e.defaultBaseUrl || e.baseUrl || '').toLowerCase().includes(q),
+    )
+  }, [presets, pickerQuery])
+
+  const presetGroups = useMemo(() => {
+    const order = ['relay', 'local', 'official', 'custom'] as const
+    const labels: Record<string, string> = {
+      relay: '中转站',
+      local: '本地',
+      official: '厂商',
+      custom: '其它',
+    }
+    const map = new Map<string, EndpointView[]>()
+    for (const ep of filteredPresets) {
+      const g = ep.group || 'custom'
+      if (!map.has(g)) map.set(g, [])
+      map.get(g)!.push(ep)
+    }
+    return order
+      .filter((g) => map.has(g))
+      .map((g) => ({ id: g, label: labels[g] || g, items: map.get(g)! }))
+  }, [filteredPresets])
+
+  const canCreateFromQuery = useMemo(() => {
+    const q = pickerQuery.trim()
+    if (!q) return false
+    const exact = presets.some((e) => e.label.toLowerCase() === q.toLowerCase() || e.id === q)
+    return !exact
+  }, [pickerQuery, presets])
+
+  useEffect(() => {
+    if (!pickerOpen) return
+    function onDoc(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false)
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setPickerOpen(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDoc)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [pickerOpen])
+
+  function resetAddForm() {
+    setPresetId('')
+    setNewLabel('')
+    setNewUrl('')
+    setNewKey('')
+    setNewProtocol('openai-compat')
+    setPickerQuery('')
+    setPickerOpen(false)
+  }
+
+  function pickPreset(ep: EndpointView) {
+    setPresetId(ep.id)
+    setNewLabel('')
+    setNewUrl(ep.defaultBaseUrl || ep.baseUrl || '')
+    setPickerQuery('')
+    setPickerOpen(false)
+    setError('')
+  }
+
+  function createCustom(name: string) {
+    const label = name.trim()
+    if (!label) return
+    setPresetId('')
+    setNewLabel(label)
+    setNewUrl('')
+    setPickerQuery('')
+    setPickerOpen(false)
+    setError('')
+  }
+
+  function clearConnectionPick() {
+    setPresetId('')
+    setNewLabel('')
+    setNewUrl('')
+    setPickerQuery('')
+    setPickerOpen(true)
+    requestAnimationFrame(() => pickerInputRef.current?.focus())
+  }
+
   function applyPublic(data: ChatPublicConfig, preferActive?: string) {
     const eps = Array.isArray(data.endpoints) ? data.endpoints : []
     setEndpoints(eps)
@@ -396,10 +501,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     }
 
     setAdding(false)
-    setPresetId('')
-    setNewLabel('')
-    setNewUrl('')
-    setNewKey('')
+    resetAddForm()
     setStatus('已接入')
   }
 
@@ -535,8 +637,11 @@ export function ChatConfig(props?: { onClose?: () => void }) {
               }`}
               onClick={() => {
                 setAdding(true)
+                resetAddForm()
                 setError('')
                 setStatus('')
+                setPickerOpen(true)
+                requestAnimationFrame(() => pickerInputRef.current?.focus())
               }}
             >
               <LuPlus className="size-3.5" />
@@ -552,80 +657,253 @@ export function ChatConfig(props?: { onClose?: () => void }) {
               <div className="border-b border-[var(--dsw-border)] px-4 py-3">
                 <h3 className="text-[14px] font-semibold text-[var(--dsw-label)]">添加连接</h3>
                 <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
-                  选中转站预设，或填自定义 Base URL + Token
+                  搜索预设，或输入名称创建自定义连接
                 </p>
               </div>
-              <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-3">
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">预设</span>
-                  <select
-                    className={inputCls}
-                    value={presetId}
-                    onChange={(e) => {
-                      const id = e.target.value
-                      setPresetId(id)
-                      const ep = endpoints.find((x) => x.id === id)
-                      if (ep) {
-                        setNewUrl(ep.defaultBaseUrl || ep.baseUrl)
-                        setNewLabel('')
-                      } else {
-                        setNewUrl('')
-                      }
-                    }}
-                  >
-                    <option value="">自定义 URL…</option>
-                    {presets.map((ep) => (
-                      <option key={ep.id} value={ep.id}>
-                        {ep.label}
-                        {ep.note ? ` · ${ep.note}` : ''}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                {!presetId ? (
-                  <>
-                    <label className="flex flex-col gap-1.5">
-                      <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">名称</span>
-                      <input
-                        className={inputCls}
-                        placeholder="My OneAPI"
-                        value={newLabel}
-                        onChange={(e) => setNewLabel(e.target.value)}
-                      />
-                    </label>
-                    <label className="flex flex-col gap-1.5">
-                      <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">协议</span>
-                      <select
-                        className={inputCls}
-                        value={newProtocol}
-                        onChange={(e) => setNewProtocol(e.target.value as 'openai-compat' | 'anthropic')}
+              <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto px-3 py-2">
+                {/* Notion 风格属性行：连接选择 */}
+                <div className="flex items-start gap-3 rounded-[6px] px-2 py-2 hover:bg-[var(--dsw-hover)]">
+                  <div className="w-[72px] shrink-0 pt-[7px] text-[12px] text-[var(--dsw-label-3)]">连接</div>
+                  <div className="relative min-w-0 flex-1" ref={pickerRef}>
+                    {!pickerOpen && (selectedPreset || newLabel.trim()) ? (
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 rounded-[6px] border border-transparent px-2 py-[6px] text-left transition-colors hover:border-[var(--dsw-border)] hover:bg-[var(--dsw-muted-fill)]"
+                        onClick={() => {
+                          setPickerOpen(true)
+                          setPickerQuery(selectedPreset?.label || newLabel || '')
+                          requestAnimationFrame(() => {
+                            pickerInputRef.current?.focus()
+                            pickerInputRef.current?.select()
+                          })
+                        }}
                       >
-                        <option value="openai-compat">OpenAI 兼容</option>
-                        <option value="anthropic">Anthropic Messages</option>
-                      </select>
-                    </label>
-                  </>
+                        <span className="min-w-0 flex-1 truncate text-[13px] text-[var(--dsw-label)]">
+                          {selectedPreset ? selectedPreset.label : newLabel.trim()}
+                        </span>
+                        {!selectedPreset ? (
+                          <span className="shrink-0 rounded-[4px] bg-[var(--dsw-muted-fill)] px-1.5 py-0.5 text-[10px] text-[var(--dsw-label-3)]">
+                            自定义
+                          </span>
+                        ) : null}
+                        <span
+                          role="button"
+                          tabIndex={0}
+                          className="grid size-5 shrink-0 place-items-center rounded-[4px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover-strong)] hover:text-[var(--dsw-label)]"
+                          aria-label="清除"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            clearConnectionPick()
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              clearConnectionPick()
+                            }
+                          }}
+                        >
+                          <LuX className="size-3" />
+                        </span>
+                      </button>
+                    ) : (
+                      <div
+                        className={`flex items-center gap-1.5 rounded-[6px] border px-2 py-[5px] transition-colors ${
+                          pickerOpen
+                            ? 'border-[var(--dsw-label-3)] bg-[var(--dsw-input)] shadow-[0_0_0_1px_var(--dsw-border)]'
+                            : 'border-[var(--dsw-border)] bg-[var(--dsw-input)] hover:border-[var(--dsw-label-3)]'
+                        }`}
+                      >
+                        <LuSearch className="size-3.5 shrink-0 text-[var(--dsw-label-3)]" />
+                        <input
+                          ref={pickerInputRef}
+                          className="min-w-0 flex-1 bg-transparent text-[13px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)]"
+                          placeholder="搜索或创建连接…"
+                          value={pickerQuery}
+                          onChange={(e) => {
+                            setPickerQuery(e.target.value)
+                            setPickerOpen(true)
+                          }}
+                          onFocus={() => setPickerOpen(true)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              e.preventDefault()
+                              if (filteredPresets.length === 1) {
+                                pickPreset(filteredPresets[0]!)
+                              } else if (canCreateFromQuery) {
+                                createCustom(pickerQuery)
+                              }
+                            }
+                          }}
+                          aria-label="搜索或创建连接"
+                          aria-expanded={pickerOpen}
+                          aria-controls="connection-picker-menu"
+                        />
+                        <LuChevronDown
+                          className={`size-3.5 shrink-0 text-[var(--dsw-label-3)] transition-transform ${
+                            pickerOpen ? 'rotate-180' : ''
+                          }`}
+                        />
+                      </div>
+                    )}
+
+                    {pickerOpen ? (
+                      <div
+                        id="connection-picker-menu"
+                        role="listbox"
+                        className="absolute z-20 mt-1 max-h-[280px] w-full overflow-y-auto rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] py-1 shadow-[var(--dsw-shadow-lv2)]"
+                      >
+                        {presetGroups.length ? (
+                          presetGroups.map((group) => (
+                            <div key={group.id} className="py-1">
+                              <div className="px-2.5 py-1 text-[10px] font-medium tracking-wide text-[var(--dsw-label-3)]">
+                                {group.label}
+                              </div>
+                              {group.items.map((ep) => {
+                                const active = ep.id === presetId
+                                return (
+                                  <button
+                                    key={ep.id}
+                                    type="button"
+                                    role="option"
+                                    aria-selected={active}
+                                    className={`flex w-full items-center gap-2 px-2.5 py-[7px] text-left transition-colors ${
+                                      active
+                                        ? 'bg-[var(--dsw-hover-strong)]'
+                                        : 'hover:bg-[var(--dsw-hover)]'
+                                    }`}
+                                    onClick={() => pickPreset(ep)}
+                                  >
+                                    <span className="min-w-0 flex-1">
+                                      <span className="block truncate text-[13px] text-[var(--dsw-label)]">
+                                        {ep.label}
+                                      </span>
+                                      <span className="block truncate font-mono text-[10px] text-[var(--dsw-label-3)]">
+                                        {ep.note || ep.defaultBaseUrl || ep.baseUrl}
+                                      </span>
+                                    </span>
+                                    {active ? (
+                                      <LuCheck className="size-3.5 shrink-0 text-[var(--dsw-label)]" />
+                                    ) : null}
+                                  </button>
+                                )
+                              })}
+                            </div>
+                          ))
+                        ) : !canCreateFromQuery ? (
+                          <div className="px-3 py-4 text-center text-[12px] text-[var(--dsw-label-3)]">
+                            没有匹配的预设
+                          </div>
+                        ) : null}
+
+                        {canCreateFromQuery ? (
+                          <>
+                            {presetGroups.length ? (
+                              <div className="mx-2 my-1 border-t border-[var(--dsw-border)]" />
+                            ) : null}
+                            <button
+                              type="button"
+                              role="option"
+                              className="flex w-full items-center gap-2 px-2.5 py-[8px] text-left hover:bg-[var(--dsw-hover)]"
+                              onClick={() => createCustom(pickerQuery)}
+                            >
+                              <span className="grid size-5 shrink-0 place-items-center rounded-[4px] bg-[var(--dsw-muted-fill)] text-[var(--dsw-label-2)]">
+                                <LuPlus className="size-3" />
+                              </span>
+                              <span className="min-w-0 text-[13px] text-[var(--dsw-label)]">
+                                创建「
+                                <span className="font-medium">{pickerQuery.trim()}</span>
+                                」
+                              </span>
+                            </button>
+                          </>
+                        ) : null}
+
+                        {!pickerQuery.trim() && presets.length > 0 ? (
+                          <>
+                            <div className="mx-2 my-1 border-t border-[var(--dsw-border)]" />
+                            <button
+                              type="button"
+                              className="flex w-full items-center gap-2 px-2.5 py-[8px] text-left hover:bg-[var(--dsw-hover)]"
+                              onClick={() => {
+                                setPickerOpen(false)
+                                setPresetId('')
+                                setNewLabel('')
+                                setNewUrl('')
+                              }}
+                            >
+                              <span className="grid size-5 shrink-0 place-items-center rounded-[4px] bg-[var(--dsw-muted-fill)] text-[var(--dsw-label-2)]">
+                                <LuPlus className="size-3" />
+                              </span>
+                              <span className="text-[13px] text-[var(--dsw-label-2)]">自定义 Base URL…</span>
+                            </button>
+                          </>
+                        ) : null}
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+
+                {!selectedPreset ? (
+                  <div className="flex items-center gap-3 rounded-[6px] px-2 py-2 hover:bg-[var(--dsw-hover)]">
+                    <div className="w-[72px] shrink-0 text-[12px] text-[var(--dsw-label-3)]">名称</div>
+                    <input
+                      className="min-w-0 flex-1 rounded-[6px] border border-transparent bg-transparent px-2 py-[6px] text-[13px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)] hover:border-[var(--dsw-border)] focus:border-[var(--dsw-label-3)] focus:bg-[var(--dsw-input)]"
+                      placeholder="My OneAPI"
+                      value={newLabel}
+                      onChange={(e) => setNewLabel(e.target.value)}
+                    />
+                  </div>
                 ) : null}
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">Base URL</span>
+
+                {!selectedPreset ? (
+                  <div className="flex items-center gap-3 rounded-[6px] px-2 py-2 hover:bg-[var(--dsw-hover)]">
+                    <div className="w-[72px] shrink-0 text-[12px] text-[var(--dsw-label-3)]">协议</div>
+                    <div className="flex gap-1">
+                      {(
+                        [
+                          { id: 'openai-compat' as const, label: 'OpenAI 兼容' },
+                          { id: 'anthropic' as const, label: 'Anthropic' },
+                        ] as const
+                      ).map((opt) => (
+                        <button
+                          key={opt.id}
+                          type="button"
+                          className={`rounded-[6px] px-2.5 py-[5px] text-[12px] transition-colors ${
+                            newProtocol === opt.id
+                              ? 'bg-[var(--dsw-hover-strong)] text-[var(--dsw-label)]'
+                              : 'text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label-2)]'
+                          }`}
+                          onClick={() => setNewProtocol(opt.id)}
+                        >
+                          {opt.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                <div className="flex items-center gap-3 rounded-[6px] px-2 py-2 hover:bg-[var(--dsw-hover)]">
+                  <div className="w-[72px] shrink-0 text-[12px] text-[var(--dsw-label-3)]">Base URL</div>
                   <input
-                    className={inputCls}
+                    className="min-w-0 flex-1 rounded-[6px] border border-transparent bg-transparent px-2 py-[6px] font-mono text-[12px] text-[var(--dsw-label)] outline-none placeholder:font-sans placeholder:text-[var(--dsw-label-3)] hover:border-[var(--dsw-border)] focus:border-[var(--dsw-label-3)] focus:bg-[var(--dsw-input)]"
                     placeholder="https://api.example.com/v1"
                     value={newUrl}
                     onChange={(e) => setNewUrl(e.target.value)}
                   />
-                </label>
-                <label className="flex flex-col gap-1.5">
-                  <span className="text-[11px] font-semibold text-[var(--dsw-label-3)]">API Key</span>
+                </div>
+
+                <div className="flex items-center gap-3 rounded-[6px] px-2 py-2 hover:bg-[var(--dsw-hover)]">
+                  <div className="w-[72px] shrink-0 text-[12px] text-[var(--dsw-label-3)]">API Key</div>
                   <input
-                    className={inputCls}
+                    className="min-w-0 flex-1 rounded-[6px] border border-transparent bg-transparent px-2 py-[6px] text-[13px] text-[var(--dsw-label)] outline-none placeholder:text-[var(--dsw-label-3)] hover:border-[var(--dsw-border)] focus:border-[var(--dsw-label-3)] focus:bg-[var(--dsw-input)]"
                     type="password"
                     autoComplete="off"
-                    placeholder="sk-…"
+                    placeholder="sk-…（可选，稍后可补）"
                     value={newKey}
                     onChange={(e) => setNewKey(e.target.value)}
                   />
-                </label>
+                </div>
               </div>
               <div className="flex items-center justify-end gap-2 border-t border-[var(--dsw-border)] px-4 py-2.5">
                 {error ? (
@@ -633,14 +911,17 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                 ) : null}
                 <button
                   type="button"
-                  className="rounded-[8px] px-3 py-[6px] text-[12px] text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)]"
-                  onClick={() => setAdding(false)}
+                  className="rounded-[6px] px-3 py-[6px] text-[12px] text-[var(--dsw-label-2)] hover:bg-[var(--dsw-hover)]"
+                  onClick={() => {
+                    setAdding(false)
+                    resetAddForm()
+                  }}
                 >
                   取消
                 </button>
                 <button
                   type="button"
-                  className="rounded-[8px] px-3.5 py-[7px] text-[13px] font-medium text-[var(--dsw-bg)]"
+                  className="rounded-[6px] px-3.5 py-[7px] text-[13px] font-medium text-[var(--dsw-bg)]"
                   style={{ background: 'var(--dsw-business)' }}
                   onClick={() => void onAddConnection()}
                 >

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -7,7 +7,7 @@
  * 3. 一处保存，不再拆成三块互相抢焦点
  */
 import { useEffect, useMemo, useState } from 'react'
-import { LuCheck, LuLoaderCircle, LuPlus, LuSearch, LuTrash2, LuUnplug, LuX } from 'react-icons/lu'
+import { LuCheck, LuLoaderCircle, LuPlus, LuTrash2, LuUnplug, LuX } from 'react-icons/lu'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -83,7 +83,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
 
   const [keyDraft, setKeyDraft] = useState('')
   const [urlDraft, setUrlDraft] = useState('')
-  const [query, setQuery] = useState('')
   const [newModelName, setNewModelName] = useState('')
   const [status, setStatus] = useState('')
   const [error, setError] = useState('')
@@ -148,26 +147,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
       ),
     [endpoints, connectedThird],
   )
-
-  const filteredOfficial = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    if (!q) return officialList
-    return officialList.filter(
-      (e) => e.label.toLowerCase().includes(q) || e.id.includes(q),
-    )
-  }, [officialList, query])
-
-  const filteredThird = useMemo(() => {
-    const q = query.trim().toLowerCase()
-    if (!q) return connectedThird
-    return connectedThird.filter(
-      (e) =>
-        e.label.toLowerCase().includes(q) ||
-        e.id.includes(q) ||
-        e.baseUrl.toLowerCase().includes(q),
-    )
-  }, [connectedThird, query])
-
   function applyPublic(data: ChatPublicConfig, preferActive?: string) {
     const eps = Array.isArray(data.endpoints) ? data.endpoints : []
     setEndpoints(eps)
@@ -305,13 +284,21 @@ export function ChatConfig(props?: { onClose?: () => void }) {
           ...(!isDefaultProvider && activeModels[0]?.model ? { model: activeModels[0].model } : {}),
         }),
       })
-      const data = (await res.json()) as { ok?: boolean; detail?: string; latencyMs?: number }
+      const data = (await res.json()) as {
+        ok?: boolean
+        detail?: string
+        latencyMs?: number
+        config?: ChatPublicConfig
+      }
+      // 失败：服务端拉黑入口（绿点变灰、下拉不可选）；成功：解除拉黑并可写入草稿 Key
+      if (data.config) applyPublic(data.config, activeId)
       if (data.ok) {
+        setKeyDraft('')
         setTestHint(data.detail || '连接成功')
         setStatus('连接正常')
       } else {
         setTestHint('')
-        setError(data.detail || `连接失败（HTTP ${res.status}）`)
+        setError(data.detail || `连接失败（HTTP ${res.status}）· 已从可选模型中移除`)
       }
     } catch (err) {
       setError(String(err))
@@ -503,46 +490,37 @@ export function ChatConfig(props?: { onClose?: () => void }) {
       aria-label={asDialog ? '模型配置' : undefined}
       onClick={asDialog ? (e) => e.stopPropagation() : undefined}
     >
+      <div className="flex shrink-0 items-center justify-between border-b border-[var(--dsw-border)] px-4 py-3">
+        <h2 className="text-[14px] font-semibold text-[var(--dsw-label)]">模型配置</h2>
+        {asDialog ? (
+          <button
+            type="button"
+            className="grid size-8 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+            aria-label="关闭"
+            onClick={props?.onClose}
+          >
+            <LuX className="size-4" />
+          </button>
+        ) : (
+          <span className="text-[11px] text-[var(--dsw-label-3)]">官方 Key / 第三方 URL</span>
+        )}
+      </div>
+
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* 左：Provider 列表 */}
         <aside className="flex w-[200px] shrink-0 flex-col border-r border-[var(--dsw-border)] bg-[var(--dsw-sidebar)]">
-          <div className="border-b border-[var(--dsw-border)] p-2.5">
-            <div className="flex items-center gap-1.5">
-              <div className="relative min-w-0 flex-1">
-                <LuSearch className="pointer-events-none absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-[var(--dsw-label-3)]" />
-                <input
-                  className={`${inputCls} pl-7`}
-                  placeholder="搜索…"
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                  aria-label="搜索 Provider"
-                />
-              </div>
-              {asDialog ? (
-                <button
-                  type="button"
-                  className="grid size-8 shrink-0 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
-                  aria-label="关闭"
-                  onClick={props?.onClose}
-                >
-                  <LuX className="size-4" />
-                </button>
-              ) : null}
-            </div>
-          </div>
-
           <div className="min-h-0 flex-1 overflow-y-auto py-1">
             <div className="px-3 pt-2 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
               官方
             </div>
-            {filteredOfficial.map((ep) => providerRow(ep, { removable: false }))}
+            {officialList.map((ep) => providerRow(ep, { removable: false }))}
 
-            {filteredThird.length > 0 ? (
+            {connectedThird.length > 0 ? (
               <>
                 <div className="px-3 pt-3 pb-1 text-[10px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
                   第三方
                 </div>
-                {filteredThird.map((ep) => providerRow(ep, { removable: true }))}
+                {connectedThird.map((ep) => providerRow(ep, { removable: true }))}
               </>
             ) : null}
           </div>

--- a/packages/cap-chat/src/web/index.test.ts
+++ b/packages/cap-chat/src/web/index.test.ts
@@ -10,7 +10,7 @@ import * as projectView from '@biu/web-project-view'
 import * as chat from './index.ts'
 import * as shell from '@biu/web-app-shell'
 
-test('one plugin fills thread, trajectory, composer, approvals dock and models', async () => {
+test('one plugin fills thread, trajectory, composer and approvals dock', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   await ctx.plugin(appModules)
@@ -25,7 +25,7 @@ test('one plugin fills thread, trajectory, composer, approvals dock and models',
   assert.equal(ctx.slots.list('trajectory').some((item) => item.id === 'trajectory'), true)
   assert.equal(ctx.slots.list('project').length, 0)
   assert.equal(ctx.slots.list('dock').some((item) => item.id === 'approvals'), true)
-  assert.equal(ctx.slots.list('models')[0]?.id, 'chat-config')
+  assert.equal(ctx.slots.list('models').length, 0)
   assert.equal(ctx.slots.list('inspector-panels').some((item) => item.id === 'chat-traj'), true)
   assert.equal(ctx.slots.list('inspector-panels').some((item) => item.id === 'chat-usage'), true)
 })

--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -5,7 +5,6 @@ import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import type { SlotProps } from '@biu/web-slots'
 import { ApprovalsRail } from './approvals.tsx'
 import { ChatComposer } from './composer.tsx'
-import { ChatConfig } from './config.tsx'
 import { ChatConfigBanner } from './config-banner.tsx'
 import { ChatThread } from './thread.tsx'
 import { TrajectoryView } from './trajectory.tsx'
@@ -49,7 +48,6 @@ export function apply(ctx: Context) {
   ctx.slots.place('composer', ChatComposer, { key: 'chat', order: 10, props })
   ctx.slots.place('dock', ChatConfigBanner, { key: 'chat-config-banner', order: 1 })
   ctx.slots.place('dock', ApprovalsRail, { key: 'approvals', order: 5, props })
-  ctx.slots.place('models', ChatConfig, { key: 'chat-config', order: 10 })
   ctx.slots.place('inspector-panels', InspectorTrajectory, {
     key: 'chat-traj',
     order: 1,

--- a/packages/cap-chat/src/web/model-config-dialog.tsx
+++ b/packages/cap-chat/src/web/model-config-dialog.tsx
@@ -1,7 +1,6 @@
-import { LuX } from 'react-icons/lu'
 import { ChatConfig } from './config.tsx'
 
-/** 从 Composer 模型选框唤起的模型配置弹层。 */
+/** 从 Composer 模型选框唤起的模型配置弹层（单层壳，内容即 ChatConfig）。 */
 export function ModelConfigDialog(props: { open: boolean; onClose: () => void }) {
   if (!props.open) return null
   return (
@@ -17,25 +16,7 @@ export function ModelConfigDialog(props: { open: boolean; onClose: () => void })
         className="flex h-[min(640px,calc(100vh-48px))] w-[min(720px,calc(100vw-32px))] flex-col overflow-hidden rounded-[16px] bg-[var(--dsw-surface)] shadow-2xl"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="flex shrink-0 items-center justify-between border-b border-[var(--dsw-border)] px-4 py-3">
-          <div>
-            <h2 className="text-[14px] font-semibold text-[var(--dsw-label)]">模型配置</h2>
-            <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
-              官方 Key / 第三方 URL · 选模型 · 测试连接
-            </p>
-          </div>
-          <button
-            type="button"
-            className="grid size-8 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
-            aria-label="关闭"
-            onClick={props.onClose}
-          >
-            <LuX className="size-4" />
-          </button>
-        </div>
-        <div className="min-h-0 flex-1 overflow-hidden p-3">
-          <ChatConfig />
-        </div>
+        <ChatConfig onClose={props.onClose} />
       </div>
     </div>
   )

--- a/packages/cap-chat/src/web/model-config-dialog.tsx
+++ b/packages/cap-chat/src/web/model-config-dialog.tsx
@@ -1,0 +1,42 @@
+import { LuX } from 'react-icons/lu'
+import { ChatConfig } from './config.tsx'
+
+/** 从 Composer 模型选框唤起的模型配置弹层。 */
+export function ModelConfigDialog(props: { open: boolean; onClose: () => void }) {
+  if (!props.open) return null
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-[var(--dsw-overlay)] p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="模型配置"
+      data-testid="model-config-dialog"
+      onClick={props.onClose}
+    >
+      <div
+        className="flex h-[min(640px,calc(100vh-48px))] w-[min(720px,calc(100vw-32px))] flex-col overflow-hidden rounded-[16px] bg-[var(--dsw-surface)] shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-[var(--dsw-border)] px-4 py-3">
+          <div>
+            <h2 className="text-[14px] font-semibold text-[var(--dsw-label)]">模型配置</h2>
+            <p className="mt-0.5 text-[11px] text-[var(--dsw-label-3)]">
+              官方 Key / 第三方 URL · 选模型 · 测试连接
+            </p>
+          </div>
+          <button
+            type="button"
+            className="grid size-8 place-items-center rounded-[8px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+            aria-label="关闭"
+            onClick={props.onClose}
+          >
+            <LuX className="size-4" />
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden p-3">
+          <ChatConfig />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/cap-chat/src/web/model-config-dialog.tsx
+++ b/packages/cap-chat/src/web/model-config-dialog.tsx
@@ -1,23 +1,17 @@
 import { ChatConfig } from './config.tsx'
 
-/** 从 Composer 模型选框唤起的模型配置弹层（单层壳，内容即 ChatConfig）。 */
+/**
+ * 遮罩 + 直接弹出主从面板（不再外套一层标题白盒）。
+ */
 export function ModelConfigDialog(props: { open: boolean; onClose: () => void }) {
   if (!props.open) return null
   return (
     <div
       className="fixed inset-0 z-30 flex items-center justify-center bg-[var(--dsw-overlay)] p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-label="模型配置"
       data-testid="model-config-dialog"
       onClick={props.onClose}
     >
-      <div
-        className="flex h-[min(640px,calc(100vh-48px))] w-[min(720px,calc(100vw-32px))] flex-col overflow-hidden rounded-[16px] bg-[var(--dsw-surface)] shadow-2xl"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <ChatConfig onClose={props.onClose} />
-      </div>
+      <ChatConfig onClose={props.onClose} />
     </div>
   )
 }

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -135,7 +135,8 @@ function renderReplyPartList({
   const elements: ReactNode[] = []
   let lastStep: number | undefined
 
-  for (const part of parts) {
+  for (let index = 0; index < parts.length; index += 1) {
+    const part = parts[index]!
     const step = part.step
     if (showSteps && step != null && step !== lastStep) {
       const stat = stepMap.get(step) ?? {
@@ -145,14 +146,14 @@ function renderReplyPartList({
         toolCount: 0,
         messageChars: 0,
       }
-      elements.push(<StepBar key={`step-${step}`} stat={stat} />)
+      elements.push(<StepBar key={`step-${step}@${index}`} stat={stat} />)
       lastStep = step
     }
 
     if (part.kind === 'assistant') {
       const partStreaming = Boolean(part.streaming)
       elements.push(
-        <div key={part.id} className="chat-assistant-body">
+        <div key={`${part.id}@${index}`} className="chat-assistant-body">
           {part.text ? (
             <MarkdownBody text={part.text} streaming={partStreaming} />
           ) : partStreaming ? (
@@ -164,7 +165,7 @@ function renderReplyPartList({
         </div>,
       )
     } else {
-      elements.push(<ToolCard key={part.id} node={part} onInspect={onInspect} />)
+      elements.push(<ToolCard key={`${part.id}@${index}`} node={part} onInspect={onInspect} />)
     }
   }
 

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -36,6 +36,128 @@ export function resolveAnthropicMessagesUrl(baseUrl: string | undefined): string
   return 'https://api.anthropic.com/v1/messages'
 }
 
+/** OpenAI 兼容：列出模型的 GET 地址（…/models）。 */
+export function resolveModelsListUrl(baseUrl: string | undefined, provider: ChatProvider): string {
+  if (baseUrl?.trim()) {
+    const trimmed = baseUrl.trim().replace(/\/+$/, '')
+    if (/\/models$/i.test(trimmed)) return trimmed
+    if (/\/chat\/completions$/i.test(trimmed)) return trimmed.replace(/\/chat\/completions$/i, '/models')
+    return `${trimmed}/models`
+  }
+  return provider === 'deepseek' ? 'https://api.deepseek.com/models' : 'https://api.openai.com/v1/models'
+}
+
+export type LlmProbeResult =
+  | { ok: true; latencyMs: number; detail: string }
+  | { ok: false; latencyMs: number; detail: string }
+
+/**
+ * 轻量连通性探测：优先 GET /models；失败则发一条极短非流式 chat。
+ * Anthropic 走一条 max_tokens=1 的 Messages 请求。
+ */
+export async function probeLlmConnection(
+  config: LlmConfig,
+  opts?: { signal?: AbortSignal },
+): Promise<LlmProbeResult> {
+  const started = Date.now()
+  const apiKey = config.apiKey?.trim() || ''
+  if (!apiKey) {
+    return { ok: false, latencyMs: 0, detail: '未配置 API Key' }
+  }
+
+  try {
+    if (config.provider === 'anthropic') {
+      const url = resolveAnthropicMessagesUrl(config.baseUrl)
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: config.model || 'claude-3-5-haiku-20241022',
+          max_tokens: 1,
+          messages: [{ role: 'user', content: 'ping' }],
+        }),
+        signal: opts?.signal,
+      })
+      const latencyMs = Date.now() - started
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`
+        try {
+          const err = (await res.json()) as { error?: { message?: string } }
+          if (err.error?.message) detail = err.error.message
+        } catch {
+          /* ignore */
+        }
+        return { ok: false, latencyMs, detail }
+      }
+      return { ok: true, latencyMs, detail: `Anthropic Messages · ${latencyMs}ms` }
+    }
+
+    // OpenAI 兼容：先试 /models
+    const modelsUrl = resolveModelsListUrl(config.baseUrl, config.provider)
+    const listRes = await fetch(modelsUrl, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${apiKey}`, accept: 'application/json' },
+      signal: opts?.signal,
+    })
+    if (listRes.ok) {
+      const latencyMs = Date.now() - started
+      let count = 0
+      try {
+        const body = (await listRes.json()) as { data?: unknown[] }
+        if (Array.isArray(body.data)) count = body.data.length
+      } catch {
+        /* ignore */
+      }
+      return {
+        ok: true,
+        latencyMs,
+        detail: count > 0 ? `GET /models · ${count} 个模型 · ${latencyMs}ms` : `GET /models · ${latencyMs}ms`,
+      }
+    }
+
+    // /models 不可用时回退 chat/completions
+    const chatUrl = resolveChatCompletionsUrl(config.baseUrl, config.provider)
+    const chatRes = await fetch(chatUrl, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: config.model || 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'ping' }],
+        max_tokens: 1,
+        stream: false,
+      }),
+      signal: opts?.signal,
+    })
+    const latencyMs = Date.now() - started
+    if (!chatRes.ok) {
+      let detail = `HTTP ${chatRes.status}`
+      try {
+        const err = (await chatRes.json()) as { error?: { message?: string } }
+        if (err.error?.message) detail = err.error.message
+      } catch {
+        /* ignore */
+      }
+      // 附带 /models 失败信息，便于排查
+      detail = `${detail}（/models → ${listRes.status}）`
+      return { ok: false, latencyMs, detail }
+    }
+    return { ok: true, latencyMs, detail: `chat/completions · ${latencyMs}ms` }
+  } catch (error) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - started,
+      detail: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
 /** DeepSeek 视觉模型：检测到图片输入时自动路由到它。 */
 export const DEEPSEEK_VISION_MODEL = 'deepseek-v4-flash-vision-exp'
 

--- a/packages/host-llm/src/host/llm.probe.test.ts
+++ b/packages/host-llm/src/host/llm.probe.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import { test } from 'vitest'
+import { resolveModelsListUrl, resolveChatCompletionsUrl } from '@biu/host-llm'
+
+test('resolveModelsListUrl derives from baseUrl', () => {
+  assert.equal(resolveModelsListUrl('https://api.openai.com/v1', 'openai'), 'https://api.openai.com/v1/models')
+  assert.equal(
+    resolveModelsListUrl('https://api.closeai-asia.com/v1/chat/completions', 'openai'),
+    'https://api.closeai-asia.com/v1/models',
+  )
+  assert.equal(resolveModelsListUrl(undefined, 'deepseek'), 'https://api.deepseek.com/models')
+})
+
+test('resolveChatCompletionsUrl still works alongside models url', () => {
+  assert.equal(
+    resolveChatCompletionsUrl('https://api.openai.com/v1', 'openai'),
+    'https://api.openai.com/v1/chat/completions',
+  )
+})

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -431,7 +431,6 @@ function Shell(props: SlotProps) {
             <ul className="space-y-1 text-sm text-[var(--dsw-label-2)]">
               {[
                 { key: 'plugins', label: 'Plugins' },
-                { key: 'demos', label: 'Demos' },
                 { key: 'routes', label: 'Routes' },
                 { key: 'events', label: 'Events' },
               ].map((item) => (
@@ -465,11 +464,6 @@ function Shell(props: SlotProps) {
             <div className="flex-1 space-y-6 overflow-y-auto px-5 py-4">
               {settingsTab === 'plugins' ? (
                 <section>{props.renderSlot('sidebar')}</section>
-              ) : null}
-              {settingsTab === 'demos' ? (
-                <section>
-                  <div className="space-y-3">{props.renderSlot('demos')}</div>
-                </section>
               ) : null}
               {settingsTab === 'routes' ? (
                 <section>{props.renderSlot('routes')}</section>

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -431,7 +431,6 @@ function Shell(props: SlotProps) {
             <ul className="space-y-1 text-sm text-[var(--dsw-label-2)]">
               {[
                 { key: 'plugins', label: 'Plugins' },
-                { key: 'models', label: 'Models' },
                 { key: 'demos', label: 'Demos' },
                 { key: 'routes', label: 'Routes' },
                 { key: 'events', label: 'Events' },
@@ -466,9 +465,6 @@ function Shell(props: SlotProps) {
             <div className="flex-1 space-y-6 overflow-y-auto px-5 py-4">
               {settingsTab === 'plugins' ? (
                 <section>{props.renderSlot('sidebar')}</section>
-              ) : null}
-              {settingsTab === 'models' ? (
-                <section className="relative min-h-[400px]">{props.renderSlot('models')}</section>
               ) : null}
               {settingsTab === 'demos' ? (
                 <section>
@@ -510,7 +506,6 @@ export function apply(ctx: Context) {
       project: { kind: 'single' },
       composer: { kind: 'single' },
       settings: { kind: 'list' },
-      models: { kind: 'single' },
       log: { kind: 'single' },
       routes: { kind: 'single' },
       'app-modules': { kind: 'list' },

--- a/packages/web-session-view/src/web/session-project.test.ts
+++ b/packages/web-session-view/src/web/session-project.test.ts
@@ -419,3 +419,43 @@ test('reply & step histPct is token-weighted average over all llm.chat usage', (
   assert.equal(reply.steps?.[0]?.histPct, 0.2)
   assert.equal(reply.steps?.[1]?.histPct, 0.8)
 })
+
+test('dedupes repeated tool/call with the same id (no duplicate part keys)', () => {
+  const nodes = projectNodes([
+    { type: 'session/open', version: 1, seq: 0, ts: 1 },
+    { type: 'user/message', text: 'hi', kind: 'wake', seq: 1, ts: 2 },
+    {
+      type: 'tool/call',
+      id: 'call_00_dup',
+      name: 'bash',
+      arguments: '{}',
+      seq: 2,
+      ts: 3,
+    },
+    {
+      type: 'tool/call',
+      id: 'call_00_dup',
+      name: 'bash',
+      arguments: '{"command":"echo"}',
+      seq: 3,
+      ts: 4,
+    },
+    {
+      type: 'tool/result',
+      id: 'call_00_dup',
+      name: 'bash',
+      ok: true,
+      detail: 'ok',
+      seq: 4,
+      ts: 5,
+    },
+  ])
+  const reply = nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  const tools = reply.parts.filter((part) => part.kind === 'tool')
+  assert.equal(tools.length, 1)
+  assert.equal(tools[0]?.id, 't-call_00_dup')
+  assert.equal(tools[0]?.kind === 'tool' && tools[0].arguments, '{"command":"echo"}')
+  assert.equal(tools[0]?.kind === 'tool' && tools[0].result?.detail, 'ok')
+})

--- a/packages/web-session-view/src/web/session-project.ts
+++ b/packages/web-session-view/src/web/session-project.ts
@@ -383,23 +383,15 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       const r = ensureReply(event.seq)
       r.streamingId = null
       if (currentTurn != null) r.streaming = true
-      if (currentStep != null) ensureStepStat(currentStep).toolCount += 1
-      const part: ChatToolPart = {
-        id: `t-${event.id}`,
-        kind: 'tool',
-        callId: event.id,
-        name: event.name,
-        arguments: event.arguments,
-        ...(currentStep != null ? { step: currentStep } : {}),
-      }
-      r.tools.set(event.id, part)
-      r.parts.push(part)
-    } else if (event.type === 'tool/result') {
-      const r = ensureReply(event.seq)
-      if (currentTurn != null) r.streaming = true
       const existing = r.tools.get(event.id)
       if (existing) {
-        const next = { ...existing, result: { ok: event.ok, detail: event.detail } }
+        // 重放 / 重复 tool/call：就地更新，避免 parts 出现相同 key
+        const next: ChatToolPart = {
+          ...existing,
+          name: event.name,
+          arguments: event.arguments,
+          ...(currentStep != null ? { step: currentStep } : {}),
+        }
         r.tools.set(event.id, next)
         const idx = r.parts.findIndex((part) => part.id === existing.id)
         if (idx >= 0) r.parts[idx] = next
@@ -410,12 +402,38 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
           kind: 'tool',
           callId: event.id,
           name: event.name,
+          arguments: event.arguments,
+          ...(currentStep != null ? { step: currentStep } : {}),
+        }
+        r.tools.set(event.id, part)
+        r.parts.push(part)
+      }
+    } else if (event.type === 'tool/result') {
+      const r = ensureReply(event.seq)
+      if (currentTurn != null) r.streaming = true
+      const existing = r.tools.get(event.id)
+      if (existing) {
+        const next = { ...existing, result: { ok: event.ok, detail: event.detail } }
+        r.tools.set(event.id, next)
+        const idx = r.parts.findIndex((part) => part.id === existing.id)
+        if (idx >= 0) r.parts[idx] = next
+      } else {
+        // 仅有 result、未见 call：补一条；若 parts 里已有同 id 则更新
+        const partId = `t-${event.id}`
+        const idx = r.parts.findIndex((part) => part.id === partId)
+        if (currentStep != null && idx < 0) ensureStepStat(currentStep).toolCount += 1
+        const part: ChatToolPart = {
+          id: partId,
+          kind: 'tool',
+          callId: event.id,
+          name: event.name,
           arguments: '',
           result: { ok: event.ok, detail: event.detail },
           ...(currentStep != null ? { step: currentStep } : {}),
         }
         r.tools.set(event.id, part)
-        r.parts.push(part)
+        if (idx >= 0) r.parts[idx] = part
+        else r.parts.push(part)
       }
     } else if (event.type === 'turn/end') {
       flushReply(event.ts, true)

--- a/packages/web-ui-hub/src/web/index.test.ts
+++ b/packages/web-ui-hub/src/web/index.test.ts
@@ -39,7 +39,6 @@ test('ui-hub mounts configured ui packages including chat', async () => {
       dock: { kind: 'list' },
       project: { kind: 'single' },
       composer: { kind: 'single' },
-      models: { kind: 'single' },
       settings: { kind: 'list' },
       'app-modules': { kind: 'list' },
       'inspector-panels': { kind: 'list' },
@@ -63,5 +62,4 @@ test('ui-hub mounts configured ui packages including chat', async () => {
   }
   assert.equal(ctx.slots.list('demos').length >= 1, true)
   assert.equal(ctx.slots.list('composer').some((item) => item.id === 'chat'), true)
-  assert.equal(ctx.slots.list('models').some((item) => item.id === 'chat-config'), true)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -2353,7 +2353,7 @@ body {
   right: 0;
   bottom: calc(100% + 8px);
   z-index: 9;
-  min-width: 200px;
+  min-width: 220px;
   max-height: min(360px, 50vh);
   overflow-x: hidden;
   overflow-y: auto;
@@ -2361,6 +2361,44 @@ body {
   border-radius: 12px;
   background: color-mix(in srgb, var(--dsw-sidebar) 96%, #000);
   box-shadow: var(--dsw-shadow-lv2);
+}
+
+.composer-model-menu-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 8px 6px 12px;
+  border-bottom: 1px solid var(--dsw-border);
+  background: color-mix(in srgb, var(--dsw-sidebar) 96%, #000);
+}
+
+.composer-model-menu-title {
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.composer-model-settings {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+}
+
+.composer-model-settings:hover {
+  background: var(--dsw-hover-strong);
+  color: var(--dsw-label);
 }
 
 .composer-model-group-label {
@@ -2414,46 +2452,6 @@ body {
   color: var(--dsw-label-3);
   font-size: 11px;
   line-height: 1.5;
-}
-
-.composer-model-config-entry {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 0;
-  border-top: 1px solid var(--dsw-border);
-  background: transparent;
-  padding: 9px 12px;
-  color: var(--dsw-label-2);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.composer-model-config-entry:hover {
-  background: var(--dsw-hover-strong);
-  color: var(--dsw-business);
-}
-
-.composer-model-add {
-  display: grid;
-  place-items: center;
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-  border: 1px dashed var(--dsw-border);
-  border-radius: 8px;
-  background: transparent;
-  color: var(--dsw-label-3);
-  cursor: pointer;
-}
-
-.composer-model-add:hover {
-  border-style: solid;
-  color: var(--dsw-business);
-  background: var(--dsw-hover);
 }
 
 .composer-send,

--- a/web/style.css
+++ b/web/style.css
@@ -2416,6 +2416,46 @@ body {
   line-height: 1.5;
 }
 
+.composer-model-config-entry {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border: 0;
+  border-top: 1px solid var(--dsw-border);
+  background: transparent;
+  padding: 9px 12px;
+  color: var(--dsw-label-2);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.composer-model-config-entry:hover {
+  background: var(--dsw-hover-strong);
+  color: var(--dsw-business);
+}
+
+.composer-model-add {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border: 1px dashed var(--dsw-border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--dsw-label-3);
+  cursor: pointer;
+}
+
+.composer-model-add:hover {
+  border-style: solid;
+  color: var(--dsw-business);
+  background: var(--dsw-hover);
+}
+
 .composer-send,
 .composer-stop {
   display: grid;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要
模型配置：官方 Key + 第三方中转/自定义 URL；可增即可删。

## 入口
- 输入框旁 **不再展示 ＋**
- 打开 **选择模型** 下拉，**右上角设置按钮** 进入配置

## 其它
- 添加连接：Notion 风格搜索/创建
- 测试失败拉黑入口；弹层单壳主从面板
- DeepSeek 仅 Flash / Pro / Vision

请在本分支跑 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bc2719a-7efb-45af-8aa8-91cbc5d70ce8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bc2719a-7efb-45af-8aa8-91cbc5d70ce8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

