### PR TITLE
fix(ui): 擦除按钮历史底色改回樱桃红

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -267,7 +267,7 @@ export function ApprovalsRail(props: SlotProps) {
           >
             {histRatio != null && histRatio > 0 ? (
               <span className="project-chip-hist" aria-hidden>
-                <span className="project-chip-hist-bar" style={{ height: `${Math.round(histRatio * 100)}%`, backgroundColor: '#E85854' }} />
+                <span className="project-chip-hist-bar" style={{ height: `${Math.round(histRatio * 100)}%` }} />
               </span>
             ) : null}
             <PaintBrushIcon className="size-4 relative z-[1]" aria-hidden />

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -44,6 +44,17 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.pick-overlay-marquee[\s\S]*background:\s*var\(--dsw-pick-fill\)/)
   })
 
+  it('paints the context-clear hist fill as opaque cherry red without blend or color-scheme overrides', () => {
+    const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
+    const approvals = readFileSync(resolve(root, 'packages/cap-chat/src/web/approvals.tsx'), 'utf8')
+    expect(css).toMatch(/--dsw-chat-hist-fill:\s*#EA5955/)
+    expect(css).toMatch(/\.project-chip-hist-bar\s*\{[^}]*background:\s*var\(--dsw-chat-hist-fill\)/s)
+    expect(css).not.toMatch(/\.project-chip-hist-bar\s*\{[^}]*color-scheme:/s)
+    expect(css).not.toMatch(/\.project-chip-hist-bar\s*\{[^}]*mix-blend-mode:/s)
+    expect(approvals).toMatch(/project-chip-hist-bar/)
+    expect(approvals).not.toMatch(/backgroundColor/)
+  })
+
   it('paints inspector trajectory and usage on the same sidebar token as the left rail', () => {
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     expect(css).toMatch(/\.traj-root\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)

--- a/web/style.css
+++ b/web/style.css
@@ -47,7 +47,7 @@
   --dsw-chat-reply-pad-x: 12px;
   --dsw-chat-max-width: 768px;
   --dsw-chat-code-bg: var(--dsw-sidebar);
-  --dsw-chat-hist-fill: #E85854;
+  --dsw-chat-hist-fill: #EA5955;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
     "Microsoft YaHei", system-ui, sans-serif;
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Consolas, monospace;
@@ -967,9 +967,7 @@ body {
   left: 0;
   width: 100%;
   transform-origin: bottom;
-  color-scheme: light;
-  opacity: 1;
-  mix-blend-mode: normal;
+  background: var(--dsw-chat-hist-fill);
   transition: height 0.2s ease;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取按钮右侧的「清空上下文」橡皮擦，历史占比底色配置是樱桃红 `#EA5955`，实际取色却接近印度红 `#D66858`。

原因：
- hist 条被改成行内 `#E85854`，不再走 `--dsw-chat-hist-fill`
- `.project-chip-hist-bar` 上加了 `color-scheme: light` 和 `mix-blend-mode`，在根节点 `color-scheme: dark` 下会改写合成色

改动：
- `--dsw-chat-hist-fill` 收回到 `#EA5955`
- 条只用 CSS 实色 `background: var(--dsw-chat-hist-fill)`，高度仍由 inline style 控制
- 去掉会改色的 `color-scheme` / `mix-blend-mode` / 行内 backgroundColor

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e361bff-4b0f-4b30-8ed6-6c0a15131940?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e361bff-4b0f-4b30-8ed6-6c0a15131940&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

