### PR TITLE
fix: 左右面板收起后切换按钮跟着改方向

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -340,7 +340,7 @@ function Shell(props: SlotProps) {
                   aria-label="Expand sidebar"
                   onClick={expandSidebar}
                 >
-                  <ChevronDoubleLeftIcon {...chromeIcon} />
+                  <ChevronDoubleRightIcon {...chromeIcon} />
                 </button>
               ) : null}
               {project ? (
@@ -371,7 +371,11 @@ function Shell(props: SlotProps) {
                 data-testid="inspector-toggle"
                 onClick={toggleInspector}
               >
-                <ChevronDoubleRightIcon {...chromeIcon} />
+                {inspectorOpen ? (
+                  <ChevronDoubleRightIcon {...chromeIcon} />
+                ) : (
+                  <ChevronDoubleLeftIcon {...chromeIcon} />
+                )}
               </button>
             </div>
           </header>

--- a/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
+++ b/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+
+describe('panel collapse chevrons follow panel state', () => {
+  it('points right to expand a collapsed left sidebar', () => {
+    expect(shell).toMatch(
+      /onClick=\{expandSidebar\}\s*>\s*<ChevronDoubleRightIcon/,
+    )
+  })
+
+  it('points left to open the inspector and right to collapse it', () => {
+    expect(shell).toMatch(
+      /inspectorOpen \?\s*\(\s*<ChevronDoubleRightIcon[\s\S]*:\s*\(\s*<ChevronDoubleLeftIcon/,
+    )
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏收起后顶栏按钮改为双箭头向右（展开）；检查器关闭时顶栏按钮改为双箭头向左（打开），打开时仍向右收起。左侧栏展开时头部按钮本来就是向左收起，未改。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

