### PR TITLE
feat(plugin-store): SQLite 存插件，host/web 按需二选一

### DIFF
--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -1,97 +1,74 @@
 /** @vitest-environment node */
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { mkdtemp, rm, access } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { Context } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
-import { PluginStoreService, defaultCatalogDir } from './index.ts'
-import { writePluginToCatalog } from './plugin-create.ts'
+import { PluginStoreService, defaultDbPath } from './index.ts'
 
-test('default catalog is repo-root .biu/plugin-catalog', () => {
-  const dir = defaultCatalogDir().replace(/\\/g, '/')
-  assert.equal(dir.endsWith('.biu/plugin-catalog'), true)
-  assert.equal(dirname(fileURLToPath(import.meta.url)).includes('cap-plugin-store'), true)
-})
-
-test('bundled hello in .biu/plugin-catalog is listable', async () => {
-  const dataDir = await mkdtemp(join(tmpdir(), 'plugin-store-'))
-  try {
-    const ctx = new Context()
-    ;(ctx as unknown as { hub: unknown }).hub = {
-      async adopt() {},
-      async drop() {},
-      snapshot() {
-        return { plugins: [] }
-      },
-    }
-    const store = new PluginStoreService(ctx, defaultCatalogDir(), dataDir)
-    const hello = (await store.list()).find((item) => item.id === 'store-hello')
-    assert.ok(hello, 'store-hello should ship in .biu/plugin-catalog')
-    assert.equal(hello.installed, false)
-    assert.equal(hello.name, 'Hello')
-  } finally {
-    await rm(dataDir, { recursive: true, force: true })
-  }
-})
-
-test('missing .biu catalog lists no plugins', async () => {
-  const catalogDir = join(tmpdir(), `missing-plugin-catalog-${Date.now()}`)
-  const dataDir = await mkdtemp(join(tmpdir(), 'plugin-store-'))
-  try {
-    const ctx = new Context()
-    ;(ctx as unknown as { hub: unknown }).hub = {
-      async adopt() {},
-      async drop() {},
-      snapshot() {
-        return { plugins: [] }
-      },
-    }
-    const store = new PluginStoreService(ctx, catalogDir, dataDir)
-    assert.deepEqual(await store.list(), [])
-  } finally {
-    await rm(dataDir, { recursive: true, force: true })
-  }
-})
-
-test('install copies catalog js and adopt; uninstall drops it', async () => {
-  const catalogDir = await mkdtemp(join(tmpdir(), 'plugin-catalog-'))
-  const dataDir = await mkdtemp(join(tmpdir(), 'plugin-store-'))
+function stubHub(ctx: Context) {
   const adopted: string[] = []
   const dropped: string[] = []
   const forks = new Map<string, CatalogEntry>()
+  ;(ctx as unknown as { hub: unknown }).hub = {
+    async adopt(entry: CatalogEntry) {
+      forks.set(entry.id, entry)
+      adopted.push(entry.id)
+    },
+    async drop(id: string) {
+      forks.delete(id)
+      dropped.push(id)
+    },
+    snapshot() {
+      return {
+        plugins: [...forks.values()].map((entry) => ({
+          id: entry.id,
+          enabled: true,
+          state: 'active',
+          web: entry.web,
+        })),
+      }
+    },
+  }
+  return { adopted, dropped, forks }
+}
+
+test('default db is process cwd .cordis/plugins.sqlite', () => {
+  const path = defaultDbPath().replace(/\\/g, '/')
+  assert.equal(path.endsWith('.cordis/plugins.sqlite'), true)
+})
+
+test('empty sqlite lists no plugins until hello is seeded', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-db-'))
   try {
     const ctx = new Context()
-    ;(ctx as unknown as { hub: unknown }).hub = {
-      async adopt(entry: CatalogEntry) {
-        forks.set(entry.id, entry)
-        adopted.push(entry.id)
-      },
-      async drop(id: string) {
-        forks.delete(id)
-        dropped.push(id)
-      },
-      snapshot() {
-        return {
-          plugins: [...forks.values()].map((entry) => ({
-            id: entry.id,
-            enabled: true,
-            state: 'active',
-            web: entry.web,
-          })),
-        }
-      },
-    }
-    await writePluginToCatalog(catalogDir, {
+    stubHub(ctx)
+    const store = new PluginStoreService(ctx, join(dir, 'plugins.sqlite')).open()
+    assert.deepEqual(await store.list(), [])
+    store.ensureHello()
+    const hello = (await store.list()).find((item) => item.id === 'store-hello')
+    assert.ok(hello)
+    assert.equal(hello.installed, false)
+    assert.equal(hello.name, 'Hello')
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('create writes sqlite; install toggles enabled and adopt; uninstall keeps the row', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-db-'))
+  try {
+    const ctx = new Context()
+    const { adopted, dropped, forks } = stubHub(ctx)
+    const store = new PluginStoreService(ctx, join(dir, 'plugins.sqlite')).open()
+    await store.create({
       id: 'store-echo',
       name: 'Echo',
       hostJs: `export const name = 'store-echo'\nexport function apply() {}\n`,
     })
-    const store = new PluginStoreService(ctx, catalogDir, dataDir)
-    const listed = await store.list()
-    const echo = listed.find((item) => item.id === 'store-echo')
+    const echo = (await store.list()).find((item) => item.id === 'store-echo')
     assert.ok(echo)
     assert.equal(echo.installed, false)
 
@@ -101,18 +78,39 @@ test('install copies catalog js and adopt; uninstall drops it', async () => {
     assert.deepEqual(adopted, ['store-echo'])
     const entry = forks.get('store-echo')
     assert.equal(entry?.packageName, 'store:store-echo')
-    assert.equal(entry?.web, '/api/plugin-store/files/store-echo/web.js')
+    assert.equal(entry?.web, undefined)
     const hostJs = await store.readInstalledFile('store-echo', 'host.js')
     assert.match(hostJs, /store-echo/)
-    assert.doesNotMatch(hostJs, /from ['"]typescript/)
 
     await store.uninstall('store-echo')
     assert.deepEqual(dropped, ['store-echo'])
     const after = (await store.list()).find((item) => item.id === 'store-echo')
     assert.equal(after?.installed, false)
-    await access(join(catalogDir, 'echo', 'host.js'))
+    assert.equal(after?.name, 'Echo')
   } finally {
-    await rm(catalogDir, { recursive: true, force: true })
-    await rm(dataDir, { recursive: true, force: true })
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('web-only plugin installs without host.js', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-db-'))
+  try {
+    const ctx = new Context()
+    const { forks } = stubHub(ctx)
+    const store = new PluginStoreService(ctx, join(dir, 'plugins.sqlite')).open()
+    await store.create({
+      id: 'store-banner',
+      name: 'Banner',
+      webJs: `export const name = 'store-banner-web'\nexport const inject = ['slots']\nexport function apply() {}\n`,
+    })
+    await assert.rejects(() => store.create({ id: 'store-empty', name: 'Empty' }), /hostJs or webJs/)
+    const installed = await store.install('store-banner')
+    assert.equal(installed?.installed, true)
+    assert.equal(forks.get('store-banner')?.web, '/api/plugin-store/files/store-banner/web.js')
+    const webJs = await store.readInstalledFile('store-banner', 'web.js')
+    assert.match(webJs, /store-banner-web/)
+    await assert.rejects(() => store.readInstalledFile('store-banner', 'host.js'))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
   }
 })

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -1,11 +1,13 @@
-import { cp, mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
-import { pathToFileURL } from 'node:url'
-import type { Context, Plugin } from 'cordis'
-import { findRepoRoot } from '@biu/host-plugin-loader'
+import { mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { createRequire } from 'node:module'
+import { Service, type Context, type Plugin } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
-import { registerPluginCreate } from './plugin-create.ts'
+import { compileStoreModule, registerPluginCreate, type PluginCreateInput } from './plugin-create.ts'
+
+type DatabaseSync = import('node:sqlite').DatabaseSync
+
+const require = createRequire(import.meta.url)
 
 export const name = 'plugin-store'
 export const inject = ['http', 'hub', 'tools']
@@ -18,10 +20,13 @@ export type StoreListing = {
   running: boolean
 }
 
-export type StoreManifest = {
+type PluginRow = {
   id: string
   name: string
   blurb: string
+  host_js: string
+  web_js: string
+  enabled: number
 }
 
 type StoreHub = {
@@ -30,164 +35,227 @@ type StoreHub = {
   snapshot(): { plugins: Array<{ id: string; enabled?: boolean; state?: string }> }
 }
 
+const ALLOWED_FILES = new Set(['manifest.json', 'host.js', 'web.js'])
+
+const HELLO_HOST_JS = `export const name = 'store-hello'
+export const inject = ['http']
+
+export function apply(ctx) {
+  ctx.http.route('GET', '/api/store-hello', (route) => {
+    route.send(200, { message: 'hello from store plugin', installed: true })
+  })
+}
+`
+
+const HELLO_WEB_JS = `const React = globalThis.React
+
+export const name = 'store-hello-web'
+export const inject = ['slots']
+
+function HelloBanner() {
+  return React.createElement(
+    'div',
+    {
+      'data-testid': 'store-hello-banner',
+      className:
+        'rounded-[8px] border border-[var(--dsw-ok)]/40 bg-[var(--dsw-surface)] px-3 py-2 text-[13px] text-[var(--dsw-label)]',
+    },
+    'Hello 商店插件已运行',
+  )
+}
+
+export function apply(ctx) {
+  ctx.slots.place('plugin-store-extras', HelloBanner, {
+    key: 'store-hello-banner',
+    order: 10,
+  })
+}
+`
+
 export function storeWebUrl(id: string) {
   return `/api/plugin-store/files/${encodeURIComponent(id)}/web.js`
 }
 
-export function defaultCatalogDir() {
-  return process.env.BIU_PLUGIN_CATALOG_DIR || join(findRepoRoot(), '.biu', 'plugin-catalog')
-}
-
-export function defaultDataDir() {
-  return process.env.BIU_PLUGIN_STORE_DIR || join(findRepoRoot(), '.biu', 'plugin-store')
-}
-
-async function readManifest(dir: string): Promise<StoreManifest> {
-  const raw = JSON.parse(await readFile(join(dir, 'manifest.json'), 'utf8')) as StoreManifest
-  if (!raw.id || !raw.name) throw new Error(`invalid plugin manifest in ${dir}`)
-  return raw
+export function defaultDbPath() {
+  return process.env.BIU_PLUGIN_DB || join(process.cwd(), '.cordis', 'plugins.sqlite')
 }
 
 function isSafeId(id: string) {
   return /^[a-z][a-z0-9-]{1,40}$/.test(id)
 }
 
-const ALLOWED_FILES = new Set(['manifest.json', 'host.js', 'web.js'])
+function importHostModule(code: string) {
+  return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
+}
 
-export class PluginStoreService {
-  constructor(
-    private readonly ctx: Context,
-    readonly catalogDir: string,
-    readonly dataDir: string,
-  ) {}
+export class PluginStoreService extends Service {
+  private db!: DatabaseSync
+
+  constructor(ctx: Context, private readonly dbPath: string) {
+    super(ctx, 'pluginStore')
+  }
+
+  open() {
+    mkdirSync(dirname(this.dbPath), { recursive: true })
+    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
+    this.db = new DatabaseSync(this.dbPath)
+    this.db.exec('PRAGMA journal_mode = WAL')
+    this.db.exec('PRAGMA synchronous = NORMAL')
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS plugins (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        blurb TEXT NOT NULL DEFAULT '',
+        host_js TEXT NOT NULL DEFAULT '',
+        web_js TEXT NOT NULL DEFAULT '',
+        enabled INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `)
+    return this
+  }
+
+  ensureHello() {
+    const existing = this.getRow('store-hello')
+    if (existing) return
+    const now = Date.now()
+    this.db
+      .prepare(
+        `INSERT INTO plugins (id, name, blurb, host_js, web_js, enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 0, ?, ?)`,
+      )
+      .run(
+        'store-hello',
+        'Hello',
+        '内置测试插件：安装后在本页显示横幅，并提供 GET /api/store-hello。',
+        HELLO_HOST_JS,
+        HELLO_WEB_JS,
+        now,
+        now,
+      )
+  }
 
   private hub(): StoreHub {
     return this.ctx.hub as unknown as StoreHub
   }
 
+  private getRow(id: string) {
+    return this.db.prepare('SELECT id, name, blurb, host_js, web_js, enabled FROM plugins WHERE id = ?').get(id) as
+      | PluginRow
+      | undefined
+  }
+
+  async create(input: PluginCreateInput) {
+    const id = String(input.id ?? '').trim()
+    const name = String(input.name ?? '').trim()
+    const hostJs = String(input.hostJs ?? '').trim()
+    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
+    if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
+    if (!name) throw new Error('plugin name required')
+    if (!hostJs && !webSrc) throw new Error('hostJs or webJs required')
+    const hostCompiled = hostJs ? await compileStoreModule(hostJs, 'host') : ''
+    const webCompiled = webSrc ? await compileStoreModule(webSrc, 'web') : ''
+    const now = Date.now()
+    const prev = this.getRow(id)
+    this.db
+      .prepare(
+        `INSERT INTO plugins (id, name, blurb, host_js, web_js, enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           name = excluded.name,
+           blurb = excluded.blurb,
+           host_js = excluded.host_js,
+           web_js = excluded.web_js,
+           updated_at = excluded.updated_at`,
+      )
+      .run(id, name, String(input.blurb ?? '').trim() || name, hostCompiled, webCompiled, prev?.enabled ?? 0, now, now)
+    if (prev?.enabled === 1) await this.mount(this.getRow(id)!)
+    return { id }
+  }
+
   async list(): Promise<StoreListing[]> {
-    const names = existsSync(this.catalogDir) ? await readdir(this.catalogDir) : []
     const running = new Set(
       this.hub()
         .snapshot()
         .plugins.filter((row) => row.enabled || row.state === 'active')
         .map((row) => row.id),
     )
-    const items: StoreListing[] = []
-    for (const name of names.sort()) {
-      const dir = join(this.catalogDir, name)
-      if (!(await stat(dir)).isDirectory()) continue
-      if (!existsSync(join(dir, 'manifest.json'))) continue
-      const manifest = await readManifest(dir)
-      const installed = existsSync(join(this.dataDir, manifest.id, 'host.js'))
-      items.push({
-        ...manifest,
-        installed,
-        running: installed && running.has(manifest.id),
-      })
-    }
-    return items
+    const rows = this.db
+      .prepare('SELECT id, name, blurb, host_js, web_js, enabled FROM plugins ORDER BY name COLLATE NOCASE, id')
+      .all() as PluginRow[]
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      blurb: row.blurb,
+      installed: row.enabled === 1,
+      running: row.enabled === 1 && running.has(row.id),
+    }))
   }
 
   async install(id: string) {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
-    const source = join(this.catalogDir, id.replace(/^store-/, ''))
-    const catalogHit = existsSync(join(source, 'manifest.json'))
-      ? source
-      : await this.findCatalogById(id)
-    if (!catalogHit) throw new Error(`unknown store plugin: ${id}`)
-    const manifest = await readManifest(catalogHit)
-    const dest = join(this.dataDir, manifest.id)
-    await mkdir(this.dataDir, { recursive: true })
-    await rm(dest, { recursive: true, force: true })
-    await mkdir(dest, { recursive: true })
-    for (const file of ALLOWED_FILES) {
-      const from = join(catalogHit, file)
-      if (!existsSync(from)) continue
-      await cp(from, join(dest, file))
-    }
-    await this.mountInstalled(manifest)
-    await this.writeIndex()
-    return (await this.list()).find((item) => item.id === manifest.id)
+    const row = this.getRow(id)
+    if (!row) throw new Error(`unknown store plugin: ${id}`)
+    this.db.prepare('UPDATE plugins SET enabled = 1, updated_at = ? WHERE id = ?').run(Date.now(), id)
+    await this.mount({ ...row, enabled: 1 })
+    return (await this.list()).find((item) => item.id === id)
   }
 
   async uninstall(id: string) {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     await this.hub().drop(id)
-    await rm(join(this.dataDir, id), { recursive: true, force: true })
-    await this.writeIndex()
+    this.db.prepare('UPDATE plugins SET enabled = 0, updated_at = ? WHERE id = ?').run(Date.now(), id)
   }
 
   async restore() {
-    if (!existsSync(this.dataDir)) return
-    const names = await readdir(this.dataDir)
-    for (const name of names) {
-      const dir = join(this.dataDir, name)
-      if (!(await stat(dir)).isDirectory()) continue
-      if (!existsSync(join(dir, 'manifest.json'))) continue
-      const manifest = await readManifest(dir)
-      await this.mountInstalled(manifest)
-    }
+    const rows = this.db.prepare('SELECT id, name, blurb, host_js, web_js, enabled FROM plugins WHERE enabled = 1').all() as PluginRow[]
+    for (const row of rows) await this.mount(row)
   }
 
   async readInstalledFile(id: string, file: string) {
     if (!isSafeId(id) || !ALLOWED_FILES.has(file)) throw new Error('not found')
-    const path = join(this.dataDir, id, file)
-    if (!existsSync(path)) throw new Error('not found')
-    return readFile(path, 'utf8')
-  }
-
-  private async findCatalogById(id: string) {
-    if (!existsSync(this.catalogDir)) return null
-    for (const name of await readdir(this.catalogDir)) {
-      const dir = join(this.catalogDir, name)
-      if (!(await stat(dir)).isDirectory()) continue
-      if (!existsSync(join(dir, 'manifest.json'))) continue
-      const manifest = await readManifest(dir)
-      if (manifest.id === id) return dir
+    const row = this.getRow(id)
+    if (!row || row.enabled !== 1) throw new Error('not found')
+    if (file === 'host.js') {
+      if (!row.host_js.trim()) throw new Error('not found')
+      return row.host_js
     }
-    return null
+    if (file === 'web.js') {
+      if (!row.web_js.trim()) throw new Error('not found')
+      return row.web_js
+    }
+    return `${JSON.stringify({ id: row.id, name: row.name, blurb: row.blurb }, null, 2)}\n`
   }
 
-  private async mountInstalled(manifest: StoreManifest) {
-    const hostFile = join(this.dataDir, manifest.id, 'host.js')
-    if (!existsSync(hostFile)) throw new Error(`missing host.js for ${manifest.id}`)
-    const mod = (await importHostModule(hostFile)) as Plugin & { inject?: string[] }
+  private async mount(row: PluginRow) {
+    const hostCode = row.host_js.trim()
+    const webCode = row.web_js.trim()
+    if (!hostCode && !webCode) throw new Error(`plugin ${row.id} has neither host nor web`)
+    const mod = (hostCode
+      ? await importHostModule(hostCode)
+      : { name: row.id, apply() {} }) as Plugin & { inject?: string[] }
     const entry: CatalogEntry = {
-      id: manifest.id,
-      name: manifest.name,
+      id: row.id,
+      name: row.name,
       layer: 'capability',
-      blurb: manifest.blurb,
+      blurb: row.blurb,
       plugin: mod,
       inject: mod.inject,
       togglable: true,
       enabled: true,
-      web: storeWebUrl(manifest.id),
-      packageName: `store:${manifest.id}`,
+      web: webCode ? storeWebUrl(row.id) : undefined,
+      packageName: `store:${row.id}`,
     }
     await this.hub().adopt(entry)
-  }
-
-  private async writeIndex() {
-    const items = existsSync(this.dataDir) ? await readdir(this.dataDir) : []
-    await mkdir(this.dataDir, { recursive: true })
-    await writeFile(join(this.dataDir, 'index.json'), JSON.stringify({ items }, null, 2))
-  }
-}
-
-async function importHostModule(hostFile: string) {
-  try {
-    return await import(pathToFileURL(hostFile).href)
-  } catch {
-    const code = await readFile(hostFile, 'utf8')
-    return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
   }
 }
 
 export async function apply(ctx: Context) {
-  const store = new PluginStoreService(ctx, defaultCatalogDir(), defaultDataDir())
+  const store = new PluginStoreService(ctx, defaultDbPath()).open()
+  store.ensureHello()
   await store.restore()
-  registerPluginCreate(ctx, store.catalogDir)
+  registerPluginCreate(ctx, store)
 
   ctx.http.route('GET', '/api/plugin-store', async (route) => {
     route.send(200, { items: await store.list() })
@@ -225,4 +293,10 @@ export async function apply(ctx: Context) {
       route.send(404, { error: 'not found' })
     }
   })
+}
+
+declare module 'cordis' {
+  interface Context {
+    pluginStore: PluginStoreService
+  }
 }

--- a/packages/cap-plugin-store/src/host/plugin-create.test.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.test.ts
@@ -1,31 +1,39 @@
 /** @vitest-environment node */
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { compileStoreModule, writePluginToCatalog } from './plugin-create.ts'
+import { Context } from 'cordis'
+import { PluginStoreService } from './index.ts'
+import { compileStoreModule } from './plugin-create.ts'
 
-test('writePluginToCatalog dumps files into catalog dir', async () => {
-  const catalogDir = await mkdtemp(join(tmpdir(), 'plugin-catalog-'))
+test('create compiles TypeScript into sqlite instead of catalog files', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-create-'))
   try {
-    const result = await writePluginToCatalog(catalogDir, {
+    const ctx = new Context()
+    ;(ctx as unknown as { hub: unknown }).hub = {
+      adopt: async () => {},
+      drop: async () => {},
+      snapshot: () => ({ plugins: [] }),
+    }
+    const store = new PluginStoreService(ctx, join(dir, 'plugins.sqlite')).open()
+    const result = await store.create({
       id: 'store-echo',
       name: 'Echo',
       blurb: '回声',
-      hostJs: `export const name = 'store-echo'\nexport function apply() {}`,
+      hostJs: `export const name = 'store-echo'\nexport function apply(ctx: { ok: boolean }) { return ctx.ok }`,
     })
     assert.equal(result.id, 'store-echo')
-    assert.equal(result.catalogPath, join(catalogDir, 'echo'))
-    const manifest = JSON.parse(await readFile(join(catalogDir, 'echo', 'manifest.json'), 'utf8')) as {
-      id: string
-      name: string
-    }
-    assert.equal(manifest.id, 'store-echo')
-    assert.equal(manifest.name, 'Echo')
-    assert.match(await readFile(join(catalogDir, 'echo', 'host.js'), 'utf8'), /\bapply\b/)
+    const listed = await store.list()
+    assert.equal(listed[0]?.id, 'store-echo')
+    assert.equal(listed[0]?.name, 'Echo')
+    await store.install('store-echo')
+    const hostJs = await store.readInstalledFile('store-echo', 'host.js')
+    assert.match(hostJs, /\bapply\b/)
+    assert.doesNotMatch(hostJs, /ctx: \{/)
   } finally {
-    await rm(catalogDir, { recursive: true, force: true })
+    await rm(dir, { recursive: true, force: true })
   }
 })
 

--- a/packages/cap-plugin-store/src/host/plugin-create.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.ts
@@ -1,12 +1,11 @@
-import { mkdir, writeFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { Context } from 'cordis'
+import type { PluginStoreService } from './index.ts'
 
 export type PluginCreateInput = {
   id: string
   name: string
   blurb?: string
-  hostJs: string
+  hostJs?: string
   webJs?: string
 }
 
@@ -31,47 +30,18 @@ export async function compileStoreModule(source: string, kind: 'host' | 'web') {
   return code.endsWith('\n') ? code : `${code}\n`
 }
 
-function isSafeId(id: string) {
-  return /^[a-z][a-z0-9-]{1,40}$/.test(id)
-}
-
-export function catalogSlug(id: string) {
-  return id.replace(/^store-/, '')
-}
-
-/** 把商店插件三件套写进仓库根 .biu/plugin-catalog/<slug>/（没有 .biu 则创建）。 */
-export async function writePluginToCatalog(catalogDir: string, input: PluginCreateInput) {
-  const id = String(input.id ?? '').trim()
-  const name = String(input.name ?? '').trim()
-  const hostJs = String(input.hostJs ?? '').trim()
-  if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
-  if (!name) throw new Error('plugin name required')
-  if (!hostJs) throw new Error('host.js is empty')
-  const dest = join(catalogDir, catalogSlug(id))
-  await mkdir(dest, { recursive: true })
-  await writeFile(
-    join(dest, 'manifest.json'),
-    `${JSON.stringify({ id, name, blurb: String(input.blurb ?? '').trim() || name }, null, 2)}\n`,
-  )
-  await writeFile(join(dest, 'host.js'), await compileStoreModule(hostJs, 'host'))
-  const webJs = input.webJs != null ? String(input.webJs).trim() : ''
-  if (webJs) {
-    await writeFile(join(dest, 'web.js'), await compileStoreModule(webJs, 'web'))
-  }
-  return { id, catalogPath: dest }
-}
-
 const PLUGIN_CREATE_DESCRIPTION = [
-  '把 Cordis 商店插件写入仓库根 .biu/plugin-catalog/<slug>/（manifest.json + host.js，可选 web.js）。不要用 fs_write/bash 改 packages/ 或 cordis.plugins.json。',
-  '没有 .biu/plugin-catalog 时商店显示「没有插件」。本工具会建目录。可交 TS/TSX：当前 host 进程内 esbuild.transform 成 ESM 再落盘，不重启主进程、不跑 Vite。',
-  '写完出现在商店，需用户点「安装」才会 hub.adopt 运行。「卸载」只停运行副本（.biu/plugin-store），原文件留在 plugin-catalog。',
+  '把 Cordis 商店插件写入 .cordis/plugins.sqlite（与 tasks 插件同一套 node:sqlite）。不要用 fs_write/bash 改 packages/ 或 cordis.plugins.json，也不要写 .biu 目录。',
+  'hostJs 与 webJs 按需二选一即可：只要后端（路由/服务）就只交 hostJs；只要前端 UI 就只交 webJs；两边都要才两个都交。至少交一个。',
+  '库空时商店显示「没有插件」。本工具 INSERT/UPDATE 一行。可交 TS/TSX：当前 host 进程内 esbuild.transform 成 ESM 再入库，不重启主进程、不跑 Vite。',
+  '写完出现在商店，需用户点「安装」才会把 enabled 置 1 并运行。「卸载」只把 enabled 置 0 并停运行，SQLite 行和代码保留。',
   '契约：id 与 export const name 必须相同。Host inject 只能写真正用到的服务（http 等）。Web inject 一般是 ["slots"]。',
-  '副作用必须走 ctx，这样卸载时 fiber.dispose 会拆掉。Host：ctx.http.route。Web：ctx.slots.place("plugin-store-extras", Comp, { key: 唯一且稳定 })。禁止 document/window 全局挂载、禁止 setInterval 不清理、禁止 import "react" / "@biu/..." / 相对路径。',
+  '副作用必须走 ctx。Host：ctx.http.route。Web：ctx.slots.place("plugin-store-extras", Comp, { key: 唯一且稳定 })。禁止 import "react" / "@biu/..." / 相对路径。',
   'Host 最小示例：export const name = "store-echo"; export const inject = ["http"]; export function apply(ctx) { ctx.http.route("GET", "/api/store-echo", (route) => { route.send(200, { ok: true }); }); }',
   'Web 最小示例：export const name = "store-echo-web"; export const inject = ["slots"]; function Banner() { return <div>echo 已运行</div>; } export function apply(ctx) { ctx.slots.place("plugin-store-extras", Banner, { key: "store-echo-banner", order: 10 }); }',
 ].join(' ')
 
-export function registerPluginCreate(ctx: Context, catalogDir: string) {
+export function registerPluginCreate(ctx: Context, store: PluginStoreService) {
   ctx.tools.register({
     name: 'plugin_create',
     description: PLUGIN_CREATE_DESCRIPTION,
@@ -87,22 +57,22 @@ export function registerPluginCreate(ctx: Context, catalogDir: string) {
         hostJs: {
           type: 'string',
           description:
-            'Host 半边完整源码（可 TS）。必须是单一 ESM 文件：export const name（等于 id）、export const inject（数组，只用到的服务如 http）、export function apply(ctx)。副作用只能挂在 ctx 上（如 ctx.http.route）。禁止 import 相对路径、禁止 import react、禁止 import @biu/*。',
+            '可选。需要后端时交 Host 源码（可 TS）：export const name（等于 id）、export const inject、export function apply(ctx)。不要为了凑数写空 host。',
         },
         webJs: {
           type: 'string',
           description:
-            '可选 Client 半边（可 TSX）。export const name、export const inject=[\'slots\']、export function apply(ctx)。UI 必须 ctx.slots.place(\'plugin-store-extras\', Component, { key })，卸载才能收回。JSX 可用；不要 import react 或任何 npm 包。禁止直接 document.body.append。',
+            "可选。需要前端时交 Client 源码（可 TSX）：export const name、export const inject=['slots']、export function apply(ctx)。UI 必须 ctx.slots.place('plugin-store-extras', Component, { key })。不要为了凑数写空 web。",
         },
       },
-      required: ['id', 'name', 'hostJs'],
+      required: ['id', 'name'],
     },
     execute: async (args) => {
-      const result = await writePluginToCatalog(catalogDir, {
+      const result = await store.create({
         id: String(args.id ?? ''),
         name: String(args.name ?? ''),
         blurb: args.blurb != null ? String(args.blurb) : undefined,
-        hostJs: String(args.hostJs ?? ''),
+        hostJs: args.hostJs != null ? String(args.hostJs) : undefined,
         webJs: args.webJs != null ? String(args.webJs) : undefined,
       })
       return JSON.stringify(result)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
已合入今日主干 `dev-2026-08-27`（`65c1d7d`）。

商店插件对齐 tasks：数据写在 `.cordis/plugins.sqlite`。hostJs / webJs 按需二选一。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a398f0e-a611-4745-ab4d-45d3957f3a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a398f0e-a611-4745-ab4d-45d3957f3a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

