### PR TITLE
fix(ui): 全页底板与中间对话区同色

### DIFF
--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -126,7 +126,7 @@ export const SessionInspector = memo(function SessionInspector({
 
   return (
     <aside
-      className="relative flex min-h-0 min-w-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] text-[var(--dsw-label)]"
+      className="relative flex min-h-0 min-w-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-bg)] text-[var(--dsw-label)]"
       data-testid="session-inspector"
       aria-label="会话检查器"
     >

--- a/web/style.css
+++ b/web/style.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
-/* Neutral dark chrome — canvas/nav #191919, rails #202020 */
+/* Neutral dark chrome — canvas, rails, inspector share #191919 */
 :root {
   color-scheme: dark;
   --dsw-bg: #191919;
-  --dsw-sidebar: #202020;
+  --dsw-sidebar: var(--dsw-bg);
   --dsw-label: #f2f1ed;
   --dsw-label-2: rgba(242, 241, 237, 0.72);
   --dsw-label-3: rgba(242, 241, 237, 0.45);
@@ -13,8 +13,8 @@
   --dsw-business: #f2f1ed;
   --dsw-business-soft: rgba(242, 241, 237, 0.1);
   --dsw-input: var(--dsw-bg);
-  --dsw-tool: #202020;
-  --dsw-surface: #202020;
+  --dsw-tool: var(--dsw-bg);
+  --dsw-surface: var(--dsw-bg);
   --dsw-danger: #cf2d56;
   --dsw-danger-soft: rgba(207, 45, 86, 0.14);
   --dsw-ok: #1f8a65;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把左右侧栏、右侧检查器、用量/轨迹等底板统一成中间对话区的 `#191919`（`--dsw-bg`）。

`--dsw-sidebar`、`--dsw-surface`、`--dsw-tool` 都指向同一色；气泡 `--dsw-bubble` 和选中行 `--dsw-hover` 仍保留对比，方便阅读。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

