### PR TITLE
feat(plugin-store): 右侧检查器加入插件面板

### DIFF
--- a/packages/cap-plugin-store/src/web/index.test.ts
+++ b/packages/cap-plugin-store/src/web/index.test.ts
@@ -12,11 +12,18 @@ test('plugin store registers the plugins activity module', async () => {
   ctx.slots.fill('root', () => null, {
     children: {
       'app-modules': { kind: 'list' },
+      'inspector-panels': { kind: 'list' },
     },
   })
   await ctx.plugin(storeUi)
   const mods = ctx.appModules.list()
   assert.equal(mods.some((item) => item.id === 'plugins' && item.path === '/plugins'), true)
   assert.equal(ctx.slots.list('app-modules').some((item) => item.id === 'plugin-store-module'), true)
+  const inspector = ctx.slots.list('inspector-panels').find((item) => item.id === 'plugin-store-inspector')
+  assert.ok(inspector)
+  assert.equal(inspector.order, 11)
+  const extra = inspector.props?.() ?? {}
+  assert.equal(extra.tabId, 'plugins')
+  assert.equal(extra.tabLabel, '插件')
   assert.ok(ctx.slots.specOf('plugin-store-extras'))
 })

--- a/packages/cap-plugin-store/src/web/index.tsx
+++ b/packages/cap-plugin-store/src/web/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import type { Context } from 'cordis'
+import { LuPuzzle } from 'react-icons/lu'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 
@@ -33,7 +34,7 @@ async function readJson<T>(path: string, init?: RequestInit): Promise<T> {
   return body
 }
 
-function PluginStorePage({ slots }: { slots: SlotsService }) {
+function PluginStorePage({ slots, compact = false }: { slots: SlotsService; compact?: boolean }) {
   const extras = useSlotEntries(slots, 'plugin-store-extras')
   const [items, setItems] = useState<StoreListing[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -91,10 +92,15 @@ function PluginStorePage({ slots }: { slots: SlotsService }) {
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-auto px-8 py-6" data-testid="plugin-store-page">
-      <header className="mb-6">
-        <h1 className="m-0 text-[22px] font-semibold tracking-tight text-[var(--dsw-label)]">插件</h1>
-      </header>
+    <div
+      className={`flex min-h-0 flex-1 flex-col overflow-auto ${compact ? 'px-3 py-3' : 'px-8 py-6'}`}
+      data-testid={compact ? 'plugin-store-inspector' : 'plugin-store-page'}
+    >
+      {compact ? null : (
+        <header className="mb-6">
+          <h1 className="m-0 text-[22px] font-semibold tracking-tight text-[var(--dsw-label)]">插件</h1>
+        </header>
+      )}
 
       {error ? (
         <p className="mb-4 text-[13px] text-[var(--dsw-danger)]" data-testid="plugin-store-error">
@@ -122,7 +128,7 @@ function PluginStorePage({ slots }: { slots: SlotsService }) {
         {items.map((item) => (
           <li
             key={item.id}
-            className="flex items-center justify-between gap-4 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-4 py-3"
+            className={`flex items-center justify-between gap-3 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] ${compact ? 'px-3 py-2.5' : 'px-4 py-3'}`}
             data-testid={`plugin-store-card-${item.id}`}
             data-biu-kind="plugin"
             data-biu-id={item.id}
@@ -142,7 +148,11 @@ function PluginStorePage({ slots }: { slots: SlotsService }) {
                   </span>
                 )}
               </div>
-              <p className="mt-1 m-0 text-[12px] leading-5 text-[var(--dsw-label-3)]">{item.blurb}</p>
+              {item.blurb ? (
+                <p className={`mt-1 m-0 leading-5 text-[var(--dsw-label-3)] ${compact ? 'text-[11px]' : 'text-[12px]'}`}>
+                  {item.blurb}
+                </p>
+              ) : null}
             </div>
             {item.installed ? (
               <button
@@ -187,6 +197,11 @@ type AppModulesService = {
 }
 
 const moduleProps = { moduleId: 'plugins' }
+const inspectorProps = { tabId: 'plugins', tabLabel: '插件', tabIcon: LuPuzzle }
+
+function PluginStoreInspectorPanel({ slots }: { slots: SlotsService }) {
+  return <PluginStorePage slots={slots} compact />
+}
 
 export function apply(ctx: Context) {
   const slots = ctx.get('slots') as SlotsService | undefined
@@ -208,5 +223,10 @@ export function apply(ctx: Context) {
     children: {
       'plugin-store-extras': { kind: 'list' },
     },
+  })
+  slots.place('inspector-panels', PluginStoreInspectorPanel, {
+    key: 'plugin-store-inspector',
+    order: 11,
+    props: () => ({ ...inspectorProps, slots }),
   })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
已合入 `dev-2026-08-27`。

右侧检查器在「任务」右侧增加「插件」页签，可安装/卸载商店插件。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a398f0e-a611-4745-ab4d-45d3957f3a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a398f0e-a611-4745-ab4d-45d3957f3a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

