### PR TITLE
fix(pick): 左侧边栏 session 选取改用 agent 图标

### DIFF
--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -5,6 +5,7 @@ import { pickKindIcon } from './chip.tsx'
 
 test('chip icons exist on react-icons/lu (Vite ESM named exports)', () => {
   const needed = [
+    'LuBot',
     'LuCoins',
     'LuGitCommitHorizontal',
     'LuHash',
@@ -21,4 +22,5 @@ test('chip icons exist on react-icons/lu (Vite ESM named exports)', () => {
   assert.equal('LuGitCommit' in lu, false)
   assert.equal(typeof pickKindIcon('event'), 'function')
   assert.equal(typeof pickKindIcon('usage'), 'function')
+  assert.equal(typeof pickKindIcon('session'), 'function')
 })

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -1,4 +1,5 @@
 import {
+  LuBot,
   LuCoins,
   LuGitCommitHorizontal,
   LuHash,
@@ -14,7 +15,7 @@ import type { PickRef } from './types.ts'
 import { chipLabel } from './types.ts'
 
 const KIND_ICONS: Record<string, IconType> = {
-  session: LuMessageSquare,
+  session: LuBot,
   task: LuListTodo,
   plugin: LuPuzzle,
   message: LuMessageSquare,

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -57,6 +57,8 @@ test('parsePicks recovers chips that markdown would strip', () => {
 
 test('kind maps to distinct icons', () => {
   assert.equal(pickKindIcon('session'), LuBot)
+  assert.equal(pickKindIcon('message'), LuMessageSquare)
+  assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
   assert.equal(pickKindIcon('task'), LuListTodo)
   assert.equal(pickKindIcon('plugin'), LuPuzzle)
   assert.equal(pickKindIcon('unknown'), LuTag)

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { resolvePickFromNode, resolvePicksInRect } from './resolve.ts'
 import { formatPicks, parsePicks, chipLabel, dedupePicks } from './types.ts'
 import { pickKindIcon } from './chip.tsx'
-import { LuListTodo, LuMessageSquare, LuPuzzle, LuTag } from 'react-icons/lu'
+import { LuBot, LuListTodo, LuMessageSquare, LuPuzzle, LuTag } from 'react-icons/lu'
 
 test('merges child action onto parent kind/id', () => {
   const card = document.createElement('div')
@@ -56,7 +56,7 @@ test('parsePicks recovers chips that markdown would strip', () => {
 })
 
 test('kind maps to distinct icons', () => {
-  assert.equal(pickKindIcon('session'), LuMessageSquare)
+  assert.equal(pickKindIcon('session'), LuBot)
   assert.equal(pickKindIcon('task'), LuListTodo)
   assert.equal(pickKindIcon('plugin'), LuPuzzle)
   assert.equal(pickKindIcon('unknown'), LuTag)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取芯片里，左侧边栏的 session（agent）原先和中间聊天的 message/reply 都用 `LuMessageSquare`，看起来一样。

- session 改为 `LuBot`（与任务面板 agent 图标一致）
- 中间聊天 message/reply 仍用气泡图标

测试锁定 `session !== message`，并确认 `LuBot` 在 `react-icons/lu` 有命名导出。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a398f0e-a611-4745-ab4d-45d3957f3a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a398f0e-a611-4745-ab4d-45d3957f3a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

