### PR TITLE
插件沙箱调试后再打包进货架

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .cordis/
+.plugin-dev/
 .workspace/
 *.log
 .DS_Store

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -47,7 +47,7 @@ test('missing .plugin lists no plugins', async () => {
   try {
     const ctx = new Context()
     stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'plugins.sqlite')).open()
+    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
     assert.deepEqual(await store.list(), [])
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -60,13 +60,15 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
   try {
     const ctx = new Context()
     const { adopted, dropped, forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite')).open()
-    const created = await store.create({
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const created = await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
       hostJs: `export const name = 'store-echo'\nexport function apply() {}\n`,
     })
-    assert.equal(created.pluginPath, join(pluginDir, 'store-echo'))
+    assert.equal(created.sandboxPath, join(dir, '.plugin-dev', 'store-echo'))
+    const packed = await store.pack('store-echo')
+    assert.equal(packed.pluginPath, join(pluginDir, 'store-echo'))
     const echo = (await store.list()).find((item) => item.id === 'store-echo')
     assert.ok(echo)
     assert.equal(echo.enabled, false)
@@ -96,13 +98,14 @@ test('web-only plugin opens without host.js', async () => {
   try {
     const ctx = new Context()
     const { forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'plugins.sqlite')).open()
-    await store.create({
+    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    await store.initSandbox({
       id: 'store-banner',
       name: 'Banner',
       webJs: `export const name = 'store-banner-web'\nexport const inject = ['slots']\nexport function apply() {}\n`,
     })
-    await assert.rejects(() => store.create({ id: 'store-empty', name: 'Empty' }), /hostJs or webJs/)
+    await assert.rejects(() => store.pack('store-empty'), /sandbox not found/)
+    await store.pack('store-banner')
     await store.openPlugin('store-banner')
     assert.equal(forks.get('store-banner')?.web, '/api/plugin-store/files/store-banner/web.js')
     await assert.rejects(() => store.readInstalledFile('store-banner', 'host.js'))

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -2,10 +2,19 @@ import { mkdirSync } from 'node:fs'
 import { existsSync } from 'node:fs'
 import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { createRequire } from 'node:module'
 import { Service, type Context, type Plugin } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
-import { compileStoreModule, registerPluginCreate, type PluginCreateInput } from './plugin-create.ts'
+import {
+  bundleStoreEntry,
+  findEntry,
+  HOST_ENTRIES,
+  readSandboxManifest,
+  registerPluginCreate,
+  WEB_ENTRIES,
+  type PluginCreateInput,
+} from './plugin-create.ts'
 
 type DatabaseSync = import('node:sqlite').DatabaseSync
 
@@ -44,8 +53,8 @@ export function defaultPluginDir() {
   return process.env.BIU_PLUGIN_DIR || join(process.cwd(), '.plugin')
 }
 
-export function defaultDbPath() {
-  return process.env.BIU_PLUGIN_DB || join(process.cwd(), '.cordis', 'plugins.sqlite')
+export function defaultSandboxDir() {
+  return process.env.BIU_PLUGIN_DEV_DIR || join(process.cwd(), '.plugin-dev')
 }
 
 function isSafeId(id: string) {
@@ -54,6 +63,14 @@ function isSafeId(id: string) {
 
 function importHostModule(code: string) {
   return import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
+}
+
+async function importHostFile(hostFile: string) {
+  try {
+    return await import(`${pathToFileURL(hostFile).href}?t=${Date.now()}`)
+  } catch {
+    return importHostModule(await readFile(hostFile, 'utf8'))
+  }
 }
 
 async function readManifest(dir: string): Promise<StoreManifest> {
@@ -69,6 +86,7 @@ export class PluginStoreService extends Service {
     ctx: Context,
     readonly pluginDir: string,
     private readonly dbPath: string,
+    readonly sandboxDir: string = defaultSandboxDir(),
   ) {
     super(ctx, 'pluginStore')
   }
@@ -112,26 +130,47 @@ export class PluginStoreService extends Service {
     return join(this.pluginDir, id)
   }
 
-  async create(input: PluginCreateInput) {
+  sandboxPath(id: string) {
+    return join(this.sandboxDir, id)
+  }
+
+  /** 在 .plugin-dev/<id>/ 开沙箱，不写入货架。 */
+  async initSandbox(input: PluginCreateInput) {
     const id = String(input.id ?? '').trim()
     const name = String(input.name ?? '').trim()
-    const hostJs = String(input.hostJs ?? '').trim()
-    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     if (!name) throw new Error('plugin name required')
-    if (!hostJs && !webSrc) throw new Error('hostJs or webJs required')
-    const dest = this.pluginPath(id)
+    const dest = this.sandboxPath(id)
     mkdirSync(dest, { recursive: true })
     await writeFile(
       join(dest, 'manifest.json'),
       `${JSON.stringify({ id, name, blurb: String(input.blurb ?? '').trim() || name }, null, 2)}\n`,
     )
-    if (hostJs) await writeFile(join(dest, 'host.js'), await compileStoreModule(hostJs, 'host'))
+    const hostJs = String(input.hostJs ?? '').trim()
+    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
+    if (hostJs) await writeFile(join(dest, 'host.ts'), hostJs.endsWith('\n') ? hostJs : `${hostJs}\n`)
+    if (webSrc) await writeFile(join(dest, 'web.tsx'), webSrc.endsWith('\n') ? webSrc : `${webSrc}\n`)
+    return { id, sandboxPath: dest }
+  }
+
+  /** 把沙箱 bundle 进 .plugin/<id>/。 */
+  async pack(id: string) {
+    if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
+    const sandbox = this.sandboxPath(id)
+    if (!existsSync(join(sandbox, 'manifest.json'))) throw new Error(`sandbox not found: ${sandbox}`)
+    const manifest = await readSandboxManifest(sandbox)
+    const hostEntry = findEntry(sandbox, HOST_ENTRIES)
+    const webEntry = findEntry(sandbox, WEB_ENTRIES)
+    if (!hostEntry && !webEntry) throw new Error('sandbox needs host.ts/js or web.tsx/ts/js')
+    const dest = this.pluginPath(manifest.id)
+    mkdirSync(dest, { recursive: true })
+    await writeFile(join(dest, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+    if (hostEntry) await writeFile(join(dest, 'host.js'), await bundleStoreEntry(hostEntry, 'host'))
     else if (existsSync(join(dest, 'host.js'))) await rm(join(dest, 'host.js'))
-    if (webSrc) await writeFile(join(dest, 'web.js'), await compileStoreModule(webSrc, 'web'))
+    if (webEntry) await writeFile(join(dest, 'web.js'), await bundleStoreEntry(webEntry, 'web'))
     else if (existsSync(join(dest, 'web.js'))) await rm(join(dest, 'web.js'))
-    if (this.isEnabled(id)) await this.mountFromDisk(await readManifest(dest), dest)
-    return { id, pluginPath: dest }
+    if (this.isEnabled(manifest.id)) await this.mountFromDisk(manifest, dest)
+    return { id: manifest.id, sandboxPath: sandbox, pluginPath: dest }
   }
 
   async list(): Promise<StoreListing[]> {
@@ -224,7 +263,7 @@ export class PluginStoreService extends Service {
     const hasWeb = existsSync(webFile)
     if (!hostCode && !hasWeb) throw new Error(`plugin ${manifest.id} has neither host nor web`)
     const mod = (hostCode
-      ? await importHostModule(hostCode)
+      ? await importHostFile(hostFile)
       : { name: manifest.id, apply() {} }) as Plugin & { inject?: string[] }
     const entry: CatalogEntry = {
       id: manifest.id,
@@ -243,7 +282,7 @@ export class PluginStoreService extends Service {
 }
 
 export async function apply(ctx: Context) {
-  const store = new PluginStoreService(ctx, defaultPluginDir(), defaultDbPath()).open()
+  const store = new PluginStoreService(ctx, defaultPluginDir(), defaultDbPath(), defaultSandboxDir()).open()
   await store.restore()
   registerPluginCreate(ctx, store)
 

--- a/packages/cap-plugin-store/src/host/plugin-create.test.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.test.ts
@@ -1,31 +1,38 @@
 /** @vitest-environment node */
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from 'cordis'
 import { PluginStoreService } from './index.ts'
 import { compileStoreModule } from './plugin-create.ts'
 
-test('create dumps compiled files into .plugin/<id>/', async () => {
+function stubHub(ctx: Context) {
+  ;(ctx as unknown as { hub: unknown }).hub = {
+    adopt: async () => {},
+    drop: async () => {},
+    snapshot: () => ({ plugins: [] }),
+  }
+}
+
+test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-create-'))
   try {
     const ctx = new Context()
-    ;(ctx as unknown as { hub: unknown }).hub = {
-      adopt: async () => {},
-      drop: async () => {},
-      snapshot: () => ({ plugins: [] }),
-    }
+    stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite')).open()
-    const result = await store.create({
+    const sandboxDir = join(dir, '.plugin-dev')
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), sandboxDir).open()
+    const result = await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
       blurb: '回声',
       hostJs: `export const name = 'store-echo'\nexport function apply(ctx: { ok: boolean }) { return ctx.ok }`,
     })
-    assert.equal(result.pluginPath, join(pluginDir, 'store-echo'))
+    assert.equal(result.sandboxPath, join(sandboxDir, 'store-echo'))
+    const packed = await store.pack('store-echo')
+    assert.equal(packed.pluginPath, join(pluginDir, 'store-echo'))
     const manifest = JSON.parse(await readFile(join(pluginDir, 'store-echo', 'manifest.json'), 'utf8')) as {
       id: string
       name: string
@@ -34,6 +41,33 @@ test('create dumps compiled files into .plugin/<id>/', async () => {
     const hostJs = await readFile(join(pluginDir, 'store-echo', 'host.js'), 'utf8')
     assert.match(hostJs, /\bapply\b/)
     assert.doesNotMatch(hostJs, /ctx: \{/)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('pack bundles relative imports from sandbox', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-pack-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'plugins.sqlite'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await store.initSandbox({ id: 'store-math', name: 'Math' })
+    const sandbox = join(dir, '.plugin-dev', 'store-math')
+    await writeFile(join(sandbox, 'util.ts'), `export const ping = 'pong'\n`)
+    await writeFile(
+      join(sandbox, 'host.ts'),
+      `import { ping } from './util.ts'\nexport const name = 'store-math'\nexport function apply() { return ping }\n`,
+    )
+    await store.pack('store-math')
+    const hostJs = await readFile(join(dir, '.plugin', 'store-math', 'host.js'), 'utf8')
+    assert.match(hostJs, /pong/)
+    assert.doesNotMatch(hostJs, /from ['"]\.\/util/)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/cap-plugin-store/src/host/plugin-create.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.ts
@@ -1,3 +1,6 @@
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import type { Context } from 'cordis'
 import type { PluginStoreService } from './index.ts'
 
@@ -9,7 +12,14 @@ export type PluginCreateInput = {
   webJs?: string
 }
 
-/** 当前进程内把 TS/TSX 编成 ESM 字符串。不 spawn vite/tsc，不 watch，不重启 host。 */
+const HOST_ENTRIES = ['host.ts', 'host.tsx', 'host.js']
+const WEB_ENTRIES = ['web.tsx', 'web.ts', 'web.js']
+
+export function findEntry(dir: string, names: string[]) {
+  return names.map((name) => join(dir, name)).find((path) => existsSync(path)) ?? null
+}
+
+/** 单文件 TS/TSX → ESM（无 bundle）。 */
 export async function compileStoreModule(source: string, kind: 'host' | 'web') {
   const trimmed = source.trim()
   if (!trimmed) throw new Error(`${kind} source is empty`)
@@ -23,21 +33,59 @@ export async function compileStoreModule(source: string, kind: 'host' | 'web') {
     jsxFragment: 'React.Fragment',
     sourcemap: false,
   })
-  let code = result.code.trim()
-  if (kind === 'web' && /React\.createElement/.test(code) && !code.includes('globalThis.React')) {
-    code = `const React = globalThis.React\n${code}`
+  return finishBundle(result.code, kind)
+}
+
+/** 沙箱入口打包：可相对 import 同目录其它文件。 */
+export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') {
+  const { build } = await import('esbuild')
+  const result = await build({
+    absWorkingDir: dirname(entryFile),
+    entryPoints: [entryFile],
+    bundle: true,
+    write: false,
+    format: 'esm',
+    platform: 'neutral',
+    target: 'es2022',
+    jsx: 'transform',
+    jsxFactory: 'React.createElement',
+    jsxFragment: 'React.Fragment',
+    logLevel: 'silent',
+  })
+  const text = result.outputFiles?.[0]?.text
+  if (!text?.trim()) throw new Error(`${kind} bundle is empty`)
+  return finishBundle(text, kind)
+}
+
+function finishBundle(code: string, kind: 'host' | 'web') {
+  let out = code.trim()
+  if (kind === 'web' && /React\.createElement/.test(out) && !out.includes('globalThis.React')) {
+    out = `const React = globalThis.React\n${out}`
   }
-  return code.endsWith('\n') ? code : `${code}\n`
+  return out.endsWith('\n') ? out : `${out}\n`
+}
+
+export async function readSandboxManifest(dir: string) {
+  const raw = JSON.parse(await readFile(join(dir, 'manifest.json'), 'utf8')) as {
+    id?: string
+    name?: string
+    blurb?: string
+  }
+  if (!raw.id || !raw.name) throw new Error(`invalid plugin manifest in ${dir}`)
+  return { id: raw.id, name: raw.name, blurb: String(raw.blurb ?? '').trim() || raw.name }
 }
 
 const PLUGIN_CREATE_DESCRIPTION = [
-  '把 Cordis 商店插件写入仓库根 .plugin/<id>/（manifest.json，以及按需的 host.js / web.js）。不要用 fs_write/bash 改 packages/ 或 cordis.plugins.json，也不要写 .biu 或 plugin-catalog。',
-  'hostJs 与 webJs 按需二选一：只要后端就只交 hostJs；只要前端就只交 webJs；两边都要才两个都交。至少交一个。',
-  '没有 .plugin 或目录为空时商店显示「没有插件」。本工具会建 .plugin/<id>/。可交 TS/TSX：当前 host 进程内 esbuild.transform 成 ESM 再落盘。',
-  '打开把 enabled 置 1 并运行；关闭停运行并保留 .plugin/<id>/。「卸载」才会删掉 .plugin/<id>/ 代码。没有「安装」。',
-  '契约：id 与 export const name 必须相同。副作用必须走 ctx。Host：ctx.http.route。Web：ctx.slots.place("plugin-store-extras", Comp, { key })。',
-  'Host 最小示例：export const name = "store-echo"; export const inject = ["http"]; export function apply(ctx) { ctx.http.route("GET", "/api/store-echo", (route) => { route.send(200, { ok: true }); }); }',
-  'Web 最小示例：export const name = "store-echo-web"; export const inject = ["slots"]; function Banner() { return <div>echo 已运行</div>; } export function apply(ctx) { ctx.slots.place("plugin-store-extras", Banner, { key: "store-echo-banner", order: 10 }); }',
+  '在仓库根 .plugin-dev/<id>/ 开一个插件沙箱（不是最终货架）。用 bash / str_replace_editor 在这个目录里写代码、加文件、相对 import，不要把整份源码塞进本工具参数。',
+  '本工具只建/更新沙箱：manifest.json，以及可选写入 host.ts / web.tsx 作为起点。不要改 packages/ 或 cordis.plugins.json。',
+  'host 与 web 按需：只要后端就 host.ts，只要前端就 web.tsx，两边都要就两个都有。可以再加 util.ts 等，打包时 esbuild bundle。',
+  '调完后必须再调 plugin_pack，才会打进 .plugin/<id>/ 出现在商店。打开/关闭只影响已打包货架；卸载删的是 .plugin/<id>/，沙箱还在。',
+  '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。Web：ctx.slots.place("plugin-store-extras", Comp, { key })。',
+].join(' ')
+
+const PLUGIN_PACK_DESCRIPTION = [
+  '把 .plugin-dev/<id>/ 沙箱打包进 .plugin/<id>/（manifest.json + 编好的 host.js / web.js）。多文件会 bundle 成各一个入口文件。',
+  '入口：host.ts|host.tsx|host.js 与 web.tsx|web.ts|web.js，至少要有一个。调完商店才看得到。已打开的插件会重新挂上。',
 ].join(' ')
 
 export function registerPluginCreate(ctx: Context, store: PluginStoreService) {
@@ -49,25 +97,23 @@ export function registerPluginCreate(ctx: Context, store: PluginStoreService) {
       properties: {
         id: {
           type: 'string',
-          description: '插件 id：小写字母开头，仅 [a-z0-9-]，最长 41。建议 store-foo。目录就是 .plugin/<id>/。',
+          description: '插件 id：小写字母开头，仅 [a-z0-9-]，最长 41。沙箱目录 .plugin-dev/<id>/。',
         },
-        name: { type: 'string', description: '商店卡片标题，给人看的短名' },
-        blurb: { type: 'string', description: '一行简介，出现在卡片上' },
+        name: { type: 'string', description: '商店卡片标题' },
+        blurb: { type: 'string', description: '一行简介' },
         hostJs: {
           type: 'string',
-          description:
-            '可选。需要后端时交 Host 源码（可 TS）：export const name（等于 id）、export const inject、export function apply(ctx)。不要为了凑数写空 host。',
+          description: '可选。写入沙箱 host.ts 的起点源码，不是最终货架。大逻辑请用文件工具在沙箱里改。',
         },
         webJs: {
           type: 'string',
-          description:
-            "可选。需要前端时交 Client 源码（可 TSX）：export const name、export const inject=['slots']、export function apply(ctx)。UI 必须 ctx.slots.place('plugin-store-extras', Component, { key })。不要为了凑数写空 web。",
+          description: '可选。写入沙箱 web.tsx 的起点源码。大逻辑请在沙箱里改。',
         },
       },
       required: ['id', 'name'],
     },
     execute: async (args) => {
-      const result = await store.create({
+      const result = await store.initSandbox({
         id: String(args.id ?? ''),
         name: String(args.name ?? ''),
         blurb: args.blurb != null ? String(args.blurb) : undefined,
@@ -77,4 +123,18 @@ export function registerPluginCreate(ctx: Context, store: PluginStoreService) {
       return JSON.stringify(result)
     },
   })
+  ctx.tools.register({
+    name: 'plugin_pack',
+    description: PLUGIN_PACK_DESCRIPTION,
+    parameters: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: '要打包的插件 id，对应 .plugin-dev/<id>/' },
+      },
+      required: ['id'],
+    },
+    execute: async (args) => JSON.stringify(await store.pack(String(args.id ?? ''))),
+  })
 }
+
+export { HOST_ENTRIES, WEB_ENTRIES }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     host: '127.0.0.1',
     watch: {
       // 商店插件写在仓库根 .plugin，不能触发 Vite 整页刷新
-      ignored: ['**/.plugin/**'],
+      ignored: ['**/.plugin/**', '**/.plugin-dev/**'],
     },
     proxy: {
       '/api': 'http://127.0.0.1:3141',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 在 `.plugin-dev/<id>/` 里写代码、相对 import；`plugin_pack` 用 esbuild bundle 进 `.plugin/<id>/`。`plugin_create` 只建沙箱，不再把整份源码塞进工具参数当主路径。卸载只删货架目录，沙箱保留。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a398f0e-a611-4745-ab4d-45d3957f3a20?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a398f0e-a611-4745-ab4d-45d3957f3a20&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

