### PR TITLE
usage 胶囊：去掉叠色和细条，只留中性数字

### DIFF
--- a/packages/cap-chat/src/web/trajectory.tsx
+++ b/packages/cap-chat/src/web/trajectory.tsx
@@ -58,13 +58,6 @@ function UsageCard({ usage, label = 'Token usage' }: { usage: TrajectoryUsage; l
           {usage.cacheReadTokens ? (
             <em className="traj-usage-stat-sub">cache {formatTok(usage.cacheReadTokens)}</em>
           ) : null}
-          {pct != null ? (
-            <span className="traj-usage-meters">
-              <span className="traj-usage-meter is-cache" aria-hidden>
-                <i style={{ width: `${pct}%` }} />
-              </span>
-            </span>
-          ) : null}
         </div>
         <div className="traj-usage-stat traj-usage-stat-out">
           <span>Output</span>

--- a/packages/cap-chat/src/web/trajectory.tsx
+++ b/packages/cap-chat/src/web/trajectory.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { memo, type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { LuArrowUp } from 'react-icons/lu'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
@@ -48,21 +48,22 @@ function cacheHitPct(usage: TrajectoryUsage): number | null {
 function UsageCard({ usage, label = 'Token usage' }: { usage: TrajectoryUsage; label?: string }) {
   const total = usage.totalTokens ?? usage.inputTokens + usage.outputTokens
   const pct = cacheHitPct(usage)
-  const inStyle: CSSProperties | undefined =
-    pct != null
-      ? {
-          backgroundImage: `linear-gradient(90deg, rgba(34, 140, 90, 0.22) 0%, rgba(34, 140, 90, 0.22) ${pct}%, rgba(15, 17, 21, 0.04) ${pct}%, rgba(15, 17, 21, 0.04) 100%)`,
-        }
-      : undefined
   return (
     <section className="traj-usage-card" aria-label={label}>
       <div className="traj-usage-card-title">{label}</div>
       <div className="traj-usage-grid">
-        <div className="traj-usage-stat traj-usage-stat-in" style={inStyle}>
+        <div className="traj-usage-stat traj-usage-stat-in">
           <span>Input{pct != null ? ` · cache ${pct}%` : ''}</span>
           <strong>{formatTok(usage.inputTokens)}</strong>
           {usage.cacheReadTokens ? (
             <em className="traj-usage-stat-sub">cache {formatTok(usage.cacheReadTokens)}</em>
+          ) : null}
+          {pct != null ? (
+            <span className="traj-usage-meters">
+              <span className="traj-usage-meter is-cache" aria-hidden>
+                <i style={{ width: `${pct}%` }} />
+              </span>
+            </span>
           ) : null}
         </div>
         <div className="traj-usage-stat traj-usage-stat-out">

--- a/packages/cap-chat/src/web/usage-inline.tsx
+++ b/packages/cap-chat/src/web/usage-inline.tsx
@@ -18,17 +18,8 @@ function isHistPct(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1
 }
 
-function Meter({ kind, pct }: { kind: 'hist' | 'cache'; pct: number }) {
-  return (
-    <span className={`traj-usage-meter is-${kind}`} aria-hidden>
-      <i style={{ width: `${pct}%` }} />
-    </span>
-  )
-}
-
 /**
- * Input 胶囊：数字在上，历史占比 / cache hit 各一条独立细进度条，不再红绿叠层。
- * histPct 默认取 usage.histPct，也可用 histPct 参数覆盖。
+ * Input 胶囊：中性底板 + 数字。历史占比在左、cache hit 在右，不再叠色、不再画条。
  */
 export function UsageInline({
   usage,
@@ -55,21 +46,10 @@ export function UsageInline({
 
   return (
     <span className="traj-usage" title={formatTrajectoryUsage(usage)}>
-      <span className="traj-usage-in-col">
-        <span
-          className={`traj-usage-in-wrap${pct != null ? ' has-cache' : ''}${hist != null ? ' has-hist' : ''}`}
-          title={title}
-        >
-          {hist != null ? <span className="traj-usage-hist-pct">{hist}%</span> : null}
-          <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
-          {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
-        </span>
-        {hist != null || pct != null ? (
-          <span className="traj-usage-meters">
-            {hist != null ? <Meter kind="hist" pct={hist} /> : null}
-            {pct != null ? <Meter kind="cache" pct={pct} /> : null}
-          </span>
-        ) : null}
+      <span className="traj-usage-in-wrap" title={title}>
+        {hist != null ? <span className="traj-usage-hist-pct">{hist}%</span> : null}
+        <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
+        {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
       </span>
       <span className="traj-usage-arrow" aria-hidden>
         →

--- a/packages/cap-chat/src/web/usage-inline.tsx
+++ b/packages/cap-chat/src/web/usage-inline.tsx
@@ -1,4 +1,3 @@
-import { type CSSProperties } from 'react'
 import {
   formatTokens,
   formatTrajectoryUsage,
@@ -14,16 +13,22 @@ function cacheHitPct(usage: TrajectoryUsage): number | null {
   return Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100))
 }
 
-/** 历史占比是 0~1 的有限数值才纳入合成背景。 */
+/** 历史占比是 0~1 的有限数值才纳入。 */
 function isHistPct(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 1
 }
 
+function Meter({ kind, pct }: { kind: 'hist' | 'cache'; pct: number }) {
+  return (
+    <span className={`traj-usage-meter is-${kind}`} aria-hidden>
+      <i style={{ width: `${pct}%` }} />
+    </span>
+  )
+}
+
 /**
- * Input 包成胶囊；绿色(cache hit)与红色(历史占比)各自从左→右铺设，多段 linear-gradient
- * 合成在同一背景上：红色层在下、绿色层在上，alpha 混合呈现叠加色，两段互不强制铺满。
- *
- * histPct 默认取 usage.histPct（探底成功则出红色历史占比段），但也可用 histPct 参数覆盖。
+ * Input 胶囊：数字在上，历史占比 / cache hit 各一条独立细进度条，不再红绿叠层。
+ * histPct 默认取 usage.histPct，也可用 histPct 参数覆盖。
  */
 export function UsageInline({
   usage,
@@ -41,32 +46,30 @@ export function UsageInline({
     ? Math.round((histPct !== undefined ? histPct : usage.histPct!) * 100)
     : null
 
-  // 红、绿各 0~100%，独立叠加；任一存在才设背景。红层在下、绿层在上。
-  const layers: string[] = []
-  if (hist != null) layers.push(`linear-gradient(90deg, rgba(229, 72, 77, 0.3) 0%, rgba(229, 72, 77, 0.3) ${hist}%, transparent ${hist}%)`)
-  if (pct != null)
-    layers.push(
-      `linear-gradient(90deg, rgba(34, 140, 90, 0.28) 0%, rgba(34, 140, 90, 0.28) ${pct}%, rgba(15, 17, 21, 0.06) ${pct}%, rgba(15, 17, 21, 0.06) 100%)`,
-    )
-  const inStyle: CSSProperties | undefined =
-    layers.length > 0 ? { backgroundImage: layers.join(', ') } : undefined
-
-  const title = hist != null
-    ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct ?? 0}% · 历史占比 ${hist}%`
-    : pct != null
-      ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct}% (${formatTok(usage.cacheReadTokens!)})`
-      : `input ${formatTok(usage.inputTokens)}`
+  const title =
+    hist != null
+      ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct ?? 0}% · 历史占比 ${hist}%`
+      : pct != null
+        ? `input ${formatTok(usage.inputTokens)} · cache hit ${pct}% (${formatTok(usage.cacheReadTokens!)})`
+        : `input ${formatTok(usage.inputTokens)}`
 
   return (
     <span className="traj-usage" title={formatTrajectoryUsage(usage)}>
-      <span
-        className={`traj-usage-in-wrap${pct != null ? ' has-cache' : ''}${hist != null ? ' has-hist' : ''}`}
-        style={inStyle}
-        title={title}
-      >
-        {hist != null ? <span className="traj-usage-hist-pct">{hist}%</span> : null}
-        <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
-        {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
+      <span className="traj-usage-in-col">
+        <span
+          className={`traj-usage-in-wrap${pct != null ? ' has-cache' : ''}${hist != null ? ' has-hist' : ''}`}
+          title={title}
+        >
+          {hist != null ? <span className="traj-usage-hist-pct">{hist}%</span> : null}
+          <span className="traj-usage-in">{formatTok(usage.inputTokens)}</span>
+          {pct != null ? <span className="traj-usage-cache-pct">{pct}%</span> : null}
+        </span>
+        {hist != null || pct != null ? (
+          <span className="traj-usage-meters">
+            {hist != null ? <Meter kind="hist" pct={hist} /> : null}
+            {pct != null ? <Meter kind="cache" pct={pct} /> : null}
+          </span>
+        ) : null}
       </span>
       <span className="traj-usage-arrow" aria-hidden>
         →

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -2410,16 +2410,11 @@ function eventEndOf(t: Task): number | null {
   return null
 }
 
-/** 消耗胶囊：与 Live/thread 的 .traj-usage 对齐——绿色缓冲背景(=cache hit 覆盖) + 两侧 in/out 数值 + 分隔箭头。 */
+/** 消耗胶囊：与 Live/thread 的 .traj-usage 对齐——cache 独立细条，不再绿底叠层。 */
 function UsageCapsule({ usage, aggregate }: { usage: SumUsage; aggregate: boolean }) {
   if (usage.totalTokens <= 0) return <span className="tasks-usage-empty">—</span>
   const pct =
     usage.inputTokens && usage.cacheReadTokens ? Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100)) : null
-  const inStyle: CSSProperties | undefined = pct
-    ? {
-        backgroundImage: `linear-gradient(90deg, rgba(34,140,90,0.30) 0%, rgba(34,140,90,0.30) ${pct}%, transparent ${pct}%, transparent 100%)`,
-      }
-    : undefined
   return (
     <span
       className={`tasks-usage-capsule${aggregate ? ' is-agg' : ''}`}
@@ -2429,8 +2424,17 @@ function UsageCapsule({ usage, aggregate }: { usage: SumUsage; aggregate: boolea
           : `本任务各回合消耗：in ${formatTokens(usage.inputTokens)} / out ${formatTokens(usage.outputTokens)}${usage.cacheReadTokens ? ` / cache ${formatTokens(usage.cacheReadTokens)}` : ''}`
       }
     >
-      <span className={`tasks-usage-input${pct != null ? ' has-cache' : ''}`} style={inStyle}>
-        {formatTokens(usage.inputTokens)}
+      <span className="traj-usage-in-col">
+        <span className={`tasks-usage-input${pct != null ? ' has-cache' : ''}`}>
+          {formatTokens(usage.inputTokens)}
+        </span>
+        {pct != null ? (
+          <span className="traj-usage-meters">
+            <span className="traj-usage-meter is-cache" aria-hidden>
+              <i style={{ width: `${pct}%` }} />
+            </span>
+          </span>
+        ) : null}
       </span>
       <span className="tasks-usage-arrow">→</span>
       <span className="tasks-usage-output">{formatTokens(usage.outputTokens)}</span>
@@ -3715,7 +3719,7 @@ if (typeof document !== 'undefined') {
 .tasks-col-usage { width:96px; min-width:96px; color:var(--dsw-label-2); font-variant-numeric:tabular-nums; }
 .tasks-usage-empty { color:var(--dsw-label-4); }
 
-/* 消耗胶囊：与 Live/thread 的 .traj-usage 对齐的设计 */
+/* 消耗胶囊：与 Live/thread 的 .traj-usage 对齐（数字 + cache 细条） */
 .tasks-usage-capsule {
   display: inline-flex;
   align-items: center;
@@ -3724,7 +3728,7 @@ if (typeof document !== 'undefined') {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
-/* 输入胶囊：绿色缓冲背景(缓存命中覆盖)+左侧内边距留白给 ∑ */
+/* 输入胶囊底板 */
 .tasks-usage-input {
   display: inline-flex;
   align-items: center;

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -2410,11 +2410,9 @@ function eventEndOf(t: Task): number | null {
   return null
 }
 
-/** 消耗胶囊：与 Live/thread 的 .traj-usage 对齐——cache 独立细条，不再绿底叠层。 */
+/** 消耗胶囊：与 Live/thread 的 .traj-usage 对齐——中性底板 + in → out。 */
 function UsageCapsule({ usage, aggregate }: { usage: SumUsage; aggregate: boolean }) {
   if (usage.totalTokens <= 0) return <span className="tasks-usage-empty">—</span>
-  const pct =
-    usage.inputTokens && usage.cacheReadTokens ? Math.min(100, Math.round((usage.cacheReadTokens / usage.inputTokens) * 100)) : null
   return (
     <span
       className={`tasks-usage-capsule${aggregate ? ' is-agg' : ''}`}
@@ -2424,18 +2422,7 @@ function UsageCapsule({ usage, aggregate }: { usage: SumUsage; aggregate: boolea
           : `本任务各回合消耗：in ${formatTokens(usage.inputTokens)} / out ${formatTokens(usage.outputTokens)}${usage.cacheReadTokens ? ` / cache ${formatTokens(usage.cacheReadTokens)}` : ''}`
       }
     >
-      <span className="traj-usage-in-col">
-        <span className={`tasks-usage-input${pct != null ? ' has-cache' : ''}`}>
-          {formatTokens(usage.inputTokens)}
-        </span>
-        {pct != null ? (
-          <span className="traj-usage-meters">
-            <span className="traj-usage-meter is-cache" aria-hidden>
-              <i style={{ width: `${pct}%` }} />
-            </span>
-          </span>
-        ) : null}
-      </span>
+      <span className="tasks-usage-input">{formatTokens(usage.inputTokens)}</span>
       <span className="tasks-usage-arrow">→</span>
       <span className="tasks-usage-output">{formatTokens(usage.outputTokens)}</span>
     </span>
@@ -3719,7 +3706,7 @@ if (typeof document !== 'undefined') {
 .tasks-col-usage { width:96px; min-width:96px; color:var(--dsw-label-2); font-variant-numeric:tabular-nums; }
 .tasks-usage-empty { color:var(--dsw-label-4); }
 
-/* 消耗胶囊：与 Live/thread 的 .traj-usage 对齐（数字 + cache 细条） */
+/* 消耗胶囊：与 Live/thread 的 .traj-usage 对齐 */
 .tasks-usage-capsule {
   display: inline-flex;
   align-items: center;
@@ -3738,10 +3725,9 @@ if (typeof document !== 'undefined') {
   border-radius: 999px;
   background: var(--dsw-hover);
   padding: 1px 7px;
-  color: var(--dsw-label-2);
+  color: var(--dsw-label);
   font-weight: 600;
 }
-.tasks-usage-input.has-cache { color: var(--dsw-label); }
 .tasks-usage-arrow { color: var(--dsw-label-3); opacity: 0.7; flex: none; }
 .tasks-usage-output { color: var(--dsw-label); font-weight: 600; flex: none; }
 .tasks-col-actor { width:130px; }

--- a/web/style.css
+++ b/web/style.css
@@ -18,6 +18,9 @@
   --dsw-danger: #cf2d56;
   --dsw-danger-soft: rgba(207, 45, 86, 0.14);
   --dsw-ok: #1f8a65;
+  /* usage 胶囊：历史占比灰蓝 / cache 鼠尾草，避免红绿叠层 */
+  --dsw-usage-hist: #8a97ab;
+  --dsw-usage-cache: #7d9b8a;
   --dsw-pick: #2383e2;
   --dsw-pick-fill: rgba(35, 131, 226, 0.18);
   --dsw-pick-stroke: rgba(35, 131, 226, 0.4);
@@ -1127,6 +1130,15 @@ body {
   color: var(--dsw-label-3);
 }
 
+.traj-usage-in-col {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 3px;
+  min-width: 0;
+  max-width: 100%;
+}
+
 .traj-usage-in-wrap {
   display: inline-flex;
   align-items: center;
@@ -1140,7 +1152,8 @@ body {
   line-height: 1;
 }
 
-.traj-usage-in-wrap.has-cache {
+.traj-usage-in-wrap.has-cache,
+.traj-usage-in-wrap.has-hist {
   color: var(--dsw-label);
 }
 
@@ -1150,7 +1163,7 @@ body {
 }
 
 .traj-usage-cache-pct {
-  color: var(--dsw-ok);
+  color: var(--dsw-usage-cache);
   font-size: 10px;
   font-weight: 700;
 }
@@ -1166,14 +1179,39 @@ body {
 }
 
 .traj-usage-hist-pct {
-  color: var(--dsw-danger);
+  color: var(--dsw-usage-hist);
   font-size: 10px;
   font-weight: 700;
 }
 
-/* 历史占比红色层与 cache 绿色层都由 .traj-usage-in-wrap 的 backgroundImage 多段渐变合成 */
-.traj-usage-in-wrap.has-hist {
-  color: var(--dsw-label);
+.traj-usage-meters {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  padding: 0 1px;
+}
+
+.traj-usage-meter {
+  display: block;
+  height: 2px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(242, 241, 237, 0.08);
+}
+
+.traj-usage-meter > i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.traj-usage-meter.is-hist > i {
+  background: var(--dsw-usage-hist);
+}
+
+.traj-usage-meter.is-cache > i {
+  background: var(--dsw-usage-cache);
 }
 
 .traj-usage-card {
@@ -1525,7 +1563,7 @@ body {
 
 .traj-usage-stat-sub {
   margin-top: 2px;
-  color: var(--dsw-ok);
+  color: var(--dsw-usage-cache);
   font-size: 10px;
   font-style: normal;
   font-weight: 600;

--- a/web/style.css
+++ b/web/style.css
@@ -18,9 +18,6 @@
   --dsw-danger: #cf2d56;
   --dsw-danger-soft: rgba(207, 45, 86, 0.14);
   --dsw-ok: #1f8a65;
-  /* usage 胶囊：历史占比灰蓝 / cache 鼠尾草，避免红绿叠层 */
-  --dsw-usage-hist: #8a97ab;
-  --dsw-usage-cache: #7d9b8a;
   --dsw-pick: #2383e2;
   --dsw-pick-fill: rgba(35, 131, 226, 0.18);
   --dsw-pick-stroke: rgba(35, 131, 226, 0.4);
@@ -1130,15 +1127,6 @@ body {
   color: var(--dsw-label-3);
 }
 
-.traj-usage-in-col {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 3px;
-  min-width: 0;
-  max-width: 100%;
-}
-
 .traj-usage-in-wrap {
   display: inline-flex;
   align-items: center;
@@ -1147,14 +1135,9 @@ body {
   border-radius: 999px;
   background: var(--dsw-hover);
   padding: 2px 7px;
-  color: var(--dsw-label-2);
+  color: var(--dsw-label);
   font-weight: 600;
   line-height: 1;
-}
-
-.traj-usage-in-wrap.has-cache,
-.traj-usage-in-wrap.has-hist {
-  color: var(--dsw-label);
 }
 
 .traj-usage-in {
@@ -1162,10 +1145,11 @@ body {
   font-weight: 600;
 }
 
-.traj-usage-cache-pct {
-  color: var(--dsw-usage-cache);
+.traj-usage-cache-pct,
+.traj-usage-hist-pct {
+  color: var(--dsw-label-3);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .traj-usage-arrow {
@@ -1176,42 +1160,6 @@ body {
 .traj-usage-out {
   color: var(--dsw-label);
   font-weight: 600;
-}
-
-.traj-usage-hist-pct {
-  color: var(--dsw-usage-hist);
-  font-size: 10px;
-  font-weight: 700;
-}
-
-.traj-usage-meters {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  padding: 0 1px;
-}
-
-.traj-usage-meter {
-  display: block;
-  height: 2px;
-  overflow: hidden;
-  border-radius: 999px;
-  background: rgba(242, 241, 237, 0.08);
-}
-
-.traj-usage-meter > i {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-}
-
-.traj-usage-meter.is-hist > i {
-  background: var(--dsw-usage-hist);
-}
-
-.traj-usage-meter.is-cache > i {
-  background: var(--dsw-usage-cache);
 }
 
 .traj-usage-card {
@@ -1563,7 +1511,7 @@ body {
 
 .traj-usage-stat-sub {
   margin-top: 2px;
-  color: var(--dsw-usage-cache);
+  color: var(--dsw-label-3);
   font-size: 10px;
   font-style: normal;
   font-weight: 600;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
第二版：把细条和双色都拿掉了。

胶囊只剩 `--dsw-hover` 底板。中间是 input token，左边历史占比、右边 cache hit，两个百分比都用 `--dsw-label-3` 灰字，不再叠填充、不再画条。

仍在 `cursor/usage-pill-meters-1214`，未合今日分支。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9ba636c-ce4c-43ce-b4ca-e3b2ac571214&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

