### PR TITLE
feat(plugin): 分层任务编排插件，三级 workflow 按层调用不同模型

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist/
 .plugin-dev/*
 !.plugin-dev/store-heavy-ping/
 !.plugin-dev/store-heavy-ping/**
+!.plugin-dev/task-tier-router/
+!.plugin-dev/task-tier-router/**
 .workspace/
 *.log
 .DS_Store

--- a/.plugin-dev/task-tier-router/flow.ts
+++ b/.plugin-dev/task-tier-router/flow.ts
@@ -1,0 +1,338 @@
+/**
+ * 分层 workflow 编排：plan → coord 分派 → exec 并行 → coord 验收整合。
+ *
+ * 每一步都落到任务面板上（父任务 = 目标，子任务 = 规划出的 subtask），
+ * 并用 task_report 的同一套语义写进度，所以整条链在任务面板里可回溯。
+ */
+
+import { coordTier, execSlots, planTier, type TierDef } from './tiers.ts'
+import { parseAssignments, parsePlan, type PlanResult } from './parse.ts'
+import { effectiveModel, ensureWorker, type HostLike, type WorkerHandle } from './workers.ts'
+
+export interface TaskRowLike {
+  id: string
+  title: string
+}
+
+export interface TasksLike {
+  create(input: Record<string, unknown>): TaskRowLike
+  update(id: string, patch: Record<string, unknown>): TaskRowLike
+  report(id: string, report: Record<string, unknown>): TaskRowLike
+}
+
+export interface FlowHost extends HostLike {
+  tasks: TasksLike
+}
+
+export interface RunInput {
+  goal: string
+  project?: string
+  /** 只跑规划+分派，不真正执行（用来预览编排结果） */
+  dryRun?: boolean
+}
+
+export interface StepTrace {
+  tier: string
+  slot: string
+  model: string
+  sessionId: string
+  ms: number
+  chars: number
+}
+
+export interface ExecOutcome {
+  index: number
+  slot: string
+  title: string
+  taskId: string
+  model: string
+  text: string
+  ms: number
+  ok: boolean
+  error?: string
+}
+
+export interface RunResult {
+  goal: string
+  runLabel: string
+  rootTaskId: string
+  plan: PlanResult
+  trace: StepTrace[]
+  outcomes: ExecOutcome[]
+  review: string
+  degraded: string[]
+  totalMs: number
+}
+
+function runLabelOf(goal: string): string {
+  const stamp = new Date().toISOString().slice(11, 19)
+  return `${goal.slice(0, 18)}@${stamp}`
+}
+
+async function timed<T>(fn: () => Promise<T>): Promise<{ value: T; ms: number }> {
+  const started = Date.now()
+  const value = await fn()
+  return { value, ms: Date.now() - started }
+}
+
+function trace(worker: WorkerHandle, host: FlowHost, ms: number, text: string): StepTrace {
+  return {
+    tier: worker.def.tier,
+    slot: worker.def.slot,
+    model: effectiveModel(host, worker.sessionId) || worker.def.model,
+    sessionId: worker.sessionId,
+    ms,
+    chars: text.length,
+  }
+}
+
+export async function runTieredFlow(host: FlowHost, input: RunInput): Promise<RunResult> {
+  const goal = input.goal.trim()
+  if (!goal) throw new Error('goal required')
+  const startedAll = Date.now()
+  const runLabel = runLabelOf(goal)
+  const pool = new Map<string, string>()
+  const traces: StepTrace[] = []
+  const degraded: string[] = []
+  const log = host.logger('tier-router')
+
+  const wanted = { project: input.project, pool }
+
+  // ── 根任务：整条 workflow 的锚点 ──
+  const root = host.tasks.create({
+    title: `分层执行：${goal.slice(0, 60)}`,
+    description: goal,
+    status: 'doing',
+    priority: 'high',
+    project: 'tier-router',
+    tags: ['tier-router', 'workflow'],
+    creator: { kind: 'agent', name: 'tier-router' },
+  })
+
+  // ── 一层：Claude 规划 ──
+  const planner = await ensureWorker(host, planTier(), runLabel, wanted)
+  const planRun = await timed(() =>
+    planner.ask(
+      [
+        `目标：${goal}`,
+        input.project ? `工作目录：${input.project}` : '',
+        '请按你的 JSON 规范输出拆解方案。',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+    ),
+  )
+  traces.push(trace(planner, host, planRun.ms, planRun.value))
+  const plan = parsePlan(planRun.value, goal)
+  if (plan.degraded) degraded.push('规划层未返回可解析 JSON，已降级为单子任务')
+  host.tasks.report(root.id, {
+    sessionId: planner.sessionId,
+    turn: null,
+    status: 'doing',
+    note: `规划完成：${plan.subtasks.length} 个子任务（${effectiveModel(host, planner.sessionId)}）`,
+    ts: Date.now(),
+  })
+
+  // 子任务建档：挂在根任务下，形成 workflow 的树结构
+  const childTasks = plan.subtasks.map((sub) =>
+    host.tasks.create({
+      title: sub.title,
+      description: sub.detail,
+      status: 'todo',
+      difficulty: sub.difficulty,
+      parentId: root.id,
+      project: 'tier-router',
+      tags: ['tier-router', 'exec'],
+      creator: { kind: 'agent', name: 'tier-router' },
+    }),
+  )
+
+  // ── 二层：GPT 统筹分派 ──
+  const slots = execSlots()
+  const coordinator = await ensureWorker(host, coordTier(), runLabel, wanted)
+  const dispatchRun = await timed(() =>
+    coordinator.ask(
+      [
+        `目标：${plan.goal}`,
+        '子任务清单：',
+        ...plan.subtasks.map((s, i) => `${i}. ${s.title} —— ${s.detail}`),
+        `可用 worker 槽位：${slots.map((s) => `${s.slot}(${s.label})`).join('、')}`,
+        '请输出分派 JSON。',
+      ].join('\n'),
+    ),
+  )
+  traces.push(trace(coordinator, host, dispatchRun.ms, dispatchRun.value))
+  const parsedAssign = parseAssignments(
+    dispatchRun.value,
+    plan.subtasks.length,
+    slots.map((s) => s.slot),
+  )
+  if (parsedAssign.degraded) degraded.push('统筹层分派不完整，缺失项已按 round-robin 补齐')
+
+  // 把分派结果写回任务的 assignee，任务面板上能看到谁在做哪条
+  const execWorkers = new Map<string, WorkerHandle>()
+  for (const def of slots) {
+    execWorkers.set(def.slot, await ensureWorker(host, def, runLabel, wanted))
+  }
+  for (const item of parsedAssign.assignments) {
+    const worker = execWorkers.get(item.slot)
+    const task = childTasks[item.index]
+    if (!worker || !task) continue
+    host.tasks.update(task.id, {
+      assignee: { kind: 'agent', name: worker.def.label, sessionId: worker.sessionId },
+      assignedAt: Date.now(),
+      notes: item.brief,
+    })
+  }
+
+  if (input.dryRun) {
+    host.tasks.report(root.id, {
+      sessionId: coordinator.sessionId,
+      turn: null,
+      status: 'doing',
+      note: 'dryRun：已完成规划与分派，未执行',
+      ts: Date.now(),
+    })
+    return {
+      goal: plan.goal,
+      runLabel,
+      rootTaskId: root.id,
+      plan,
+      trace: traces,
+      outcomes: parsedAssign.assignments.map((a) => ({
+        index: a.index,
+        slot: a.slot,
+        title: plan.subtasks[a.index]?.title ?? '',
+        taskId: childTasks[a.index]?.id ?? '',
+        model: execWorkers.get(a.slot)?.def.model ?? '',
+        text: '',
+        ms: 0,
+        ok: true,
+      })),
+      review: '（dryRun 未执行）',
+      degraded,
+      totalMs: Date.now() - startedAll,
+    }
+  }
+
+  // ── 三层：Kimi / DeepSeek 并行执行 ──
+  // 同 slot 的多条子任务要串行（一个 session 一次只能跑一个回合），
+  // 不同 slot 之间并行。按 slot 分组后组内顺序、组间 Promise.all。
+  const bySlot = new Map<string, typeof parsedAssign.assignments>()
+  for (const item of parsedAssign.assignments) {
+    const list = bySlot.get(item.slot) ?? []
+    list.push(item)
+    bySlot.set(item.slot, list)
+  }
+
+  const outcomes: ExecOutcome[] = []
+  await Promise.all(
+    [...bySlot.entries()].map(async ([slot, items]) => {
+      const worker = execWorkers.get(slot)
+      if (!worker) return
+      for (const item of items) {
+        const sub = plan.subtasks[item.index]
+        const task = childTasks[item.index]
+        if (!sub || !task) continue
+        host.tasks.update(task.id, { status: 'doing' })
+        try {
+          const run = await timed(() =>
+            worker.ask(
+              [
+                `总目标：${plan.goal}`,
+                `你的子任务：${sub.title}`,
+                sub.detail ? `要求：${sub.detail}` : '',
+                item.brief ? `统筹层补充：${item.brief}` : '',
+                '直接给出成品结果。',
+              ]
+                .filter(Boolean)
+                .join('\n'),
+            ),
+          )
+          traces.push(trace(worker, host, run.ms, run.value))
+          outcomes.push({
+            index: item.index,
+            slot,
+            title: sub.title,
+            taskId: task.id,
+            model: effectiveModel(host, worker.sessionId) || worker.def.model,
+            text: run.value,
+            ms: run.ms,
+            ok: true,
+          })
+          host.tasks.report(task.id, {
+            sessionId: worker.sessionId,
+            turn: null,
+            status: 'done',
+            note: `${worker.def.label} 完成（${run.value.length} 字）`,
+            ts: Date.now(),
+          })
+          host.tasks.update(task.id, { status: 'done' })
+        } catch (error) {
+          const detail = String(error)
+          log.error(`exec failed slot=${slot} index=${item.index}: ${detail}`)
+          degraded.push(`执行层 ${slot} 子任务#${item.index} 失败：${detail}`)
+          outcomes.push({
+            index: item.index,
+            slot,
+            title: sub.title,
+            taskId: task.id,
+            model: worker.def.model,
+            text: '',
+            ms: 0,
+            ok: false,
+            error: detail,
+          })
+          host.tasks.report(task.id, {
+            sessionId: worker.sessionId,
+            turn: null,
+            status: 'doing',
+            note: `执行失败：${detail.slice(0, 200)}`,
+            ts: Date.now(),
+          })
+        }
+      }
+    }),
+  )
+  outcomes.sort((a, b) => a.index - b.index)
+
+  // ── 回到二层：GPT 验收 + 整合 ──
+  const reviewRun = await timed(() =>
+    coordinator.ask(
+      [
+        `目标：${plan.goal}`,
+        '各 worker 交付如下，请验收并整合成一份最终结果。',
+        ...outcomes.map(
+          (o) =>
+            `【子任务${o.index}·${o.slot}·${o.model}】${o.title}\n${o.ok ? o.text.slice(0, 4000) : `（失败：${o.error}）`}`,
+        ),
+        '输出格式：一、整合结果（可直接交付的内容）；二、验收意见（每条子任务一句，指出问题或确认通过）；三、若有缺口列出补救建议。',
+      ].join('\n\n'),
+    ),
+  )
+  traces.push(trace(coordinator, host, reviewRun.ms, reviewRun.value))
+
+  const allOk = outcomes.every((o) => o.ok)
+  host.tasks.report(root.id, {
+    sessionId: coordinator.sessionId,
+    turn: null,
+    status: allOk ? 'done' : 'doing',
+    note: allOk
+      ? `统筹验收完成，${outcomes.length} 条子任务全部交付`
+      : `统筹验收完成，存在失败子任务（${outcomes.filter((o) => !o.ok).length} 条）`,
+    ts: Date.now(),
+  })
+  host.tasks.update(root.id, { status: allOk ? 'done' : 'doing' })
+
+  return {
+    goal: plan.goal,
+    runLabel,
+    rootTaskId: root.id,
+    plan,
+    trace: traces,
+    outcomes,
+    review: reviewRun.value,
+    degraded,
+    totalMs: Date.now() - startedAll,
+  }
+}

--- a/.plugin-dev/task-tier-router/host.ts
+++ b/.plugin-dev/task-tier-router/host.ts
@@ -1,0 +1,120 @@
+/**
+ * 分层任务编排插件。
+ *
+ * 三级 workflow：
+ *   plan（Claude）→ coord（GPT 分派）→ exec（Kimi ‖ DeepSeek）→ coord（GPT 验收整合）
+ *
+ * 每层跑各自模型：通过写 session.config.{provider,model} 实现，
+ * cap-chat.resolveLlm(sessionId) 会让该 session 的每个回合走对应上游。
+ */
+
+import { TIERS } from './tiers.ts'
+import { runTieredFlow, type FlowHost, type RunResult } from './flow.ts'
+
+export const name = 'task-tier-router'
+export const inject = ['tools', 'sessions', 'agents', 'tasks']
+
+interface Ctx extends FlowHost {
+  tools: {
+    register(spec: {
+      name: string
+      description: string
+      parameters: Record<string, unknown>
+      execute: (args: Record<string, unknown>) => unknown
+    }): unknown
+  }
+}
+
+/** 报告：把 trace 做成表格，肉眼可核对每层用了哪个模型。 */
+function renderReport(result: RunResult): string {
+  const lines: string[] = []
+  lines.push(`目标：${result.goal}`)
+  lines.push(`根任务：${result.rootTaskId} · 总耗时 ${(result.totalMs / 1000).toFixed(1)}s`)
+  lines.push('')
+  lines.push('层级调用轨迹：')
+  lines.push('| 层级 | 槽位 | 模型 | 耗时 | 输出字数 |')
+  lines.push('|---|---|---|---|---|')
+  for (const t of result.trace) {
+    lines.push(`| ${t.tier} | ${t.slot} | ${t.model} | ${(t.ms / 1000).toFixed(1)}s | ${t.chars} |`)
+  }
+  lines.push('')
+  lines.push(`规划层拆出 ${result.plan.subtasks.length} 条子任务：`)
+  for (const [i, sub] of result.plan.subtasks.entries()) {
+    const outcome = result.outcomes.find((o) => o.index === i)
+    const who = outcome ? `${outcome.slot}/${outcome.model}` : '未分派'
+    lines.push(`${i}. ${sub.title} → ${who}${outcome && !outcome.ok ? ' ❌' : ''}`)
+  }
+  if (result.plan.risks.length) {
+    lines.push('')
+    lines.push(`规划层提示风险：${result.plan.risks.join('；')}`)
+  }
+  if (result.degraded.length) {
+    lines.push('')
+    lines.push('降级记录：')
+    for (const d of result.degraded) lines.push(`- ${d}`)
+  }
+  lines.push('')
+  lines.push('统筹层验收与整合：')
+  lines.push(result.review)
+  return lines.join('\n')
+}
+
+export function apply(ctx: Ctx) {
+  ctx.tools.register({
+    name: 'tier_flow_run',
+    description:
+      '分层 workflow：接到目标后 Claude 规划拆解 → GPT 统筹分派 → Kimi/DeepSeek 并行执行 → GPT 验收整合。' +
+      '每层跑各自模型，全过程落任务面板（根任务+子任务+report）。返回各层调用轨迹与最终整合结果。',
+    parameters: {
+      type: 'object',
+      properties: {
+        goal: { type: 'string', description: '要交付的目标，一句话描述' },
+        project: { type: 'string', description: '可选：给各层 session 绑定的工作目录绝对路径' },
+        dryRun: { type: 'boolean', description: '只做规划与分派预览，不真正执行' },
+        format: {
+          type: 'string',
+          enum: ['report', 'json'],
+          description: 'report=可读报告（默认）；json=原始结构',
+        },
+      },
+      required: ['goal'],
+    },
+    execute: async (args) => {
+      const result = await runTieredFlow(ctx, {
+        goal: String(args.goal ?? ''),
+        ...(typeof args.project === 'string' && args.project.trim()
+          ? { project: args.project.trim() }
+          : {}),
+        dryRun: args.dryRun === true,
+      })
+      if (args.format === 'json') return result
+      return {
+        rootTaskId: result.rootTaskId,
+        totalMs: result.totalMs,
+        report: renderReport(result),
+        sessions: result.trace.map((t) => ({
+          tier: t.tier,
+          slot: t.slot,
+          model: t.model,
+          sessionId: t.sessionId,
+        })),
+      }
+    },
+  })
+
+  ctx.tools.register({
+    name: 'tier_flow_tiers',
+    description: '查看分层 workflow 的层级 → 模型映射（规划/统筹/执行各用哪个模型）。',
+    parameters: { type: 'object', properties: {} },
+    execute: () => ({
+      tiers: TIERS.map((t) => ({
+        tier: t.tier,
+        slot: t.slot,
+        label: t.label,
+        provider: t.provider,
+        model: t.model,
+      })),
+      note: '模型按 session.config 覆盖生效；改映射请编辑插件 tiers.ts 后重新 plugin_pack。',
+    }),
+  })
+}

--- a/.plugin-dev/task-tier-router/manifest.json
+++ b/.plugin-dev/task-tier-router/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "task-tier-router",
+  "name": "分层任务编排",
+  "blurb": "三级 workflow：Claude 规划 → GPT 统筹 → Kimi/DeepSeek 并行执行 → GPT 验收与整合，各层跑各自模型。",
+  "tags": [
+    "workflow",
+    "agent",
+    "tool"
+  ],
+  "author": "Biu",
+  "authorUrl": "",
+  "createdAt": 1787948034795
+}

--- a/.plugin-dev/task-tier-router/parse.ts
+++ b/.plugin-dev/task-tier-router/parse.ts
@@ -1,0 +1,130 @@
+/**
+ * 模型输出的结构化解析。
+ *
+ * 现实约束：即使 prompt 里写了「严格 JSON」，模型仍可能裹 markdown 围栏、
+ * 或在 JSON 前后加一句解释。这里做容错提取，失败时给出可降级的结果，
+ * 而不是让整条 workflow 崩掉。
+ */
+
+export interface PlanSubtask {
+  title: string
+  detail: string
+  difficulty: 'low' | 'med' | 'high'
+}
+
+export interface PlanResult {
+  goal: string
+  subtasks: PlanSubtask[]
+  risks: string[]
+  /** true 表示 JSON 没解析出来、走了降级路径 */
+  degraded: boolean
+  raw: string
+}
+
+export interface Assignment {
+  index: number
+  slot: string
+  brief: string
+}
+
+/** 从可能带围栏/前后缀的文本里抠出第一个 JSON 对象。 */
+export function extractJson(text: string): unknown {
+  const cleaned = text.replace(/```json/gi, '```').trim()
+  const fenced = cleaned.match(/```\s*([\s\S]*?)```/)
+  const candidates: string[] = []
+  if (fenced?.[1]) candidates.push(fenced[1].trim())
+  const start = cleaned.indexOf('{')
+  const end = cleaned.lastIndexOf('}')
+  if (start >= 0 && end > start) candidates.push(cleaned.slice(start, end + 1))
+  candidates.push(cleaned)
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate)
+    } catch {
+      continue
+    }
+  }
+  return null
+}
+
+function asDifficulty(value: unknown): 'low' | 'med' | 'high' {
+  return value === 'low' || value === 'high' ? value : 'med'
+}
+
+export function parsePlan(text: string, fallbackGoal: string): PlanResult {
+  const raw = text
+  const data = extractJson(text) as Record<string, unknown> | null
+  const subtasksRaw = Array.isArray(data?.subtasks) ? data!.subtasks : []
+  const subtasks: PlanSubtask[] = subtasksRaw
+    .map((item) => {
+      const row = (item ?? {}) as Record<string, unknown>
+      const title = String(row.title ?? '').trim()
+      if (!title) return null
+      return {
+        title: title.slice(0, 120),
+        detail: String(row.detail ?? '').trim(),
+        difficulty: asDifficulty(row.difficulty),
+      }
+    })
+    .filter((item): item is PlanSubtask => item !== null)
+    .slice(0, 6)
+
+  if (!subtasks.length) {
+    // 降级：规划层没给出可用 JSON，就把原目标当成单个子任务往下走，
+    // workflow 仍然完整，只是并行度退化为 1。
+    return {
+      goal: fallbackGoal,
+      subtasks: [{ title: fallbackGoal.slice(0, 120), detail: raw.slice(0, 2000), difficulty: 'med' }],
+      risks: [],
+      degraded: true,
+      raw,
+    }
+  }
+
+  const risks = Array.isArray(data?.risks)
+    ? data!.risks.map((r) => String(r).trim()).filter(Boolean).slice(0, 8)
+    : []
+
+  return {
+    goal: String(data?.goal ?? '').trim() || fallbackGoal,
+    subtasks,
+    risks,
+    degraded: false,
+    raw,
+  }
+}
+
+/**
+ * 解析统筹层的分派方案。
+ * 解析失败或覆盖不全时，用 round-robin 补齐——保证每个子任务都有 worker，
+ * 不会因为统筹层漏写一条就把子任务丢掉。
+ */
+export function parseAssignments(
+  text: string,
+  subtaskCount: number,
+  slots: string[],
+): { assignments: Assignment[]; degraded: boolean } {
+  const data = extractJson(text) as Record<string, unknown> | null
+  const rows = Array.isArray(data?.assignments) ? data!.assignments : []
+  const bySlot = new Map<number, Assignment>()
+  for (const item of rows) {
+    const row = (item ?? {}) as Record<string, unknown>
+    const index = Number(row.index)
+    if (!Number.isInteger(index) || index < 0 || index >= subtaskCount) continue
+    const slot = slots.includes(String(row.slot)) ? String(row.slot) : slots[index % slots.length]!
+    bySlot.set(index, {
+      index,
+      slot,
+      brief: String(row.brief ?? '').trim(),
+    })
+  }
+  const degraded = bySlot.size < subtaskCount
+  for (let i = 0; i < subtaskCount; i += 1) {
+    if (bySlot.has(i)) continue
+    bySlot.set(i, { index: i, slot: slots[i % slots.length]!, brief: '' })
+  }
+  return {
+    assignments: [...bySlot.values()].sort((a, b) => a.index - b.index),
+    degraded,
+  }
+}

--- a/.plugin-dev/task-tier-router/tiers.ts
+++ b/.plugin-dev/task-tier-router/tiers.ts
@@ -1,0 +1,110 @@
+/**
+ * 三级 workflow 的层级定义。
+ *
+ * 每层绑定一个模型：层级职责不同，对模型的要求也不同——
+ *  - plan（规划）：长链推理、拆解，用 Claude
+ *  - coord（统筹）：分派、验收、整合，用 GPT
+ *  - exec（执行）：并行干活，用 Kimi / DeepSeek 两个 worker
+ *
+ * provider 统一 'openai'：当前 aiapi 入口是 OpenAI 兼容协议，
+ * 真正决定走哪家上游的是 model 名（chat.resolveLlm 按 endpoint 取 baseUrl + key）。
+ */
+
+export type TierId = 'plan' | 'coord' | 'exec'
+
+export type TierProvider = 'deepseek' | 'openai' | 'anthropic'
+
+export interface TierDef {
+  /** 层级 id */
+  tier: TierId
+  /** worker 槽位 key，exec 层有多个 */
+  slot: string
+  /** 展示名 */
+  label: string
+  provider: TierProvider
+  model: string
+  /** 该槽位 session 的 systemPrompt */
+  persona: string
+}
+
+const PLAN_PERSONA = [
+  '你是分层 workflow 的【规划层】，使用 Claude。',
+  '职责：把用户目标拆成可独立执行的子任务，只做规划不做执行。',
+  '输出严格用 JSON，不要 markdown 代码围栏，不要额外解释：',
+  '{"goal":"一句话目标","subtasks":[{"title":"子任务标题","detail":"要做什么、验收标准","difficulty":"low|med|high"}],"risks":["风险点"]}',
+  'subtasks 控制在 2~4 条，彼此尽量独立以便并行。',
+].join('\n')
+
+const COORD_PERSONA = [
+  '你是分层 workflow 的【统筹层】，使用 GPT。',
+  '职责：把规划层的子任务分派给执行层 worker，并在执行完成后验收、整合。',
+  '分派阶段输出严格 JSON，不要 markdown 代码围栏：',
+  '{"assignments":[{"index":0,"slot":"kimi|deepseek","brief":"给该 worker 的执行指令"}]}',
+  'slot 只能是 kimi 或 deepseek，index 是子任务下标。尽量让两个 worker 负载均衡。',
+  '验收阶段按要求输出中文报告，不需要 JSON。',
+].join('\n')
+
+function execPersona(label: string): string {
+  return [
+    `你是分层 workflow 的【执行层】worker（${label}）。`,
+    '职责：按统筹层给的指令直接产出结果，不要再往下派工。',
+    '要求：输出可直接使用的成品内容，简洁、无寒暄、不要复述指令。',
+  ].join('\n')
+}
+
+/** 层级 → 模型的固定映射。改模型只动这里。 */
+export const TIERS: TierDef[] = [
+  {
+    tier: 'plan',
+    slot: 'claude',
+    label: 'Claude 规划',
+    provider: 'openai',
+    model: 'claude-sonnet-4-6',
+    persona: PLAN_PERSONA,
+  },
+  {
+    tier: 'coord',
+    slot: 'gpt',
+    label: 'GPT 统筹',
+    provider: 'openai',
+    model: 'gpt-5.1',
+    persona: COORD_PERSONA,
+  },
+  {
+    tier: 'exec',
+    slot: 'kimi',
+    label: 'Kimi 执行',
+    provider: 'openai',
+    model: 'kimi-k3',
+    persona: execPersona('Kimi'),
+  },
+  {
+    tier: 'exec',
+    slot: 'deepseek',
+    label: 'DeepSeek 执行',
+    provider: 'openai',
+    model: 'deepseek-v3.2',
+    persona: execPersona('DeepSeek'),
+  },
+]
+
+export function tierBySlot(slot: string): TierDef | undefined {
+  return TIERS.find((t) => t.slot === slot)
+}
+
+export function execSlots(): TierDef[] {
+  return TIERS.filter((t) => t.tier === 'exec')
+}
+
+export function planTier(): TierDef {
+  return TIERS.find((t) => t.tier === 'plan')!
+}
+
+export function coordTier(): TierDef {
+  return TIERS.find((t) => t.tier === 'coord')!
+}
+
+/** 会话标题：带层级前缀，便于在侧栏一眼区分。 */
+export function sessionTitle(def: TierDef, runLabel: string): string {
+  return `[${def.tier}] ${def.label} · ${runLabel}`
+}

--- a/.plugin-dev/task-tier-router/workers.ts
+++ b/.plugin-dev/task-tier-router/workers.ts
@@ -1,0 +1,106 @@
+/**
+ * 分层 worker 池：为每个层级槽位准备一个专属 session，并让它跑指定模型。
+ *
+ * 关键点：模型切换不改核心逻辑，而是写 session.config.{provider,model}。
+ * cap-chat 的 resolveLlm(sessionId) 会用会话覆盖盖掉全局默认，
+ * host-agents 每回合都调它，所以同一进程里不同 session 可以并行跑不同模型。
+ */
+
+import { sessionTitle, type TierDef } from './tiers.ts'
+
+export interface SessionRecordLike {
+  id: string
+  config?: { title?: string; model?: string; provider?: string; systemPrompt?: string }
+}
+
+export interface HostLike {
+  sessions: {
+    create(id?: string, opts?: Record<string, unknown>): Promise<SessionRecordLike>
+    get(id: string): Promise<SessionRecordLike | undefined>
+    peek(id: string): SessionRecordLike | undefined
+    patchConfig(id: string, patch: Record<string, unknown>): Promise<SessionRecordLike>
+    setProject(id: string, project: { path: string } | null): Promise<unknown>
+  }
+  agents: {
+    create(sessionId?: string): Promise<{
+      sessionId: string
+      send(text: string, opts?: Record<string, unknown>): Promise<{ text: string; steps?: unknown[] }>
+    }>
+  }
+  logger(tag: string): { info(msg: string): void; error(msg: unknown): void }
+}
+
+export interface WorkerHandle {
+  def: TierDef
+  sessionId: string
+  /** 跑一轮对话，返回文本 */
+  ask(prompt: string): Promise<string>
+}
+
+/**
+ * 建（或复用）某槽位的 session。
+ * 一次 run 内 slot → sessionId 缓存在 pool 里，避免同层重复建会话。
+ */
+export async function ensureWorker(
+  host: HostLike,
+  def: TierDef,
+  runLabel: string,
+  opts: { project?: string; pool: Map<string, string> },
+): Promise<WorkerHandle> {
+  const cached = opts.pool.get(def.slot)
+  if (cached) {
+    const alive = host.sessions.peek(cached) ?? (await host.sessions.get(cached))
+    if (alive) return makeHandle(host, def, cached)
+  }
+
+  const record = await host.sessions.create(undefined, {
+    type: 'chat',
+    title: sessionTitle(def, runLabel),
+    config: {
+      provider: def.provider,
+      model: def.model,
+      systemPrompt: def.persona,
+      // 执行层需要动手的能力，统一给 standard；规划/统筹只出文本也用 standard，
+      // 保持一致以免 minimal 模式下工具缺失导致行为不一致。
+      agentMode: 'standard',
+      tags: ['tier-router', def.tier],
+    },
+  })
+
+  // create 时的 config 已带 provider/model，这里再 patch 一次做兜底：
+  // normalizeSessionConfig 对未知字段会静默丢弃，patch 后回读校验更稳。
+  await host.sessions.patchConfig(record.id, {
+    provider: def.provider,
+    model: def.model,
+    systemPrompt: def.persona,
+  })
+
+  if (opts.project) {
+    try {
+      await host.sessions.setProject(record.id, { path: opts.project })
+    } catch (error) {
+      host.logger('tier-router').error(`bind project failed slot=${def.slot}: ${String(error)}`)
+    }
+  }
+
+  opts.pool.set(def.slot, record.id)
+  return makeHandle(host, def, record.id)
+}
+
+function makeHandle(host: HostLike, def: TierDef, sessionId: string): WorkerHandle {
+  return {
+    def,
+    sessionId,
+    ask: async (prompt: string) => {
+      const agent = await host.agents.create(sessionId)
+      const turn = await agent.send(prompt, { wait: true })
+      return String(turn.text ?? '').trim()
+    },
+  }
+}
+
+/** 回读 session 实际生效的模型，用于报告里证明「这一层真的走了那个模型」。 */
+export function effectiveModel(host: HostLike, sessionId: string): string {
+  const peek = host.sessions.peek(sessionId)
+  return peek?.config?.model ?? '(unknown)'
+}

--- a/.plugin/task-tier-router/host.js
+++ b/.plugin/task-tier-router/host.js
@@ -1,0 +1,539 @@
+// tiers.ts
+var PLAN_PERSONA = [
+  "\u4F60\u662F\u5206\u5C42 workflow \u7684\u3010\u89C4\u5212\u5C42\u3011\uFF0C\u4F7F\u7528 Claude\u3002",
+  "\u804C\u8D23\uFF1A\u628A\u7528\u6237\u76EE\u6807\u62C6\u6210\u53EF\u72EC\u7ACB\u6267\u884C\u7684\u5B50\u4EFB\u52A1\uFF0C\u53EA\u505A\u89C4\u5212\u4E0D\u505A\u6267\u884C\u3002",
+  "\u8F93\u51FA\u4E25\u683C\u7528 JSON\uFF0C\u4E0D\u8981 markdown \u4EE3\u7801\u56F4\u680F\uFF0C\u4E0D\u8981\u989D\u5916\u89E3\u91CA\uFF1A",
+  '{"goal":"\u4E00\u53E5\u8BDD\u76EE\u6807","subtasks":[{"title":"\u5B50\u4EFB\u52A1\u6807\u9898","detail":"\u8981\u505A\u4EC0\u4E48\u3001\u9A8C\u6536\u6807\u51C6","difficulty":"low|med|high"}],"risks":["\u98CE\u9669\u70B9"]}',
+  "subtasks \u63A7\u5236\u5728 2~4 \u6761\uFF0C\u5F7C\u6B64\u5C3D\u91CF\u72EC\u7ACB\u4EE5\u4FBF\u5E76\u884C\u3002"
+].join("\n");
+var COORD_PERSONA = [
+  "\u4F60\u662F\u5206\u5C42 workflow \u7684\u3010\u7EDF\u7B79\u5C42\u3011\uFF0C\u4F7F\u7528 GPT\u3002",
+  "\u804C\u8D23\uFF1A\u628A\u89C4\u5212\u5C42\u7684\u5B50\u4EFB\u52A1\u5206\u6D3E\u7ED9\u6267\u884C\u5C42 worker\uFF0C\u5E76\u5728\u6267\u884C\u5B8C\u6210\u540E\u9A8C\u6536\u3001\u6574\u5408\u3002",
+  "\u5206\u6D3E\u9636\u6BB5\u8F93\u51FA\u4E25\u683C JSON\uFF0C\u4E0D\u8981 markdown \u4EE3\u7801\u56F4\u680F\uFF1A",
+  '{"assignments":[{"index":0,"slot":"kimi|deepseek","brief":"\u7ED9\u8BE5 worker \u7684\u6267\u884C\u6307\u4EE4"}]}',
+  "slot \u53EA\u80FD\u662F kimi \u6216 deepseek\uFF0Cindex \u662F\u5B50\u4EFB\u52A1\u4E0B\u6807\u3002\u5C3D\u91CF\u8BA9\u4E24\u4E2A worker \u8D1F\u8F7D\u5747\u8861\u3002",
+  "\u9A8C\u6536\u9636\u6BB5\u6309\u8981\u6C42\u8F93\u51FA\u4E2D\u6587\u62A5\u544A\uFF0C\u4E0D\u9700\u8981 JSON\u3002"
+].join("\n");
+function execPersona(label) {
+  return [
+    `\u4F60\u662F\u5206\u5C42 workflow \u7684\u3010\u6267\u884C\u5C42\u3011worker\uFF08${label}\uFF09\u3002`,
+    "\u804C\u8D23\uFF1A\u6309\u7EDF\u7B79\u5C42\u7ED9\u7684\u6307\u4EE4\u76F4\u63A5\u4EA7\u51FA\u7ED3\u679C\uFF0C\u4E0D\u8981\u518D\u5F80\u4E0B\u6D3E\u5DE5\u3002",
+    "\u8981\u6C42\uFF1A\u8F93\u51FA\u53EF\u76F4\u63A5\u4F7F\u7528\u7684\u6210\u54C1\u5185\u5BB9\uFF0C\u7B80\u6D01\u3001\u65E0\u5BD2\u6684\u3001\u4E0D\u8981\u590D\u8FF0\u6307\u4EE4\u3002"
+  ].join("\n");
+}
+var TIERS = [
+  {
+    tier: "plan",
+    slot: "claude",
+    label: "Claude \u89C4\u5212",
+    provider: "openai",
+    model: "claude-sonnet-4-6",
+    persona: PLAN_PERSONA
+  },
+  {
+    tier: "coord",
+    slot: "gpt",
+    label: "GPT \u7EDF\u7B79",
+    provider: "openai",
+    model: "gpt-5.1",
+    persona: COORD_PERSONA
+  },
+  {
+    tier: "exec",
+    slot: "kimi",
+    label: "Kimi \u6267\u884C",
+    provider: "openai",
+    model: "kimi-k3",
+    persona: execPersona("Kimi")
+  },
+  {
+    tier: "exec",
+    slot: "deepseek",
+    label: "DeepSeek \u6267\u884C",
+    provider: "openai",
+    model: "deepseek-v3.2",
+    persona: execPersona("DeepSeek")
+  }
+];
+function execSlots() {
+  return TIERS.filter((t) => t.tier === "exec");
+}
+function planTier() {
+  return TIERS.find((t) => t.tier === "plan");
+}
+function coordTier() {
+  return TIERS.find((t) => t.tier === "coord");
+}
+function sessionTitle(def, runLabel) {
+  return `[${def.tier}] ${def.label} \xB7 ${runLabel}`;
+}
+
+// parse.ts
+function extractJson(text) {
+  const cleaned = text.replace(/```json/gi, "```").trim();
+  const fenced = cleaned.match(/```\s*([\s\S]*?)```/);
+  const candidates = [];
+  if (fenced?.[1]) candidates.push(fenced[1].trim());
+  const start = cleaned.indexOf("{");
+  const end = cleaned.lastIndexOf("}");
+  if (start >= 0 && end > start) candidates.push(cleaned.slice(start, end + 1));
+  candidates.push(cleaned);
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+function asDifficulty(value) {
+  return value === "low" || value === "high" ? value : "med";
+}
+function parsePlan(text, fallbackGoal) {
+  const raw = text;
+  const data = extractJson(text);
+  const subtasksRaw = Array.isArray(data?.subtasks) ? data.subtasks : [];
+  const subtasks = subtasksRaw.map((item) => {
+    const row = item ?? {};
+    const title = String(row.title ?? "").trim();
+    if (!title) return null;
+    return {
+      title: title.slice(0, 120),
+      detail: String(row.detail ?? "").trim(),
+      difficulty: asDifficulty(row.difficulty)
+    };
+  }).filter((item) => item !== null).slice(0, 6);
+  if (!subtasks.length) {
+    return {
+      goal: fallbackGoal,
+      subtasks: [{ title: fallbackGoal.slice(0, 120), detail: raw.slice(0, 2e3), difficulty: "med" }],
+      risks: [],
+      degraded: true,
+      raw
+    };
+  }
+  const risks = Array.isArray(data?.risks) ? data.risks.map((r) => String(r).trim()).filter(Boolean).slice(0, 8) : [];
+  return {
+    goal: String(data?.goal ?? "").trim() || fallbackGoal,
+    subtasks,
+    risks,
+    degraded: false,
+    raw
+  };
+}
+function parseAssignments(text, subtaskCount, slots) {
+  const data = extractJson(text);
+  const rows = Array.isArray(data?.assignments) ? data.assignments : [];
+  const bySlot = /* @__PURE__ */ new Map();
+  for (const item of rows) {
+    const row = item ?? {};
+    const index = Number(row.index);
+    if (!Number.isInteger(index) || index < 0 || index >= subtaskCount) continue;
+    const slot = slots.includes(String(row.slot)) ? String(row.slot) : slots[index % slots.length];
+    bySlot.set(index, {
+      index,
+      slot,
+      brief: String(row.brief ?? "").trim()
+    });
+  }
+  const degraded = bySlot.size < subtaskCount;
+  for (let i = 0; i < subtaskCount; i += 1) {
+    if (bySlot.has(i)) continue;
+    bySlot.set(i, { index: i, slot: slots[i % slots.length], brief: "" });
+  }
+  return {
+    assignments: [...bySlot.values()].sort((a, b) => a.index - b.index),
+    degraded
+  };
+}
+
+// workers.ts
+async function ensureWorker(host, def, runLabel, opts) {
+  const cached = opts.pool.get(def.slot);
+  if (cached) {
+    const alive = host.sessions.peek(cached) ?? await host.sessions.get(cached);
+    if (alive) return makeHandle(host, def, cached);
+  }
+  const record = await host.sessions.create(void 0, {
+    type: "chat",
+    title: sessionTitle(def, runLabel),
+    config: {
+      provider: def.provider,
+      model: def.model,
+      systemPrompt: def.persona,
+      // 执行层需要动手的能力，统一给 standard；规划/统筹只出文本也用 standard，
+      // 保持一致以免 minimal 模式下工具缺失导致行为不一致。
+      agentMode: "standard",
+      tags: ["tier-router", def.tier]
+    }
+  });
+  await host.sessions.patchConfig(record.id, {
+    provider: def.provider,
+    model: def.model,
+    systemPrompt: def.persona
+  });
+  if (opts.project) {
+    try {
+      await host.sessions.setProject(record.id, { path: opts.project });
+    } catch (error) {
+      host.logger("tier-router").error(`bind project failed slot=${def.slot}: ${String(error)}`);
+    }
+  }
+  opts.pool.set(def.slot, record.id);
+  return makeHandle(host, def, record.id);
+}
+function makeHandle(host, def, sessionId) {
+  return {
+    def,
+    sessionId,
+    ask: async (prompt) => {
+      const agent = await host.agents.create(sessionId);
+      const turn = await agent.send(prompt, { wait: true });
+      return String(turn.text ?? "").trim();
+    }
+  };
+}
+function effectiveModel(host, sessionId) {
+  const peek = host.sessions.peek(sessionId);
+  return peek?.config?.model ?? "(unknown)";
+}
+
+// flow.ts
+function runLabelOf(goal) {
+  const stamp = (/* @__PURE__ */ new Date()).toISOString().slice(11, 19);
+  return `${goal.slice(0, 18)}@${stamp}`;
+}
+async function timed(fn) {
+  const started = Date.now();
+  const value = await fn();
+  return { value, ms: Date.now() - started };
+}
+function trace(worker, host, ms, text) {
+  return {
+    tier: worker.def.tier,
+    slot: worker.def.slot,
+    model: effectiveModel(host, worker.sessionId) || worker.def.model,
+    sessionId: worker.sessionId,
+    ms,
+    chars: text.length
+  };
+}
+async function runTieredFlow(host, input) {
+  const goal = input.goal.trim();
+  if (!goal) throw new Error("goal required");
+  const startedAll = Date.now();
+  const runLabel = runLabelOf(goal);
+  const pool = /* @__PURE__ */ new Map();
+  const traces = [];
+  const degraded = [];
+  const log = host.logger("tier-router");
+  const wanted = { project: input.project, pool };
+  const root = host.tasks.create({
+    title: `\u5206\u5C42\u6267\u884C\uFF1A${goal.slice(0, 60)}`,
+    description: goal,
+    status: "doing",
+    priority: "high",
+    project: "tier-router",
+    tags: ["tier-router", "workflow"],
+    creator: { kind: "agent", name: "tier-router" }
+  });
+  const planner = await ensureWorker(host, planTier(), runLabel, wanted);
+  const planRun = await timed(
+    () => planner.ask(
+      [
+        `\u76EE\u6807\uFF1A${goal}`,
+        input.project ? `\u5DE5\u4F5C\u76EE\u5F55\uFF1A${input.project}` : "",
+        "\u8BF7\u6309\u4F60\u7684 JSON \u89C4\u8303\u8F93\u51FA\u62C6\u89E3\u65B9\u6848\u3002"
+      ].filter(Boolean).join("\n")
+    )
+  );
+  traces.push(trace(planner, host, planRun.ms, planRun.value));
+  const plan = parsePlan(planRun.value, goal);
+  if (plan.degraded) degraded.push("\u89C4\u5212\u5C42\u672A\u8FD4\u56DE\u53EF\u89E3\u6790 JSON\uFF0C\u5DF2\u964D\u7EA7\u4E3A\u5355\u5B50\u4EFB\u52A1");
+  host.tasks.report(root.id, {
+    sessionId: planner.sessionId,
+    turn: null,
+    status: "doing",
+    note: `\u89C4\u5212\u5B8C\u6210\uFF1A${plan.subtasks.length} \u4E2A\u5B50\u4EFB\u52A1\uFF08${effectiveModel(host, planner.sessionId)}\uFF09`,
+    ts: Date.now()
+  });
+  const childTasks = plan.subtasks.map(
+    (sub) => host.tasks.create({
+      title: sub.title,
+      description: sub.detail,
+      status: "todo",
+      difficulty: sub.difficulty,
+      parentId: root.id,
+      project: "tier-router",
+      tags: ["tier-router", "exec"],
+      creator: { kind: "agent", name: "tier-router" }
+    })
+  );
+  const slots = execSlots();
+  const coordinator = await ensureWorker(host, coordTier(), runLabel, wanted);
+  const dispatchRun = await timed(
+    () => coordinator.ask(
+      [
+        `\u76EE\u6807\uFF1A${plan.goal}`,
+        "\u5B50\u4EFB\u52A1\u6E05\u5355\uFF1A",
+        ...plan.subtasks.map((s, i) => `${i}. ${s.title} \u2014\u2014 ${s.detail}`),
+        `\u53EF\u7528 worker \u69FD\u4F4D\uFF1A${slots.map((s) => `${s.slot}(${s.label})`).join("\u3001")}`,
+        "\u8BF7\u8F93\u51FA\u5206\u6D3E JSON\u3002"
+      ].join("\n")
+    )
+  );
+  traces.push(trace(coordinator, host, dispatchRun.ms, dispatchRun.value));
+  const parsedAssign = parseAssignments(
+    dispatchRun.value,
+    plan.subtasks.length,
+    slots.map((s) => s.slot)
+  );
+  if (parsedAssign.degraded) degraded.push("\u7EDF\u7B79\u5C42\u5206\u6D3E\u4E0D\u5B8C\u6574\uFF0C\u7F3A\u5931\u9879\u5DF2\u6309 round-robin \u8865\u9F50");
+  const execWorkers = /* @__PURE__ */ new Map();
+  for (const def of slots) {
+    execWorkers.set(def.slot, await ensureWorker(host, def, runLabel, wanted));
+  }
+  for (const item of parsedAssign.assignments) {
+    const worker = execWorkers.get(item.slot);
+    const task = childTasks[item.index];
+    if (!worker || !task) continue;
+    host.tasks.update(task.id, {
+      assignee: { kind: "agent", name: worker.def.label, sessionId: worker.sessionId },
+      assignedAt: Date.now(),
+      notes: item.brief
+    });
+  }
+  if (input.dryRun) {
+    host.tasks.report(root.id, {
+      sessionId: coordinator.sessionId,
+      turn: null,
+      status: "doing",
+      note: "dryRun\uFF1A\u5DF2\u5B8C\u6210\u89C4\u5212\u4E0E\u5206\u6D3E\uFF0C\u672A\u6267\u884C",
+      ts: Date.now()
+    });
+    return {
+      goal: plan.goal,
+      runLabel,
+      rootTaskId: root.id,
+      plan,
+      trace: traces,
+      outcomes: parsedAssign.assignments.map((a) => ({
+        index: a.index,
+        slot: a.slot,
+        title: plan.subtasks[a.index]?.title ?? "",
+        taskId: childTasks[a.index]?.id ?? "",
+        model: execWorkers.get(a.slot)?.def.model ?? "",
+        text: "",
+        ms: 0,
+        ok: true
+      })),
+      review: "\uFF08dryRun \u672A\u6267\u884C\uFF09",
+      degraded,
+      totalMs: Date.now() - startedAll
+    };
+  }
+  const bySlot = /* @__PURE__ */ new Map();
+  for (const item of parsedAssign.assignments) {
+    const list = bySlot.get(item.slot) ?? [];
+    list.push(item);
+    bySlot.set(item.slot, list);
+  }
+  const outcomes = [];
+  await Promise.all(
+    [...bySlot.entries()].map(async ([slot, items]) => {
+      const worker = execWorkers.get(slot);
+      if (!worker) return;
+      for (const item of items) {
+        const sub = plan.subtasks[item.index];
+        const task = childTasks[item.index];
+        if (!sub || !task) continue;
+        host.tasks.update(task.id, { status: "doing" });
+        try {
+          const run = await timed(
+            () => worker.ask(
+              [
+                `\u603B\u76EE\u6807\uFF1A${plan.goal}`,
+                `\u4F60\u7684\u5B50\u4EFB\u52A1\uFF1A${sub.title}`,
+                sub.detail ? `\u8981\u6C42\uFF1A${sub.detail}` : "",
+                item.brief ? `\u7EDF\u7B79\u5C42\u8865\u5145\uFF1A${item.brief}` : "",
+                "\u76F4\u63A5\u7ED9\u51FA\u6210\u54C1\u7ED3\u679C\u3002"
+              ].filter(Boolean).join("\n")
+            )
+          );
+          traces.push(trace(worker, host, run.ms, run.value));
+          outcomes.push({
+            index: item.index,
+            slot,
+            title: sub.title,
+            taskId: task.id,
+            model: effectiveModel(host, worker.sessionId) || worker.def.model,
+            text: run.value,
+            ms: run.ms,
+            ok: true
+          });
+          host.tasks.report(task.id, {
+            sessionId: worker.sessionId,
+            turn: null,
+            status: "done",
+            note: `${worker.def.label} \u5B8C\u6210\uFF08${run.value.length} \u5B57\uFF09`,
+            ts: Date.now()
+          });
+          host.tasks.update(task.id, { status: "done" });
+        } catch (error) {
+          const detail = String(error);
+          log.error(`exec failed slot=${slot} index=${item.index}: ${detail}`);
+          degraded.push(`\u6267\u884C\u5C42 ${slot} \u5B50\u4EFB\u52A1#${item.index} \u5931\u8D25\uFF1A${detail}`);
+          outcomes.push({
+            index: item.index,
+            slot,
+            title: sub.title,
+            taskId: task.id,
+            model: worker.def.model,
+            text: "",
+            ms: 0,
+            ok: false,
+            error: detail
+          });
+          host.tasks.report(task.id, {
+            sessionId: worker.sessionId,
+            turn: null,
+            status: "doing",
+            note: `\u6267\u884C\u5931\u8D25\uFF1A${detail.slice(0, 200)}`,
+            ts: Date.now()
+          });
+        }
+      }
+    })
+  );
+  outcomes.sort((a, b) => a.index - b.index);
+  const reviewRun = await timed(
+    () => coordinator.ask(
+      [
+        `\u76EE\u6807\uFF1A${plan.goal}`,
+        "\u5404 worker \u4EA4\u4ED8\u5982\u4E0B\uFF0C\u8BF7\u9A8C\u6536\u5E76\u6574\u5408\u6210\u4E00\u4EFD\u6700\u7EC8\u7ED3\u679C\u3002",
+        ...outcomes.map(
+          (o) => `\u3010\u5B50\u4EFB\u52A1${o.index}\xB7${o.slot}\xB7${o.model}\u3011${o.title}
+${o.ok ? o.text.slice(0, 4e3) : `\uFF08\u5931\u8D25\uFF1A${o.error}\uFF09`}`
+        ),
+        "\u8F93\u51FA\u683C\u5F0F\uFF1A\u4E00\u3001\u6574\u5408\u7ED3\u679C\uFF08\u53EF\u76F4\u63A5\u4EA4\u4ED8\u7684\u5185\u5BB9\uFF09\uFF1B\u4E8C\u3001\u9A8C\u6536\u610F\u89C1\uFF08\u6BCF\u6761\u5B50\u4EFB\u52A1\u4E00\u53E5\uFF0C\u6307\u51FA\u95EE\u9898\u6216\u786E\u8BA4\u901A\u8FC7\uFF09\uFF1B\u4E09\u3001\u82E5\u6709\u7F3A\u53E3\u5217\u51FA\u8865\u6551\u5EFA\u8BAE\u3002"
+      ].join("\n\n")
+    )
+  );
+  traces.push(trace(coordinator, host, reviewRun.ms, reviewRun.value));
+  const allOk = outcomes.every((o) => o.ok);
+  host.tasks.report(root.id, {
+    sessionId: coordinator.sessionId,
+    turn: null,
+    status: allOk ? "done" : "doing",
+    note: allOk ? `\u7EDF\u7B79\u9A8C\u6536\u5B8C\u6210\uFF0C${outcomes.length} \u6761\u5B50\u4EFB\u52A1\u5168\u90E8\u4EA4\u4ED8` : `\u7EDF\u7B79\u9A8C\u6536\u5B8C\u6210\uFF0C\u5B58\u5728\u5931\u8D25\u5B50\u4EFB\u52A1\uFF08${outcomes.filter((o) => !o.ok).length} \u6761\uFF09`,
+    ts: Date.now()
+  });
+  host.tasks.update(root.id, { status: allOk ? "done" : "doing" });
+  return {
+    goal: plan.goal,
+    runLabel,
+    rootTaskId: root.id,
+    plan,
+    trace: traces,
+    outcomes,
+    review: reviewRun.value,
+    degraded,
+    totalMs: Date.now() - startedAll
+  };
+}
+
+// host.ts
+var name = "task-tier-router";
+var inject = ["tools", "sessions", "agents", "tasks"];
+function renderReport(result) {
+  const lines = [];
+  lines.push(`\u76EE\u6807\uFF1A${result.goal}`);
+  lines.push(`\u6839\u4EFB\u52A1\uFF1A${result.rootTaskId} \xB7 \u603B\u8017\u65F6 ${(result.totalMs / 1e3).toFixed(1)}s`);
+  lines.push("");
+  lines.push("\u5C42\u7EA7\u8C03\u7528\u8F68\u8FF9\uFF1A");
+  lines.push("| \u5C42\u7EA7 | \u69FD\u4F4D | \u6A21\u578B | \u8017\u65F6 | \u8F93\u51FA\u5B57\u6570 |");
+  lines.push("|---|---|---|---|---|");
+  for (const t of result.trace) {
+    lines.push(`| ${t.tier} | ${t.slot} | ${t.model} | ${(t.ms / 1e3).toFixed(1)}s | ${t.chars} |`);
+  }
+  lines.push("");
+  lines.push(`\u89C4\u5212\u5C42\u62C6\u51FA ${result.plan.subtasks.length} \u6761\u5B50\u4EFB\u52A1\uFF1A`);
+  for (const [i, sub] of result.plan.subtasks.entries()) {
+    const outcome = result.outcomes.find((o) => o.index === i);
+    const who = outcome ? `${outcome.slot}/${outcome.model}` : "\u672A\u5206\u6D3E";
+    lines.push(`${i}. ${sub.title} \u2192 ${who}${outcome && !outcome.ok ? " \u274C" : ""}`);
+  }
+  if (result.plan.risks.length) {
+    lines.push("");
+    lines.push(`\u89C4\u5212\u5C42\u63D0\u793A\u98CE\u9669\uFF1A${result.plan.risks.join("\uFF1B")}`);
+  }
+  if (result.degraded.length) {
+    lines.push("");
+    lines.push("\u964D\u7EA7\u8BB0\u5F55\uFF1A");
+    for (const d of result.degraded) lines.push(`- ${d}`);
+  }
+  lines.push("");
+  lines.push("\u7EDF\u7B79\u5C42\u9A8C\u6536\u4E0E\u6574\u5408\uFF1A");
+  lines.push(result.review);
+  return lines.join("\n");
+}
+function apply(ctx) {
+  ctx.tools.register({
+    name: "tier_flow_run",
+    description: "\u5206\u5C42 workflow\uFF1A\u63A5\u5230\u76EE\u6807\u540E Claude \u89C4\u5212\u62C6\u89E3 \u2192 GPT \u7EDF\u7B79\u5206\u6D3E \u2192 Kimi/DeepSeek \u5E76\u884C\u6267\u884C \u2192 GPT \u9A8C\u6536\u6574\u5408\u3002\u6BCF\u5C42\u8DD1\u5404\u81EA\u6A21\u578B\uFF0C\u5168\u8FC7\u7A0B\u843D\u4EFB\u52A1\u9762\u677F\uFF08\u6839\u4EFB\u52A1+\u5B50\u4EFB\u52A1+report\uFF09\u3002\u8FD4\u56DE\u5404\u5C42\u8C03\u7528\u8F68\u8FF9\u4E0E\u6700\u7EC8\u6574\u5408\u7ED3\u679C\u3002",
+    parameters: {
+      type: "object",
+      properties: {
+        goal: { type: "string", description: "\u8981\u4EA4\u4ED8\u7684\u76EE\u6807\uFF0C\u4E00\u53E5\u8BDD\u63CF\u8FF0" },
+        project: { type: "string", description: "\u53EF\u9009\uFF1A\u7ED9\u5404\u5C42 session \u7ED1\u5B9A\u7684\u5DE5\u4F5C\u76EE\u5F55\u7EDD\u5BF9\u8DEF\u5F84" },
+        dryRun: { type: "boolean", description: "\u53EA\u505A\u89C4\u5212\u4E0E\u5206\u6D3E\u9884\u89C8\uFF0C\u4E0D\u771F\u6B63\u6267\u884C" },
+        format: {
+          type: "string",
+          enum: ["report", "json"],
+          description: "report=\u53EF\u8BFB\u62A5\u544A\uFF08\u9ED8\u8BA4\uFF09\uFF1Bjson=\u539F\u59CB\u7ED3\u6784"
+        }
+      },
+      required: ["goal"]
+    },
+    execute: async (args) => {
+      const result = await runTieredFlow(ctx, {
+        goal: String(args.goal ?? ""),
+        ...typeof args.project === "string" && args.project.trim() ? { project: args.project.trim() } : {},
+        dryRun: args.dryRun === true
+      });
+      if (args.format === "json") return result;
+      return {
+        rootTaskId: result.rootTaskId,
+        totalMs: result.totalMs,
+        report: renderReport(result),
+        sessions: result.trace.map((t) => ({
+          tier: t.tier,
+          slot: t.slot,
+          model: t.model,
+          sessionId: t.sessionId
+        }))
+      };
+    }
+  });
+  ctx.tools.register({
+    name: "tier_flow_tiers",
+    description: "\u67E5\u770B\u5206\u5C42 workflow \u7684\u5C42\u7EA7 \u2192 \u6A21\u578B\u6620\u5C04\uFF08\u89C4\u5212/\u7EDF\u7B79/\u6267\u884C\u5404\u7528\u54EA\u4E2A\u6A21\u578B\uFF09\u3002",
+    parameters: { type: "object", properties: {} },
+    execute: () => ({
+      tiers: TIERS.map((t) => ({
+        tier: t.tier,
+        slot: t.slot,
+        label: t.label,
+        provider: t.provider,
+        model: t.model
+      })),
+      note: "\u6A21\u578B\u6309 session.config \u8986\u76D6\u751F\u6548\uFF1B\u6539\u6620\u5C04\u8BF7\u7F16\u8F91\u63D2\u4EF6 tiers.ts \u540E\u91CD\u65B0 plugin_pack\u3002"
+    })
+  });
+}
+export {
+  apply,
+  inject,
+  name
+};

--- a/.plugin/task-tier-router/manifest.json
+++ b/.plugin/task-tier-router/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "task-tier-router",
+  "name": "分层任务编排",
+  "blurb": "三级 workflow：Claude 规划 → GPT 统筹 → Kimi/DeepSeek 并行执行 → GPT 验收与整合，各层跑各自模型。",
+  "tags": [
+    "workflow",
+    "agent",
+    "tool"
+  ],
+  "author": "Biu",
+  "authorUrl": "",
+  "createdAt": 1787948034795
+}


### PR DESCRIPTION
## 做了什么

新增插件 `task-tier-router`，把一个目标跑成三级 workflow，每层用各自的模型：

| 层级 | 槽位 | 模型 | 职责 |
|---|---|---|---|
| plan | claude | `claude-sonnet-4-6` | 拆解目标，输出 JSON 子任务清单 |
| coord | gpt | `gpt-5.1` | 分派 worker + 事后验收整合 |
| exec | kimi | `kimi-k3` | 并行执行 |
| exec | deepseek | `deepseek-v3.2` | 并行执行 |

## 分层调模型怎么实现的

没有改动核心，靠 session 配置覆盖：为每个层级槽位建专属 session，写入 `config.{provider, model, systemPrompt}`。`cap-chat.resolveLlm(sessionId)` 会用会话配置盖掉全局默认，而 `host-agents` 每个回合都调它，因此同进程内不同 session 可并行跑不同上游。

这同时绕开了两个现有限制：`subagent_spawn` 不接受 model 参数，`session_create` 仅在 live session 可用。插件内直接用 `ctx.sessions` + `ctx.agents`，不受 live 门槛约束。

## 编排设计

```
plan(Claude) → coord 分派(GPT) → exec 并行(Kimi ‖ DeepSeek) → coord 验收整合(GPT)
```

统筹层调用两次，执行完回到 GPT 做验收整合，形成闭环而不是单向流水线。执行层按 slot 分组，组内串行（一个 session 一次只能跑一个回合）、组间 `Promise.all` 并行。

全过程落任务面板：根任务 = 目标，子任务挂其下，assignee 写成对应 worker session，每步走 `task_report`，因此整条链在面板里可回溯。

## 容错

- 规划层 JSON 解析失败 → 降级为单子任务继续跑，并行度退化为 1 而非整条崩掉
- 统筹层漏派 → round-robin 补齐，不丢子任务
- 单个 worker 失败 → 只标记该条，其余照常交付
- 降级原因统一汇总进报告的「降级记录」

## 工具

- `tier_flow_run(goal, project?, dryRun?, format?)` — 跑完整流程，`dryRun` 只看规划与分派预览
- `tier_flow_tiers()` — 查层级→模型映射

均为商店插件工具，仅在 `agentMode: create` 的会话可见。

## 验证

实跑一轮全链路，目标「写一份 Cordis 插件开发上手指南」，总耗时 183s：

```
| 层级  | 槽位     | 模型               | 耗时  | 输出字数 |
| plan  | claude   | claude-sonnet-4-6  | 14.4s | 836   |
| coord | gpt      | gpt-5.1            | 8.0s  | 1340  |
| exec  | deepseek | deepseek-v3.2      | 27.7s | 2066  |
| exec  | kimi     | kimi-k3            | 39.3s | 3935  |
| exec  | deepseek | deepseek-v3.2      | 33.0s | 4018  |
| exec  | kimi     | kimi-k3            | 79.0s | 8983  |
| coord | gpt      | gpt-5.1            | 42.6s | 12837 |
```

Claude 拆出 4 条子任务，Kimi 与 DeepSeek 各接 2 条并行执行，GPT 输出 12837 字整合稿。任务面板核对：根任务 done、4 条子任务全部 done 且 assignee 正确、reports 齐全。

## 附带改动

`.gitignore` 加两行例外，放开 `.plugin-dev/task-tier-router/`，使插件源码入库（与现有 `store-heavy-ping` 写法一致）。否则仓库里只有 bundle 后的 `host.js`，无法二次开发。

## 说明

- 模型可用性经过探测后选定：`claude-opus-4-5` 与 `claude-sonnet-4-5` 在网关返回 `No available accounts`，故规划层用 `claude-sonnet-4-6`
- 改模型映射只需编辑 `tiers.ts` 后重新 `plugin_pack`
- 本 PR 只含本插件相关的 9 个文件，工作区其他无关改动（cap-chat、host-llm 等）未包含
- 未跑仓库测试套件，改动集中在独立插件目录，不触碰 `packages/`