### PR TITLE
侧栏删除弹窗 + 插件图标 16px 居中

### DIFF
--- a/packages/cap-plugin-store/src/web/index.tsx
+++ b/packages/cap-plugin-store/src/web/index.tsx
@@ -99,7 +99,8 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
 
   const pending = items.find((item) => item.id === pendingUninstall) ?? null
   const iconBtn =
-    'grid size-6 shrink-0 cursor-pointer place-items-center rounded-[6px] border-0 bg-transparent text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)] disabled:opacity-40'
+    'inline-grid size-6 shrink-0 cursor-pointer place-items-center rounded-[6px] border-0 bg-transparent p-0 leading-none text-[var(--dsw-label-3)] hover:bg-[var(--dsw-hover)] hover:text-[var(--dsw-label)] disabled:opacity-40'
+  const actionIcon = { size: 16, strokeWidth: 2, className: 'block' } as const
 
   return (
     <div
@@ -128,7 +129,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
         {items.map((item) => (
           <li
             key={item.id}
-            className="flex items-start justify-between gap-2 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-2.5 py-2"
+            className="flex items-center justify-between gap-2 rounded-[8px] border border-[var(--dsw-border)] bg-[var(--dsw-surface)] px-2.5 py-2"
             data-testid={`plugin-store-card-${item.id}`}
             data-biu-kind="plugin"
             data-biu-id={item.id}
@@ -156,7 +157,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                 </p>
               ) : null}
             </div>
-            <div className="flex shrink-0 items-center gap-px pt-px">
+            <div className="flex shrink-0 items-center self-center gap-px">
               {item.enabled ? (
                 <button
                   type="button"
@@ -168,7 +169,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                   disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                   onClick={() => void closePlugin(item.id)}
                 >
-                  <LuSquare className="size-3" />
+                  <LuSquare {...actionIcon} />
                 </button>
               ) : (
                 <button
@@ -181,7 +182,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                   disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                   onClick={() => void openPlugin(item.id)}
                 >
-                  <LuPlay className="size-3" />
+                  <LuPlay {...actionIcon} />
                 </button>
               )}
               <button
@@ -193,7 +194,7 @@ function PluginStorePage({ compact = false }: { compact?: boolean }) {
                 disabled={Boolean(busy?.endsWith(`:${item.id}`))}
                 onClick={() => setPendingUninstall(item.id)}
               >
-                <LuTrash2 className="size-3" />
+                <LuTrash2 {...actionIcon} />
               </button>
             </div>
           </li>

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { createPortal } from 'react-dom'
 import { Link, useNavigate } from 'react-router-dom'
 import { isMascotDancing, subscribeMascotDance } from '@biu/web-mascot'
 import {
@@ -202,6 +203,7 @@ export const ChatSidebar = memo(function ChatSidebar({
   const sections = useMemo(() => buildSidebarSections(sessions, groupBy), [sessions, groupBy])
   // 板块级收缩（点击标题可展开/收缩，不显示收缩按钮，层级靠 kind 图标表达）
   const [collapsedSections, setCollapsedSections] = useState<Partial<Record<SidebarSectionKind, boolean>>>({})
+  const [pendingDelete, setPendingDelete] = useState<SessionListItem | null>(null)
   const toggleSection = useCallback((kind: SidebarSectionKind) => {
     setCollapsedSections((prev) => ({ ...prev, [kind]: !prev[kind] }))
   }, [])
@@ -231,18 +233,21 @@ export const ChatSidebar = memo(function ChatSidebar({
     [navigate, sessionView],
   )
 
-  const deleteChat = useCallback(
-    (item: SessionListItem) => {
-      if (!window.confirm(`Delete session “${item.title}”?`)) return
-      const wasActive = item.id === sessionId
-      void sessionView.deleteSession(item.id).then(() => {
-        if (!wasActive) return
-        const next = sessionView.get().sessionId
-        navigate(next ? `/s/${next}` : '/')
-      })
-    },
-    [navigate, sessionId, sessionView],
-  )
+  const requestDeleteChat = useCallback((item: SessionListItem) => {
+    setPendingDelete(item)
+  }, [])
+
+  const confirmDeleteChat = useCallback(() => {
+    if (!pendingDelete) return
+    const item = pendingDelete
+    setPendingDelete(null)
+    const wasActive = item.id === sessionId
+    void sessionView.deleteSession(item.id).then(() => {
+      if (!wasActive) return
+      const next = sessionView.get().sessionId
+      navigate(next ? `/s/${next}` : '/')
+    })
+  }, [navigate, pendingDelete, sessionId, sessionView])
 
   const pinChat = useCallback(
     (item: SessionListItem) => {
@@ -359,7 +364,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                               active={item.id === routeSessionId}
                               busy={Boolean(busySessions[item.id]) || (item.id === routeSessionId && agentBusy)}
                               dancing={dancing}
-                              onDelete={deleteChat}
+                              onDelete={requestDeleteChat}
                               onPin={pinChat}
                             />
                           ))
@@ -433,7 +438,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                                   active={item.id === routeSessionId}
                                   busy={Boolean(busySessions[item.id]) || (item.id === routeSessionId && agentBusy)}
                                   dancing={dancing}
-                                  onDelete={deleteChat}
+                                  onDelete={requestDeleteChat}
                                   onPin={pinChat}
                                 />
                               ))}
@@ -450,6 +455,49 @@ export const ChatSidebar = memo(function ChatSidebar({
           )}
         </div>
       </div>
+      {pendingDelete && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              className="fixed inset-0 z-[80] flex items-center justify-center bg-black/55 p-4"
+              data-testid="chat-session-delete-dialog"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="chat-session-delete-title"
+              onClick={() => setPendingDelete(null)}
+            >
+              <div
+                className="w-[min(100%,320px)] rounded-[10px] border border-[var(--dsw-border)] bg-[var(--dsw-sidebar)] p-4 text-[var(--dsw-label)]"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <h2 id="chat-session-delete-title" className="m-0 text-[13px] font-semibold">
+                  删除「{pendingDelete.title}」？
+                </h2>
+                <p className="mt-1.5 mb-0 text-[11px] leading-[1.45] text-[var(--dsw-label-3)]">
+                  删除后无法恢复这份会话。
+                </p>
+                <div className="mt-3 flex justify-end gap-1.5">
+                  <button
+                    type="button"
+                    className="rounded-[6px] border-0 bg-[var(--dsw-hover)] px-2.5 py-1 text-[11px] text-[var(--dsw-label)] hover:bg-[#353535]"
+                    data-testid="chat-session-delete-cancel"
+                    onClick={() => setPendingDelete(null)}
+                  >
+                    取消
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded-[6px] border-0 bg-[var(--dsw-hover)] px-2.5 py-1 text-[11px] font-medium text-[var(--dsw-label)] hover:bg-[#353535]"
+                    data-testid="chat-session-delete-confirm"
+                    onClick={confirmDeleteChat}
+                  >
+                    确认删除
+                  </button>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
     </aside>
   )
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动
- 左侧边栏删除会话改为与插件卸载相同的确认弹窗（取消 / 确认删除），不再使用 `window.confirm`。
- 右侧检查器插件卡片的打开/关闭与卸载图标改为 16×16（线宽 2），按钮网格居中，卡片 `items-center` 垂直对齐。

## 验证
- 删除会话会弹出居中对话框，取消不删，确认后走原有 `deleteSession` 导航逻辑。
- 插件卡片上两个操作图标与壳层其它描边图标尺寸一致，并相对卡片垂直居中。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

