### PR TITLE
feat: 侧栏插件商店（安装已编译包，不二次编译）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.biu/
 .cordis/
 .workspace/
 *.log

--- a/cordis.plugins.json
+++ b/cordis.plugins.json
@@ -73,6 +73,16 @@
       "web": "@biu/cap-tasks/web",
       "togglable": true,
       "enabled": true
+    },
+    {
+      "id": "plugin-store",
+      "name": "插件商店",
+      "layer": "capability",
+      "blurb": "@biu/cap-plugin-store。安装已编译包，不重编主应用。",
+      "package": "@biu/cap-plugin-store/host",
+      "web": "@biu/cap-plugin-store/web",
+      "togglable": true,
+      "enabled": true
     }
   ]
 }

--- a/packages/cap-plugin-store/fixtures/hello/host.js
+++ b/packages/cap-plugin-store/fixtures/hello/host.js
@@ -1,0 +1,9 @@
+/** Prebuilt Host half — the app never compiles this file. */
+export const name = 'store-hello'
+export const inject = ['http']
+
+export function apply(ctx) {
+  ctx.http.route('GET', '/api/store-hello', (route) => {
+    route.send(200, { message: 'hello from store plugin', installed: true })
+  })
+}

--- a/packages/cap-plugin-store/fixtures/hello/manifest.json
+++ b/packages/cap-plugin-store/fixtures/hello/manifest.json
@@ -1,0 +1,5 @@
+{
+  "id": "store-hello",
+  "name": "Hello",
+  "blurb": "最小商店插件：安装后在本页显示横幅，并提供 GET /api/store-hello。发布物已是纯 JS。"
+}

--- a/packages/cap-plugin-store/fixtures/hello/web.js
+++ b/packages/cap-plugin-store/fixtures/hello/web.js
@@ -1,0 +1,24 @@
+/** Prebuilt Client half — loaded with import(url), not Vite. React comes from globalThis. */
+const React = globalThis.React
+
+export const name = 'store-hello-web'
+export const inject = ['slots']
+
+function HelloBanner() {
+  return React.createElement(
+    'div',
+    {
+      'data-testid': 'store-hello-banner',
+      className:
+        'rounded-[8px] border border-[var(--dsw-ok)]/40 bg-[var(--dsw-surface)] px-3 py-2 text-[13px] text-[var(--dsw-label)]',
+    },
+    'Hello 商店插件已运行（主应用没有为它二次编译）',
+  )
+}
+
+export function apply(ctx) {
+  ctx.slots.place('plugin-store-extras', HelloBanner, {
+    key: 'store-hello-banner',
+    order: 10,
+  })
+}

--- a/packages/cap-plugin-store/package.json
+++ b/packages/cap-plugin-store/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@biu/cap-plugin-store",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "插件商店：安装已编译包，不重编主应用",
+  "exports": {
+    "./host": "./src/host/index.ts",
+    "./web": "./src/web/index.tsx"
+  },
+  "peerDependencies": {
+    "cordis": "4.0.0-rc.8",
+    "react": "^19.1.1"
+  }
+}

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -1,0 +1,68 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Context } from 'cordis'
+import type { CatalogEntry } from '@biu/host-hub'
+import { PluginStoreService, defaultCatalogDir } from './index.ts'
+
+test('catalog dir contains the prebuilt hello fixture', () => {
+  const dir = defaultCatalogDir()
+  assert.equal(dir.endsWith('fixtures'), true)
+  assert.equal(dirname(fileURLToPath(import.meta.url)).includes('cap-plugin-store'), true)
+})
+
+test('install copies prebuilt js and adopt; uninstall drops it', async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), 'plugin-store-'))
+  const adopted: string[] = []
+  const dropped: string[] = []
+  const forks = new Map<string, CatalogEntry>()
+  try {
+    const ctx = new Context()
+    ;(ctx as unknown as { hub: unknown }).hub = {
+      async adopt(entry: CatalogEntry) {
+        forks.set(entry.id, entry)
+        adopted.push(entry.id)
+      },
+      async drop(id: string) {
+        forks.delete(id)
+        dropped.push(id)
+      },
+      snapshot() {
+        return {
+          plugins: [...forks.values()].map((entry) => ({
+            id: entry.id,
+            enabled: true,
+            state: 'active',
+            web: entry.web,
+          })),
+        }
+      },
+    }
+    const store = new PluginStoreService(ctx, defaultCatalogDir(), dataDir)
+    const listed = await store.list()
+    const hello = listed.find((item) => item.id === 'store-hello')
+    assert.ok(hello, 'hello fixture should be listed')
+    assert.equal(hello.installed, false)
+
+    const installed = await store.install('store-hello')
+    assert.equal(installed?.installed, true)
+    assert.equal(installed?.running, true)
+    assert.deepEqual(adopted, ['store-hello'])
+    const entry = forks.get('store-hello')
+    assert.equal(entry?.packageName, 'store:store-hello')
+    assert.equal(entry?.web, '/api/plugin-store/files/store-hello/web.js')
+    const hostJs = await store.readInstalledFile('store-hello', 'host.js')
+    assert.match(hostJs, /store-hello/)
+    assert.doesNotMatch(hostJs, /from ['"]typescript/)
+
+    await store.uninstall('store-hello')
+    assert.deepEqual(dropped, ['store-hello'])
+    const after = (await store.list()).find((item) => item.id === 'store-hello')
+    assert.equal(after?.installed, false)
+  } finally {
+    await rm(dataDir, { recursive: true, force: true })
+  }
+})

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -1,0 +1,226 @@
+import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { pathToFileURL } from 'node:url'
+import type { Context, Plugin } from 'cordis'
+import { findRepoRoot } from '@biu/host-plugin-loader'
+import type { CatalogEntry } from '@biu/host-hub'
+
+export const name = 'plugin-store'
+export const inject = ['http', 'hub']
+
+export type StoreListing = {
+  id: string
+  name: string
+  blurb: string
+  installed: boolean
+  running: boolean
+}
+
+export type StoreManifest = {
+  id: string
+  name: string
+  blurb: string
+}
+
+type StoreHub = {
+  adopt(entry: CatalogEntry): Promise<unknown>
+  drop(id: string): Promise<unknown>
+  snapshot(): { plugins: Array<{ id: string; enabled?: boolean; state?: string }> }
+}
+
+export function storeWebUrl(id: string) {
+  return `/api/plugin-store/files/${encodeURIComponent(id)}/web.js`
+}
+
+export function defaultCatalogDir() {
+  return join(findRepoRoot(), 'packages/cap-plugin-store/fixtures')
+}
+
+export function defaultDataDir() {
+  return process.env.BIU_PLUGIN_STORE_DIR || join(findRepoRoot(), '.biu', 'plugin-store')
+}
+
+async function readManifest(dir: string): Promise<StoreManifest> {
+  const raw = JSON.parse(await readFile(join(dir, 'manifest.json'), 'utf8')) as StoreManifest
+  if (!raw.id || !raw.name) throw new Error(`invalid plugin manifest in ${dir}`)
+  return raw
+}
+
+function isSafeId(id: string) {
+  return /^[a-z][a-z0-9-]{1,40}$/.test(id)
+}
+
+const ALLOWED_FILES = new Set(['manifest.json', 'host.js', 'web.js'])
+
+export class PluginStoreService {
+  constructor(
+    private readonly ctx: Context,
+    readonly catalogDir: string,
+    readonly dataDir: string,
+  ) {}
+
+  private hub(): StoreHub {
+    return this.ctx.hub as unknown as StoreHub
+  }
+
+  async list(): Promise<StoreListing[]> {
+    const names = existsSync(this.catalogDir) ? await readdir(this.catalogDir) : []
+    const running = new Set(
+      this.hub()
+        .snapshot()
+        .plugins.filter((row) => row.enabled || row.state === 'active')
+        .map((row) => row.id),
+    )
+    const items: StoreListing[] = []
+    for (const name of names.sort()) {
+      const dir = join(this.catalogDir, name)
+      if (!(await stat(dir)).isDirectory()) continue
+      const manifest = await readManifest(dir)
+      const installed = existsSync(join(this.dataDir, manifest.id, 'host.js'))
+      items.push({
+        ...manifest,
+        installed,
+        running: installed && running.has(manifest.id),
+      })
+    }
+    return items
+  }
+
+  async install(id: string) {
+    if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
+    const source = join(this.catalogDir, id.replace(/^store-/, ''))
+    const catalogHit = existsSync(join(source, 'manifest.json'))
+      ? source
+      : await this.findCatalogById(id)
+    if (!catalogHit) throw new Error(`unknown store plugin: ${id}`)
+    const manifest = await readManifest(catalogHit)
+    const dest = join(this.dataDir, manifest.id)
+    await mkdir(this.dataDir, { recursive: true })
+    await rm(dest, { recursive: true, force: true })
+    await mkdir(dest, { recursive: true })
+    for (const file of ALLOWED_FILES) {
+      const from = join(catalogHit, file)
+      if (!existsSync(from)) continue
+      await cp(from, join(dest, file))
+    }
+    await this.mountInstalled(manifest)
+    await this.writeIndex()
+    return (await this.list()).find((item) => item.id === manifest.id)
+  }
+
+  async uninstall(id: string) {
+    if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
+    await this.hub().drop(id)
+    await rm(join(this.dataDir, id), { recursive: true, force: true })
+    await this.writeIndex()
+  }
+
+  async restore() {
+    if (!existsSync(this.dataDir)) return
+    const names = await readdir(this.dataDir)
+    for (const name of names) {
+      const dir = join(this.dataDir, name)
+      if (!(await stat(dir)).isDirectory()) continue
+      if (!existsSync(join(dir, 'manifest.json'))) continue
+      const manifest = await readManifest(dir)
+      await this.mountInstalled(manifest)
+    }
+  }
+
+  async readInstalledFile(id: string, file: string) {
+    if (!isSafeId(id) || !ALLOWED_FILES.has(file)) throw new Error('not found')
+    const path = join(this.dataDir, id, file)
+    if (!existsSync(path)) throw new Error('not found')
+    return readFile(path, 'utf8')
+  }
+
+  private async findCatalogById(id: string) {
+    if (!existsSync(this.catalogDir)) return null
+    for (const name of await readdir(this.catalogDir)) {
+      const dir = join(this.catalogDir, name)
+      if (!(await stat(dir)).isDirectory()) continue
+      if (!existsSync(join(dir, 'manifest.json'))) continue
+      const manifest = await readManifest(dir)
+      if (manifest.id === id) return dir
+    }
+    return null
+  }
+
+  private async mountInstalled(manifest: StoreManifest) {
+    const hostFile = join(this.dataDir, manifest.id, 'host.js')
+    if (!existsSync(hostFile)) throw new Error(`missing host.js for ${manifest.id}`)
+    const mod = (await importHostModule(hostFile)) as Plugin & { inject?: string[] }
+    const entry: CatalogEntry = {
+      id: manifest.id,
+      name: manifest.name,
+      layer: 'capability',
+      blurb: manifest.blurb,
+      plugin: mod,
+      inject: mod.inject,
+      togglable: true,
+      enabled: true,
+      web: storeWebUrl(manifest.id),
+      packageName: `store:${manifest.id}`,
+    }
+    await this.hub().adopt(entry)
+  }
+
+  private async writeIndex() {
+    const items = existsSync(this.dataDir) ? await readdir(this.dataDir) : []
+    await mkdir(this.dataDir, { recursive: true })
+    await writeFile(join(this.dataDir, 'index.json'), JSON.stringify({ items }, null, 2))
+  }
+}
+
+async function importHostModule(hostFile: string) {
+  try {
+    return await import(pathToFileURL(hostFile).href)
+  } catch {
+    const code = await readFile(hostFile, 'utf8')
+    return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
+  }
+}
+
+export async function apply(ctx: Context) {
+  const store = new PluginStoreService(ctx, defaultCatalogDir(), defaultDataDir())
+  await store.restore()
+
+  ctx.http.route('GET', '/api/plugin-store', async (route) => {
+    route.send(200, { items: await store.list() })
+  })
+  ctx.http.route('POST', '/api/plugin-store/install', async (route) => {
+    const payload = (await route.json()) as { id?: string }
+    try {
+      route.send(200, { item: await store.install(String(payload?.id ?? '')) })
+    } catch (error) {
+      route.send(400, { error: String(error) })
+    }
+  })
+  ctx.http.route('POST', '/api/plugin-store/uninstall', async (route) => {
+    const payload = (await route.json()) as { id?: string }
+    try {
+      await store.uninstall(String(payload?.id ?? ''))
+      route.send(200, { ok: true, items: await store.list() })
+    } catch (error) {
+      route.send(400, { error: String(error) })
+    }
+  })
+  ctx.http.route('GET', '/api/plugin-store/files/:id/:file', async (route) => {
+    try {
+      const body = await store.readInstalledFile(route.params.id, route.params.file)
+      const mime = route.params.file.endsWith('.js')
+        ? 'text/javascript; charset=utf-8'
+        : 'application/json; charset=utf-8'
+      route.res.writeHead(200, {
+        'content-type': mime,
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-store',
+      })
+      route.res.end(body)
+    } catch {
+      route.send(404, { error: 'not found' })
+    }
+  })
+}

--- a/packages/cap-plugin-store/src/web/index.test.ts
+++ b/packages/cap-plugin-store/src/web/index.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import * as slots from '@biu/web-slots'
+import * as appModules from '@biu/web-app-modules'
+import * as storeUi from './index.tsx'
+
+test('plugin store registers the plugins activity module', async () => {
+  const ctx = new Context()
+  await ctx.plugin(slots)
+  await ctx.plugin(appModules)
+  ctx.slots.fill('root', () => null, {
+    children: {
+      'app-modules': { kind: 'list' },
+    },
+  })
+  await ctx.plugin(storeUi)
+  const mods = ctx.appModules.list()
+  assert.equal(mods.some((item) => item.id === 'plugins' && item.path === '/plugins'), true)
+  assert.equal(ctx.slots.list('app-modules').some((item) => item.id === 'plugin-store-module'), true)
+  assert.ok(ctx.slots.specOf('plugin-store-extras'))
+})

--- a/packages/cap-plugin-store/src/web/index.tsx
+++ b/packages/cap-plugin-store/src/web/index.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { Context } from 'cordis'
+import { useSlotEntries } from '@biu/web-slots'
+import type { SlotsService } from '@biu/web-slots'
+
+export const name = 'plugin-store-ui'
+export const inject = ['slots', 'appModules']
+
+type StoreListing = {
+  id: string
+  name: string
+  blurb: string
+  installed: boolean
+  running: boolean
+}
+
+function PuzzleIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className ?? 'size-5'} fill="none" stroke="currentColor" strokeWidth="1.7" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8 3.5a2 2 0 0 1 2 2V7h4V5.5a2 2 0 1 1 4 0V7h1.5A1.5 1.5 0 0 1 21 8.5V11h-1.5a2 2 0 1 0 0 4H21v2.5a1.5 1.5 0 0 1-1.5 1.5H18v1.5a2 2 0 1 1-4 0V19h-4v1.5a2 2 0 1 1-4 0V19H4.5A1.5 1.5 0 0 1 3 17.5V15h1.5a2 2 0 1 0 0-4H3V8.5A1.5 1.5 0 0 1 4.5 7H6V5.5a2 2 0 0 1 2-2z"
+      />
+    </svg>
+  )
+}
+
+async function readJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, init)
+  const body = (await res.json()) as T & { error?: string }
+  if (!res.ok) throw new Error(body.error || res.statusText)
+  return body
+}
+
+function PluginStorePage({ slots }: { slots: SlotsService }) {
+  const extras = useSlotEntries(slots, 'plugin-store-extras')
+  const [items, setItems] = useState<StoreListing[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await readJson<{ items: StoreListing[] }>('/api/plugin-store')
+      setItems(data.items ?? [])
+      setError(null)
+    } catch (err) {
+      setError(String(err))
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  async function install(id: string) {
+    setBusy(id)
+    try {
+      await readJson('/api/plugin-store/install', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id }),
+      })
+      await refresh()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  async function uninstall(id: string) {
+    setBusy(id)
+    try {
+      await readJson('/api/plugin-store/uninstall', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id }),
+      })
+      await refresh()
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-auto px-8 py-6" data-testid="plugin-store-page">
+      <header className="mb-6">
+        <h1 className="m-0 text-[22px] font-semibold tracking-tight text-[var(--dsw-label)]">插件</h1>
+        <p className="mt-1.5 max-w-[42rem] text-[13px] leading-5 text-[var(--dsw-label-3)]">
+          商店包是作者已经编译好的 ESM。安装只是复制到本地并动态 import，不会重编本应用。
+        </p>
+      </header>
+
+      {error ? (
+        <p className="mb-4 text-[13px] text-[var(--dsw-danger)]" data-testid="plugin-store-error">
+          {error}
+        </p>
+      ) : null}
+
+      {extras.length > 0 ? (
+        <div className="mb-5 flex flex-col gap-2">
+          {extras
+            .sort((a, b) => a.order - b.order)
+            .map((entry) => {
+              const Component = entry.Component
+              return <Component key={entry.id} renderSlot={() => null} />
+            })}
+        </div>
+      ) : null}
+
+      <ul className="m-0 flex list-none flex-col gap-3 p-0">
+        {items.map((item) => (
+          <li
+            key={item.id}
+            className="flex items-start justify-between gap-4 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-4 py-3"
+            data-testid={`plugin-store-card-${item.id}`}
+          >
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-medium text-[var(--dsw-label)]">{item.name}</span>
+                <span className="font-mono text-[11px] text-[var(--dsw-label-3)]">{item.id}</span>
+                {item.installed ? (
+                  <span className="rounded-[4px] bg-[var(--dsw-ok)]/15 px-1.5 py-px text-[10px] font-medium text-[var(--dsw-ok)]">
+                    {item.running ? '运行中' : '已安装'}
+                  </span>
+                ) : (
+                  <span className="rounded-[4px] bg-[var(--dsw-hover)] px-1.5 py-px text-[10px] text-[var(--dsw-label-3)]">
+                    未安装
+                  </span>
+                )}
+              </div>
+              <p className="mt-1 m-0 text-[12px] leading-5 text-[var(--dsw-label-3)]">{item.blurb}</p>
+            </div>
+            {item.installed ? (
+              <button
+                type="button"
+                className="shrink-0 rounded-[8px] border border-[var(--dsw-border)] px-3 py-1.5 text-[12px] text-[var(--dsw-label)] hover:bg-[var(--dsw-hover)]"
+                data-testid={`plugin-store-uninstall-${item.id}`}
+                disabled={busy === item.id}
+                onClick={() => void uninstall(item.id)}
+              >
+                {busy === item.id ? '卸载中…' : '卸载'}
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="shrink-0 rounded-[8px] bg-[var(--dsw-business)] px-3 py-1.5 text-[12px] font-medium text-[var(--dsw-bg)] hover:opacity-90"
+                data-testid={`plugin-store-install-${item.id}`}
+                disabled={busy === item.id}
+                onClick={() => void install(item.id)}
+              >
+                {busy === item.id ? '安装中…' : '安装'}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+type AppModulesService = {
+  register: (mod: {
+    id: string
+    label: string
+    path: string
+    description?: string
+    order?: number
+    Icon?: (props: { className?: string }) => unknown
+  }) => unknown
+}
+
+const moduleProps = { moduleId: 'plugins' }
+
+export function apply(ctx: Context) {
+  const slots = ctx.get('slots') as SlotsService | undefined
+  const appModules = ctx.get('appModules') as AppModulesService | undefined
+  if (!slots) throw new Error('slots service required')
+  if (!appModules) throw new Error('appModules service required')
+  appModules.register({
+    id: 'plugins',
+    label: '插件',
+    path: '/plugins',
+    description: 'Install prebuilt plugins without rebuilding the app',
+    order: 30,
+    Icon: PuzzleIcon,
+  })
+  slots.place('app-modules', PluginStorePage, {
+    key: 'plugin-store-module',
+    order: 30,
+    props: () => ({ ...moduleProps, slots }),
+    children: {
+      'plugin-store-extras': { kind: 'list' },
+    },
+  })
+}

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -108,6 +108,32 @@ export class HubService extends Service {
     return this.snapshot()
   }
 
+  /** 运行时挂上商店已安装包（预编译 ESM），不改 cordis.plugins.json。 */
+  async adopt(entry: CatalogEntry) {
+    const existing = this.forks.get(entry.id)
+    if (existing && !isStorePackage(existing.entry.packageName)) {
+      throw new Error(`cannot replace built-in plugin ${entry.id}`)
+    }
+    if (existing?.fiber) await this.unmount(entry.id)
+    this.forks.set(entry.id, { entry })
+    if (entry.enabled !== false) await this.mount(entry.id)
+    this.ctx.emit(HUB_CHANGE)
+    return this.snapshot()
+  }
+
+  /** 卸掉商店包，内置 cap 不能走这条路径。 */
+  async drop(id: string) {
+    const existing = this.forks.get(id)
+    if (!existing) return this.snapshot()
+    if (!isStorePackage(existing.entry.packageName)) {
+      throw new Error(`cannot drop built-in plugin ${id}`)
+    }
+    await this.unmount(id)
+    this.forks.delete(id)
+    this.ctx.emit(HUB_CHANGE)
+    return this.snapshot()
+  }
+
   private async mount(id: string) {
     const record = this.forks.get(id)
     if (!record || (record.fiber && record.fiber.uid !== null)) return
@@ -130,6 +156,12 @@ function clone(value: unknown): unknown[] {
     return ['[unserializable]']
   }
 }
+
+function isStorePackage(packageName?: string) {
+  return typeof packageName === 'string' && packageName.startsWith('store:')
+}
+
+export type { CatalogEntry } from './catalog.ts'
 
 export const name = 'hub'
 export const inject = ['http', 'tools']

--- a/packages/web-ui-hub/src/web/index.test.ts
+++ b/packages/web-ui-hub/src/web/index.test.ts
@@ -7,6 +7,7 @@ import * as snapshot from '@biu/web-snapshot'
 import * as sessionView from '@biu/web-session-view'
 import * as projectView from '@biu/web-project-view'
 import * as uiHub from './index.ts'
+import { isRuntimeWebModule } from './index.ts'
 import { uiPackageLoaders } from 'virtual:cordis-ui-loaders'
 
 const Dummy = () => null
@@ -24,6 +25,11 @@ function plugin(id: string, enabled: boolean, web?: string) {
     ...(web ? { web } : {}),
   }
 }
+
+test('store plugin web urls are runtime modules', () => {
+  assert.equal(isRuntimeWebModule('/api/plugin-store/files/store-hello/web.js'), true)
+  assert.equal(isRuntimeWebModule('@biu/cap-tasks/web'), false)
+})
 
 test('ui-hub mounts configured ui packages including chat', async () => {
   const ctx = new Context()

--- a/packages/web-ui-hub/src/web/index.ts
+++ b/packages/web-ui-hub/src/web/index.ts
@@ -1,10 +1,21 @@
 import type { Context, Fiber, Plugin } from 'cordis'
+import * as React from 'react'
 import { uiPackageLoaders } from 'virtual:cordis-ui-loaders'
 
 export const name = 'ui-hub'
 export const inject = ['slots', 'snapshot']
 
+/** 商店包的 web 入口是已编译 ESM 的 URL，不在 Vite 虚拟表里。 */
+export function isRuntimeWebModule(web: string) {
+  return web.startsWith('/') || /^https?:\/\//.test(web)
+}
+
 export function apply(ctx: Context) {
+  if (typeof globalThis !== 'undefined') {
+    const g = globalThis as typeof globalThis & { React?: typeof React }
+    g.React = React
+  }
+
   const forks = new Map<string, Fiber>()
   let pending = false
   let running = false
@@ -13,6 +24,10 @@ export function apply(ctx: Context) {
     if (!web) return undefined
     const loader = uiPackageLoaders[web]
     if (loader) return loader()
+    if (isRuntimeWebModule(web)) {
+      const href = web.startsWith('/') ? new URL(web, window.location.origin).href : web
+      return import(/* @vite-ignore */ href)
+    }
     return undefined
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
最小插件商店闭环：

- 左侧活动栏增加「插件」页（`/plugins`）
- 商店货架里有一个预编译的 Hello 示例（纯 JS，不经过本应用 tsc/vite build）
- 安装：复制到 `.biu/plugin-store`，Host `import` 已编译 `host.js`，浏览器 `import()` 已编译 `web.js`
- 卸载：drop fiber 并删本地文件
- 主应用不会为商店插件再编译一遍

示例插件安装后会在本页显示横幅，并注册 `GET /api/store-hello`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

