### PR TITLE
fix: 新建会话后右侧轨迹不再停更

### DIFF
--- a/packages/cap-chat/src/web/trajectory.tsx
+++ b/packages/cap-chat/src/web/trajectory.tsx
@@ -208,12 +208,8 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
     )
   }
 
-  if (!rows.length) {
-    return <div className="traj-root" aria-hidden />
-  }
-
   return (
-    <div className={`traj-root${selectedSeq != null ? ' traj-root-split' : ''}`}>
+    <div className={`traj-root${selectedSeq != null ? ' traj-root-split' : ''}${!rows.length ? ' traj-root-empty' : ''}`}>
       <div className="traj-pane">
         <div className="traj-meta">
           {trajectoryHasMore ? (

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -244,6 +244,10 @@ export class SessionViewService extends Service {
   private cache = new Map<string, SessionCacheEntry>()
   private cacheOrder: string[] = []
   private loadGen = 0
+  /** 右侧检查器或 debug 路由要实时轨迹：与 ConversationView 解耦 */
+  private trajectoryLive = false
+  private trajGen = 0
+  private trajFetchSessionId: string | null = null
   private dispatchedPoll: ReturnType<typeof setInterval> | null = null
 
   constructor(ctx: Context) {
@@ -317,7 +321,11 @@ export class SessionViewService extends Service {
 
   setView(view: ConversationView) {
     this.replace({ view, focusCallId: view === 'chat' ? undefined : this.value.focusCallId })
-    if (view === 'debug') void this.ensureTrajectory()
+    if (this.wantsTrajectory(view)) void this.ensureTrajectory()
+  }
+
+  private wantsTrajectory(view: ConversationView = this.value.view) {
+    return this.trajectoryLive || view === 'debug'
   }
 
   inspectCall(callId: string) {
@@ -334,6 +342,8 @@ export class SessionViewService extends Service {
       if (!this.value.sessionId && this.value.view === 'chat') return
       this.stashCurrent()
       this.loadGen += 1
+      this.trajectoryLive = false
+      this.trajGen += 1
       this.replace({
         sessionId: null,
         events: [],
@@ -382,7 +392,7 @@ export class SessionViewService extends Service {
         focusCallId: route.view === 'chat' ? undefined : this.value.focusCallId,
       })
     }
-    if (route.view === 'debug') await this.ensureTrajectory()
+    if (this.wantsTrajectory(route.view)) await this.ensureTrajectory()
   }
 
   ingest(sessionId: string, event: SessionEvent) {
@@ -422,8 +432,8 @@ export class SessionViewService extends Service {
     }
     this.replace(patch)
     this.stashCurrent()
-    // Trajectory 索引走独立接口；运行中只做轻量刷新，不塞全文 events
-    if (this.value.view === 'debug') void this.refreshTrajectoryIndex()
+    // 检查器打开后 trajectoryLive=true：即使 URL 仍是 chat 也要刷新右侧轨迹
+    if (this.wantsTrajectory()) void this.refreshTrajectoryIndex()
     void this.refreshSessions()
   }
 
@@ -669,13 +679,15 @@ export class SessionViewService extends Service {
       if (cached) {
         this.touchCache(sessionId)
         this.loadGen += 1
+        if (needSwap) this.trajGen += 1
         this.applyCached(sessionId, cached, view)
-        if (view === 'debug') void this.ensureTrajectory()
+        if (this.wantsTrajectory(view)) void this.ensureTrajectory()
         void this.revalidate(sessionId, view)
         return
       }
       if (needSwap) {
         this.loadGen += 1
+        this.trajGen += 1
         // 有上一段内容时先保留画面，只换 sessionId；无缓存清空会闪 EmptyHero
         if (this.value.sessionId && (this.value.nodes.length > 0 || this.value.events.length > 0)) {
           this.replace({
@@ -710,7 +722,7 @@ export class SessionViewService extends Service {
             switchingSession: true,
           })
         }
-        if (view === 'debug') void this.ensureTrajectory()
+        if (this.wantsTrajectory(view)) void this.ensureTrajectory()
         void this.revalidate(sessionId, view)
         return
       }
@@ -718,6 +730,7 @@ export class SessionViewService extends Service {
 
     // wait：发送后等同会话刷新，必须等网络；切会话时也先换目标再 await
     this.loadGen += 1
+    if (needSwap) this.trajGen += 1
     if (needSwap) {
       if (cached) {
         this.touchCache(sessionId)
@@ -757,7 +770,7 @@ export class SessionViewService extends Service {
       }
     }
     await this.revalidate(sessionId, view)
-    if (view === 'debug') await this.ensureTrajectory()
+    if (this.wantsTrajectory(view)) await this.ensureTrajectory()
   }
 
   /** 静默拉取并套用；若用户已切走则丢弃 */
@@ -833,12 +846,12 @@ export class SessionViewService extends Service {
         dispatchedUsageByTurn: byTurn,
         dispatchedTasksByTurn: tasksByTurn,
         dispatchedUsage,
-        trajectory: view === 'debug' ? this.value.trajectory : [],
+        trajectory: this.wantsTrajectory(view) ? this.value.trajectory : [],
         switchingSession: false,
         error: undefined,
       })
       this.syncDispatchedPoll()
-      if (view === 'debug') void this.ensureTrajectory()
+      if (this.wantsTrajectory(view)) void this.ensureTrajectory()
       void this.refreshInbox(sessionId)
     } catch {
       /* 静默 */
@@ -943,16 +956,20 @@ export class SessionViewService extends Service {
     }
   }
 
-  /** 进入 Trajectory：只拉轻量 rows 索引，不拉全文 events。 */
+  /** 进入 Trajectory：只拉轻量 rows 索引，不拉全文 events。不改 ConversationView，避免 /s/:id 把 debug 打回 chat。 */
   async ensureTrajectory() {
     const sessionId = this.value.sessionId
     if (!sessionId) return
-    if (this.value.trajectoryLoading) return
-    this.replace({ trajectoryLoading: true, view: 'debug' })
+    this.trajectoryLive = true
+    if (this.value.trajectoryLoading && this.trajFetchSessionId === sessionId) return
+    const gen = ++this.trajGen
+    this.trajFetchSessionId = sessionId
+    this.replace({ trajectoryLoading: true })
     try {
       const res = await fetch(
         `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,
       )
+      if (gen !== this.trajGen || this.value.sessionId !== sessionId) return
       if (!res.ok) throw new Error(`加载 trajectory 失败：${res.status}`)
       const body = (await res.json()) as TrajectoryPayload
       this.replace({
@@ -960,20 +977,22 @@ export class SessionViewService extends Service {
         trajectoryHasMore: Boolean(body.hasMore),
         trajectoryLoading: false,
         totalTurns: typeof body.totalTurns === 'number' ? body.totalTurns : this.value.totalTurns,
-        view: 'debug',
       })
     } catch (error) {
+      if (gen !== this.trajGen || this.value.sessionId !== sessionId) return
       this.replace({ trajectoryLoading: false, error: String(error) })
     }
   }
 
   async refreshTrajectoryIndex() {
     const sessionId = this.value.sessionId
-    if (!sessionId || this.value.view !== 'debug') return
+    if (!sessionId || !this.wantsTrajectory()) return
+    const gen = this.trajGen
     try {
       const res = await fetch(
         `/api/sessions/${sessionId}/trajectory?turns=${TRAJECTORY_TAIL_TURNS}`,
       )
+      if (gen !== this.trajGen || this.value.sessionId !== sessionId) return
       if (!res.ok) return
       const body = (await res.json()) as TrajectoryPayload
       this.replace({

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -544,3 +544,54 @@ test('deleteSession removes from list before DELETE resolves', async () => {
   await pending
   assert.equal(view.get().sessions.map((row) => row.id).join(','), 's2')
 })
+
+test('ensureTrajectory keeps live index on chat route after new session navigate', async () => {
+  let trajRows: Array<{ id: string; seq: number; turn: number; step: null; depth: number; type: string; summary: string }> = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    if (url.includes('/trajectory')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 's-new', rows: trajRows, hasMore: false, totalTurns: trajRows.length ? 1 : 0 }),
+      } as Response
+    }
+    if (url.includes('/api/sessions/s-new?turns=')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: 's-new',
+          events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+          hasMore: false,
+          totalTurns: 0,
+        }),
+      } as Response
+    }
+    if (url.includes('/api/sessions')) {
+      return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response
+    }
+    if (url.includes('/api/approvals')) {
+      return { ok: true, status: 200, json: async () => ({ mode: 'auto', pending: [] }) } as Response
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response
+  }) as typeof fetch
+
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s-new', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  await view.ensureTrajectory()
+  assert.equal(view.get().view, 'chat')
+  assert.equal(view.get().trajectory.length, 0)
+
+  // 新建会话后 navigate(`/s/${id}`) 会 applyRoute chat，不应关掉轨迹订阅
+  await view.applyRoute({ kind: 'session', sessionId: 's-new', view: 'chat' })
+  assert.equal(view.get().view, 'chat')
+
+  trajRows = [{ id: 'tr-1', seq: 1, turn: 0, step: null, depth: 0, type: 'user/message', summary: 'hi' }]
+  view.ingest('s-new', { type: 'user/message', text: 'hi', seq: 1, ts: 2 })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert.equal(view.get().trajectory.length, 1)
+  assert.equal(view.get().view, 'chat')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

右侧检查器打开「轨迹」时，主区仍走 `/s/:id`（`view=chat`）。原先 `ensureTrajectory()` 会把 `view` 写成 `debug`，新建会话后 `navigate(/s/:id)` 的 `applyRoute` 又把它打回 `chat`。之后 `ingest` 只在 `view === 'debug'` 时刷新轨迹索引，所以：

- 已有轨迹数据的旧会话：检查器拉过索引且没再被路由打回，能滚动、能刷新
- 新建会话：先拉到空索引，路由切回 chat 后发消息也不再刷新，右侧一直空

## 改动

- 用 `trajectoryLive` 表示检查器要实时轨迹，与 ConversationView 解耦
- `ensureTrajectory` 不再改 `view`
- `ingest` / `revalidate` / `load` 在 live 或 debug 时刷新索引
- 切会话丢弃过期 trajectory 请求
- 空轨迹仍渲染列表容器，第一条到达时可以贴底滚动

## 测试

- `ensureTrajectory keeps live index on chat route after new session navigate`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

