### PR TITLE
右侧检查器 tab 选中改为底部白条

### DIFF
--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -2088,14 +2088,6 @@ function TasksBoard({
                   {task.blocked ? (
                     <span className="tasks-card-blocked" title="被依赖任务阻塞，无法开工"><LuLock size={11} aria-hidden /></span>
                   ) : null}
-                  <span className={`tasks-card-badge is-p-${task.priority}`} title={`优先级：${PRIORITY_LABEL[task.priority]}`}>
-                    <LuFlag size={10} aria-hidden />
-                    {PRIORITY_LABEL[task.priority]}
-                  </span>
-                  <span className={`tasks-card-badge is-d-${task.difficulty}`} title={`难度：${DIFFICULTY_LABEL[task.difficulty]}`}>
-                    <LuGauge size={10} aria-hidden />
-                    {DIFFICULTY_LABEL[task.difficulty]}
-                  </span>
                 </div>
                 {task.description ? (
                   <div className="tasks-card-desc" title={task.description}>
@@ -2119,6 +2111,16 @@ function TasksBoard({
                       {new Date(task.dueAt).toLocaleDateString()}
                     </span>
                   ) : null}
+                </div>
+                <div className="tasks-card-badges">
+                  <span className={`tasks-card-badge is-p-${task.priority}`} title={`优先级：${PRIORITY_LABEL[task.priority]}`}>
+                    <LuFlag size={10} aria-hidden />
+                    {PRIORITY_LABEL[task.priority]}
+                  </span>
+                  <span className={`tasks-card-badge is-d-${task.difficulty}`} title={`难度：${DIFFICULTY_LABEL[task.difficulty]}`}>
+                    <LuGauge size={10} aria-hidden />
+                    {DIFFICULTY_LABEL[task.difficulty]}
+                  </span>
                 </div>
                 {(task.project || task.tags?.length) ? (
                   <div className="tasks-card-tags">
@@ -3690,6 +3692,7 @@ if (typeof document !== 'undefined') {
 .tasks-card-meta { display:flex; align-items:center; gap:6px; font-size:10px; color:var(--dsw-label-3); margin-top:2px; }
 .tasks-card-assignee { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .tasks-card-reports { margin-left:auto; color:var(--dsw-label-2); }
+.tasks-card-badges { display:flex; align-items:center; gap:4px; flex-wrap:wrap; }
 .tasks-card-tags { display:flex; align-items:center; gap:4px; flex-wrap:wrap; padding-top:5px; border-top:1px solid color-mix(in srgb, var(--dsw-border) 60%, transparent); }
 .tasks-card-due.is-overdue { color:var(--dsw-danger); font-weight:650; }
 .tasks-board-empty { color:var(--dsw-label-3); font-size:11px; padding:14px 6px; text-align:center; }

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -2097,7 +2097,11 @@ function TasksBoard({
                     {DIFFICULTY_LABEL[task.difficulty]}
                   </span>
                 </div>
-                {task.description ? <div className="tasks-card-desc">{task.description}</div> : null}
+                {task.description ? (
+                  <div className="tasks-card-desc" title={task.description}>
+                    {task.description}
+                  </div>
+                ) : null}
                 <div className="tasks-card-meta">
                   {task.assignee && task.assignee.kind === 'agent' && task.assignee.mascot ? (
                     <MascotAvatar
@@ -3659,7 +3663,7 @@ if (typeof document !== 'undefined') {
 /* ---- 看板视图（Notion 风格：极轻边框、无重色、悬浮轻阴影）---- */
 .tasks-board { display:grid; grid-template-columns:repeat(5, minmax(190px, 1fr)); gap:10px; margin-top:10px; align-items:start; overflow-x:auto; }
 .tasks-board.is-compact { gap:8px; }
-.tasks-board-col { display:flex; flex-direction:column; min-height:120px; background:color-mix(in srgb, var(--dsw-muted-fill) 38%, transparent); border-radius:10px; padding:6px; }
+.tasks-board-col { display:flex; flex-direction:column; min-width:0; min-height:120px; background:color-mix(in srgb, var(--dsw-muted-fill) 38%, transparent); border-radius:10px; padding:6px; }
 .tasks-board-colhead { display:flex; align-items:center; gap:6px; padding:4px 6px 8px; color:var(--dsw-label-2); font-size:11px; font-weight:600; }
 .tasks-board-col.is-overdue .tasks-board-colhead { color:var(--dsw-danger); font-weight:700; }
 .tasks-board-col.is-blocked .tasks-board-colhead { color:#9a6700; }
@@ -3667,7 +3671,7 @@ if (typeof document !== 'undefined') {
 .tasks-board-col.is-done .tasks-board-colhead { color:#2f7d4c; }
 .tasks-board-count { margin-left:auto; color:var(--dsw-label-3); font-size:10px; font-weight:600; background:var(--dsw-muted-fill); border-radius:8px; padding:1px 6px; }
 .tasks-board-list { display:flex; flex-direction:column; gap:6px; }
-.tasks-card { display:flex; flex-direction:column; gap:5px; width:100%; text-align:left; border:0; border-radius:7px; padding:8px 9px; background:var(--dsw-surface); color:var(--dsw-label); font:inherit; cursor:pointer; box-shadow:0 0 0 1px color-mix(in srgb, var(--dsw-border) 65%, transparent); transition:box-shadow .12s ease, transform .08s ease; }
+.tasks-card { display:flex; flex-direction:column; gap:5px; width:100%; min-width:0; overflow:hidden; text-align:left; border:0; border-radius:7px; padding:8px 9px; background:var(--dsw-surface); color:var(--dsw-label); font:inherit; cursor:pointer; box-shadow:0 0 0 1px color-mix(in srgb, var(--dsw-border) 65%, transparent); transition:box-shadow .12s ease, transform .08s ease; }
 .tasks-card:hover { box-shadow:0 1px 3px rgba(0,0,0,.08), 0 0 0 1px color-mix(in srgb, var(--dsw-border) 85%, transparent); transform:translateY(-1px); }
 .tasks-card.is-active { background:color-mix(in srgb, var(--dsw-business) 6%, var(--dsw-surface)); }
 .tasks-card-title { display:flex; align-items:flex-start; gap:6px; font-size:12px; font-weight:620; line-height:1.35; }
@@ -3682,7 +3686,7 @@ if (typeof document !== 'undefined') {
 .tasks-card-badge.is-d-high { color:#d64545; background:color-mix(in srgb, #d64545 12%, transparent); }
 .tasks-card-badge.is-d-med { color:#e07a2f; background:color-mix(in srgb, #e07a2f 12%, transparent); }
 .tasks-card-badge.is-d-low { color:#3d9a5f; background:color-mix(in srgb, #3d9a5f 12%, transparent); }
-.tasks-card-desc { font-size:11px; color:var(--dsw-label-2); line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
+.tasks-card-desc { min-width:0; max-width:100%; font-size:11px; color:var(--dsw-label-2); line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; overflow-wrap:anywhere; word-break:break-word; }
 .tasks-card-meta { display:flex; align-items:center; gap:6px; font-size:10px; color:var(--dsw-label-3); margin-top:2px; }
 .tasks-card-assignee { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .tasks-card-reports { margin-left:auto; color:var(--dsw-label-2); }

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -29,13 +29,6 @@ function inspectorStoredTab(sid: string | null | undefined, allowed: string[]): 
   return undefined
 }
 
-const tabClass = (active: boolean) =>
-  `inline-flex cursor-pointer items-center gap-1.5 rounded-[6px] border-0 px-2 py-1.5 text-[11px] font-semibold ${
-    active
-      ? 'bg-[color-mix(in_srgb,var(--dsw-business)_14%,transparent)] text-[var(--dsw-business)]'
-      : 'bg-transparent text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]'
-  }`
-
 export const SessionInspector = memo(function SessionInspector({
   open,
   width,
@@ -143,21 +136,25 @@ export const SessionInspector = memo(function SessionInspector({
       />
 
       <div className="app-side-bar-head">
-        <div className="flex min-w-0 items-center gap-1" role="tablist" aria-label="检查器分区">
-          {extraTabs.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              role="tab"
-              aria-selected={tab === item.id}
-              className={tabClass(tab === item.id)}
-              onClick={() => setTab(item.id)}
-              data-testid={`inspector-tab-${item.id}`}
-            >
-              {item.Icon ? <item.Icon className="size-3.5" /> : <LuLayoutGrid className="size-3.5" />}
-              {item.label}
-            </button>
-          ))}
+        <div className="inspector-tabs" role="tablist" aria-label="检查器分区">
+          {extraTabs.map((item) => {
+            const active = tab === item.id
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="tab"
+                aria-selected={active}
+                className={`inspector-tab${active ? ' is-active' : ''}`}
+                onClick={() => setTab(item.id)}
+                data-testid={`inspector-tab-${item.id}`}
+              >
+                <span className="inspector-tab-indicator" aria-hidden />
+                {item.Icon ? <item.Icon className="size-3.5" /> : <LuLayoutGrid className="size-3.5" />}
+                {item.label}
+              </button>
+            )
+          })}
         </div>
         <button
           type="button"

--- a/web/style.css
+++ b/web/style.css
@@ -209,6 +209,51 @@ body {
   padding: 0 12px;
 }
 
+/* 右侧检查器 tab：选中用底部白色指示条，与左栏 activity 的侧边条同一套语言 */
+.inspector-tabs {
+  display: flex;
+  min-width: 0;
+  align-items: stretch;
+  align-self: stretch;
+  gap: 2px;
+}
+
+.inspector-tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  padding: 0 8px;
+  color: var(--dsw-label-3);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.inspector-tab:hover {
+  color: var(--dsw-label);
+}
+
+.inspector-tab.is-active {
+  color: var(--dsw-label);
+}
+
+.inspector-tab-indicator {
+  position: absolute;
+  right: 8px;
+  bottom: 0;
+  left: 8px;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: transparent;
+}
+
+.inspector-tab.is-active .inspector-tab-indicator {
+  background: var(--dsw-business);
+}
+
 .chat-view-header-left,
 .chat-view-header-right {
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 右侧检查器 tab
右侧边栏分区 tab 原先选中时是浅色填充背景。现改为与左栏 activity 相同的指示条语言：无背景色，选中项底部出现 2px 白色（`--dsw-business`）边条，文字加亮。

## 看板卡片
- 描述过长不再撑破列宽：最多两行截断并断词，悬停可看全文。
- 优先级、难度徽标从标题行移到卡片下方，标题单独占行，不再被徽标挤占。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

