### PR TITLE
fix(ui): step 统计条增加上下内边距

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -1987,14 +1987,13 @@ body {
 
 .chat-step-bar {
   display: flex;
-  height: 30px;
   align-items: center;
   width: 100%;
-  margin: 2px 0;
+  margin: 6px 0;
   border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--dsw-bg) 55%, var(--dsw-surface));
-  padding: 0 12px;
+  padding: 8px 12px;
   box-shadow: none;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
每个 step 的统计条原先写死 `height: 30px` 且只有左右 padding，视觉上挤在内容里。

改成去掉固定高度，使用 `padding: 8px 12px`，并略微加大上下外边距。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

