### PR TITLE
fix: 粘贴图片不再重复成两张

### DIFF
--- a/packages/cap-chat/src/web/clipboard-images.test.ts
+++ b/packages/cap-chat/src/web/clipboard-images.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { collectClipboardImages, uniqueImageFiles } from './clipboard-images.ts'
+
+function png(name: string, sizeHint = 12): File {
+  const bytes = new Uint8Array(sizeHint)
+  return new File([bytes], name, { type: 'image/png', lastModified: 1_700_000_000_000 })
+}
+
+describe('uniqueImageFiles', () => {
+  it('drops the same screenshot listed twice (files + items)', () => {
+    const shot = png('image.png', 40)
+    expect(uniqueImageFiles([shot, shot])).toHaveLength(1)
+  })
+
+  it('keeps two different files', () => {
+    expect(uniqueImageFiles([png('a.png', 10), png('b.png', 20)])).toHaveLength(2)
+  })
+
+  it('ignores non-images', () => {
+    const txt = new File([new Uint8Array(4)], 'notes.txt', { type: 'text/plain' })
+    expect(uniqueImageFiles([txt, png('ok.png')])).toHaveLength(1)
+  })
+})
+
+describe('collectClipboardImages', () => {
+  it('dedups when files and items both expose the same screenshot', () => {
+    const shot = png('paste.png', 64)
+    const clipboard = {
+      files: [shot] as unknown as FileList,
+      items: [{ kind: 'file' as const, getAsFile: () => shot }],
+    } as unknown as DataTransfer
+    const images = collectClipboardImages(clipboard)
+    expect(images).toHaveLength(1)
+    expect(images[0]?.name).toBe('paste.png')
+  })
+})

--- a/packages/cap-chat/src/web/clipboard-images.ts
+++ b/packages/cap-chat/src/web/clipboard-images.ts
@@ -1,0 +1,39 @@
+const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
+
+export { IMAGE_MIMES }
+
+function fileFingerprint(file: File): string {
+  return `${file.name}\0${file.size}\0${file.lastModified}\0${file.type}`
+}
+
+/** Drop / file-input: keep image files only. */
+export function collectImageFiles(list: FileList | File[] | null | undefined): File[] {
+  if (!list) return []
+  return uniqueImageFiles([...list])
+}
+
+/**
+ * Paste often exposes the same screenshot via both `clipboardData.files`
+ * and `clipboardData.items`. Dedup by name/size/mtime/type so one paste
+ * becomes one pending image.
+ */
+export function uniqueImageFiles(files: Array<File | null | undefined>): File[] {
+  const seen = new Set<string>()
+  const out: File[] = []
+  for (const file of files) {
+    if (!file || !IMAGE_MIMES.has(file.type)) continue
+    const key = fileFingerprint(file)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(file)
+  }
+  return out
+}
+
+export function collectClipboardImages(clipboard: DataTransfer | null | undefined): File[] {
+  if (!clipboard) return []
+  const fromFiles = [...(clipboard.files ?? [])]
+  const fromItems = [...clipboard.items]
+    .map((item) => (item.kind === 'file' ? item.getAsFile() : null))
+  return uniqueImageFiles([...fromFiles, ...fromItems])
+}

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -6,6 +6,7 @@ import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { formatPicks, PickChipLabel, usePickState, type PickService } from '@biu/cap-pick/web'
 import { ModelConfigDialog } from './model-config-dialog.tsx'
 import { ImageThumbs } from './image-thumbs.tsx'
+import { collectClipboardImages, collectImageFiles } from './clipboard-images.ts'
 
 /** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
 const INPUT_DEBOUNCE_MS = 120
@@ -53,15 +54,9 @@ function clearDraft(sessionId: string) {
   }
 }
 
-const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
 const MAX_PENDING_IMAGES = 6
 
 type PendingImage = { id: string; name: string; mime: string; previewUrl: string; file: File }
-
-function collectImageFiles(list: FileList | File[] | null | undefined): File[] {
-  if (!list) return []
-  return [...list].filter((file) => IMAGE_MIMES.has(file.type))
-}
 
 function readFileDataUrl(file: File): Promise<{ name: string; mime: string; url: string }> {
   return new Promise((resolve, reject) => {
@@ -443,11 +438,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   }, [])
 
   function onPaste(event: ClipboardEvent<HTMLTextAreaElement>) {
-    const files = collectImageFiles(event.clipboardData?.files)
-    const fromItems = [...(event.clipboardData?.items ?? [])]
-      .map((item) => (item.kind === 'file' ? item.getAsFile() : null))
-      .filter((file): file is File => Boolean(file))
-    const images = collectImageFiles([...files, ...fromItems])
+    const images = collectClipboardImages(event.clipboardData)
     if (!images.length) return
     addImageFiles(images)
     if (!event.clipboardData?.getData('text/plain')) event.preventDefault()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题
Ctrl/Cmd+V 一张图会在输入栏出现两张缩略图。原因是 `onPaste` 同时读了 `clipboardData.files` 和 `clipboardData.items`，多数浏览器同一张剪贴板图会出现在两处。

## 修复
- 合并两处来源后按 `name + size + lastModified + type` 去重。
- 抽出 `clipboard-images.ts` 并加单测。

## 发送后图片怎么处理（说明，非本次代码改动）
1. 预览用 `URL.createObjectURL`；点发送时 `FileReader.readAsDataURL` 转成 **data URL**（不单独上传文件）。
2. `sessionView.send` 只保留 `data:image/`，最多 6 张；纯图无文字时正文为 `（图片）`。
3. `POST /api/sessions/:id/messages` 带 `images: [{ name, mime, url }]`。
4. host 侧 `sanitizeImages`（mime、data URL、约 8MB、最多 6 张）后写入 session。
5. `deriveMessages` 把用户消息编成多模态：`text` + `{ type: 'image_url', image_url: { url } }` 送给 LLM（有图时 DeepSeek 走 vision 模型）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

