### PR TITLE
fix(ui): 左侧栏/导航改回 #202020，选中条改回白色

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
-/* Neutral dark chrome — canvas, rails, inspector share #191919 */
+/* Neutral dark chrome — canvas/right inspector #191919, left rails #202020 */
 :root {
   color-scheme: dark;
   --dsw-bg: #191919;
-  --dsw-sidebar: var(--dsw-bg);
+  --dsw-sidebar: #202020;
   --dsw-label: #f2f1ed;
   --dsw-label-2: rgba(242, 241, 237, 0.72);
   --dsw-label-3: rgba(242, 241, 237, 0.45);
@@ -487,7 +487,7 @@ body {
   flex-direction: column;
   align-items: stretch;
   border-right: 1px solid var(--dsw-border);
-  background: var(--dsw-bg);
+  background: var(--dsw-sidebar);
 }
 
 .app-activity-brand {
@@ -610,7 +610,7 @@ body {
 }
 
 .app-activity-item.is-active .app-activity-indicator {
-  background: var(--dsw-pick);
+  background: var(--dsw-business);
 }
 
 .app-activity-live {
@@ -849,9 +849,13 @@ body {
   border-top: 1px solid var(--dsw-border);
 }
 
-/* 右侧三个检查器板块底板与左侧栏同一色 */
-[data-testid='session-inspector'] .usage-panel {
-  background: var(--dsw-sidebar);
+/* 右侧检查器底板与中间画布同色，不跟左侧栏 */
+[data-testid='session-inspector'] .usage-panel,
+[data-testid='session-inspector'] .traj-root,
+[data-testid='session-inspector'] .traj-meta,
+[data-testid='session-inspector'] .traj-head,
+[data-testid='session-inspector'] .traj-detail {
+  background: var(--dsw-bg);
   box-shadow: none;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上次把左右底板一起改成中间色了，范围过大。

本次只把**左侧会话栏**和**最左导航栏**改回 `#202020`，右侧检查器仍跟中间画布 `#191919`。导航选中左侧竖条从选取蓝改回原来的白色（`--dsw-business`）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

