### PR TITLE
橡皮擦保留历史占比红色底

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { LuEraser } from 'react-icons/lu'
 import type { SlotProps } from '@biu/web-slots'
-import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
-import { type ChatNode } from '@biu/web-session-view'
+import { bindSessionView, type ChatNode, type SessionViewService } from '@biu/web-session-view'
 import { SessionProjectPanel } from './project-panel.tsx'
 
 type AgentMode = 'standard' | 'minimal'

--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -1,10 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { LuEraser } from 'react-icons/lu'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+import { type ChatNode } from '@biu/web-session-view'
 import { SessionProjectPanel } from './project-panel.tsx'
 
 type AgentMode = 'standard' | 'minimal'
+
+/** 最新一条回复的历史输入占比（0..1），驱动橡皮擦底色。 */
+function latestHistRatio(nodes: ChatNode[]): number | null {
+  const last = nodes.at(-1)
+  if (!last || last.kind !== 'reply') return null
+  const hist = last.usage?.histPct
+  if (typeof hist !== 'number' || !Number.isFinite(hist)) return null
+  return Math.min(1, Math.max(0, hist))
+}
 
 /** Dock 顶栏：左侧文件 + 选取 + 清空上下文 + 标准/极简胶囊，右侧 auto/hold。 */
 export function ApprovalsRail(props: SlotProps) {
@@ -13,6 +23,8 @@ export function ApprovalsRail(props: SlotProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const approvals = useSessionView((state) => state.approvals)
   const approvalMode = useSessionView((state) => state.approvalMode)
+  const nodes = useSessionView((state) => state.nodes)
+  const histRatio = useMemo(() => latestHistRatio(nodes), [nodes])
   const [agentMode, setAgentMode] = useState<AgentMode>('standard')
   const [modeBusy, setModeBusy] = useState(false)
   const [clearBusy, setClearBusy] = useState(false)
@@ -132,11 +144,22 @@ export function ApprovalsRail(props: SlotProps) {
             type="button"
             disabled={!sessionId || clearBusy}
             aria-label="清空上下文"
-            title="清空上下文"
-            className="project-chip project-chip-icon-only"
+            title={
+              histRatio != null
+                ? `清空上下文 · 历史 ${Math.round(histRatio * 100)}%`
+                : '清空上下文'
+            }
+            className="project-chip project-chip-icon-only relative overflow-hidden"
             onClick={() => void clearContext()}
           >
-            <LuEraser className="project-chip-icon" aria-hidden />
+            {histRatio != null && histRatio > 0 ? (
+              <span
+                className="pointer-events-none absolute inset-y-0 left-0 bg-[var(--dsw-danger)]/20"
+                style={{ width: `${Math.round(histRatio * 100)}%` }}
+                aria-hidden
+              />
+            ) : null}
+            <LuEraser className="project-chip-icon relative z-[1]" aria-hidden />
           </button>
           <span className="sr-only">Agent mode</span>
           <div className="dock-seg">

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -90,19 +90,17 @@ const SessionRow = memo(function SessionRow({
     >
       <Link
         to={`/s/${item.id}`}
-        className="flex min-w-0 flex-1 items-center gap-2 py-1 pr-1.5 text-left text-[12px] leading-4"
+        className="flex min-w-0 flex-1 items-center gap-1.5 px-1.5 py-1 text-left text-[12px] leading-4"
       >
-        <span className="grid size-5 shrink-0 place-items-center">
-          <SidebarMascot
-            size={20}
-            sessionId={item.id}
-            identity={identity}
-            busy={busy}
-            animate={false}
-            dancing={dancing}
-            title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
-          />
-        </span>
+        <SidebarMascot
+          size={24}
+          sessionId={item.id}
+          identity={identity}
+          busy={busy}
+          animate={false}
+          dancing={dancing}
+          title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
+        />
         <span className="min-w-0 flex-1 truncate font-medium">
           {(item.type ?? 'chat') === 'live' ? (
             <span className="mr-1 text-[9px] font-semibold tracking-wide text-[var(--dsw-label-3)] uppercase">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
橡皮擦按钮仍无文字、与选取同尺寸；按最新一条回复的历史占比铺红色背景（例如 50% 就红一半）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

