### PR TITLE
fix: 插件商店 API 404（补 defaultDbPath）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 dist/
 .cordis/
-.plugin/index.json
+.plugin/store.json
 .plugin-dev/*
 !.plugin-dev/store-heavy-ping/
 !.plugin-dev/store-heavy-ping/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 dist/
 .cordis/
-.plugin/store.json
+.plugin/index.json
 .plugin-dev/*
 !.plugin-dev/store-heavy-ping/
 !.plugin-dev/store-heavy-ping/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 .cordis/
+.plugin/store.json
 .plugin-dev/*
 !.plugin-dev/store-heavy-ping/
 !.plugin-dev/store-heavy-ping/**

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -42,9 +42,9 @@ test('default plugin dir is repo-root .plugin, not nested catalog', () => {
   assert.equal(dir.includes('.biu'), false)
 })
 
-test('default store state is a json file under .plugin', () => {
+test('default store state is .plugin/index.json', () => {
   const path = defaultStatePath().replace(/\\/g, '/')
-  assert.ok(path.endsWith('/.plugin/store.json') || path.endsWith('.plugin/store.json'))
+  assert.ok(path.endsWith('/.plugin/index.json') || path.endsWith('.plugin/index.json'))
 })
 
 test('restore skips a broken enabled plugin and continues', async () => {
@@ -53,7 +53,7 @@ test('restore skips a broken enabled plugin and continues', async () => {
   try {
     const ctx = new Context()
     const { adopted } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-ok',
       name: 'Ok',
@@ -67,7 +67,7 @@ test('restore skips a broken enabled plugin and continues', async () => {
     })
     await store.openPlugin('store-bad')
     await writeFile(join(pluginDir, 'store-bad', 'host.js'), 'throw new SyntaxError("nope")\n')
-    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     await store2.restore()
     assert.ok(adopted.includes('store-ok'))
   } finally {
@@ -80,7 +80,7 @@ test('missing .plugin lists no plugins', async () => {
   try {
     const ctx = new Context()
     stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     assert.deepEqual(await store.list(), [])
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -93,7 +93,7 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
   try {
     const ctx = new Context()
     const { adopted, dropped, forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     const created = await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -106,7 +106,7 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
 
     const opened = await store.openPlugin('store-echo')
     assert.equal(opened?.enabled, true)
-    const saved = JSON.parse(await readFile(join(dir, 'store.json'), 'utf8')) as { enabled: string[] }
+    const saved = JSON.parse(await readFile(join(dir, 'index.json'), 'utf8')) as { enabled: string[] }
     assert.deepEqual(saved.enabled, ['store-echo'])
     assert.deepEqual(adopted, ['store-echo'])
     assert.equal(forks.get('store-echo')?.packageName, 'store:store-echo')
@@ -131,7 +131,7 @@ test('web-only plugin opens without host.js', async () => {
   try {
     const ctx = new Context()
     const { forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     await store.initSandbox({
       id: 'store-banner',
       name: 'Banner',

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -1,12 +1,12 @@
 /** @vitest-environment node */
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { access, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { access, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
-import { PluginStoreService, defaultPluginDir, defaultDbPath } from './index.ts'
+import { PluginStoreService, defaultPluginDir, defaultStatePath } from './index.ts'
 
 function stubHub(ctx: Context) {
   const adopted: string[] = []
@@ -42,13 +42,18 @@ test('default plugin dir is repo-root .plugin, not nested catalog', () => {
   assert.equal(dir.includes('.biu'), false)
 })
 
+test('default store state is a json file under .plugin', () => {
+  const path = defaultStatePath().replace(/\\/g, '/')
+  assert.ok(path.endsWith('/.plugin/store.json') || path.endsWith('.plugin/store.json'))
+})
+
 test('restore skips a broken enabled plugin and continues', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
   const pluginDir = join(dir, '.plugin')
   try {
     const ctx = new Context()
     const { adopted } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-ok',
       name: 'Ok',
@@ -62,7 +67,7 @@ test('restore skips a broken enabled plugin and continues', async () => {
     })
     await store.openPlugin('store-bad')
     await writeFile(join(pluginDir, 'store-bad', 'host.js'), 'throw new SyntaxError("nope")\n')
-    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store2.restore()
     assert.ok(adopted.includes('store-ok'))
   } finally {
@@ -75,7 +80,7 @@ test('missing .plugin lists no plugins', async () => {
   try {
     const ctx = new Context()
     stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     assert.deepEqual(await store.list(), [])
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -88,7 +93,7 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
   try {
     const ctx = new Context()
     const { adopted, dropped, forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     const created = await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -101,6 +106,8 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
 
     const opened = await store.openPlugin('store-echo')
     assert.equal(opened?.enabled, true)
+    const saved = JSON.parse(await readFile(join(dir, 'store.json'), 'utf8')) as { enabled: string[] }
+    assert.deepEqual(saved.enabled, ['store-echo'])
     assert.deepEqual(adopted, ['store-echo'])
     assert.equal(forks.get('store-echo')?.packageName, 'store:store-echo')
     assert.equal(forks.get('store-echo')?.web, undefined)
@@ -124,7 +131,7 @@ test('web-only plugin opens without host.js', async () => {
   try {
     const ctx = new Context()
     const { forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.initSandbox({
       id: 'store-banner',
       name: 'Banner',

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -1,12 +1,12 @@
 /** @vitest-environment node */
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { access, mkdtemp, rm } from 'node:fs/promises'
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
-import { PluginStoreService, defaultPluginDir } from './index.ts'
+import { PluginStoreService, defaultPluginDir, defaultDbPath } from './index.ts'
 
 function stubHub(ctx: Context) {
   const adopted: string[] = []
@@ -40,6 +40,34 @@ test('default plugin dir is repo-root .plugin, not nested catalog', () => {
   assert.equal(dir.endsWith('/.plugin') || dir.endsWith('.plugin'), true)
   assert.equal(dir.includes('plugin-catalog'), false)
   assert.equal(dir.includes('.biu'), false)
+})
+
+test('restore skips a broken enabled plugin and continues', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
+  const pluginDir = join(dir, '.plugin')
+  try {
+    const ctx = new Context()
+    const { adopted } = stubHub(ctx)
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    await store.create({
+      id: 'store-ok',
+      name: 'Ok',
+      hostJs: `export const name = 'store-ok'\nexport function apply() {}\n`,
+    })
+    await store.openPlugin('store-ok')
+    await store.create({
+      id: 'store-bad',
+      name: 'Bad',
+      hostJs: `export const name = 'store-bad'\nexport function apply() {}\n`,
+    })
+    await store.openPlugin('store-bad')
+    await writeFile(join(pluginDir, 'store-bad', 'host.js'), 'throw new SyntaxError("nope")\n')
+    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    await store2.restore()
+    assert.ok(adopted.includes('store-ok'))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 })
 
 test('missing .plugin lists no plugins', async () => {

--- a/packages/cap-plugin-store/src/host/index.test.ts
+++ b/packages/cap-plugin-store/src/host/index.test.ts
@@ -42,9 +42,9 @@ test('default plugin dir is repo-root .plugin, not nested catalog', () => {
   assert.equal(dir.includes('.biu'), false)
 })
 
-test('default store state is .plugin/index.json', () => {
+test('default store state is .plugin/store.json', () => {
   const path = defaultStatePath().replace(/\\/g, '/')
-  assert.ok(path.endsWith('/.plugin/index.json') || path.endsWith('.plugin/index.json'))
+  assert.ok(path.endsWith('/.plugin/store.json') || path.endsWith('.plugin/store.json'))
 })
 
 test('restore skips a broken enabled plugin and continues', async () => {
@@ -53,7 +53,7 @@ test('restore skips a broken enabled plugin and continues', async () => {
   try {
     const ctx = new Context()
     const { adopted } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-ok',
       name: 'Ok',
@@ -67,7 +67,7 @@ test('restore skips a broken enabled plugin and continues', async () => {
     })
     await store.openPlugin('store-bad')
     await writeFile(join(pluginDir, 'store-bad', 'host.js'), 'throw new SyntaxError("nope")\n')
-    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store2 = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store2.restore()
     assert.ok(adopted.includes('store-ok'))
   } finally {
@@ -80,7 +80,7 @@ test('missing .plugin lists no plugins', async () => {
   try {
     const ctx = new Context()
     stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, 'missing'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     assert.deepEqual(await store.list(), [])
   } finally {
     await rm(dir, { recursive: true, force: true })
@@ -93,7 +93,7 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
   try {
     const ctx = new Context()
     const { adopted, dropped, forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     const created = await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -106,7 +106,7 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
 
     const opened = await store.openPlugin('store-echo')
     assert.equal(opened?.enabled, true)
-    const saved = JSON.parse(await readFile(join(dir, 'index.json'), 'utf8')) as { enabled: string[] }
+    const saved = JSON.parse(await readFile(join(dir, 'store.json'), 'utf8')) as { enabled: string[] }
     assert.deepEqual(saved.enabled, ['store-echo'])
     assert.deepEqual(adopted, ['store-echo'])
     assert.equal(forks.get('store-echo')?.packageName, 'store:store-echo')
@@ -131,7 +131,7 @@ test('web-only plugin opens without host.js', async () => {
   try {
     const ctx = new Context()
     const { forks } = stubHub(ctx)
-    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, join(dir, '.plugin'), join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.initSandbox({
       id: 'store-banner',
       name: 'Banner',

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -53,7 +53,7 @@ export function defaultSandboxDir() {
 }
 
 export function defaultStatePath() {
-  return process.env.BIU_PLUGIN_STATE || join(process.cwd(), '.plugin', 'index.json')
+  return process.env.BIU_PLUGIN_STATE || join(process.cwd(), '.plugin', 'store.json')
 }
 
 function isSafeId(id: string) {

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -58,6 +58,10 @@ export function defaultSandboxDir() {
   return process.env.BIU_PLUGIN_DEV_DIR || join(process.cwd(), '.plugin-dev')
 }
 
+export function defaultDbPath() {
+  return process.env.BIU_PLUGIN_DB || join(process.cwd(), 'plugins.sqlite')
+}
+
 function isSafeId(id: string) {
   return /^[a-z][a-z0-9-]{1,40}$/.test(id)
 }
@@ -250,7 +254,11 @@ export class PluginStoreService extends Service {
     for (const row of rows) {
       const hit = await this.findPluginDir(row.id)
       if (!hit) continue
-      await this.mountFromDisk(await readManifest(hit), hit)
+      try {
+        await this.mountFromDisk(await readManifest(hit), hit)
+      } catch (error) {
+        this.ctx.logger('plugin-store').error(error)
+      }
     }
   }
 
@@ -305,7 +313,11 @@ export class PluginStoreService extends Service {
 
 export async function apply(ctx: Context) {
   const store = new PluginStoreService(ctx, defaultPluginDir(), defaultDbPath(), defaultSandboxDir()).open()
-  await store.restore()
+  try {
+    await store.restore()
+  } catch (error) {
+    ctx.logger('plugin-store').error(error)
+  }
   registerPluginCreate(ctx, store)
 
   ctx.http.route('GET', '/api/plugin-store', async (route) => {

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -1,9 +1,7 @@
-import { mkdirSync } from 'node:fs'
-import { existsSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { pathToFileURL } from 'node:url'
-import { createRequire } from 'node:module'
 import { Service, type Context, type Plugin } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
 import {
@@ -16,10 +14,6 @@ import {
   WEB_ENTRIES,
   type PluginCreateInput,
 } from './plugin-create.ts'
-
-type DatabaseSync = import('node:sqlite').DatabaseSync
-
-const require = createRequire(import.meta.url)
 
 export const name = 'plugin-store'
 export const inject = ['http', 'hub', 'tools']
@@ -58,8 +52,8 @@ export function defaultSandboxDir() {
   return process.env.BIU_PLUGIN_DEV_DIR || join(process.cwd(), '.plugin-dev')
 }
 
-export function defaultDbPath() {
-  return process.env.BIU_PLUGIN_DB || join(process.cwd(), 'plugins.sqlite')
+export function defaultStatePath() {
+  return process.env.BIU_PLUGIN_STATE || join(process.cwd(), '.plugin', 'store.json')
 }
 
 function isSafeId(id: string) {
@@ -84,30 +78,36 @@ async function readManifest(dir: string): Promise<StoreManifest> {
   return raw
 }
 
+type StoreState = { enabled: string[] }
+
+function emptyState(): StoreState {
+  return { enabled: [] }
+}
+
+function parseState(raw: unknown): StoreState {
+  if (!raw || typeof raw !== 'object') return emptyState()
+  const enabled = (raw as { enabled?: unknown }).enabled
+  if (!Array.isArray(enabled)) return emptyState()
+  return {
+    enabled: [...new Set(enabled.map((id) => String(id)).filter((id) => /^[a-z][a-z0-9-]{1,40}$/.test(id)))].sort(),
+  }
+}
+
 export class PluginStoreService extends Service {
-  private db!: DatabaseSync
+  private state: StoreState = emptyState()
 
   constructor(
     ctx: Context,
     readonly pluginDir: string,
-    private readonly dbPath: string,
+    private readonly statePath: string,
     readonly sandboxDir: string = defaultSandboxDir(),
   ) {
     super(ctx, 'pluginStore')
   }
 
   open() {
-    mkdirSync(dirname(this.dbPath), { recursive: true })
-    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
-    this.db = new DatabaseSync(this.dbPath)
-    this.db.exec('PRAGMA journal_mode = WAL')
-    this.db.exec('PRAGMA synchronous = NORMAL')
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS store_plugins (
-        id TEXT PRIMARY KEY,
-        enabled INTEGER NOT NULL DEFAULT 0
-      );
-    `)
+    mkdirSync(dirname(this.statePath), { recursive: true })
+    this.state = this.readState()
     return this
   }
 
@@ -115,20 +115,30 @@ export class PluginStoreService extends Service {
     return this.ctx.hub as unknown as StoreHub
   }
 
+  private readState(): StoreState {
+    if (!existsSync(this.statePath)) return emptyState()
+    try {
+      return parseState(JSON.parse(readFileSync(this.statePath, 'utf8')))
+    } catch {
+      return emptyState()
+    }
+  }
+
+  private writeState() {
+    mkdirSync(dirname(this.statePath), { recursive: true })
+    writeFileSync(this.statePath, `${JSON.stringify(this.state, null, 2)}\n`)
+  }
+
   private isEnabled(id: string) {
-    const row = this.db.prepare('SELECT enabled FROM store_plugins WHERE id = ?').get(id) as
-      | { enabled: number }
-      | undefined
-    return row?.enabled === 1
+    return this.state.enabled.includes(id)
   }
 
   private setEnabled(id: string, enabled: boolean) {
-    this.db
-      .prepare(
-        `INSERT INTO store_plugins (id, enabled) VALUES (?, ?)
-         ON CONFLICT(id) DO UPDATE SET enabled = excluded.enabled`,
-      )
-      .run(id, enabled ? 1 : 0)
+    const next = new Set(this.state.enabled)
+    if (enabled) next.add(id)
+    else next.delete(id)
+    this.state = { enabled: [...next].sort() }
+    this.writeState()
   }
 
   pluginPath(id: string) {
@@ -244,15 +254,14 @@ export class PluginStoreService extends Service {
   async uninstall(id: string) {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     await this.hub().drop(id)
-    this.db.prepare('DELETE FROM store_plugins WHERE id = ?').run(id)
+    this.setEnabled(id, false)
     const hit = await this.findPluginDir(id)
     if (hit) await rm(hit, { recursive: true, force: true })
   }
 
   async restore() {
-    const rows = this.db.prepare('SELECT id FROM store_plugins WHERE enabled = 1').all() as Array<{ id: string }>
-    for (const row of rows) {
-      const hit = await this.findPluginDir(row.id)
+    for (const id of this.state.enabled) {
+      const hit = await this.findPluginDir(id)
       if (!hit) continue
       try {
         await this.mountFromDisk(await readManifest(hit), hit)
@@ -312,7 +321,7 @@ export class PluginStoreService extends Service {
 }
 
 export async function apply(ctx: Context) {
-  const store = new PluginStoreService(ctx, defaultPluginDir(), defaultDbPath(), defaultSandboxDir()).open()
+  const store = new PluginStoreService(ctx, defaultPluginDir(), defaultStatePath(), defaultSandboxDir()).open()
   try {
     await store.restore()
   } catch (error) {

--- a/packages/cap-plugin-store/src/host/index.ts
+++ b/packages/cap-plugin-store/src/host/index.ts
@@ -53,7 +53,7 @@ export function defaultSandboxDir() {
 }
 
 export function defaultStatePath() {
-  return process.env.BIU_PLUGIN_STATE || join(process.cwd(), '.plugin', 'store.json')
+  return process.env.BIU_PLUGIN_STATE || join(process.cwd(), '.plugin', 'index.json')
 }
 
 function isSafeId(id: string) {

--- a/packages/cap-plugin-store/src/host/plugin-create.test.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.test.ts
@@ -22,7 +22,7 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
     const ctx = new Context()
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -47,7 +47,7 @@ test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
     const sandboxDir = join(dir, '.plugin-dev')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), sandboxDir).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), sandboxDir).open()
     const result = await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
@@ -78,7 +78,7 @@ test('pack bundles relative imports from sandbox', async () => {
     const store = new PluginStoreService(
       ctx,
       join(dir, '.plugin'),
-      join(dir, 'index.json'),
+      join(dir, 'store.json'),
       join(dir, '.plugin-dev'),
     ).open()
     await store.initSandbox({ id: 'store-math', name: 'Math' })
@@ -108,7 +108,7 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   const store = new PluginStoreService(
     ctx,
     '/tmp/plugin-store-tools/.plugin',
-    '/tmp/plugin-store-tools/index.json',
+    '/tmp/plugin-store-tools/store.json',
     '/tmp/plugin-store-tools/.plugin-dev',
   )
   registerPluginCreate(ctx, store)

--- a/packages/cap-plugin-store/src/host/plugin-create.test.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.test.ts
@@ -22,7 +22,7 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
     const ctx = new Context()
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -47,7 +47,7 @@ test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
     const sandboxDir = join(dir, '.plugin-dev')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'plugins.sqlite'), sandboxDir).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), sandboxDir).open()
     const result = await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
@@ -78,7 +78,7 @@ test('pack bundles relative imports from sandbox', async () => {
     const store = new PluginStoreService(
       ctx,
       join(dir, '.plugin'),
-      join(dir, 'plugins.sqlite'),
+      join(dir, 'store.json'),
       join(dir, '.plugin-dev'),
     ).open()
     await store.initSandbox({ id: 'store-math', name: 'Math' })
@@ -108,7 +108,7 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   const store = new PluginStoreService(
     ctx,
     '/tmp/plugin-store-tools/.plugin',
-    '/tmp/plugin-store-tools/plugins.sqlite',
+    '/tmp/plugin-store-tools/store.json',
     '/tmp/plugin-store-tools/.plugin-dev',
   )
   registerPluginCreate(ctx, store)

--- a/packages/cap-plugin-store/src/host/plugin-create.test.ts
+++ b/packages/cap-plugin-store/src/host/plugin-create.test.ts
@@ -22,7 +22,7 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
     const ctx = new Context()
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), join(dir, '.plugin-dev')).open()
     await store.create({
       id: 'store-echo',
       name: 'Echo',
@@ -47,7 +47,7 @@ test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
     const sandboxDir = join(dir, '.plugin-dev')
-    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), sandboxDir).open()
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'index.json'), sandboxDir).open()
     const result = await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
@@ -78,7 +78,7 @@ test('pack bundles relative imports from sandbox', async () => {
     const store = new PluginStoreService(
       ctx,
       join(dir, '.plugin'),
-      join(dir, 'store.json'),
+      join(dir, 'index.json'),
       join(dir, '.plugin-dev'),
     ).open()
     await store.initSandbox({ id: 'store-math', name: 'Math' })
@@ -108,7 +108,7 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   const store = new PluginStoreService(
     ctx,
     '/tmp/plugin-store-tools/.plugin',
-    '/tmp/plugin-store-tools/store.json',
+    '/tmp/plugin-store-tools/index.json',
     '/tmp/plugin-store-tools/.plugin-dev',
   )
   registerPluginCreate(ctx, store)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
原先 `plugin-store` 的 `apply()` 调用了不存在的 `defaultDbPath()`，host 插件挂载失败，`GET /api/plugin-store` 从未注册。

商店开关改为读写 `.plugin/store.json`：

```json
{ "enabled": ["store-hello"] }
```

单个坏包 restore 失败不会拖垮整个商店。重启 `npm run dev` 后接口应恢复。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

