### PR TITLE
聊天顶栏会话名、任务溢出与输入框粘贴图片

### DIFF
--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -1236,6 +1236,7 @@ export function apply(ctx: Context) {
       kind?: 'wake' | 'inject'
       wait?: boolean
       extraTools?: string[]
+      images?: Array<{ name?: string; mime?: string; url?: string }>
     }
     const agent = await ctx.agents.create(route.params.id)
     // re-sync in-memory LLM without rewriting disk
@@ -1246,6 +1247,7 @@ export function apply(ctx: Context) {
     const sendOpts = {
       ...(extraTools.length ? { extraTools } : {}),
       ...(payload.wait === false ? { wait: false as const } : {}),
+      ...(Array.isArray(payload.images) ? { images: payload.images } : {}),
     }
     if (payload.kind === 'inject') {
       agent.inject(payload.text ?? '', sendOpts)

--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -1,42 +1,21 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { LuEraser } from 'react-icons/lu'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
-import { formatTokens, type ChatNode } from '@biu/web-session-view'
 import { SessionProjectPanel } from './project-panel.tsx'
 
 type AgentMode = 'standard' | 'minimal'
 
-/** 最新一条 thread（reply）的历史上下文信息：占比 histPct + 历史 token 数（inputTokens×histPct）。 */
-function latestHistInfo(
-  nodes: ChatNode[],
-): { ratio: number; histTokens: number } | null {
-  const last = nodes.at(-1)
-  if (!last || last.kind !== 'reply') return null
-  const usage = last.usage
-  const hist = usage?.histPct
-  if (typeof hist !== 'number' || !Number.isFinite(hist)) return null
-  const input = usage?.inputTokens ?? 0
-  return {
-    ratio: Math.min(1, Math.max(0, hist)),
-    histTokens: Math.round(input * hist),
-  }
-}
-
-/** Dock 顶栏：左侧文件 + 标准/极简胶囊，右侧 auto/hold；同一水平线。 */
+/** Dock 顶栏：左侧文件 + 选取 + 清空上下文 + 标准/极简胶囊，右侧 auto/hold。 */
 export function ApprovalsRail(props: SlotProps) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const sessionView = props.sessionView as SessionViewService
   const sessionId = useSessionView((state) => state.sessionId)
   const approvals = useSessionView((state) => state.approvals)
   const approvalMode = useSessionView((state) => state.approvalMode)
-  const nodes = useSessionView((state) => state.nodes)
   const [agentMode, setAgentMode] = useState<AgentMode>('standard')
   const [modeBusy, setModeBusy] = useState(false)
   const [clearBusy, setClearBusy] = useState(false)
-
-  // 红色占比 = 最新一条 thread（reply）的 usage.histPct（历史输入占比）。
-  const histInfo = useMemo(() => latestHistInfo(nodes), [nodes])
 
   const refreshAgentMode = useCallback(async () => {
     try {
@@ -149,6 +128,16 @@ export function ApprovalsRail(props: SlotProps) {
         <div className="flex min-w-0 items-center gap-2">
           <SessionProjectPanel {...props} />
           {props.renderSlot('header-tools')}
+          <button
+            type="button"
+            disabled={!sessionId || clearBusy}
+            aria-label="清空上下文"
+            title="清空上下文"
+            className="project-chip project-chip-icon-only"
+            onClick={() => void clearContext()}
+          >
+            <LuEraser className="project-chip-icon" aria-hidden />
+          </button>
           <span className="sr-only">Agent mode</span>
           <div className="dock-seg">
             {([
@@ -171,30 +160,6 @@ export function ApprovalsRail(props: SlotProps) {
               </button>
             ))}
           </div>
-          <button
-            type="button"
-            disabled={!sessionId || clearBusy}
-            aria-label="清空上下文"
-            title="清空上下文（不经过大模型，写入一条日志）"
-            className="relative flex items-center gap-1 overflow-hidden rounded-full border border-[var(--dsw-border)] px-2 py-1 text-[var(--dsw-label-3)] transition-colors hover:bg-[var(--dsw-hover)] disabled:opacity-40"
-            onClick={() => void clearContext()}
-          >
-            {histInfo != null && histInfo.ratio > 0 ? (
-              <span
-                className="pointer-events-none absolute inset-0 bg-[var(--dsw-danger)]/20 transition-[width] duration-200"
-                style={{ width: `${Math.round(histInfo.ratio * 100)}%` }}
-                aria-hidden
-              />
-            ) : null}
-            <LuEraser className="relative h-3 w-3" aria-hidden />
-            {histInfo != null ? (
-              <span className="relative tabular-nums" title={`历史上下文占比 ${Math.round(histInfo.ratio * 100)}% · ${formatTokens(histInfo.histTokens)} token`}>
-                {Math.round(histInfo.ratio * 100)}%·{formatTokens(histInfo.histTokens)}
-              </span>
-            ) : (
-              <span className="relative tabular-nums">0</span>
-            )}
-          </button>
         </div>
         <div className="dock-seg">
           <span className="sr-only">Tool approval mode</span>

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -1,10 +1,11 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type ClipboardEvent, type DragEvent, type FormEvent, type KeyboardEvent } from 'react'
 import { LuChevronDown, LuPlus, LuSettings } from 'react-icons/lu'
 import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { formatPicks, PickChipLabel, usePickState, type PickService } from '@biu/cap-pick/web'
 import { ModelConfigDialog } from './model-config-dialog.tsx'
+import { ImageThumbs } from './image-thumbs.tsx'
 
 /** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
 const INPUT_DEBOUNCE_MS = 120
@@ -52,7 +53,30 @@ function clearDraft(sessionId: string) {
   }
 }
 
-type ToolCatalogItem = { name: string; description: string }
+const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
+const MAX_PENDING_IMAGES = 6
+
+type PendingImage = { id: string; name: string; mime: string; previewUrl: string; file: File }
+
+function collectImageFiles(list: FileList | File[] | null | undefined): File[] {
+  if (!list) return []
+  return [...list].filter((file) => IMAGE_MIMES.has(file.type))
+}
+
+function readFileDataUrl(file: File): Promise<{ name: string; mime: string; url: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onerror = () => reject(new Error('read image failed'))
+    reader.onload = () => {
+      resolve({
+        name: file.name || 'image.png',
+        mime: file.type || 'image/png',
+        url: String(reader.result ?? ''),
+      })
+    }
+    reader.readAsDataURL(file)
+  })
+}
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
 type ModelOption = {
@@ -63,6 +87,8 @@ type ModelOption = {
   model: string
   note?: string
 }
+
+type ToolCatalogItem = { name: string; description: string }
 
 type SlashState = {
   open: boolean
@@ -114,6 +140,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   })
   const [modelBusy, setModelBusy] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)
+  const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
   /** 各入口是否已配置 token（key = endpointId）。 */
@@ -147,15 +174,16 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   function syncComposerShape(
     el: HTMLTextAreaElement | null = textareaRef.current,
     toolsCount = picked.length + pickRefs.length,
+    imageCount = pendingImages.length,
   ) {
     if (!el) {
-      setExpanded(toolsCount > 0)
+      setExpanded(toolsCount > 0 || imageCount > 0)
       return
     }
     el.style.height = 'auto'
     const next = Math.min(el.scrollHeight, 140)
     el.style.height = `${Math.max(28, next)}px`
-    const multi = next > 36 || el.value.includes('\n') || toolsCount > 0
+    const multi = next > 36 || el.value.includes('\n') || toolsCount > 0 || imageCount > 0
     setExpanded(multi)
   }
 
@@ -331,8 +359,13 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     setActiveIndex(0)
   }, [slash?.query, slash?.open, filtered.length])
 
-  function scheduleCanSubmit(value: string, tools: string[] = picked, picks = pickRefs.length) {
-    const next = Boolean(value.trim()) || tools.length > 0 || picks > 0
+  function scheduleCanSubmit(
+    value: string,
+    tools: string[] = picked,
+    picks = pickRefs.length,
+    imageCount = pendingImages.length,
+  ) {
+    const next = Boolean(value.trim()) || tools.length > 0 || picks > 0 || imageCount > 0
     if (debounceRef.current != null) clearTimeout(debounceRef.current)
     if (next === canSubmitRef.current) {
       if (next) {
@@ -349,9 +382,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   }
 
   useEffect(() => {
-    scheduleCanSubmit(textareaRef.current?.value ?? '', picked, pickRefs.length)
-    syncComposerShape(textareaRef.current, picked.length + pickRefs.length)
-  }, [pickRefs.length, picked.length])
+    scheduleCanSubmit(textareaRef.current?.value ?? '', picked, pickRefs.length, pendingImages.length)
+    syncComposerShape(textareaRef.current, picked.length + pickRefs.length, pendingImages.length)
+  }, [pickRefs.length, picked.length, pendingImages.length])
 
   /** 输入防抖写草稿：停止输入约 300ms 后写入当前 session 的 localStorage 草稿。 */
   function schedulePersistDraft(text: string) {
@@ -386,7 +419,45 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     setCanSubmit(false)
     setSlash(null)
     setPicked([])
+    setPendingImages((prev) => {
+      for (const item of prev) URL.revokeObjectURL(item.previewUrl)
+      return []
+    })
     setExpanded(false)
+  }
+
+  const addImageFiles = useCallback((files: File[]) => {
+    const next = collectImageFiles(files)
+    if (!next.length) return
+    setPendingImages((prev) => {
+      const room = MAX_PENDING_IMAGES - prev.length
+      const take = next.slice(0, Math.max(0, room)).map((file) => ({
+        id: `${Date.now()}-${file.name}-${file.size}-${Math.random().toString(36).slice(2, 8)}`,
+        name: file.name || 'image.png',
+        mime: file.type || 'image/png',
+        previewUrl: URL.createObjectURL(file),
+        file,
+      }))
+      return take.length ? [...prev, ...take] : prev
+    })
+  }, [])
+
+  function onPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
+    const files = collectImageFiles(event.clipboardData?.files)
+    const fromItems = [...(event.clipboardData?.items ?? [])]
+      .map((item) => (item.kind === 'file' ? item.getAsFile() : null))
+      .filter((file): file is File => Boolean(file))
+    const images = collectImageFiles([...files, ...fromItems])
+    if (!images.length) return
+    addImageFiles(images)
+    if (!event.clipboardData?.getData('text/plain')) event.preventDefault()
+  }
+
+  function onDrop(event: DragEvent<HTMLFormElement>) {
+    const images = collectImageFiles(event.dataTransfer?.files)
+    if (!images.length) return
+    event.preventDefault()
+    addImageFiles(images)
   }
 
   const openSlashMenu = useCallback(() => {
@@ -497,7 +568,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
     const content = (textareaRef.current?.value ?? '').trim()
     // 空回车 + 队列有 wake：abort 当前回合并立刻 claim
-    if (!content && !picked.length && !pickRefs.length) {
+    if (!content && !picked.length && !pickRefs.length && !pendingImages.length) {
       if (inbox.some((item) => item.kind === 'wake')) {
         try {
           await sessionView.flushInbox()
@@ -508,12 +579,18 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       return
     }
     const tools = [...picked]
-    const fallback = tools.length ? `请使用工具：${tools.join(', ')}` : ''
+    const fallback = tools.length ? `请使用工具：${tools.join(', ')}` : pendingImages.length ? '（图片）' : ''
     const text = [formatPicks(pickRefs), content || fallback].filter(Boolean).join('\n')
+    const packed = await Promise.all(pendingImages.map((item) => readFileDataUrl(item.file)))
     clearInput()
     pick?.clear()
     try {
-      await sessionView.send(text, 'wake', tools)
+      await sessionView.send(
+        text,
+        'wake',
+        tools,
+        packed.filter((item) => item.url.startsWith('data:image/')),
+      )
       const id = sessionView.get().sessionId
       if (id) {
         clearDraft(id)
@@ -564,6 +641,15 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         return
       }
     }
+    if ((event.key === 'Backspace' || event.key === 'Delete') && pendingImages.length && !event.currentTarget.value) {
+      event.preventDefault()
+      setPendingImages((prev) => {
+        const last = prev[prev.length - 1]
+        if (last) URL.revokeObjectURL(last.previewUrl)
+        return prev.slice(0, -1)
+      })
+      return
+    }
 
     if (event.key !== 'Enter' || event.shiftKey) return
     if (event.nativeEvent.isComposing || event.keyCode === 229) return
@@ -592,8 +678,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       ) : null}
 
       <form
-        className={`composer-pill${expanded ? ' is-expanded' : ''}${pickRefs.length || picked.length ? ' has-chips' : ''}`}
+        className={`composer-pill${expanded ? ' is-expanded' : ''}${pickRefs.length || picked.length || pendingImages.length ? ' has-chips' : ''}`}
         onSubmit={onSubmit}
+        onDragOver={(event) => {
+          if ([...(event.dataTransfer?.types ?? [])].includes('Files')) event.preventDefault()
+        }}
+        onDrop={onDrop}
       >
       {slash?.open ? (
         <div className="composer-slash" role="listbox" aria-label="工具列表">
@@ -661,6 +751,23 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         </div>
       ) : null}
 
+      {pendingImages.length ? (
+        <ImageThumbs
+          images={pendingImages.map((item) => ({
+            name: item.name,
+            mime: item.mime,
+            url: item.previewUrl,
+          }))}
+          onRemove={(index) => {
+            setPendingImages((prev) => {
+              const hit = prev[index]
+              if (hit) URL.revokeObjectURL(hit.previewUrl)
+              return prev.filter((_, i) => i !== index)
+            })
+          }}
+        />
+      ) : null}
+
       <div className="composer-pill-row">
         <button
           type="button"
@@ -693,6 +800,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           onClick={syncSlashFromTextarea}
           onKeyUp={syncSlashFromTextarea}
           onKeyDown={onKeyDown}
+          onPaste={onPaste}
         />
 
         <div className="composer-pill-right">

--- a/packages/cap-chat/src/web/image-thumbs.tsx
+++ b/packages/cap-chat/src/web/image-thumbs.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+
+export type ChatImage = {
+  name: string
+  mime: string
+  url: string
+}
+
+export function ImageThumbs({
+  images,
+  onRemove,
+}: {
+  images: ChatImage[]
+  onRemove?: (index: number) => void
+}) {
+  const [open, setOpen] = useState<number | null>(null)
+  useEffect(() => {
+    if (open == null) return
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(null)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open])
+  if (!images.length) return null
+  const current = open != null ? images[open] : null
+  return (
+    <>
+      <div className="composer-image-row" data-testid="composer-image-thumbs">
+        {images.map((image, index) => (
+          <div key={`${image.name}-${index}`} className="composer-image-thumb-wrap">
+            <button
+              type="button"
+              className="composer-image-thumb"
+              title={image.name}
+              aria-label={`查看 ${image.name}`}
+              onClick={() => setOpen(index)}
+            >
+              <img src={image.url} alt={image.name} />
+            </button>
+            {onRemove ? (
+              <button
+                type="button"
+                className="composer-image-remove"
+                title="移除图片"
+                aria-label={`移除 ${image.name}`}
+                onClick={() => onRemove(index)}
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+        ))}
+      </div>
+      {current ? (
+        <div
+          className="composer-image-lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label={current.name}
+          data-testid="image-lightbox"
+          onClick={() => setOpen(null)}
+        >
+          <img src={current.url} alt={current.name} onClick={(event) => event.stopPropagation()} />
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -16,7 +16,7 @@ import {
   LuUser,
   LuWrench,
 } from 'react-icons/lu'
-import type { SlotProps } from '@biu/web-slots'
+import { ImageThumbs } from './image-thumbs.tsx'
 import { bindSessionView, type SessionListItem, type SessionViewService } from '@biu/web-session-view'
 import {
   formatTokens,
@@ -584,6 +584,7 @@ function NodeView({
             ) : null}
             {picked.rest ? <MarkdownBody text={picked.rest} /> : null}
           </div>
+          {node.images?.length ? <ImageThumbs images={node.images} /> : null}
         </div>
         <UserTurnBar
           user={node}

--- a/packages/cap-chat/src/web/usage-panel.tsx
+++ b/packages/cap-chat/src/web/usage-panel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import ReactECharts from 'echarts-for-react'
+import { LuCoins } from 'react-icons/lu'
 import { EventDetailBody } from './trajectory.tsx'
 import { type SessionViewService } from '@biu/web-session-view'
 import type { DerivedMessage, SessionEvent } from '@biu/web-session-view'
@@ -100,7 +101,6 @@ function EChartsDualLine({
   inputData,
   outputData,
   cacheData,
-  xField,
   height,
   compactAt,
   onClick,
@@ -108,7 +108,6 @@ function EChartsDualLine({
   inputData: Array<{ x: number; value: number }>
   outputData: Array<{ x: number; value: number }>
   cacheData: Array<{ x: number; value: number }>
-  xField: string
   height: number
   compactAt?: number[]
   onClick?: (x: number) => void
@@ -122,7 +121,7 @@ function EChartsDualLine({
     const markLineData = (compactAt ?? []).map((x) => ({ xAxis: x }))
     return {
       animation: false,
-      grid: { left: 34, right: 34, top: 6, bottom: 4 },
+      grid: { left: 28, right: 28, top: 8, bottom: 4 },
       tooltip: {
         trigger: 'axis',
         backgroundColor: 'rgba(24,25,28,0.94)',
@@ -141,8 +140,6 @@ function EChartsDualLine({
       yAxis: [
         {
           type: 'value',
-          name: 'Input',
-          nameTextStyle: { color: IN, fontSize: 9 },
           position: 'left',
           splitNumber: 3,
           axisLabel: { fontSize: 9, color: 'rgba(160,167,178,0.7)', formatter: (v: number) => fmt(v) },
@@ -150,8 +147,6 @@ function EChartsDualLine({
         },
         {
           type: 'value',
-          name: 'Output',
-          nameTextStyle: { color: OUT, fontSize: 9 },
           position: 'right',
           splitNumber: 3,
           axisLabel: { fontSize: 9, color: 'rgba(160,167,178,0.7)', formatter: (v: number) => fmt(v) },
@@ -160,7 +155,7 @@ function EChartsDualLine({
       ],
       series: [
         {
-          name: `Input (${xField})`,
+          name: 'Input',
           type: 'line',
           data: toSeries(inputData),
           smooth: true,
@@ -180,7 +175,7 @@ function EChartsDualLine({
             : undefined,
         },
         {
-          name: `Input Cache (${xField})`,
+          name: 'Cache',
           type: 'line',
           data: toSeries(cacheData),
           smooth: true,
@@ -190,7 +185,7 @@ function EChartsDualLine({
           yAxisIndex: 0,
         },
         {
-          name: `Output (${xField})`,
+          name: 'Output',
           type: 'line',
           data: toSeries(outputData),
           smooth: true,
@@ -201,7 +196,7 @@ function EChartsDualLine({
         },
       ],
     }
-  }, [inputData, outputData, cacheData, xField, compactAt])
+  }, [inputData, outputData, cacheData, compactAt])
 
   return (
     <ReactECharts
@@ -227,11 +222,11 @@ function TurnStepChart({ data, height }: { data: Array<{ x: number; value: numbe
   const option = useMemo<EChartsOption>(() => {
     return {
       animation: false,
-      grid: { left: 26, right: 10, top: 6, bottom: 4 },
+      grid: { left: 26, right: 10, top: 8, bottom: 4 },
       tooltip: { trigger: 'axis', backgroundColor: 'rgba(24,25,28,0.94)', borderWidth: 0, textStyle: { color: 'rgba(210,214,220,0.95)', fontSize: 11 } },
       legend: { show: false },
       xAxis: { type: 'category', data: data.map((d) => d.x), boundaryGap: true, axisLabel: { show: data.length <= 40, fontSize: 9, color: 'rgba(160,167,178,0.7)' }, axisLine: { lineStyle: { color: 'rgba(130,140,155,0.25)' } }, axisTick: { show: false } },
-      yAxis: { type: 'value', name: 'steps', nameTextStyle: { color: 'rgba(160,167,178,0.7)', fontSize: 9 }, splitNumber: 3, axisLabel: { fontSize: 9, color: 'rgba(160,167,178,0.7)' }, splitLine: { lineStyle: { color: 'rgba(130,140,155,0.12)', type: 'dashed' } } },
+      yAxis: { type: 'value', splitNumber: 3, axisLabel: { fontSize: 9, color: 'rgba(160,167,178,0.7)' }, splitLine: { lineStyle: { color: 'rgba(130,140,155,0.12)', type: 'dashed' } } },
       series: [
         {
           name: 'steps',
@@ -343,9 +338,7 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
     >
       <div className="usage-panel-head">
         <div className="usage-panel-title">
-          <span className="usage-panel-title-icon" aria-hidden>
-            ◇
-          </span>
+          <LuCoins className="usage-panel-title-icon" aria-hidden />
           Token usage
         </div>
         <div className="usage-panel-legend">
@@ -382,7 +375,6 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
               inputData={track.input}
               outputData={track.output}
               cacheData={track.cache}
-              xField="step"
               height={150}
               compactAt={compactSteps.length ? compactSteps : undefined}
               onClick={onStepClick}
@@ -405,7 +397,6 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
               inputData={turnData.input}
               outputData={turnData.output}
               cacheData={turnData.cache}
-              xField="turn"
               height={130}
               onClick={onTurnClick}
             />
@@ -415,10 +406,7 @@ export function UsagePanel({ useSessionView, sessionView }: UsagePanelProps) {
             className="usage-panel-section"
             {...(sessionId ? pickDomAttrs('usage', `${sessionId}:steps-per-turn`, 'Steps per Turn') : {})}
           >
-            <div className="usage-panel-section-title">
-              Steps per Turn
-              <span className="usage-panel-section-hint">每回合 step 数</span>
-            </div>
+            <div className="usage-panel-section-title">Steps per Turn</div>
             <TurnStepChart data={turnSteps} height={110} />
           </div>
 

--- a/packages/cap-plugin-store/src/web/index.tsx
+++ b/packages/cap-plugin-store/src/web/index.tsx
@@ -111,61 +111,64 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
 
   const pending = items.find((item) => item.id === pendingUninstall) ?? null
   const iconBtn =
-    'grid size-8 shrink-0 cursor-pointer place-items-center rounded-[8px] border-0 bg-[var(--dsw-hover)] text-[var(--dsw-label-2)] hover:bg-[#353535] hover:text-[var(--dsw-label)] disabled:opacity-40'
+    'grid size-6 shrink-0 cursor-pointer place-items-center rounded-[6px] border-0 bg-transparent text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)] disabled:opacity-40'
 
   return (
     <div
-      className={`flex min-h-0 flex-1 flex-col overflow-auto ${compact ? 'px-3 py-3' : 'px-8 py-6'}`}
+      className={`flex min-h-0 min-w-0 flex-1 flex-col overflow-auto ${compact ? 'px-2.5 py-2.5' : 'px-5 py-4'}`}
       data-testid={compact ? 'plugin-store-inspector' : 'plugin-store-page'}
     >
       {compact ? null : (
-        <header className="mb-6">
-          <h1 className="m-0 text-[22px] font-semibold tracking-tight text-[var(--dsw-label)]">插件</h1>
+        <header className="mb-3 flex items-baseline gap-2">
+          <h1 className="m-0 text-[13px] font-semibold tracking-tight text-[var(--dsw-label)]">插件</h1>
+          <span className="text-[11px] tabular-nums text-[var(--dsw-label-3)]">{items.length}</span>
         </header>
       )}
 
       {error ? (
-        <p className="mb-4 text-[13px] text-[var(--dsw-danger)]" data-testid="plugin-store-error">
+        <p className="mb-3 text-[11px] leading-[1.45] text-[var(--dsw-danger)]" data-testid="plugin-store-error">
           {error}
         </p>
       ) : null}
 
       {items.length === 0 && !error ? (
-        <p className="m-0 text-[13px] text-[var(--dsw-label-3)]" data-testid="plugin-store-empty">
+        <p className="m-0 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]" data-testid="plugin-store-empty">
           没有插件
         </p>
       ) : (
-      <ul className="m-0 flex list-none flex-col gap-3 p-0">
+      <ul className="m-0 flex list-none flex-col gap-1.5 p-0">
         {items.map((item) => (
           <li
             key={item.id}
-            className={`flex items-center justify-between gap-3 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] ${compact ? 'px-3 py-2.5' : 'px-4 py-3'}`}
+            className="flex items-start justify-between gap-2 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-2.5 py-2"
             data-testid={`plugin-store-card-${item.id}`}
             data-biu-kind="plugin"
             data-biu-id={item.id}
             data-biu-label={item.name}
           >
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-[14px] font-medium text-[var(--dsw-label)]">{item.name}</span>
-                <span className="font-mono text-[11px] text-[var(--dsw-label-3)]">{item.id}</span>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="min-w-0 truncate text-[12px] font-medium leading-[1.3] text-[var(--dsw-label)]">
+                  {item.name}
+                </span>
+                <span className="shrink-0 font-mono text-[10px] leading-[1.3] text-[var(--dsw-label-3)]">{item.id}</span>
                 {item.enabled ? (
-                  <span className="rounded-[4px] bg-[var(--dsw-ok)]/15 px-1.5 py-px text-[10px] font-medium text-[var(--dsw-ok)]">
+                  <span className="shrink-0 rounded-[4px] bg-[var(--dsw-ok)]/12 px-1 py-px text-[9px] font-semibold tracking-wide text-[var(--dsw-ok)]">
                     {item.running ? '运行中' : '已打开'}
                   </span>
                 ) : (
-                  <span className="rounded-[4px] bg-[var(--dsw-hover)] px-1.5 py-px text-[10px] text-[var(--dsw-label-3)]">
+                  <span className="shrink-0 rounded-[4px] bg-[var(--dsw-hover)] px-1 py-px text-[9px] font-medium text-[var(--dsw-label-3)]">
                     已关闭
                   </span>
                 )}
               </div>
               {item.blurb ? (
-                <p className={`mt-1 m-0 leading-5 text-[var(--dsw-label-3)] ${compact ? 'text-[11px]' : 'text-[12px]'}`}>
+                <p className="mt-0.5 mb-0 line-clamp-2 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">
                   {item.blurb}
                 </p>
               ) : null}
             </div>
-            <div className="flex shrink-0 items-center gap-0.5">
+            <div className="flex shrink-0 items-center gap-px pt-px">
               {item.enabled ? (
                 <button
                   type="button"
@@ -177,7 +180,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                   disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                   onClick={() => void closePlugin(item.id)}
                 >
-                  <LuSquare className="size-3.5" />
+                  <LuSquare className="size-3" />
                 </button>
               ) : (
                 <button
@@ -190,7 +193,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                   disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                   onClick={() => void openPlugin(item.id)}
                 >
-                  <LuPlay className="size-3.5" />
+                  <LuPlay className="size-3" />
                 </button>
               )}
               <button
@@ -202,7 +205,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                 disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                 onClick={() => setPendingUninstall(item.id)}
               >
-                <LuTrash2 className="size-3.5" />
+                <LuTrash2 className="size-3" />
               </button>
             </div>
           </li>
@@ -224,19 +227,19 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
               }}
             >
               <div
-                className="w-[min(100%,360px)] rounded-[12px] border border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] p-5 text-[var(--dsw-label)]"
+                className="w-[min(100%,320px)] rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] p-4 text-[var(--dsw-label)]"
                 onClick={(event) => event.stopPropagation()}
               >
-                <h2 id="plugin-store-uninstall-title" className="m-0 text-[15px] font-semibold">
+                <h2 id="plugin-store-uninstall-title" className="m-0 text-[13px] font-semibold">
                   卸载「{pending.name}」？
                 </h2>
-                <p className="mt-2 mb-0 text-[13px] leading-5 text-[var(--dsw-label-3)]">
+                <p className="mt-1.5 mb-0 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">
                   卸载后会永久删除这份插件代码，货架上也会消失。若只是暂时不用，请点关闭。
                 </p>
-                <div className="mt-4 flex justify-end gap-2">
+                <div className="mt-3 flex justify-end gap-1.5">
                   <button
                     type="button"
-                    className="rounded-[8px] border-0 bg-[var(--dsw-hover)] px-3 py-1.5 text-[12px] text-[var(--dsw-label)] hover:bg-[#353535]"
+                    className="rounded-[6px] border-0 bg-[var(--dsw-hover)] px-2.5 py-1 text-[11px] text-[var(--dsw-label)] hover:bg-[#353535]"
                     data-testid="plugin-store-uninstall-cancel"
                     disabled={busy === `rm:${pending.id}`}
                     onClick={() => setPendingUninstall(null)}
@@ -245,7 +248,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                   </button>
                   <button
                     type="button"
-                    className="rounded-[8px] border-0 bg-[var(--dsw-hover)] px-3 py-1.5 text-[12px] font-medium text-[var(--dsw-label)] hover:bg-[#353535]"
+                    className="rounded-[6px] border-0 bg-[var(--dsw-hover)] px-2.5 py-1 text-[11px] font-medium text-[var(--dsw-label)] hover:bg-[#353535]"
                     data-testid="plugin-store-uninstall-confirm"
                     data-biu-action="uninstall"
                     disabled={busy === `rm:${pending.id}`}

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -3897,7 +3897,7 @@ if (typeof document !== 'undefined') {
 
 /* ---- 依赖（DAG）视图 ---- */
 /* ---- DAG 依赖图（自绘 SVG + 缩放）---- */
-.tasks-graph { margin-top:8px; border:1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent); border-radius:10px; background:color-mix(in srgb, var(--dsw-muted-fill) 26%, transparent); overflow:hidden; flex:1; min-height:320px; display:flex; flex-direction:column; }
+.tasks-graph { margin-top:8px; border:1px solid color-mix(in srgb, var(--dsw-border) 80%, transparent); border-radius:10px; background:color-mix(in srgb, var(--dsw-muted-fill) 26%, transparent); overflow:hidden; flex:1; min-width:0; min-height:320px; display:flex; flex-direction:column; }
 .tasks-graph.is-compact { min-height:200px; }
 .tasks-graph-rf { width:100%; flex:1; min-height:0; }
 .tasks-graph .react-flow__attribution { display:none; }
@@ -3921,7 +3921,7 @@ if (typeof document !== 'undefined') {
 .tasks-graph-node-meta .tasks-card-badge { font-size:8.5px; padding:0 4px; }
 
 /* ---- 队列视图（清单风格：只展示叶节点，按状态分组）---- */
-.tasks-queue { display:flex; flex-direction:column; gap:14px; margin-top:10px; overflow:auto; flex:1; min-height:0; padding-bottom:4px; }
+.tasks-queue { display:flex; flex-direction:column; gap:14px; margin-top:10px; overflow:auto; flex:1; min-width:0; width:100%; max-width:100%; min-height:0; padding-bottom:4px; }
 .tasks-queue.is-compact { gap:10px; margin-top:6px; }
 .tasks-queue-group { display:flex; flex-direction:column; gap:6px; }
 .tasks-queue-ghead { display:flex; align-items:center; gap:6px; padding:4px 6px; color:var(--dsw-label-2); font-size:11px; font-weight:650; letter-spacing:.01em; }

--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -3571,16 +3571,16 @@ if (typeof document !== 'undefined') {
   const style = document.getElementById(id) ?? document.createElement('style')
   style.id = id
   style.textContent = `
-.tasks-module-page { display:flex; flex:1; min-height:0; flex-direction:column; overflow:hidden; background:
+.tasks-module-page { display:flex; flex:1; min-width:0; min-height:0; flex-direction:column; overflow:hidden; background:
   radial-gradient(900px 360px at 10% -12%, color-mix(in srgb, var(--dsw-business) 8%, transparent), transparent 58%),
   linear-gradient(180deg, color-mix(in srgb, var(--dsw-surface) 55%, var(--dsw-bg)), var(--dsw-bg));
   color:var(--dsw-label); }
-.tasks-inspector-panel { display:flex; min-height:0; flex:1; flex-direction:column; overflow:hidden; background:var(--dsw-bg); }
-.tasks-root { display:flex; min-height:0; flex:1; gap:0; overflow:hidden; }
+.tasks-inspector-panel { display:flex; min-width:0; min-height:0; flex:1; flex-direction:column; overflow:hidden; background:var(--dsw-bg); }
+.tasks-root { display:flex; min-width:0; min-height:0; flex:1; gap:0; overflow:hidden; }
 .tasks-root.is-compact { flex-direction:column; }
-.tasks-main { display:flex; min-width:0; min-height:0; flex:1; flex-direction:column; gap:10px; padding:12px 14px 14px; overflow:auto; }
+.tasks-main { display:flex; min-width:0; min-height:0; flex:1; flex-direction:column; gap:10px; padding:12px 14px 14px; overflow-x:hidden; overflow-y:auto; }
 .tasks-root.is-compact .tasks-main { padding:8px 10px 10px; gap:8px; }
-.tasks-toolbar { display:flex; gap:12px; align-items:center; justify-content:space-between; }
+.tasks-toolbar { display:flex; gap:12px; align-items:center; justify-content:space-between; min-width:0; }
 .tasks-toolbar-left { display:flex; align-items:center; gap:6px; flex:none; min-width:0; }
 .tasks-toolbar-right { display:flex; align-items:center; gap:6px; flex:none; margin-left:auto; }
 .tasks-search { min-width:0; border:1px solid var(--dsw-border); border-radius:8px; padding:6px 8px; background:var(--dsw-input); color:var(--dsw-label); font:inherit; font-size:12px; outline:none; }
@@ -3663,7 +3663,7 @@ if (typeof document !== 'undefined') {
 .tasks-mode-item-ico { display:inline-flex; align-items:center; margin-right:6px; }
 
 /* ---- 看板视图（Notion 风格：极轻边框、无重色、悬浮轻阴影）---- */
-.tasks-board { display:grid; grid-template-columns:repeat(5, minmax(190px, 1fr)); gap:10px; margin-top:10px; align-items:start; overflow-x:auto; }
+.tasks-board { display:grid; grid-template-columns:repeat(5, minmax(190px, 1fr)); gap:10px; margin-top:10px; align-items:start; min-width:0; width:100%; max-width:100%; overflow-x:auto; }
 .tasks-board.is-compact { gap:8px; }
 .tasks-board-col { display:flex; flex-direction:column; min-width:0; min-height:120px; background:color-mix(in srgb, var(--dsw-muted-fill) 38%, transparent); border-radius:10px; padding:6px; }
 .tasks-board-colhead { display:flex; align-items:center; gap:6px; padding:4px 6px 8px; color:var(--dsw-label-2); font-size:11px; font-weight:600; }
@@ -3700,7 +3700,7 @@ if (typeof document !== 'undefined') {
 .tasks-error { border-radius:7px; padding:6px 8px; background:var(--dsw-danger-soft); color:var(--dsw-danger); font-size:11px; }
 .tasks-empty { color:var(--dsw-label-3); font-size:12px; line-height:1.45; padding:28px 16px; text-align:center; }
 .tasks-empty.is-compact { padding:16px 10px; }
-.tasks-table-wrap { overflow:auto; border:1px solid var(--dsw-border); border-radius:10px; background:color-mix(in srgb, var(--dsw-surface) 92%, transparent); }
+.tasks-table-wrap { min-width:0; width:100%; max-width:100%; overflow:auto; border:1px solid var(--dsw-border); border-radius:10px; background:color-mix(in srgb, var(--dsw-surface) 92%, transparent); }
 .tasks-table { width:max-content; min-width:100%; border-collapse:collapse; table-layout:auto; font-size:11px; white-space:nowrap; }
 .tasks-table th { padding:6px 6px; border-bottom:1px solid var(--dsw-border); color:var(--dsw-label-3); font-weight:600; text-align:left; white-space:nowrap; position:sticky; top:0; background:var(--dsw-surface); z-index:1; }
 .tasks-th { display:inline-flex; align-items:center; gap:4px; }

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -83,6 +83,7 @@ export class AgentLoop implements AgentRunner {
         text: item.text,
         kind: item.kind,
         ...(item.sender ? { sender: item.sender } : {}),
+        ...(item.images?.length ? { images: item.images } : {}),
       })
     }
 
@@ -232,7 +233,8 @@ export class AgentLoopService extends Service {
       : {
           chat: async (messages: LlmMessage[], _tools?: unknown[], _signal?: AbortSignal, options?: ChatOptions) => {
             const last = [...messages].reverse().find((item) => item.role === 'user')?.content
-            const text = `未配置 API Key，本地回声：${last ?? ''}`
+            const preview = typeof last === 'string' ? last : Array.isArray(last) ? '（含图片）' : ''
+            const text = `未配置 API Key，本地回声：${preview}`
             await options?.onDelta?.(text)
             return { content: text, toolCalls: [] }
           },

--- a/packages/host-agents/src/host/index.ts
+++ b/packages/host-agents/src/host/index.ts
@@ -11,6 +11,7 @@ export interface AgentSendOptions {
   wait?: boolean
   /** 消息来源：Live 派工时传入 { type: 'session', sessionId } */
   sender?: MessageSender
+  images?: Array<{ name: string; mime: string; url: string }>
 }
 
 export interface AgentHandle {
@@ -134,14 +135,16 @@ export class AgentsService extends Service {
       sessionId: id,
       send: async (text: string, opts?: AgentSendOptions) => {
         const trimmed = text.trim()
-        if (!trimmed) return { text: '请先输入内容。', steps: [] }
+        const images = sanitizeImages(opts?.images)
+        if (!trimmed && !images?.length) return { text: '请先输入内容。', steps: [] }
         const extraTools = sanitizeExtraTools(opts?.extraTools)
         const wait = opts?.wait !== false
         const entry = {
-          text: trimmed,
+          text: trimmed || '（图片）',
           id: nextInboxId(),
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
+          ...(images ? { images } : {}),
         }
 
         // Cursor 同款：忙碌且已有 wake 排队时，再发送 → inject（并入该 wake 的下一回合）
@@ -162,14 +165,16 @@ export class AgentsService extends Service {
       },
       inject: (text: string, opts?: AgentSendOptions) => {
         const trimmed = text.trim()
-        if (!trimmed) return
+        const images = sanitizeImages(opts?.images)
+        if (!trimmed && !images?.length) return
         const extraTools = sanitizeExtraTools(opts?.extraTools)
         live.inbox.push({
           kind: 'inject',
-          text: trimmed,
+          text: trimmed || '（图片）',
           id: nextInboxId(),
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
+          ...(images ? { images } : {}),
         })
         this.emitInbox(id)
       },
@@ -209,6 +214,22 @@ export class AgentsService extends Service {
     const agent = await this.create()
     return agent.send(last)
   }
+}
+
+function sanitizeImages(raw: AgentSendOptions['images']): ClaimedInput['images'] {
+  if (!Array.isArray(raw) || !raw.length) return undefined
+  const out: NonNullable<ClaimedInput['images']> = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const mime = String(item.mime ?? '')
+    const url = String(item.url ?? '')
+    const name = String(item.name ?? 'image.png').slice(0, 80)
+    if (!/^image\/(png|jpe?g|gif|webp)$/i.test(mime)) continue
+    if (!url.startsWith('data:image/') || url.length > 8 * 1024 * 1024) continue
+    out.push({ name: name || 'image.png', mime, url })
+    if (out.length >= 6) break
+  }
+  return out.length ? out : undefined
 }
 
 function sanitizeExtraTools(names: string[] | undefined): string[] {

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -76,7 +76,18 @@ export function deriveMessages(events: SessionEvent[]): LlmMessage[] {
       system = event.text
     } else if (event.type === 'user/message') {
       flushOrphanTools()
-      messages.push({ role: 'user', content: event.text })
+      const images = event.images?.filter((item) => item?.url && item.url.startsWith('data:image/')) ?? []
+      if (images.length) {
+        messages.push({
+          role: 'user',
+          content: [
+            ...(event.text.trim() ? [{ type: 'text' as const, text: event.text }] : []),
+            ...images.map((item) => ({ type: 'image_url' as const, image_url: { url: item.url } })),
+          ],
+        })
+      } else {
+        messages.push({ role: 'user', content: event.text })
+      }
     } else if (event.type === 'assistant/message') {
       flushOrphanTools()
       const hasToolCalls = Boolean(event.tool_calls?.length)
@@ -236,6 +247,14 @@ export function estimateTokens(text: string): number {
 }
 
 function msgTokens(m: LlmMessage): number {
+  if (Array.isArray(m.content)) {
+    let n = 0
+    for (const part of m.content) {
+      if (part.type === 'text') n += estimateTokens(part.text)
+      else n += 1200
+    }
+    return n + (typeof m.tool_calls?.length === 'number' ? m.tool_calls.length * 6 : 0)
+  }
   const content = typeof m.content === 'string' ? m.content : JSON.stringify(m.content ?? '')
   return estimateTokens(content) + (typeof m.tool_calls?.length === 'number' ? m.tool_calls.length * 6 : 0)
 }

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -279,6 +279,28 @@ test('applyContextBudget: over budget keeps head + recent tail', () => {
   assert.ok(out.length < msgs.length)
 })
 
+test('deriveMessages projects pasted images as multimodal content', () => {
+  const events: SessionEvent[] = [
+    { type: 'session/open', version: 1, seq: 0, ts: 0 },
+    {
+      type: 'user/message',
+      text: '看看这张图',
+      kind: 'wake',
+      seq: 1,
+      ts: 1,
+      images: [{ name: 'shot.png', mime: 'image/png', url: 'data:image/png;base64,abc' }],
+    },
+  ]
+  const out = deriveMessages(events)
+  const user = out.find((item) => item.role === 'user')
+  assert.ok(Array.isArray(user?.content))
+  const parts = user?.content as Array<{ type: string; text?: string; image_url?: { url: string } }>
+  assert.equal(parts[0]?.type, 'text')
+  assert.equal(parts[0]?.text, '看看这张图')
+  assert.equal(parts[1]?.type, 'image_url')
+  assert.equal(parts[1]?.image_url?.url, 'data:image/png;base64,abc')
+})
+
 test('deriveMessages honors context_compact_submit tool/call as new prefix', () => {
   const events: SessionEvent[] = [
     { type: 'session/open', version: 1, seq: 0, ts: 0 },

--- a/packages/type-agent-loop/src/index.ts
+++ b/packages/type-agent-loop/src/index.ts
@@ -11,6 +11,7 @@ export interface ClaimedInput {
   id?: string
   extraTools?: string[]
   sender?: MessageSender
+  images?: Array<{ name: string; mime: string; url: string }>
 }
 
 export interface PreStepReq {

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -7,6 +7,12 @@ export type MessageSender =
   | { type: 'user' }
   | { type: 'session'; sessionId: string }
 
+export type UserMessageImage = {
+  name: string
+  mime: string
+  url: string
+}
+
 /** 写入 append 的正文（不含 seq/ts）；与 SessionEvent 判别联合一一对应。 */
 export type SessionEventBody =
   | { type: 'session/open'; version: number }
@@ -16,7 +22,7 @@ export type SessionEventBody =
   | { type: 'step/end'; turn: number; step: number }
   | { type: 'system/prompt'; text: string }
   | { type: 'system/compact'; text: string }
-  | { type: 'user/message'; text: string; kind: InboxKind; sender?: MessageSender }
+  | { type: 'user/message'; text: string; kind: InboxKind; sender?: MessageSender; images?: UserMessageImage[] }
   | {
       type: 'assistant/message'
       text: string

--- a/packages/web-app-shell/src/web/chat-session-title.tsx
+++ b/packages/web-app-shell/src/web/chat-session-title.tsx
@@ -1,0 +1,63 @@
+import { memo, useEffect, useRef, useState } from 'react'
+import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+
+export const ChatSessionTitle = memo(function ChatSessionTitle({
+  useSessionView,
+  sessionView,
+}: {
+  useSessionView: ReturnType<typeof bindSessionView>
+  sessionView: SessionViewService
+}) {
+  const sessionId = useSessionView((state) => state.sessionId)
+  const title = useSessionView((state) => {
+    const id = state.sessionId
+    if (!id) return ''
+    return state.sessions.find((item) => item.id === id)?.title ?? ''
+  })
+  const [draft, setDraft] = useState(title)
+  const focusedRef = useRef(false)
+
+  useEffect(() => {
+    if (!focusedRef.current) setDraft(title)
+  }, [sessionId, title])
+
+  if (!sessionId) return null
+
+  return (
+    <div className="chat-view-session-title-wrap">
+      <input
+        className="chat-view-session-title"
+        value={draft}
+        placeholder="未命名会话"
+        aria-label="会话名称"
+        data-testid="chat-session-title"
+        title={draft || title || '会话名称'}
+        onChange={(event) => setDraft(event.target.value)}
+        onFocus={() => {
+          focusedRef.current = true
+        }}
+        onBlur={() => {
+          focusedRef.current = false
+          const next = draft.trim()
+          if (next === title.trim()) {
+            setDraft(title)
+            return
+          }
+          void sessionView.setSessionTitle(sessionId, next).catch(() => {
+            setDraft(title)
+          })
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            setDraft(title)
+            ;(event.target as HTMLInputElement).blur()
+            return
+          }
+          if (event.key !== 'Enter') return
+          event.preventDefault()
+          ;(event.target as HTMLInputElement).blur()
+        }}
+      />
+    </div>
+  )
+})

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -19,8 +19,6 @@ import { SidebarMascot } from '@biu/web-mascot'
 import { resolveSessionMascot } from '@biu/web-mascot'
 import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 import {
-  LuChevronDown,
-  LuChevronRight,
   LuFolderTree,
   LuPanelLeftClose,
   LuPlus,
@@ -92,17 +90,19 @@ const SessionRow = memo(function SessionRow({
     >
       <Link
         to={`/s/${item.id}`}
-        className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-left text-[12px] leading-4"
+        className="flex min-w-0 flex-1 items-center gap-2 py-1 pr-1.5 text-left text-[12px] leading-4"
       >
-        <SidebarMascot
-          size={24}
-          sessionId={item.id}
-          identity={identity}
-          busy={busy}
-          animate={false}
-          dancing={dancing}
-          title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
-        />
+        <span className="grid size-5 shrink-0 place-items-center">
+          <SidebarMascot
+            size={20}
+            sessionId={item.id}
+            identity={identity}
+            busy={busy}
+            animate={false}
+            dancing={dancing}
+            title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
+          />
+        </span>
         <span className="min-w-0 flex-1 truncate font-medium">
           {(item.type ?? 'chat') === 'live' ? (
             <span className="mr-1 text-[9px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">
@@ -280,7 +280,7 @@ export const ChatSidebar = memo(function ChatSidebar({
             onClick={() => createChat({ type: 'chat' })}
           >
             <span className="app-side-actions-icon" aria-hidden>
-              <LuPlus className="size-4" />
+              <LuPlus className="size-5" />
             </span>
             <span className="app-side-actions-label">添加聊天</span>
           </button>
@@ -292,7 +292,7 @@ export const ChatSidebar = memo(function ChatSidebar({
             onClick={() => createChat({ type: 'live' })}
           >
             <span className="app-side-actions-icon" aria-hidden>
-              <LuRadio className="size-4" />
+              <LuRadio className="size-5" />
             </span>
             <span className="app-side-actions-label">新建 Live</span>
           </button>
@@ -310,16 +310,22 @@ export const ChatSidebar = memo(function ChatSidebar({
                   <div className="sidebar-section-head min-w-0">
                     <button
                       type="button"
-                      className="flex min-w-0 flex-1 items-center gap-1 rounded-[6px] text-left text-[12px] font-bold tracking-wider text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
+                      className="flex min-w-0 flex-1 items-center gap-2 rounded-[6px] text-left text-[12px] font-bold tracking-wider text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)]"
                       aria-expanded={!sectionCollapsed}
                       onClick={() => toggleSection(section.kind)}
                     >
                       {section.kind === 'pinned' ? (
-                        <LuStar className="size-3.5 shrink-0 text-[#f5b700]" fill="currentColor" />
+                        <span className="sidebar-rail-icon">
+                          <LuStar className="size-5 text-[#f5b700]" fill="currentColor" />
+                        </span>
                       ) : section.kind === 'tag' ? (
-                        <LuTag className="size-3.5 shrink-0 opacity-80" />
+                        <span className="sidebar-rail-icon">
+                          <LuTag className="size-5 opacity-80" />
+                        </span>
                       ) : (
-                        <FolderGlyph className="size-3.5 shrink-0 opacity-80" />
+                        <span className="sidebar-rail-icon">
+                          <FolderGlyph className="size-5 opacity-80" />
+                        </span>
                       )}
                       <span className="min-w-0 flex-1 truncate tracking-normal">{section.label}</span>
                       <span className="shrink-0 font-mono text-[10px] opacity-60">
@@ -359,7 +365,9 @@ export const ChatSidebar = memo(function ChatSidebar({
                   {!sectionCollapsed ? (
                     <div className="min-w-0 space-y-1.5 pt-0.5">
                       {section.sessions
-                        ? section.sessions.map((item) => (
+                        ? (
+                          <div className="sidebar-session-list min-w-0">
+                            {section.sessions.map((item) => (
                             <SessionRow
                               key={`pinned:${item.id}`}
                               item={item}
@@ -369,18 +377,20 @@ export const ChatSidebar = memo(function ChatSidebar({
                               onDelete={deleteChat}
                               onPin={pinChat}
                             />
-                          ))
+                            ))}
+                          </div>
+                          )
                         : section.groups?.map((group) => {
                         const collapsed = Boolean(collapsedProjects[group.key])
                         const isUngrouped = group.key === UNGROUPED_PROJECT_KEY || group.key === UNGROUPED_TAG_KEY
                         const canAddHere = group.kind === 'project' || group.kind === 'ungrouped'
                         return (
                           <div key={group.key} className="min-w-0">
-                            <div className="sidebar-group-head mb-0.5 flex items-center px-1">
+                            <div className="sidebar-group-head mb-0.5 flex items-center">
                               <div
                                 role="button"
                                 tabIndex={0}
-                                className="flex min-h-[24px] min-w-0 flex-1 cursor-pointer items-center gap-1 rounded-[6px] text-left text-[12px] font-semibold tracking-wide text-[var(--dsw-label-3)] outline-none hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)] focus-visible:ring-1 focus-visible:ring-[var(--dsw-border)]"
+                                className="flex min-h-[24px] min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-[6px] text-left text-[12px] font-semibold tracking-wide text-[var(--dsw-label-3)] outline-none hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)] focus-visible:ring-1 focus-visible:ring-[var(--dsw-border)]"
                                 title={group.path ?? group.label}
                                 aria-expanded={!collapsed}
                                 onClick={() => toggleProjectGroup(group.key)}
@@ -391,21 +401,22 @@ export const ChatSidebar = memo(function ChatSidebar({
                                   }
                                 }}
                               >
-                                {collapsed ? (
-                                  <LuChevronRight className="size-3 shrink-0 opacity-70" />
-                                ) : (
-                                  <LuChevronDown className="size-3 shrink-0 opacity-70" />
-                                )}
                                 {group.kind === 'pinned' ? (
-                                  <LuStar className="size-3.5 shrink-0 text-[#f5b700]" fill="currentColor" />
+                                  <span className="sidebar-rail-icon">
+                                    <LuStar className="size-5 text-[#f5b700]" fill="currentColor" />
+                                  </span>
                                 ) : group.kind === 'tag' ? (
-                                  <LuTag className="size-3.5 shrink-0 opacity-80" />
+                                  <span className="sidebar-rail-icon">
+                                    <LuTag className="size-5 opacity-80" />
+                                  </span>
                                 ) : isUngrouped ? (
-                                  <span className="grid size-3.5 place-items-center text-[11px] opacity-70" aria-hidden>
+                                  <span className="sidebar-rail-icon text-[11px] opacity-70" aria-hidden>
                                     —
                                   </span>
                                 ) : (
-                                  <FolderGlyph className="size-3.5 shrink-0 opacity-80" />
+                                  <span className="sidebar-rail-icon">
+                                    <FolderGlyph className="size-5 opacity-80" />
+                                  </span>
                                 )}
                                 <span className="min-w-0 flex-1 truncate tracking-normal">{group.label}</span>
                                 <span className="shrink-0 font-mono text-[10px] opacity-60">{group.sessions.length}</span>
@@ -428,7 +439,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                                 ) : null}
                               </div>
                             </div>
-                            <div className={`min-w-0 ${collapsed ? 'hidden' : ''}`} aria-hidden={collapsed}>
+                            <div className={`sidebar-session-list min-w-0 ${collapsed ? 'hidden' : ''}`} aria-hidden={collapsed}>
                               {group.sessions.map((item) => (
                                 <SessionRow
                                   key={`${group.key}:${item.id}`}

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -18,6 +18,7 @@ import {
   type AppModulesService,
 } from '@biu/web-app-modules'
 import { ChatSidebar } from './chat-sidebar.tsx'
+import { ChatSessionTitle } from './chat-session-title.tsx'
 import { DanceStage } from '@biu/web-mascot'
 import { SessionInspector } from './session-inspector.tsx'
 import { SessionConfigDialog } from '@biu/web-session-view/dialog'
@@ -361,6 +362,7 @@ function Shell(props: SlotProps) {
                 </div>
               ) : null}
             </div>
+            <ChatSessionTitle useSessionView={useSessionView} sessionView={sessionView} />
             <div className="chat-view-header-right">
               <button
                 type="button"

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -158,7 +158,7 @@ function PluginModuleStage({
         return (
           <div
             key={entry.id}
-            className={show ? 'flex min-h-0 flex-1 flex-col overflow-hidden' : 'hidden'}
+            className={show ? 'flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}
             aria-hidden={!show}
             data-testid={`${moduleId}-module`}
           >

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1136,6 +1136,28 @@ export class SessionViewService extends Service {
     void this.refreshSessions()
   }
 
+  async setSessionTitle(id: string, title: string) {
+    const next = title.trim()
+    const prev = this.value.sessions
+    if (next) {
+      this.replace({
+        sessions: prev.map((item) => (item.id === id ? { ...item, title: next } : item)),
+      })
+    }
+    try {
+      const res = await fetch(`/api/sessions/${id}/config`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ title: next || null }),
+      })
+      if (!res.ok) throw new Error(`rename failed HTTP ${res.status}`)
+    } catch (error) {
+      this.replace({ sessions: prev, error: String(error) })
+      throw error
+    }
+    void this.refreshSessions()
+  }
+
   async deleteSession(id: string) {
     const prevSessions = this.value.sessions
     const wasActive = this.value.sessionId === id

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1227,9 +1227,15 @@ export class SessionViewService extends Service {
     })
   }
 
-  async send(text: string, kind: 'wake' | 'inject' = 'wake', extraTools: string[] = []) {
+  async send(
+    text: string,
+    kind: 'wake' | 'inject' = 'wake',
+    extraTools: string[] = [],
+    images: Array<{ name: string; mime: string; url: string }> = [],
+  ) {
     const content = text.trim()
-    if (!content) return
+    const pics = images.filter((item) => item?.url?.startsWith('data:image/')).slice(0, 6)
+    if (!content && !pics.length) return
     const sessionId = await this.ensureSession()
     const tools = [...new Set(extraTools.map((name) => name.trim()).filter(Boolean))]
     const busy = this.value.pending || this.value.agentStatus === 'running'
@@ -1237,13 +1243,15 @@ export class SessionViewService extends Service {
     // 忙碌且已有 wake：再发 → inject；否则 wake。忙碌时 wait:false 立刻返回。
     const effectiveKind: 'wake' | 'inject' =
       kind === 'inject' || (kind === 'wake' && busy && hasWake) ? 'inject' : 'wake'
+    const imagePayload = pics.length ? { images: pics } : {}
     const body: Record<string, unknown> =
       effectiveKind === 'inject'
-        ? { text: content, kind: 'inject', ...(tools.length ? { extraTools: tools } : {}) }
+        ? { text: content || '（图片）', kind: 'inject', ...(tools.length ? { extraTools: tools } : {}), ...imagePayload }
         : {
-            text: content,
+            text: content || '（图片）',
             ...(busy ? { wait: false } : {}),
             ...(tools.length ? { extraTools: tools } : {}),
+            ...imagePayload,
           }
 
     if (effectiveKind === 'inject') {

--- a/packages/web-session-view/src/web/session-project.ts
+++ b/packages/web-session-view/src/web/session-project.ts
@@ -84,6 +84,7 @@ export type ChatNode =
       text: string
       kindTag?: string
       ts?: number
+      images?: Array<{ name: string; mime: string; url: string }>
       /** 缺省 / user = 真人；session = Live 等其它会话派工 */
       sender?: { type: 'user' } | { type: 'session'; sessionId: string }
     }
@@ -326,6 +327,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
         kindTag: event.kind,
         ts: event.ts,
         ...(event.sender ? { sender: event.sender } : {}),
+        ...(event.images?.length ? { images: event.images } : {}),
       })
     } else if (event.type === 'assistant/chunk') {
       const r = ensureReply(event.seq)

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -76,6 +76,23 @@ test('setSessionTitle patches config title', async () => {
   assert.equal(view.get().sessions[0]?.title, '新名称')
 })
 
+test('setSessionTitle empty sends null title', async () => {
+  const calls = mockFetch({
+    '/api/sessions/s1/config': () => ({ id: 's1' }),
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: '旧名', eventCount: 1, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  await view.setSessionTitle('s1', '   ')
+  const patch = calls.find((call) => call.url.includes('/config') && call.init?.method === 'PATCH')
+  assert.ok(patch)
+  assert.match(String(patch!.init?.body), /"title":null/)
+})
+
+test('send inject posts kind without clearing running state', async () => {
   const calls = mockFetch({
     '/api/sessions': () => ({ sessions: [] }),
     '/api/approvals': () => ({ mode: 'auto', pending: [] }),

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -57,7 +57,25 @@ test('setApprovalMode posts and updates state', async () => {
   )
 })
 
-test('send inject posts kind without clearing running state', async () => {
+test('setSessionTitle patches config title', async () => {
+  let listed = '旧名'
+  const calls = mockFetch({
+    '/api/sessions/s1/config': () => ({ id: 's1' }),
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: listed, eventCount: 1, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  listed = '新名称'
+  await view.setSessionTitle('s1', '  新名称  ')
+  const patch = calls.find((call) => call.url.includes('/config') && call.init?.method === 'PATCH')
+  assert.ok(patch)
+  assert.match(String(patch!.init?.body), /"title":"新名称"/)
+  assert.equal(view.get().sessions[0]?.title, '新名称')
+})
+
   const calls = mockFetch({
     '/api/sessions': () => ({ sessions: [] }),
     '/api/approvals': () => ({ mode: 'auto', pending: [] }),

--- a/web/style.css
+++ b/web/style.css
@@ -1315,8 +1315,10 @@ body {
   letter-spacing: 0.02em;
 }
 .usage-panel-title-icon {
+  flex: none;
+  width: 13px;
+  height: 13px;
   color: var(--dsw-business);
-  font-size: 10px;
 }
 .usage-panel-legend {
   display: inline-flex;

--- a/web/style.css
+++ b/web/style.css
@@ -199,6 +199,51 @@ body {
   padding: 0 12px;
 }
 
+.chat-view-session-title-wrap {
+  position: absolute;
+  left: 50%;
+  z-index: 1;
+  display: flex;
+  max-width: min(420px, calc(100% - 220px));
+  min-width: 0;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.chat-view-session-title {
+  width: 100%;
+  min-width: 80px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 4px 10px;
+  color: var(--dsw-label);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  outline: none;
+  pointer-events: auto;
+}
+
+.chat-view-session-title::placeholder {
+  color: var(--dsw-label-3);
+  font-weight: 500;
+}
+
+.chat-view-session-title:hover {
+  background: var(--dsw-hover);
+}
+
+.chat-view-session-title:focus {
+  background: var(--dsw-hover);
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .app-side-bar-head {
   display: flex;
   height: 36px;

--- a/web/style.css
+++ b/web/style.css
@@ -394,7 +394,7 @@ body {
   align-items: center;
   gap: 8px;
   border-radius: 8px;
-  padding: 5px 8px;
+  padding: 5px 4px;
   color: var(--dsw-sidebar-fg);
   font-size: 12px;
   font-weight: 500;
@@ -430,8 +430,8 @@ body {
 
 .app-side-actions-icon {
   display: grid;
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
   place-items: center;
   color: var(--dsw-label-3);
@@ -551,12 +551,28 @@ body {
   opacity: 1;
 }
 
+.sidebar-rail-icon {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  place-items: center;
+}
+
+.sidebar-session-list {
+  padding-left: 32px;
+}
+
+.sidebar-group-head {
+  padding: 0 4px;
+}
+
 /* 顶部「收藏/项目/标签」板块标题行：普通透明形态(无胶囊质感)。
-   保留固定 22px 行高(items-center)，确保 view-switch 悬浮出现不撑高行 */
+   保留固定 24px 行高(items-center)，确保 view-switch 悬浮出现不撑高行 */
 .sidebar-section-head {
   display: flex;
   align-items: center;
-  height: 22px;
+  height: 24px;
   margin: 0 0 4px;
   padding: 0 4px;
 }

--- a/web/style.css
+++ b/web/style.css
@@ -580,7 +580,7 @@ body {
 /* 顶层板块右侧分组视图切换 tab：作为 flex 流右侧子元素参与行内布局；
    默认宽度塌陷不占位(计数贴右与「收藏」tab 对齐)，悬浮/聚焦时展开，自动令 label(flex-1 truncate)
    左移让位、文本靠左可截断，不遮字，行宽平滑过渡。无 border/padding，高度仅由按钮(20px)决定，
-   不高于标题行(22px)故悬浮出现绝不撑高行 */
+   不高于标题行(24px)故悬浮出现绝不撑高行 */
 .sidebar-view-switch {
   flex-shrink: 0;
   width: 0;

--- a/web/style.css
+++ b/web/style.css
@@ -2856,6 +2856,78 @@ body {
   padding: 10px 12px 0;
 }
 
+.composer-image-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px 0;
+}
+
+[data-testid="user-bubble"] + .composer-image-row {
+  padding: 8px 0 0;
+}
+
+.composer-image-thumb-wrap {
+  position: relative;
+  width: 56px;
+  height: 56px;
+}
+
+.composer-image-thumb {
+  display: block;
+  width: 56px;
+  height: 56px;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--dsw-border);
+  border-radius: 8px;
+  background: var(--dsw-hover);
+  cursor: zoom-in;
+}
+
+.composer-image-thumb img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.composer-image-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border: 0;
+  border-radius: 999px;
+  background: #3a3a3a;
+  color: var(--dsw-label);
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.composer-image-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.72);
+  cursor: zoom-out;
+}
+
+.composer-image-lightbox img {
+  max-width: min(920px, 92vw);
+  max-height: 88vh;
+  border-radius: 10px;
+  box-shadow: var(--dsw-shadow-lv2);
+  object-fit: contain;
+}
+
 .user-pick-chips {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 聊天顶栏
居中展示当前 session 名称，可直接编辑；回车或失焦写入配置，侧栏同步。清空则恢复推导标题。

## 任务面板溢出
表格/看板横向滚动收在模块内部，不再撑开整页大盒子。

## 插件商店
货架排版收紧：更小标题、更密卡片、更轻按钮，和任务面板密度对齐。

## 输入框粘贴图片
- 在 composer 里粘贴或拖入 PNG / JPEG / GIF / WebP（最多 6 张），输入区出现缩略图，点开可放大预览，可单独移除。
- 发送时图片以 data URL 写入 `user/message`，气泡里同样有缩略图预览。
- `deriveMessages` 投影成 multimodal `image_url`，走已有 vision 路由发给模型。空文字只贴图时文本为「（图片）」。

## 清空上下文按钮
橡皮擦紧挨选取（鼠标）按钮右侧，同样 32px 图标按钮，去掉百分比和 token 数字；占比仍看最近一条回复。

## 用量面板
Token usage 标题改用硬币图标；折线图不再在坐标轴上重复写 Input / Output（颜色只在顶部图例出现一次）。

## 左侧边栏
分组不再显示展开箭头，点击标题仍可收起；会话相对分组右缩一层。添加聊天、分组/板块图标与会话吉祥物统一 20×20，同一条垂直线对齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

