### PR TITLE
fix(tasks): 查看模式可绑定并改写当前视图

### DIFF
--- a/packages/cap-tasks/src/host/index.test.ts
+++ b/packages/cap-tasks/src/host/index.test.ts
@@ -706,26 +706,22 @@ test('trigger default state is idle and enabled=false (no auto-trigger for plain
 
 // ==================== 视图系统（Notion 风格）测试 ====================
 
-test('task_views: seeds 4 builtin views on first open and normalizes config', async () => {
+test('task_views: no builtin layout views; create / update / delete', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'tasks-views-'))
   const path = join(dir, 'tasks.sqlite')
   try {
     const ctx = new Context()
     const tasks = new TasksService(ctx, path).open()
-    const views = tasks.listTaskViews()
-    assert.equal(views.length, 4)
-    const names = views.map((v) => v.name)
-    assert.deepEqual(names.sort(), ['依赖', '看板', '表格', '队列'])
-    for (const v of views) assert.equal(v.isBuiltin, true)
-    // 默认排序 = 状态（复合：状态→优先级→截止）
-    assert.deepEqual(views[0].config.sort, { field: 'status', dir: 'asc' })
+    assert.equal(tasks.listTaskViews().length, 0)
 
-    // 再开一次不重复 seed
-    const tasks2 = new TasksService(new Context(), path).open()
-    assert.equal(tasks2.listTaskViews().length, 4)
-
-    // 脏配置归一化：非法 mode/field 回退默认
-    const v = tasks.createTaskView({ name: '  我的视图  ', config: { mode: 'gantt' as never, filter: { project: 'biu', tags: ['a', 'a', ' '], time: '99d' }, sort: { field: 'bogus' as never, dir: 'side' as never } } })
+    const v = tasks.createTaskView({
+      name: '  我的视图  ',
+      config: {
+        mode: 'gantt' as never,
+        filter: { project: 'biu', tags: ['a', 'a', ' '], time: '99d' },
+        sort: { field: 'bogus' as never, dir: 'side' as never },
+      },
+    })
     assert.equal(v.name, '我的视图')
     assert.equal(v.isBuiltin, false)
     assert.deepEqual(v.config, {
@@ -733,28 +729,10 @@ test('task_views: seeds 4 builtin views on first open and normalizes config', as
       filter: { project: 'biu', tags: ['a'], time: '' },
       sort: { field: 'status', dir: 'asc' },
     })
-  } finally {
-    await rm(dir, { recursive: true, force: true })
-  }
-})
 
-test('task_views: create / update / delete semantics (builtin cannot be deleted)', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'tasks-views-'))
-  const path = join(dir, 'tasks.sqlite')
-  try {
-    const ctx = new Context()
-    const tasks = new TasksService(ctx, path).open()
-    const v = tasks.createTaskView({
-      name: '高优待办',
-      config: {
-        mode: 'board',
-        filter: { project: '', tags: [], time: '' },
-        sort: { field: 'priority', dir: 'desc' },
-      },
-    })
-    assert.equal(tasks.listTaskViews().length, 5)
+    const tasks2 = new TasksService(new Context(), path).open()
+    assert.equal(tasks2.listTaskViews().length, 1)
 
-    // PATCH 重命名 + 更新配置
     const updated = tasks.updateTaskView(v.id, {
       name: '高优看板',
       config: { mode: 'board', filter: { project: 'biu-harness', tags: ['前端'], time: '7d' }, sort: { field: 'due', dir: 'asc' } },
@@ -763,19 +741,36 @@ test('task_views: create / update / delete semantics (builtin cannot be deleted)
     assert.deepEqual(updated.config.filter, { project: 'biu-harness', tags: ['前端'], time: '7d' })
     assert.deepEqual(updated.config.sort, { field: 'due', dir: 'asc' })
 
-    // 未知视图：update 抛错，delete 返回 false（路由层转 404）
     assert.throws(() => tasks.updateTaskView('nope', { name: 'x' }), /unknown view/)
     assert.equal(tasks.deleteTaskView('nope'), false)
-
-    // 删除自定义视图
     assert.equal(tasks.deleteTaskView(v.id), true)
     assert.equal(tasks.getTaskView(v.id), undefined)
-    assert.equal(tasks.listTaskViews().length, 4)
+    assert.equal(tasks.listTaskViews().length, 0)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
 
-    // 内置视图不可删除
-    const builtin = tasks.listTaskViews().find((x) => x.isBuiltin)!
-    assert.throws(() => tasks.deleteTaskView(builtin.id), /builtin view cannot be deleted/)
-    assert.ok(tasks.getTaskView(builtin.id))
+test('task_views: open drops leftover builtin layout rows', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'tasks-views-drop-'))
+  const path = join(dir, 'tasks.sqlite')
+  try {
+    new TasksService(new Context(), path).open()
+    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
+    const db = new DatabaseSync(path)
+    const ts = Date.now()
+    db.prepare(
+      'INSERT INTO task_views (id, name, config_json, is_builtin, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)',
+    ).run(
+      'builtin-table',
+      '表格',
+      JSON.stringify({ mode: 'table', filter: { project: '', tags: [], time: '' }, sort: { field: 'status', dir: 'asc' } }),
+      ts,
+      ts,
+    )
+    db.close()
+    const again = new TasksService(new Context(), path).open()
+    assert.equal(again.listTaskViews().length, 0)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/cap-tasks/src/host/index.ts
+++ b/packages/cap-tasks/src/host/index.ts
@@ -218,15 +218,6 @@ export function normalizeViewName(value: unknown): string {
   return s ? s.slice(0, 80) : '未命名视图'
 }
 
-/** 内置 4 个默认视图：首次启动自动 seed，不可删除。 */
-const BUILTIN_VIEWS: Array<{ id: string; name: string; config: TaskViewConfig }> = [
-  { id: 'builtin-queue', name: '队列', config: { ...defaultViewConfig(), mode: 'queue' } },
-  { id: 'builtin-table', name: '表格', config: { ...defaultViewConfig(), mode: 'table' } },
-  { id: 'builtin-board', name: '看板', config: { ...defaultViewConfig(), mode: 'board' } },
-  { id: 'builtin-graph', name: '依赖', config: { ...defaultViewConfig(), mode: 'graph' } },
-]
-
-
 export type TaskCreateInput = {
   title: string
   status?: TaskStatus
@@ -1144,7 +1135,7 @@ export class TasksService extends Service {
         /* already exists */
       }
     }
-    // ---- 视图持久化：task_views 表 + 内置视图首次启动自动 seed ----
+    // ---- 视图持久化：task_views 表。呈现方式（队列/表格/看板/依赖）不是视图，不 seed 内置行。 ----
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS task_views (
         id TEXT PRIMARY KEY,
@@ -1155,16 +1146,9 @@ export class TasksService extends Service {
         updated_at INTEGER NOT NULL
       );
     `)
-    const viewCount = (this.db.prepare('SELECT COUNT(*) AS c FROM task_views').get() as { c: number }).c
-    if (!viewCount) {
-      const ts = now()
-      const insertView = this.db.prepare(
-        'INSERT INTO task_views (id, name, config_json, is_builtin, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)',
-      )
-      for (const v of BUILTIN_VIEWS) {
-        insertView.run(v.id, v.name, JSON.stringify(v.config), ts, ts)
-      }
-    }
+    this.db.exec(
+      `DELETE FROM task_views WHERE is_builtin = 1 OR id IN ('builtin-queue','builtin-table','builtin-board','builtin-graph')`,
+    )
     return this
   }
 
@@ -1485,11 +1469,10 @@ export class TasksService extends Service {
     return this.getTaskView(id)!
   }
 
-  /** 内置视图不可删除；返回是否删除成功。 */
+  /** 返回是否删除成功。 */
   deleteTaskView(id: string): boolean {
     const current = this.getTaskView(id)
     if (!current) return false
-    if (current.isBuiltin) throw new Error('builtin view cannot be deleted')
     const result = this.db.prepare('DELETE FROM task_views WHERE id = ?').run(id) as { changes: number }
     if (result.changes > 0) this.emitChange()
     return result.changes > 0
@@ -2029,14 +2012,14 @@ export function apply(ctx: Context) {
 
   host.tools.register({
     name: 'tasks_view_list',
-    description: '列出任务面板的所有视图（含内置：队列/表格/看板/依赖）及其筛选、排序配置',
+    description: '列出任务面板已保存的视图及其筛选、排序配置（呈现方式不在视图里）',
     parameters: { type: 'object', properties: {} },
     execute: () => ({ views: tasks.listTaskViews() }),
   })
 
   host.tools.register({
     name: 'tasks_view_create',
-    description: '新建一个任务面板视图（Notion 风格）：可同时指定呈现方式 mode、筛选 filter、排序 sort',
+    description: '新建一个任务面板视图：名称 + 筛选 filter + 排序 sort（呈现方式由前端独立选择，不必绑定视图）',
     parameters: {
       type: 'object',
       properties: {
@@ -2062,7 +2045,7 @@ export function apply(ctx: Context) {
 
   host.tools.register({
     name: 'tasks_view_update',
-    description: '更新任务面板视图：可重命名，或修改筛选/排序/呈现方式（只传要改的字段，其余保持不变）',
+    description: '更新任务面板视图：可重命名，或修改筛选/排序（只传要改的字段，其余保持不变）',
     parameters: {
       type: 'object',
       properties: {
@@ -2093,7 +2076,7 @@ export function apply(ctx: Context) {
 
   host.tools.register({
     name: 'tasks_view_delete',
-    description: '删除任务面板的自定义视图（内置视图不可删除）',
+    description: '删除任务面板的已保存视图',
     parameters: {
       type: 'object',
       properties: { id: { type: 'string', description: '视图 id' } },
@@ -2223,7 +2206,7 @@ export function apply(ctx: Context) {
   // GET    /api/task-views      —— 视图列表
   // POST   /api/task-views      —— 新建/另存为（body: { name, config }）
   // PATCH  /api/task-views/:id  —— 重命名/更新配置（body: { name?, config? }）
-  // DELETE /api/task-views/:id  —— 删除（内置视图返回 400）
+  // DELETE /api/task-views/:id  —— 删除已保存视图
   host.http.route('GET', '/api/task-views', async (route) => {
     route.send(200, { views: tasks.listTaskViews() })
   })

--- a/packages/cap-tasks/src/web/index.test.ts
+++ b/packages/cap-tasks/src/web/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { buildQueueRows, buildTreeRows, sortTasks } from './index.tsx'
+import { applyViewKeepMode, buildQueueRows, buildTreeRows, sortTasks } from './index.tsx'
 import type { Task, TaskPriority, TaskStatus } from './index.tsx'
 
 function makeTask(id: string, patch: Partial<Task> = {}): Task {
@@ -78,6 +78,22 @@ describe('buildQueueRows（队列：仅叶节点，组内保持排序）', () =>
     const ids = rows.map((t) => t.id)
     // 父节点 p1 不展示；todo 组内：leafB(high) → leafC(med) → leafA(low)
     expect(ids).toEqual(['leafB', 'leafC', 'leafA'])
+  })
+})
+
+describe('applyViewKeepMode（视图与查看模式解绑）', () => {
+  test('套用已存筛选时保留当前呈现方式', () => {
+    const kept = applyViewKeepMode(
+      {
+        mode: 'table',
+        filter: { project: 'biu', tags: ['a'], time: '7d' },
+        sort: { field: 'due', dir: 'asc' },
+      },
+      'board',
+    )
+    expect(kept.mode).toBe('board')
+    expect(kept.filter.project).toBe('biu')
+    expect(kept.sort.field).toBe('due')
   })
 })
 

--- a/packages/cap-tasks/src/web/index.test.ts
+++ b/packages/cap-tasks/src/web/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { applyViewKeepMode, buildQueueRows, buildTreeRows, sortTasks } from './index.tsx'
+import { buildQueueRows, buildTreeRows, sortTasks } from './index.tsx'
 import type { Task, TaskPriority, TaskStatus } from './index.tsx'
 
 function makeTask(id: string, patch: Partial<Task> = {}): Task {
@@ -78,22 +78,6 @@ describe('buildQueueRows（队列：仅叶节点，组内保持排序）', () =>
     const ids = rows.map((t) => t.id)
     // 父节点 p1 不展示；todo 组内：leafB(high) → leafC(med) → leafA(low)
     expect(ids).toEqual(['leafB', 'leafC', 'leafA'])
-  })
-})
-
-describe('applyViewKeepMode（视图与查看模式解绑）', () => {
-  test('套用已存筛选时保留当前呈现方式', () => {
-    const kept = applyViewKeepMode(
-      {
-        mode: 'table',
-        filter: { project: 'biu', tags: ['a'], time: '7d' },
-        sort: { field: 'due', dir: 'asc' },
-      },
-      'board',
-    )
-    expect(kept.mode).toBe('board')
-    expect(kept.filter.project).toBe('biu')
-    expect(kept.sort.field).toBe('due')
   })
 })
 

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -155,11 +155,46 @@ export type TaskViewSort = {
   dir: TaskViewSortDir
 }
 
-/** 视图 = 呈现方式 + 筛选 + 排序 的完整配置 */
+/** 视图配置：筛选 + 排序；mode 仍写入后端，但前端查看模式可独立切换。 */
 export type TaskViewConfig = {
   mode: TaskViewMode
   filter: TaskViewFilter
   sort: TaskViewSort
+}
+
+export const VIEW_MODE_OPTIONS: Array<{ id: TaskViewMode; label: string }> = [
+  { id: 'queue', label: '队列' },
+  { id: 'table', label: '表格' },
+  { id: 'board', label: '看板' },
+  { id: 'graph', label: '依赖' },
+]
+
+const VIEW_MODE_STORAGE_KEY = 'tasks.viewMode'
+
+export function isTaskViewMode(value: unknown): value is TaskViewMode {
+  return value === 'queue' || value === 'table' || value === 'board' || value === 'graph'
+}
+
+/** 套用已存视图时保留当前查看模式（前端视图 ≠ 呈现方式）。 */
+export function applyViewKeepMode(viewConfig: TaskViewConfig, mode: TaskViewMode): TaskViewConfig {
+  return { ...viewConfig, mode }
+}
+
+export function readStoredViewMode(): TaskViewMode | null {
+  try {
+    const raw = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
+    return isTaskViewMode(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export function writeStoredViewMode(mode: TaskViewMode) {
+  try {
+    window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode)
+  } catch {
+    /* ignore */
+  }
 }
 
 export type TaskView = {
@@ -1200,7 +1235,12 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         }
         const target = (savedId ? list.find((v) => v.id === savedId) : undefined) ?? list[0] ?? null
         setActiveViewId(target?.id ?? null)
-        if (target) setConfig(target.config)
+        const storedMode = readStoredViewMode()
+        if (target) {
+          setConfig(storedMode ? applyViewKeepMode(target.config, storedMode) : target.config)
+        } else if (storedMode) {
+          setConfig(applyViewKeepMode(defaultViewConfig(), storedMode))
+        }
       } catch {
         /* 服务不可用：留在默认配置 */
       } finally {
@@ -1220,13 +1260,16 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
   // 排序非默认（字段≠status 或 非升序）时，排序按钮右上角显示圆点（与筛选按钮一致）
   const sortCustom = sort.field !== 'status' || sort.dir !== 'asc'
 
-  // 自动保存：配置变化 → 防抖 PATCH 回当前视图
-  const configKey = JSON.stringify(config)
+  // 自动保存：只写回筛选/排序；查看模式独立，不绑到视图
+  const configKey = JSON.stringify({ filter: config.filter, sort: config.sort })
   useEffect(() => {
     if (!hydrated || !activeView) return
-    if (configKey === JSON.stringify(activeView.config)) return
+    const persist: TaskViewConfig = { ...config, mode: activeView.config.mode }
+    if (JSON.stringify({ filter: persist.filter, sort: persist.sort }) === JSON.stringify({ filter: activeView.config.filter, sort: activeView.config.sort })) {
+      return
+    }
     const timer = window.setTimeout(() => {
-      patchTaskView(activeView.id, { config })
+      patchTaskView(activeView.id, { config: persist })
         .then((updated) => {
           setViews((prev) => prev.map((v) => (v.id === updated.id ? updated : v)))
         })
@@ -1240,7 +1283,6 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
   const switchView = async (id: string) => {
     let v: TaskView | undefined = views.find((x) => x.id === id)
     if (!v) {
-      // 本地视图列表可能已过期（如 Agent 刚新建的视图还没同步过来）→ 先拉取最新列表再切
       try {
         const list = await fetchTaskViews()
         setViews(list)
@@ -1251,7 +1293,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
     }
     if (!v) return
     setActiveViewId(id)
-    setConfig(v.config)
+    setConfig(applyViewKeepMode(v.config, config.mode))
     try {
       window.localStorage.setItem('tasks.activeViewId', id)
     } catch {
@@ -1263,7 +1305,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
   useEffect(() => {
     if (!tasksView) return
     return tasksView.subscribeViewSwitch((viewId) => {
-      switchView(viewId)
+      void switchView(viewId)
     })
   }, [tasksView, views, hydrated])
 
@@ -1317,7 +1359,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         if (activeViewId === dlg.view.id) {
           const next = rest[0] ?? null
           setActiveViewId(next?.id ?? null)
-          if (next) setConfig(next.config)
+          if (next) setConfig(applyViewKeepMode(next.config, config.mode))
         }
         setDlg(null)
       } catch (err) {
@@ -1337,7 +1379,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         const v = await createTaskView(name, config)
         setViews((prev) => [...prev, v])
         setActiveViewId(v.id)
-        setConfig(v.config)
+        setConfig(applyViewKeepMode(v.config, config.mode))
         try {
           window.localStorage.setItem('tasks.activeViewId', v.id)
         } catch {
@@ -1367,19 +1409,29 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
   // ---- 排序下拉菜单 ----
   const [sortMenuOpen, setSortMenuOpen] = useState(false)
   const sortMenuRef = useRef<HTMLDivElement>(null)
+  const [modeMenuOpen, setModeMenuOpen] = useState(false)
+  const modeMenuRef = useRef<HTMLDivElement>(null)
   // 点击外部关闭所有弹出菜单
   useEffect(() => {
-    if (!viewMenuOpen && !sortMenuOpen && !filterOpen) return
+    if (!viewMenuOpen && !sortMenuOpen && !filterOpen && !modeMenuOpen) return
     const onDown = (event: MouseEvent) => {
       const node = event.target as Node
-      if (viewMenuRef.current?.contains(node) || sortMenuRef.current?.contains(node) || filterRef.current?.contains(node)) return
+      if (
+        viewMenuRef.current?.contains(node) ||
+        sortMenuRef.current?.contains(node) ||
+        filterRef.current?.contains(node) ||
+        modeMenuRef.current?.contains(node)
+      ) {
+        return
+      }
       setViewMenuOpen(false)
       setSortMenuOpen(false)
       setFilterOpen(false)
+      setModeMenuOpen(false)
     }
     document.addEventListener('mousedown', onDown)
     return () => document.removeEventListener('mousedown', onDown)
-  }, [viewMenuOpen, sortMenuOpen, filterOpen])
+  }, [viewMenuOpen, sortMenuOpen, filterOpen, modeMenuOpen])
 
   // 项目 / 标签筛选
   const allProjects = useMemo(() => {
@@ -1389,9 +1441,14 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
     return [...new Set(tasks.flatMap((t) => t.tags))].sort()
   }, [tasks])
 
-  // 配置更新助手：改筛选 / 改排序 / 改呈现方式（触发自动保存）
+  // 配置更新助手：改筛选 / 改排序；查看模式单独落 localStorage，不跟视图下拉绑死
   const patchConfig = (patch: Partial<TaskViewConfig>) => setConfig((c) => ({ ...c, ...patch }))
   const patchFilter = (patch: Partial<TaskViewFilter>) => setConfig((c) => ({ ...c, filter: { ...c.filter, ...patch } }))
+  const setDisplayMode = (next: TaskViewMode) => {
+    if (next === mode) return
+    patchConfig({ mode: next })
+    writeStoredViewMode(next)
+  }
 
   // 排序字段点击循环：未选中 → 升序 → 降序 → 还原（默认：状态升序）
   const cycleSort = (field: TaskViewSortField) => {
@@ -1543,13 +1600,16 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
               aria-expanded={viewMenuOpen}
               onClick={() => setViewMenuOpen((v) => !v)}
             >
-              {VIEW_MODE_ICON[mode]}
-              <span className="tasks-viewdd-name">{activeView?.name ?? (mode === 'queue' ? '队列' : mode === 'board' ? '看板' : mode === 'graph' ? '依赖' : '表格')}</span>
+              <LuPanelsTopLeft size={13} aria-hidden />
+              <span className="tasks-viewdd-name">{activeView?.name ?? '未保存'}</span>
               <LuChevronDown size={13} aria-hidden />
             </button>
             {viewMenuOpen ? (
               <div className="tasks-viewdd-menu" role="menu">
                 <div className="tasks-viewdd-head">视图</div>
+                {views.length === 0 ? (
+                  <div className="tasks-viewdd-empty">还没有已保存的视图</div>
+                ) : null}
                 {views.map((v) => (
                   <div key={v.id} className={`tasks-viewdd-item${v.id === activeViewId ? ' is-active' : ''}`}>
                     <button
@@ -1559,20 +1619,17 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
                       aria-checked={v.id === activeViewId}
                       onClick={() => { switchView(v.id); setViewMenuOpen(false) }}
                     >
-                      {VIEW_MODE_ICON[v.config.mode]}
                       <span className="tasks-viewdd-item-name">{v.name}</span>
                       {v.id === activeViewId ? <LuCircleCheck size={13} aria-hidden className="tasks-viewdd-check" /> : null}
                     </button>
-                    {!v.isBuiltin ? (
-                      <span className="tasks-viewdd-item-actions">
-                        <button type="button" className="tasks-viewdd-act" title="重命名" onClick={() => openDlg({ kind: 'rename', view: v })}>
-                          <LuPenLine size={12} aria-hidden />
-                        </button>
-                        <button type="button" className="tasks-viewdd-act is-danger" title="删除" onClick={() => openDlg({ kind: 'delete', view: v })}>
-                          <LuTrash2 size={12} aria-hidden />
-                        </button>
-                      </span>
-                    ) : null}
+                    <span className="tasks-viewdd-item-actions">
+                      <button type="button" className="tasks-viewdd-act" title="重命名" onClick={() => openDlg({ kind: 'rename', view: v })}>
+                        <LuPenLine size={12} aria-hidden />
+                      </button>
+                      <button type="button" className="tasks-viewdd-act is-danger" title="删除" onClick={() => openDlg({ kind: 'delete', view: v })}>
+                        <LuTrash2 size={12} aria-hidden />
+                      </button>
+                    </span>
                   </div>
                 ))}
                 <div className="tasks-viewdd-foot">
@@ -1597,6 +1654,43 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
               onChange={(event) => setQuery(event.target.value)}
             />
           </label>
+          <div className="tasks-sort-wrap" ref={modeMenuRef}>
+            <button
+              type="button"
+              className={`tasks-sort-btn${modeMenuOpen ? ' is-active' : ''}`}
+              aria-label="查看模式"
+              title={`模式：${VIEW_MODE_OPTIONS.find((opt) => opt.id === mode)?.label ?? mode}`}
+              aria-haspopup="menu"
+              aria-expanded={modeMenuOpen}
+              onClick={() => setModeMenuOpen((v) => !v)}
+            >
+              {VIEW_MODE_ICON[mode]}
+            </button>
+            {modeMenuOpen ? (
+              <div className="tasks-sort-menu" role="menu">
+                <div className="tasks-sort-head">查看模式</div>
+                {VIEW_MODE_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.id}
+                    type="button"
+                    className={`tasks-sort-item${mode === opt.id ? ' is-active' : ''}`}
+                    role="menuitemradio"
+                    aria-checked={mode === opt.id}
+                    onClick={() => {
+                      setDisplayMode(opt.id)
+                      setModeMenuOpen(false)
+                    }}
+                  >
+                    <span className="tasks-sort-item-label">
+                      <span className="tasks-mode-item-ico">{VIEW_MODE_ICON[opt.id]}</span>
+                      {opt.label}
+                    </span>
+                    {mode === opt.id ? <LuCircleCheck size={13} aria-hidden className="tasks-sort-item-icon is-on" /> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
           {/* 排序按钮（仅图标：字段+升降序在菜单内，位于筛选按钮左侧） */}
           <div className="tasks-sort-wrap" ref={sortMenuRef}>
             <button
@@ -3472,6 +3566,7 @@ if (typeof document !== 'undefined') {
 .tasks-viewdd-name { max-width:160px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .tasks-viewdd-menu { position:absolute; top:calc(100% + 6px); left:0; z-index:40; min-width:230px; padding:6px; background:var(--dsw-sidebar); border:1px solid var(--dsw-border); border-radius:10px; box-shadow:0 8px 24px rgba(0,0,0,.18); display:flex; flex-direction:column; gap:2px; }
 .tasks-viewdd-head { padding:5px 8px 3px; font-size:10px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--dsw-label-3); }
+.tasks-viewdd-empty { padding:8px; font-size:11.5px; color:var(--dsw-label-3); }
 .tasks-viewdd-item { display:flex; align-items:center; gap:2px; border-radius:7px; }
 .tasks-viewdd-item:hover { background:var(--dsw-hover); }
 .tasks-viewdd-item.is-active { background:color-mix(in srgb, var(--dsw-business) 10%, transparent); }
@@ -3515,10 +3610,12 @@ if (typeof document !== 'undefined') {
 .tasks-sort-menu { position:absolute; top:calc(100% + 6px); right:0; z-index:40; min-width:180px; padding:8px; background:var(--dsw-sidebar); border:1px solid var(--dsw-border); border-radius:10px; box-shadow:0 8px 24px rgba(0,0,0,.18); display:flex; flex-direction:column; gap:8px; }
 .tasks-sort-head { font-size:10.5px; font-weight:600; color:var(--dsw-label-3); }
 .tasks-sort-item { display:inline-flex; align-items:center; justify-content:space-between; gap:8px; border:0; border-radius:7px; padding:6px 8px; background:transparent; color:var(--dsw-label-2); font:inherit; font-size:12px; font-weight:550; cursor:pointer; text-align:left; }
+.tasks-sort-item-label { display:inline-flex; align-items:center; min-width:0; }
 .tasks-sort-item:hover { background:var(--dsw-hover); }
 .tasks-sort-item.is-active { color:var(--dsw-business); font-weight:650; }
 .tasks-sort-item-icon { display:inline-flex; align-items:center; justify-content:center; width:16px; flex:none; color:var(--dsw-label-3); }
 .tasks-sort-item-icon.is-on { color:var(--dsw-business); }
+.tasks-mode-item-ico { display:inline-flex; align-items:center; margin-right:6px; }
 
 /* ---- 看板视图（Notion 风格：极轻边框、无重色、悬浮轻阴影）---- */
 .tasks-board { display:grid; grid-template-columns:repeat(5, minmax(190px, 1fr)); gap:10px; margin-top:10px; align-items:start; overflow-x:auto; }

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -155,7 +155,7 @@ export type TaskViewSort = {
   dir: TaskViewSortDir
 }
 
-/** 视图配置：筛选 + 排序；mode 仍写入后端，但前端查看模式可独立切换。 */
+/** 视图配置：呈现方式 + 筛选 + 排序 */
 export type TaskViewConfig = {
   mode: TaskViewMode
   filter: TaskViewFilter
@@ -168,34 +168,6 @@ export const VIEW_MODE_OPTIONS: Array<{ id: TaskViewMode; label: string }> = [
   { id: 'board', label: '看板' },
   { id: 'graph', label: '依赖' },
 ]
-
-const VIEW_MODE_STORAGE_KEY = 'tasks.viewMode'
-
-export function isTaskViewMode(value: unknown): value is TaskViewMode {
-  return value === 'queue' || value === 'table' || value === 'board' || value === 'graph'
-}
-
-/** 套用已存视图时保留当前查看模式（前端视图 ≠ 呈现方式）。 */
-export function applyViewKeepMode(viewConfig: TaskViewConfig, mode: TaskViewMode): TaskViewConfig {
-  return { ...viewConfig, mode }
-}
-
-export function readStoredViewMode(): TaskViewMode | null {
-  try {
-    const raw = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY)
-    return isTaskViewMode(raw) ? raw : null
-  } catch {
-    return null
-  }
-}
-
-export function writeStoredViewMode(mode: TaskViewMode) {
-  try {
-    window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode)
-  } catch {
-    /* ignore */
-  }
-}
 
 export type TaskView = {
   id: string
@@ -1235,12 +1207,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         }
         const target = (savedId ? list.find((v) => v.id === savedId) : undefined) ?? list[0] ?? null
         setActiveViewId(target?.id ?? null)
-        const storedMode = readStoredViewMode()
-        if (target) {
-          setConfig(storedMode ? applyViewKeepMode(target.config, storedMode) : target.config)
-        } else if (storedMode) {
-          setConfig(applyViewKeepMode(defaultViewConfig(), storedMode))
-        }
+        if (target) setConfig(target.config)
       } catch {
         /* 服务不可用：留在默认配置 */
       } finally {
@@ -1260,16 +1227,13 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
   // 排序非默认（字段≠status 或 非升序）时，排序按钮右上角显示圆点（与筛选按钮一致）
   const sortCustom = sort.field !== 'status' || sort.dir !== 'asc'
 
-  // 自动保存：只写回筛选/排序；查看模式独立，不绑到视图
-  const configKey = JSON.stringify({ filter: config.filter, sort: config.sort })
+  // 自动保存：配置变化（mode / 筛选 / 排序）→ 防抖 PATCH 回当前视图
+  const configKey = JSON.stringify(config)
   useEffect(() => {
     if (!hydrated || !activeView) return
-    const persist: TaskViewConfig = { ...config, mode: activeView.config.mode }
-    if (JSON.stringify({ filter: persist.filter, sort: persist.sort }) === JSON.stringify({ filter: activeView.config.filter, sort: activeView.config.sort })) {
-      return
-    }
+    if (configKey === JSON.stringify(activeView.config)) return
     const timer = window.setTimeout(() => {
-      patchTaskView(activeView.id, { config: persist })
+      patchTaskView(activeView.id, { config })
         .then((updated) => {
           setViews((prev) => prev.map((v) => (v.id === updated.id ? updated : v)))
         })
@@ -1293,7 +1257,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
     }
     if (!v) return
     setActiveViewId(id)
-    setConfig(applyViewKeepMode(v.config, config.mode))
+    setConfig(v.config)
     try {
       window.localStorage.setItem('tasks.activeViewId', id)
     } catch {
@@ -1359,7 +1323,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         if (activeViewId === dlg.view.id) {
           const next = rest[0] ?? null
           setActiveViewId(next?.id ?? null)
-          if (next) setConfig(applyViewKeepMode(next.config, config.mode))
+          if (next) setConfig(next.config)
         }
         setDlg(null)
       } catch (err) {
@@ -1379,7 +1343,7 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
         const v = await createTaskView(name, config)
         setViews((prev) => [...prev, v])
         setActiveViewId(v.id)
-        setConfig(applyViewKeepMode(v.config, config.mode))
+        setConfig(v.config)
         try {
           window.localStorage.setItem('tasks.activeViewId', v.id)
         } catch {
@@ -1441,13 +1405,12 @@ function TasksWorkspace({ compact = false, tasksView }: { compact?: boolean; tas
     return [...new Set(tasks.flatMap((t) => t.tags))].sort()
   }, [tasks])
 
-  // 配置更新助手：改筛选 / 改排序；查看模式单独落 localStorage，不跟视图下拉绑死
+  // 配置更新助手：改筛选 / 改排序 / 改呈现方式（均绑定当前视图并自动保存）
   const patchConfig = (patch: Partial<TaskViewConfig>) => setConfig((c) => ({ ...c, ...patch }))
   const patchFilter = (patch: Partial<TaskViewFilter>) => setConfig((c) => ({ ...c, filter: { ...c.filter, ...patch } }))
   const setDisplayMode = (next: TaskViewMode) => {
     if (next === mode) return
     patchConfig({ mode: next })
-    writeStoredViewMode(next)
   }
 
   // 排序字段点击循环：未选中 → 升序 → 降序 → 还原（默认：状态升序）


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
前端：查看模式与筛选、排序一样属于当前视图。工具栏排序旁可选模式，改完会 PATCH 写回已选视图，创建后仍可改。后端不再 seed 四个内置布局视图。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

