### PR TITLE
Merge dev-2026-08-27 into main

### DIFF
--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import type { Context } from 'cordis'
-import { LuActivity, LuListTree } from 'react-icons/lu'
+import { LuActivity, LuLogs } from 'react-icons/lu'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import type { SlotProps } from '@biu/web-slots'
 import { ApprovalsRail } from './approvals.tsx'
@@ -60,7 +60,7 @@ export function apply(ctx: Context) {
       ...slotProps,
       tabId: 'traj',
       tabLabel: '轨迹',
-      tabIcon: LuListTree,
+      tabIcon: LuLogs,
       ensureTrajectory: true,
       focusOnCall: true,
     }),

--- a/packages/cap-chat/src/web/sticky-user.test.tsx
+++ b/packages/cap-chat/src/web/sticky-user.test.tsx
@@ -61,6 +61,10 @@ describe('sticky user message markers', () => {
     expect(turns[1]?.querySelectorAll('[data-chat-kind="user"]')).toHaveLength(1)
     expect(userRows[0]?.getAttribute('data-node-id')).toBe('u-1')
     expect(userRows[1]?.getAttribute('data-node-id')).toBe('u-2')
+    expect(userRows[0]?.getAttribute('data-biu-kind')).toBe('message')
+    expect(userRows[0]?.getAttribute('data-biu-id')).toBe('u-1')
+    expect(document.querySelector('[data-testid="user-bubble"]')?.getAttribute('data-biu-kind')).toBe('message')
+    expect(replyRows[0]?.getAttribute('data-biu-kind')).toBe('reply')
   })
 
   it('keeps user sticky markers after re-render (scroll-back safe)', () => {

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -674,7 +674,7 @@ export const ChatNodeList = memo(function ChatNodeList({
                 replyNode?.turn != null ? dispatchedTasksByTurn[String(replyNode.turn)] : undefined
               const stickyUser =
                 node.kind === 'user'
-                  ? 'sticky top-0 z-[1] bg-[var(--dsw-bg)] pt-0.5 pb-1.5 shadow-[0_1px_0_color-mix(in_srgb,var(--dsw-border)_80%,transparent),0_6px_16px_-6px_rgba(0,0,0,0.12)]'
+                  ? 'sticky top-0 z-[1] bg-[var(--dsw-bg)] pb-1 shadow-[0_1px_0_color-mix(in_srgb,var(--dsw-border)_80%,transparent),0_6px_16px_-6px_rgba(0,0,0,0.12)]'
                   : ''
               const skipPaint =
                 node.kind === 'reply' || node.kind === 'turn'

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -674,7 +674,7 @@ export const ChatNodeList = memo(function ChatNodeList({
                 replyNode?.turn != null ? dispatchedTasksByTurn[String(replyNode.turn)] : undefined
               const stickyUser =
                 node.kind === 'user'
-                  ? 'sticky top-0 z-[1] bg-[var(--dsw-bg)] pb-1 shadow-[0_1px_0_color-mix(in_srgb,var(--dsw-border)_80%,transparent),0_6px_16px_-6px_rgba(0,0,0,0.12)]'
+                  ? 'sticky top-0 z-[1] bg-[var(--dsw-bg)] pb-1'
                   : ''
               const skipPaint =
                 node.kind === 'reply' || node.kind === 'turn'

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -29,7 +29,7 @@ import { SidebarMascot } from '@biu/web-mascot'
 import { StaticMascotMark } from '@biu/web-mascot'
 import { DEFAULT_SESSION_MASCOT, resolveSessionMascot } from '@biu/web-mascot'
 import type { SessionMascotIdentity } from '@biu/web-mascot'
-import { parsePicks, pickKey, PickChipLabel } from '@biu/cap-pick/web'
+import { parsePicks, pickDomAttrs, pickKey, pickPreview, PickChipLabel } from '@biu/cap-pick/web'
 import { MarkdownBody } from './markdown.tsx'
 import { ToolCard } from './tool-card.tsx'
 import { LiveDispatchTable } from './live-dispatch-table.tsx'
@@ -87,7 +87,7 @@ function MetaItem({
   )
 }
 
-function StepBar({ stat }: { stat: ChatStepStat }) {
+function StepBar({ stat, replyId }: { stat: ChatStepStat; replyId: string }) {
   const usage: TrajectoryUsage = {
     inputTokens: stat.inputTokens,
     outputTokens: stat.outputTokens,
@@ -96,7 +96,12 @@ function StepBar({ stat }: { stat: ChatStepStat }) {
     ...(stat.histPct !== undefined ? { histPct: stat.histPct } : {}),
   }
   return (
-    <div className="chat-step-bar" role="group" aria-label={stepLabel(stat.step)}>
+    <div
+      className="chat-step-bar"
+      role="group"
+      aria-label={stepLabel(stat.step)}
+      {...pickDomAttrs('step', `${replyId}:${stat.step}`, stepLabel(stat.step))}
+    >
       <div className="chat-reply-meta">
         <MetaItem icon={<LuLayers className="size-3" />} value={stat.step + 1} title={stepLabel(stat.step)} />
         <MetaItem
@@ -127,11 +132,15 @@ function renderReplyPartList({
   stepMap,
   onInspect,
   showSteps,
+  replyId,
+  streaming,
 }: {
   parts: ChatReplyPart[]
   stepMap: Map<number, ChatStepStat>
   onInspect: (callId: string) => void
   showSteps: boolean
+  replyId: string
+  streaming: boolean
 }) {
   const elements: ReactNode[] = []
   let lastStep: number | undefined
@@ -146,14 +155,18 @@ function renderReplyPartList({
         toolCount: 0,
         messageChars: 0,
       }
-      elements.push(<StepBar key={`step-${step}`} stat={stat} />)
+      elements.push(<StepBar key={`step-${step}`} stat={stat} replyId={replyId} />)
       lastStep = step
     }
 
     if (part.kind === 'assistant') {
       const partStreaming = Boolean(part.streaming)
       elements.push(
-        <div key={part.id} className="chat-assistant-body">
+        <div
+          key={part.id}
+          className="chat-assistant-body"
+          {...pickDomAttrs('message', part.id, pickPreview(part.text) || 'assistant')}
+        >
           {part.text ? (
             <MarkdownBody text={part.text} streaming={partStreaming} />
           ) : partStreaming ? (
@@ -165,7 +178,7 @@ function renderReplyPartList({
         </div>,
       )
     } else {
-      elements.push(<ToolCard key={part.id} node={part} onInspect={onInspect} />)
+      elements.push(<ToolCard key={part.id} node={part} onInspect={onInspect} live={streaming} />)
     }
   }
 
@@ -187,7 +200,7 @@ function ReplyParts({
 
   // 流式中结构还在变，整段展开渲染
   if (streaming) {
-    return <>{renderReplyPartList({ parts: node.parts, stepMap, onInspect, showSteps: true })}</>
+    return <>{renderReplyPartList({ parts: node.parts, stepMap, onInspect, showSteps: true, replyId: node.id, streaming })}</>
   }
 
   const { detailParts, finalParts, hasDetails } = splitReplyForDisplay(node)
@@ -201,11 +214,25 @@ function ReplyParts({
           hidden={!expanded}
           aria-hidden={!expanded}
         >
-          {renderReplyPartList({ parts: detailParts, stepMap, onInspect, showSteps: true })}
+          {renderReplyPartList({
+            parts: detailParts,
+            stepMap,
+            onInspect,
+            showSteps: true,
+            replyId: node.id,
+            streaming,
+          })}
         </div>
       ) : null}
       {/* 展开 Details 时也要带上最终 Message 所在 step 的统计条 */}
-      {renderReplyPartList({ parts: finalParts, stepMap, onInspect, showSteps: expanded })}
+      {renderReplyPartList({
+        parts: finalParts,
+        stepMap,
+        onInspect,
+        showSteps: expanded,
+        replyId: node.id,
+        streaming,
+      })}
     </>
   )
 }
@@ -528,11 +555,15 @@ function NodeView({
     const picked = parsePicks(node.text)
     const canExpand = overflows || expanded
     return (
-      <div className="flex w-full flex-col gap-0 overflow-hidden rounded-[var(--dsw-radius-bubble)] border border-[var(--dsw-bubble)] bg-[var(--dsw-bg)]">
+      <div
+        className="flex w-full flex-col gap-0 overflow-hidden rounded-[var(--dsw-radius-bubble)] border border-[var(--dsw-bubble)] bg-[var(--dsw-bg)]"
+        {...pickDomAttrs('message', node.id, pickPreview(picked.rest || node.text) || 'user')}
+      >
         <div className="block w-full max-w-full border-0 bg-transparent px-3 py-2.5 text-[var(--dsw-label)]">
           <div
             className={`w-full max-w-full border-0 bg-transparent p-0 text-[length:var(--dsw-chat-font-size)] leading-[var(--dsw-chat-line-height)] text-[var(--dsw-label)] outline-none${canExpand && !expanded ? ' max-h-[80px] overflow-hidden' : ''}${expanded ? ' max-h-none overflow-visible' : ''}`}
             data-testid="user-bubble"
+            {...pickDomAttrs('message', node.id, pickPreview(picked.rest || node.text) || 'user')}
           >
             {node.kindTag === 'inject' ? (
               <div className="mb-1 text-[10px] text-[var(--dsw-label-3)]">inject</div>
@@ -575,6 +606,7 @@ function NodeView({
       <div
         className={`chat-reply-block${streaming ? ' is-streaming' : ''}${expanded ? ' is-details-open' : ''}`}
         id={`reply-details-${node.id}`}
+        {...pickDomAttrs('reply', node.id, pickPreview(node.copyText) || 'reply')}
       >
         <div className="chat-reply-body">
           <ReplyParts node={node} onInspect={onInspect} expanded={expanded} />
@@ -631,7 +663,7 @@ export const ChatNodeList = memo(function ChatNodeList({
         const anchor = turn[0]!
         const startIndex = nodes.indexOf(anchor)
         return (
-          <div key={anchor.id} className="flex flex-col gap-4" data-testid="chat-turn" data-turn-anchor={anchor.id}>
+          <div key={anchor.id} className="flex flex-col gap-4" data-testid="chat-turn" data-turn-anchor={anchor.id} {...pickDomAttrs('turn', anchor.id, pickPreview(anchor.kind === 'user' ? anchor.text : anchor.id) || 'turn')}>
             {turn.map((node, offset) => {
               const index = startIndex + offset
               const replyForUser = node.kind === 'user' ? findReplyForUser(nodes, index) : undefined
@@ -642,7 +674,7 @@ export const ChatNodeList = memo(function ChatNodeList({
                 replyNode?.turn != null ? dispatchedTasksByTurn[String(replyNode.turn)] : undefined
               const stickyUser =
                 node.kind === 'user'
-                  ? 'sticky top-0 z-[1] -mt-1 bg-[var(--dsw-bg)] pt-2 pb-2.5 shadow-[0_1px_0_color-mix(in_srgb,var(--dsw-border)_80%,transparent),0_6px_16px_-6px_rgba(0,0,0,0.12)]'
+                  ? 'sticky top-0 z-[1] bg-[var(--dsw-bg)] pt-0.5 pb-1.5 shadow-[0_1px_0_color-mix(in_srgb,var(--dsw-border)_80%,transparent),0_6px_16px_-6px_rgba(0,0,0,0.12)]'
                   : ''
               const skipPaint =
                 node.kind === 'reply' || node.kind === 'turn'
@@ -654,6 +686,11 @@ export const ChatNodeList = memo(function ChatNodeList({
                   className={[stickyUser, skipPaint].filter(Boolean).join(' ')}
                   data-node-id={node.id}
                   data-chat-kind={node.kind}
+                  {...(node.kind === 'user'
+                    ? pickDomAttrs('message', node.id, pickPreview(node.text) || 'user')
+                    : node.kind === 'reply'
+                      ? pickDomAttrs('reply', node.id, pickPreview(node.copyText) || 'reply')
+                      : pickDomAttrs('turn', node.id, node.text))}
                 >
                   <NodeViewMemo
                     node={node}

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -556,7 +556,7 @@ function NodeView({
     const canExpand = overflows || expanded
     return (
       <div
-        className="flex w-full flex-col gap-0 overflow-hidden rounded-[var(--dsw-radius-bubble)] border border-[var(--dsw-bubble)] bg-[var(--dsw-bg)]"
+        className="flex w-full flex-col gap-0 overflow-hidden rounded-[var(--dsw-radius-bubble)] border border-[var(--dsw-bubble)] bg-[var(--dsw-sidebar)]"
         {...pickDomAttrs('message', node.id, pickPreview(picked.rest || node.text) || 'user')}
       >
         <div className="block w-full max-w-full border-0 bg-transparent px-3 py-2.5 text-[var(--dsw-label)]">

--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -9,6 +9,7 @@ import {
   LuLoaderCircle,
 } from 'react-icons/lu'
 import type { ChatToolPart } from '@biu/web-session-view'
+import { pickDomAttrs } from '@biu/cap-pick/web'
 import {
   diffStats,
   formatToolDetail,
@@ -203,9 +204,12 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
 export function ToolCard({
   node,
   onInspect,
+  live = false,
 }: {
   node: ChatToolPart
   onInspect: (callId: string) => void
+  /** 所在回复仍在流式输出时，无 result 才算运行中 */
+  live?: boolean
 }) {
   const parsed = useMemo(() => parseToolCall(node.name, node.arguments), [node.name, node.arguments])
   const formatted = useMemo(
@@ -223,11 +227,17 @@ export function ToolCard({
     !open && formatted?.kind === 'bash' && formatted.artifacts?.length ? formatted.artifacts : null
 
   const status = !node.result
-    ? {
-        label: '运行中',
-        className: 'tool-call-status is-running',
-        icon: <LuLoaderCircle className="size-3.5 animate-spin" aria-hidden />,
-      }
+    ? live
+      ? {
+          label: '运行中',
+          className: 'tool-call-status is-running',
+          icon: <LuLoaderCircle className="size-3.5 animate-spin" aria-hidden />,
+        }
+      : {
+          label: '成功',
+          className: 'tool-call-status is-ok',
+          icon: <LuCircleCheck className="size-3.5" aria-hidden />,
+        }
     : node.result.ok
       ? {
           label: '成功',
@@ -241,7 +251,7 @@ export function ToolCard({
         }
 
   return (
-    <div className="tool-call">
+    <div className="tool-call" {...pickDomAttrs('tool', node.callId, title)}>
       <div className="tool-call-head">
         <button
           type="button"

--- a/packages/cap-chat/src/web/trajectory.tsx
+++ b/packages/cap-chat/src/web/trajectory.tsx
@@ -13,6 +13,7 @@ import {
   type TrajectoryUsage,
 } from '@biu/web-session-view'
 import { UsageInline } from './usage-inline.tsx'
+import { pickDomAttrs, pickPreview } from '@biu/cap-pick/web'
 
 type TagTone = 'user' | 'assistant' | 'tool' | 'system' | 'turn' | 'step'
 
@@ -258,6 +259,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
                   onClick={() =>
                     setCollapsedTurns((prev) => ({ ...prev, [turnKey]: !prev[turnKey] }))
                   }
+                  {...pickDomAttrs('turn', group.turn == null ? 'meta' : String(group.turn), group.turn == null ? 'meta' : `Turn ${group.turn}`)}
                 >
                   <span className="traj-group-bar-left">
                     <FoldCaret open={!turnCollapsed} />
@@ -298,6 +300,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
                           row.type === 'assistant/message' ? ' traj-row-assistant' : ''
                         }`}
                         onClick={() => setSelectedSeq(row.seq)}
+                        {...pickDomAttrs('event', String(row.seq), pickPreview(`${row.type} ${row.summary}`) || row.type)}
                       >
                         <span className="traj-col-seq">{row.seq}</span>
                         <span className="traj-col-type">

--- a/packages/cap-chat/src/web/usage-panel.tsx
+++ b/packages/cap-chat/src/web/usage-panel.tsx
@@ -4,6 +4,7 @@ import { EventDetailBody } from './trajectory.tsx'
 import { type SessionViewService } from '@biu/web-session-view'
 import type { DerivedMessage, SessionEvent } from '@biu/web-session-view'
 import type { UsageTrend, UsageTrendPoint } from '@biu/web-session-view'
+import { pickDomAttrs } from '@biu/cap-pick/web'
 
 export interface UsagePanelProps {
   useSessionView: <T>(selector: (state: unknown) => T) => T
@@ -258,6 +259,7 @@ interface EChartsOption {
 
 /** 侧边栏用量面板：Input/Output 各自独立 Y 轴，展示 Step 用量与回合用量。 */
 export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
+  const sessionId = useSessionView((state: { sessionId?: string }) => state.sessionId)
   const [trend, setTrend] = useUsageTrend(useSessionView, sessionView)
 
   const track = useMemo(() => splitTrendData(trend?.points ?? []), [trend])
@@ -334,7 +336,11 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
   }
 
   return (
-    <div className="usage-panel" data-testid="usage-panel">
+    <div
+      className="usage-panel"
+      data-testid="usage-panel"
+      {...(sessionId ? pickDomAttrs('usage', sessionId, 'Token usage') : {})}
+    >
       <div className="usage-panel-head">
         <div className="usage-panel-title">
           <span className="usage-panel-title-icon" aria-hidden>
@@ -360,7 +366,10 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
 
       {trend && trend.points.length > 0 ? (
         <>
-          <div className="usage-panel-section">
+          <div
+            className="usage-panel-section"
+            {...(sessionId ? pickDomAttrs('usage', `${sessionId}:steps`, 'Step Token Usage') : {})}
+          >
             <div className="usage-panel-section-title">
               Step Token Usage
               <span className="usage-panel-section-hint">{trend.points.length} calls</span>
@@ -380,7 +389,10 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
             />
           </div>
 
-          <div className="usage-panel-section">
+          <div
+            className="usage-panel-section"
+            {...(sessionId ? pickDomAttrs('usage', `${sessionId}:turns`, 'Turn Token Usage') : {})}
+          >
             <div className="usage-panel-section-title">
               Turn Token Usage
               <span className="usage-panel-section-hint">{turns.length} turns</span>
@@ -399,7 +411,10 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
             />
           </div>
 
-          <div className="usage-panel-section">
+          <div
+            className="usage-panel-section"
+            {...(sessionId ? pickDomAttrs('usage', `${sessionId}:steps-per-turn`, 'Steps per Turn') : {})}
+          >
             <div className="usage-panel-section-title">
               Steps per Turn
               <span className="usage-panel-section-hint">每回合 step 数</span>

--- a/packages/cap-pick/src/host/index.ts
+++ b/packages/cap-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。',
+    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、message、reply、tool、step、event（轨迹行 seq）、turn、usage。',
   )
 }

--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import * as lu from 'react-icons/lu'
+import { pickKindIcon } from './chip.tsx'
+
+test('chip icons exist on react-icons/lu (Vite ESM named exports)', () => {
+  const needed = [
+    'LuCoins',
+    'LuGitCommitHorizontal',
+    'LuHash',
+    'LuLayers',
+    'LuListTodo',
+    'LuMessageSquare',
+    'LuPuzzle',
+    'LuTag',
+    'LuWrench',
+  ] as const
+  for (const name of needed) {
+    assert.equal(typeof (lu as Record<string, unknown>)[name], 'function', `${name} missing`)
+  }
+  assert.equal('LuGitCommit' in lu, false)
+  assert.equal(typeof pickKindIcon('event'), 'function')
+  assert.equal(typeof pickKindIcon('usage'), 'function')
+})

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -1,4 +1,14 @@
-import { LuListTodo, LuMessageSquare, LuPuzzle, LuTag } from 'react-icons/lu'
+import {
+  LuCoins,
+  LuGitCommit,
+  LuHash,
+  LuLayers,
+  LuListTodo,
+  LuMessageSquare,
+  LuPuzzle,
+  LuTag,
+  LuWrench,
+} from 'react-icons/lu'
 import type { IconType } from 'react-icons'
 import type { PickRef } from './types.ts'
 import { chipLabel } from './types.ts'
@@ -7,6 +17,13 @@ const KIND_ICONS: Record<string, IconType> = {
   session: LuMessageSquare,
   task: LuListTodo,
   plugin: LuPuzzle,
+  message: LuMessageSquare,
+  reply: LuMessageSquare,
+  tool: LuWrench,
+  step: LuLayers,
+  event: LuGitCommit,
+  turn: LuHash,
+  usage: LuCoins,
 }
 
 export function pickKindIcon(kind: string): IconType {

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -1,6 +1,6 @@
 import {
   LuCoins,
-  LuGitCommit,
+  LuGitCommitHorizontal,
   LuHash,
   LuLayers,
   LuListTodo,
@@ -21,7 +21,7 @@ const KIND_ICONS: Record<string, IconType> = {
   reply: LuMessageSquare,
   tool: LuWrench,
   step: LuLayers,
-  event: LuGitCommit,
+  event: LuGitCommitHorizontal,
   turn: LuHash,
   usage: LuCoins,
 }

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -5,7 +5,7 @@ import { PickOverlay } from './overlay.tsx'
 import { PickToggle } from './toggle.tsx'
 
 export { PickService, usePickState } from './service.ts'
-export { formatPicks, parsePicks, dedupePicks, chipLabel, pickKey, type PickRef } from './types.ts'
+export { formatPicks, parsePicks, dedupePicks, chipLabel, pickKey, pickPreview, pickDomAttrs, type PickRef } from './types.ts'
 export { PickChipLabel, PickKindGlyph, pickKindIcon } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect } from './resolve.ts'
 

--- a/packages/cap-pick/src/web/types.ts
+++ b/packages/cap-pick/src/web/types.ts
@@ -96,3 +96,17 @@ export function chipLabel(ref: PickRef) {
   if (ref.action) return `${ref.label} · ${ref.action}`
   return ref.label
 }
+
+export function pickPreview(text: string, max = 48) {
+  const value = text.replace(/\s+/g, ' ').trim()
+  if (!value) return ''
+  return value.length > max ? `${value.slice(0, max)}…` : value
+}
+
+export function pickDomAttrs(kind: string, id: string, label?: string) {
+  return {
+    'data-biu-kind': kind,
+    'data-biu-id': id,
+    ...(label ? { 'data-biu-label': label } : {}),
+  }
+}

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -12,6 +12,7 @@ import {
   LuCalendarClock,
   LuCircleCheck,
   LuCircleDashed,
+  LuClipboardList,
   LuClock,
   LuCoins,
   LuFlag,
@@ -3497,7 +3498,7 @@ export const name = 'tasks-ui'
 export const inject = ['slots', 'appModules', 'snapshot']
 
 const tasksModuleProps = { moduleId: 'tasks' }
-const tasksInspectorProps = { tabId: 'tasks', tabLabel: '任务', tabIcon: TasksRailIcon }
+const tasksInspectorProps = { tabId: 'tasks', tabLabel: '任务', tabIcon: LuClipboardList }
 
 function TasksRailIcon({ className }: { className?: string }) {
   return (

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -3568,7 +3568,7 @@ if (typeof document !== 'undefined') {
   radial-gradient(900px 360px at 10% -12%, color-mix(in srgb, var(--dsw-business) 8%, transparent), transparent 58%),
   linear-gradient(180deg, color-mix(in srgb, var(--dsw-surface) 55%, var(--dsw-bg)), var(--dsw-bg));
   color:var(--dsw-label); }
-.tasks-inspector-panel { display:flex; min-height:0; flex:1; flex-direction:column; overflow:hidden; background:var(--dsw-sidebar); }
+.tasks-inspector-panel { display:flex; min-height:0; flex:1; flex-direction:column; overflow:hidden; background:var(--dsw-bg); }
 .tasks-root { display:flex; min-height:0; flex:1; gap:0; overflow:hidden; }
 .tasks-root.is-compact { flex-direction:column; }
 .tasks-main { display:flex; min-width:0; min-height:0; flex:1; flex-direction:column; gap:10px; padding:12px 14px 14px; overflow:auto; }

--- a/packages/host-sessions/src/host/session-heal.test.ts
+++ b/packages/host-sessions/src/host/session-heal.test.ts
@@ -170,6 +170,24 @@ test('deriveMessages skips orphan tool results after error assistant', () => {
   assert.match(String(messages[1]?.content), /interrupted/)
 })
 
+test('rebuildHealedEvents keeps tool/call then matching tool/result', () => {
+  assert.equal(
+    rebuildHealedEvents([
+      ev({ type: 'turn/start', turn: 1, seq: 0 }),
+      ev({
+        type: 'assistant/message',
+        text: '',
+        tool_calls: [{ id: 'c1', name: 'bash', arguments: '{}' }],
+        seq: 1,
+      }),
+      ev({ type: 'tool/call', id: 'c1', name: 'bash', arguments: '{}', seq: 2 }),
+      ev({ type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 3 }),
+      ev({ type: 'turn/end', turn: 1, reason: 'complete', seq: 4 }),
+    ]),
+    null,
+  )
+})
+
 test('rebuildHealedEvents returns null when log is already healthy', () => {
   assert.equal(
     rebuildHealedEvents([

--- a/packages/host-sessions/src/host/session-heal.ts
+++ b/packages/host-sessions/src/host/session-heal.ts
@@ -128,8 +128,8 @@ export function rebuildHealedEvents(
       continue
     }
 
-    // chunk 可夹在 tool_calls 与 tool/result 之间；其余事件前先闭合未配对 tool
-    if (pending.size && event.type !== 'assistant/chunk') {
+    // chunk / tool/call 可夹在 tool_calls 与 tool/result 之间；其余事件前先闭合未配对 tool
+    if (pending.size && event.type !== 'assistant/chunk' && event.type !== 'tool/call') {
       flushPending()
     }
     push(stripSeqTs(event), event.ts)

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -258,20 +258,19 @@ export const ChatSidebar = memo(function ChatSidebar({
       }`}
       aria-hidden={!visible}
     >
-      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pt-3 pb-3">
-        <div className="mb-1 flex items-center justify-between gap-2 px-2">
-          <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
-          <button
-            type="button"
-            className="grid size-6 place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
-            title="Collapse sidebar"
-            aria-label="Collapse sidebar"
-            onClick={onCollapse}
-          >
-            <LuPanelLeftClose className="size-3.5" />
-          </button>
-        </div>
-
+      <div className="app-side-bar-head">
+        <span className="text-[11px] font-semibold tracking-wider text-[var(--dsw-label-3)] uppercase">Chat</span>
+        <button
+          type="button"
+          className="grid size-[26px] place-items-center rounded-[6px] text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-business)]"
+          title="Collapse sidebar"
+          aria-label="Collapse sidebar"
+          onClick={onCollapse}
+        >
+          <LuPanelLeftClose className="size-3.5" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="app-side-actions" role="navigation" aria-label="Chat actions">
           <button
             type="button"

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -121,7 +121,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
     <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       <div className="absolute inset-0 z-[1] flex min-h-0 overflow-hidden">
         <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-          <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-4 pb-44 md:px-8 lg:px-10">
+          <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 pt-0 pb-44 md:px-8 lg:px-10">
             {renderSlot('stage')}
           </div>
           <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-4 md:px-8 lg:px-10">

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -121,7 +121,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
     <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
       <div className="absolute inset-0 z-[1] flex min-h-0 overflow-hidden">
         <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
-          <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 pt-0 pb-44 md:px-8 lg:px-10">
+          <div className="chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-1 pb-44 md:px-8 lg:px-10">
             {renderSlot('stage')}
           </div>
           <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-4 md:px-8 lg:px-10">

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -126,7 +126,7 @@ export const SessionInspector = memo(function SessionInspector({
 
   return (
     <aside
-      className="relative flex min-h-0 min-w-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] text-[var(--dsw-label)]"
+      className="relative flex min-h-0 min-w-0 flex-col border-l border-[var(--dsw-border)] bg-[var(--dsw-bg)] text-[var(--dsw-label)]"
       data-testid="session-inspector"
       aria-label="会话检查器"
     >

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -142,7 +142,7 @@ export const SessionInspector = memo(function SessionInspector({
         }}
       />
 
-      <div className="flex h-9 shrink-0 items-center justify-between gap-2 border-b border-[var(--dsw-border)] px-2.5">
+      <div className="app-side-bar-head">
         <div className="flex min-w-0 items-center gap-1" role="tablist" aria-label="检查器分区">
           {extraTabs.map((item) => (
             <button

--- a/packages/web-session-view/src/web/session-project.test.ts
+++ b/packages/web-session-view/src/web/session-project.test.ts
@@ -96,6 +96,20 @@ test('keeps reply streaming across tools until turn/end (Details stay open)', ()
   }
 })
 
+test('tool/call after tool/result keeps a single completed tool part', () => {
+  const nodes = projectNodes([
+    { type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 1, ts: 1 },
+    { type: 'tool/call', id: 'c1', name: 'bash', arguments: '{}', seq: 2, ts: 2 },
+  ])
+  const reply = nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  const tools = reply.parts.filter((part) => part.kind === 'tool')
+  assert.equal(tools.length, 1)
+  assert.equal(tools[0]?.kind === 'tool' && tools[0].result?.ok, true)
+  assert.equal(tools[0]?.kind === 'tool' && tools[0].arguments, '{}')
+})
+
 test('turn/end non-complete becomes a status row', () => {
   const nodes = projectNodes([
     { type: 'turn/start', turn: 1, seq: 0, ts: 1 },

--- a/packages/web-session-view/src/web/session-project.ts
+++ b/packages/web-session-view/src/web/session-project.ts
@@ -383,26 +383,43 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       const r = ensureReply(event.seq)
       r.streamingId = null
       if (currentTurn != null) r.streaming = true
-      if (currentStep != null) ensureStepStat(currentStep).toolCount += 1
-      const part: ChatToolPart = {
-        id: `t-${event.id}`,
-        kind: 'tool',
-        callId: event.id,
-        name: event.name,
-        arguments: event.arguments,
-        ...(currentStep != null ? { step: currentStep } : {}),
+      const existing = r.tools.get(event.id)
+      if (existing) {
+        const next: ChatToolPart = {
+          ...existing,
+          name: event.name || existing.name,
+          arguments: event.arguments || existing.arguments,
+          ...(currentStep != null ? { step: existing.step ?? currentStep } : {}),
+        }
+        r.tools.set(event.id, next)
+        const idx = r.parts.findIndex((part) => part.kind === 'tool' && part.callId === event.id)
+        if (idx >= 0) r.parts[idx] = next
+        else r.parts.push(next)
+      } else {
+        if (currentStep != null) ensureStepStat(currentStep).toolCount += 1
+        const part: ChatToolPart = {
+          id: `t-${event.id}`,
+          kind: 'tool',
+          callId: event.id,
+          name: event.name,
+          arguments: event.arguments,
+          ...(currentStep != null ? { step: currentStep } : {}),
+        }
+        r.tools.set(event.id, part)
+        r.parts.push(part)
       }
-      r.tools.set(event.id, part)
-      r.parts.push(part)
     } else if (event.type === 'tool/result') {
       const r = ensureReply(event.seq)
       if (currentTurn != null) r.streaming = true
-      const existing = r.tools.get(event.id)
+      const existing =
+        r.tools.get(event.id) ??
+        r.parts.find((part): part is ChatToolPart => part.kind === 'tool' && part.callId === event.id)
       if (existing) {
         const next = { ...existing, result: { ok: event.ok, detail: event.detail } }
         r.tools.set(event.id, next)
-        const idx = r.parts.findIndex((part) => part.id === existing.id)
+        const idx = r.parts.findIndex((part) => part.kind === 'tool' && part.callId === event.id)
         if (idx >= 0) r.parts[idx] = next
+        else r.parts.push(next)
       } else {
         if (currentStep != null) ensureStepStat(currentStep).toolCount += 1
         const part: ChatToolPart = {

--- a/web/style.css
+++ b/web/style.css
@@ -195,7 +195,17 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  border-bottom: 1px solid var(--dsw-border);
+  border-bottom: 0;
+  padding: 0 12px;
+}
+
+.app-side-bar-head {
+  display: flex;
+  height: 36px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 0 12px;
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
-/* Neutral dark chrome — canvas, rails, inspector share #191919 */
+/* Neutral dark chrome — canvas/right inspector #191919, left rails #202020 */
 :root {
   color-scheme: dark;
   --dsw-bg: #191919;
-  --dsw-sidebar: var(--dsw-bg);
+  --dsw-sidebar: #202020;
   --dsw-label: #f2f1ed;
   --dsw-label-2: rgba(242, 241, 237, 0.72);
   --dsw-label-3: rgba(242, 241, 237, 0.45);
@@ -487,7 +487,7 @@ body {
   flex-direction: column;
   align-items: stretch;
   border-right: 1px solid var(--dsw-border);
-  background: var(--dsw-bg);
+  background: var(--dsw-sidebar);
 }
 
 .app-activity-brand {
@@ -610,7 +610,7 @@ body {
 }
 
 .app-activity-item.is-active .app-activity-indicator {
-  background: var(--dsw-pick);
+  background: var(--dsw-business);
 }
 
 .app-activity-live {
@@ -849,9 +849,13 @@ body {
   border-top: 1px solid var(--dsw-border);
 }
 
-/* 右侧三个检查器板块底板与左侧栏同一色 */
-[data-testid='session-inspector'] .usage-panel {
-  background: var(--dsw-sidebar);
+/* 右侧检查器底板与中间画布同色，不跟左侧栏 */
+[data-testid='session-inspector'] .usage-panel,
+[data-testid='session-inspector'] .traj-root,
+[data-testid='session-inspector'] .traj-meta,
+[data-testid='session-inspector'] .traj-head,
+[data-testid='session-inspector'] .traj-detail {
+  background: var(--dsw-bg);
   box-shadow: none;
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -1,10 +1,10 @@
 @import "tailwindcss";
 
-/* Neutral dark chrome — canvas/nav #191919, rails #202020 */
+/* Neutral dark chrome — canvas, rails, inspector share #191919 */
 :root {
   color-scheme: dark;
   --dsw-bg: #191919;
-  --dsw-sidebar: #202020;
+  --dsw-sidebar: var(--dsw-bg);
   --dsw-label: #f2f1ed;
   --dsw-label-2: rgba(242, 241, 237, 0.72);
   --dsw-label-3: rgba(242, 241, 237, 0.45);
@@ -13,8 +13,8 @@
   --dsw-business: #f2f1ed;
   --dsw-business-soft: rgba(242, 241, 237, 0.1);
   --dsw-input: var(--dsw-bg);
-  --dsw-tool: #202020;
-  --dsw-surface: #202020;
+  --dsw-tool: var(--dsw-bg);
+  --dsw-surface: var(--dsw-bg);
   --dsw-danger: #cf2d56;
   --dsw-danger-soft: rgba(207, 45, 86, 0.14);
   --dsw-ok: #1f8a65;

--- a/web/style.css
+++ b/web/style.css
@@ -2004,9 +2004,9 @@ body {
   align-items: center;
   width: 100%;
   margin: 6px 0;
-  border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
+  border: 0;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--dsw-bg) 55%, var(--dsw-surface));
+  background: var(--dsw-sidebar);
   padding: 8px 12px;
   box-shadow: none;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -2361,7 +2361,7 @@ body {
   width: 100%;
   border: 1px solid var(--dsw-bubble);
   border-radius: 999px;
-  background: var(--dsw-bg);
+  background: var(--dsw-sidebar);
   box-shadow: none;
   transition: border-radius 0.12s ease;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1987,14 +1987,13 @@ body {
 
 .chat-step-bar {
   display: flex;
-  height: 30px;
   align-items: center;
   width: 100%;
-  margin: 2px 0;
+  margin: 6px 0;
   border: 1px solid color-mix(in srgb, var(--dsw-border) 85%, transparent);
   border-radius: 8px;
   background: color-mix(in srgb, var(--dsw-bg) 55%, var(--dsw-surface));
-  padding: 0 12px;
+  padding: 8px 12px;
   box-shadow: none;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将今日开发主干 `dev-2026-08-27` 合并回 `main`。

包含今日已合入该主干的 UI / 选取 / 检查器相关提交（相对 `main` 24 个提交），例如：

- 全页底板与中间对话区同色，左右栏 / 检查器对齐
- 左侧栏与导航改回 `#202020`，选中条改回白色
- step 统计条内边距与 `#202020` 去边框
- 聊天顶栏、用户气泡吸顶、发送气泡/输入框底板
- 去掉发送气泡与回复之间的吸顶横线
- 任务 / 轨迹检查器图标、选取芯片图标与回归测试
- 收齐顶栏对齐、选取范围、工具完成态与任务底板

未包含仍为草稿的 #157（usage 胶囊改动尚未合入今日主干）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a398f0e-a611-4745-ab4d-45d3957f3a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a398f0e-a611-4745-ab4d-45d3957f3a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

