### PR TITLE
docs: 收紧 README 顶部三色 icon 与标题间距

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<p align="center">
+<h1 align="center">
   <img src="public/mascot-blue.svg" width="54" height="54" alt="biu-harness mascot" />
   <img src="public/mascot-violet.svg" width="54" height="54" alt="biu-harness mascot" />
   <img src="public/mascot-red.svg" width="54" height="54" alt="biu-harness mascot" />
-</p>
-
-<h1 align="center">biu-harness</h1>
+  <br>
+  biu-harness
+</h1>
 
 <p align="center"><b>🧭 天生驾驶者</b></p>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub 渲染 README 时，三个 mascot 包在 `<p>` 里、标题单独一个 `<h1>`，会叠上段落底边距和标题上边距，看起来 icon 和「biu-harness」离得偏远。

把三张图和标题放进同一个居中 `h1`，中间只用 `<br>`，间距会贴得更近，标题级别不变。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-63a91ad7-7692-4da4-b8cb-4bfe20b70910?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-63a91ad7-7692-4da4-b8cb-4bfe20b70910&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

