### PR TITLE
fix: 空聊天吉祥物按悬浮主区垂直居中

### DIFF
--- a/packages/cap-chat/src/web/empty-hero-center.test.ts
+++ b/packages/cap-chat/src/web/empty-hero-center.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+
+describe('empty chat hero centering', () => {
+  it('fills the stage including composer reserve so the mascot is not shifted up', () => {
+    expect(css).toMatch(/\.chat-empty-hero[\s\S]*min-height:\s*calc\(100% \+ 11rem\)/)
+    expect(css).toMatch(/\.chat-empty-hero[\s\S]*margin-bottom:\s*-11rem/)
+    expect(css).toMatch(/\.chat-empty-hero[\s\S]*padding:\s*0/)
+  })
+})

--- a/web/style.css
+++ b/web/style.css
@@ -119,20 +119,24 @@ body {
 .chat-empty-hero {
   position: relative;
   display: flex;
-  flex: 1;
+  flex: 1 1 auto;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: min(52vh, 420px);
-  padding: 48px 24px 72px;
+  box-sizing: border-box;
+  /* 输入栏是 absolute 悬浮，不占文档流。stage 的 pb-44 只给消息列表垫底，
+     空态按整块可视主区垂直居中，不跟着那块 padding 上移。 */
+  min-height: calc(100% + 11rem);
+  margin-bottom: -11rem;
+  padding: 0;
 }
 
 .chat-empty-hero-glow {
   pointer-events: none;
   position: absolute;
-  inset: 12% 18% 28%;
+  inset: 18% 20% 22%;
   background:
-    radial-gradient(ellipse at 50% 42%, rgba(242, 241, 237, 0.16), transparent 62%),
+    radial-gradient(ellipse at 50% 48%, rgba(242, 241, 237, 0.16), transparent 62%),
     radial-gradient(ellipse at 50% 58%, rgba(120, 160, 180, 0.08), transparent 70%);
   filter: blur(2px);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
输入栏是 `absolute` 悬浮，不占文档流。`chat-stage` 的 `pb-44` 只给有消息时垫底，避免最后一条钻到输入框下面。空聊天吉祥物之前在这块缩过的内容区里垂直居中，所以会偏上。空态改为按整块可视主区居中，不再跟着那块 padding 上移。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70705c09-07f8-4524-b627-16baf4f615a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70705c09-07f8-4524-b627-16baf4f615a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

