### PR TITLE
fix(file-system): 启动卡顿与导航迟迟不出现

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -40,7 +40,7 @@ test('page plugin registers every field type on /pages without a web module', as
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
   const listed = await registered[0]!.list()
   assert.equal(listed.length, page.ROW_COUNT)
-  assert.equal(listed[0]?.cover, 'https://picsum.photos/seed/p000/320/180')
+  assert.equal(String(listed[0]?.cover).startsWith('data:image/svg+xml'), true)
   const written = await registered[0]!.write!('p000', { enabled: false })
   assert.equal(written.enabled, false)
   assert.equal(written.score, listed[0]?.score)

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -5,6 +5,18 @@ export const ROW_COUNT = 240
 
 const STATUS = ['draft', 'live', 'archived'] as const
 const COLORS = ['red', 'orange', 'yellow', 'green', 'blue'] as const
+const COLOR_HEX: Record<(typeof COLORS)[number], string> = {
+  red: '#c0392b',
+  orange: '#d35400',
+  yellow: '#b7950b',
+  green: '#1e8449',
+  blue: '#1a5276',
+}
+
+function seedCover(id: string, color: (typeof COLORS)[number]) {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect fill="${COLOR_HEX[color]}" width="100%" height="100%"/><text x="50%" y="54%" fill="#fff" font-size="28" text-anchor="middle" font-family="sans-serif">${id}</text></svg>`
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+}
 
 type PageRow = DbRecord & {
   title: string
@@ -41,7 +53,7 @@ function seed(index: number, now: number): PageRow {
     publishedAt: now - index * 3600_000,
     size: 2048 + index * 128,
     homepage: `https://example.com/pages/${id}`,
-    cover: `https://picsum.photos/seed/${id}/320/180`,
+    cover: seedCover(id, color),
     pack: {
       name: `${id}.zip`,
       href: `https://example.com/files/${id}.zip`,

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -250,6 +250,8 @@ export function clampPage(limit?: number, offset?: number) {
 export class DatabaseService extends Service implements Database {
   private collections = new Map<string, CollectionSpec>()
 
+  private bumpQueued = false
+
   constructor(ctx: Context) {
     super(ctx, 'database')
   }
@@ -290,8 +292,13 @@ export class DatabaseService extends Service implements Database {
 
   private bump() {
     this.ctx.emit('database/change')
-    const http = this.ctx.get('http') as { broadcast?: (type: string, payload: unknown) => void } | undefined
-    http?.broadcast?.(DATABASE_CHANNEL, { ts: Date.now() })
+    if (this.bumpQueued) return
+    this.bumpQueued = true
+    queueMicrotask(() => {
+      this.bumpQueued = false
+      const http = this.ctx.get('http') as { broadcast?: (type: string, payload: unknown) => void } | undefined
+      http?.broadcast?.(DATABASE_CHANNEL, { ts: Date.now() })
+    })
   }
 
   async stat(path: string) {

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -284,7 +284,7 @@ function ImageThumb({ src }: { src: string }) {
           setOpen(true)
         }}
       >
-        <img className="fsdb-thumb" src={src} alt="" />
+        <img className="fsdb-thumb" src={src} alt="" loading="lazy" decoding="async" />
       </button>
       {open
         ? createPortal(
@@ -298,7 +298,7 @@ function ImageThumb({ src }: { src: string }) {
                 if (event.target === event.currentTarget) setOpen(false)
               }}
             >
-              <img src={src} alt="" onClick={(event) => event.stopPropagation()} />
+              <img src={src} alt="" decoding="async" onClick={(event) => event.stopPropagation()} />
             </div>,
             document.body,
           )
@@ -332,7 +332,7 @@ function FilePreview({ value, compact = false }: { value: unknown; compact?: boo
   const src = asImageSrc(value)
   if (src) {
     if (compact) return <ImageThumb src={src} />
-    return <img className="fsdb-fileview-img" src={src} alt="" />
+    return <img className="fsdb-fileview-img" src={src} alt="" loading="lazy" decoding="async" />
   }
   const file = asAttachment(value)
   if (file) {
@@ -626,8 +626,10 @@ export function CollectionBrowser({
         dir: sortDir,
         filter: JSON.stringify(filters),
       })
-      const nextStat = await readJson<StatResult>(`/api/db/stat?path=${encodeURIComponent(collectionPath)}`)
-      const listed = await readJson<ListResult>(`/api/db/list?${params}`)
+      const [nextStat, listed] = await Promise.all([
+        readJson<StatResult>(`/api/db/stat?path=${encodeURIComponent(collectionPath)}`),
+        readJson<ListResult>(`/api/db/list?${params}`),
+      ])
       if (gen !== reloadGen.current) return true
       setStat((prev) => (prev?.schema && JSON.stringify(prev.schema) === JSON.stringify(nextStat.schema) ? prev : nextStat))
       setItems((prev) => (recordsFingerprint(prev) === recordsFingerprint(listed.items) ? prev : listed.items))
@@ -695,7 +697,6 @@ export function CollectionBrowser({
       setQuery('')
       setFilters({})
     }
-    void reloadRef.current()
     let debounce = 0
     const onChange = () => {
       window.clearTimeout(debounce)

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -52,7 +52,9 @@ export function flattenTree(rows: DbRecord[], parentKey: string, collapsed: Reco
     const raw = String(row[parentKey] ?? '')
     const parent = raw && raw !== row.id && ids.has(raw) ? raw : ''
     if (parent) hasKids.add(parent)
-    children.set(parent, [...(children.get(parent) ?? []), row])
+    const bucket = children.get(parent)
+    if (bucket) bucket.push(row)
+    else children.set(parent, [row])
   }
   const out: TreeRow[] = []
   const seen = new Set<string>()

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -11,6 +11,7 @@ import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu
 import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseUiService } from './database-ui.ts'
+import { bootLoadCollections } from './nav-boot.ts'
 
 type SlotsService = {
   place: (slot: string, view: unknown, opts: { key: string; order?: number; props?: () => Record<string, unknown> }) => { dispose?: () => unknown }
@@ -135,13 +136,9 @@ export function apply(ctx: Context) {
   const appModules = ctx.get('appModules') as AppModulesService
   const mounted = new Map<string, () => void>()
 
-  const sync = async () => {
-    let rows: CollectionInfo[] = []
-    try {
-      rows = await loadCollections()
-    } catch {
-      return
-    }
+  slots.place('root-overlays', RegisterErrorBanner, { key: 'fsdb-nav-errors', order: 80 })
+  let stopped = false
+  const runSync = async (rows: CollectionInfo[]) => {
     const views = rows.filter((row) => row.view?.moduleId && row.view.route)
     const live = new Set(views.map((row) => row.view!.moduleId))
     for (const [id, dispose] of mounted) {
@@ -196,20 +193,37 @@ export function apply(ctx: Context) {
     setNavErrors(errors)
   }
 
-  slots.place('root-overlays', RegisterErrorBanner, { key: 'fsdb-nav-errors', order: 80 })
-  void sync()
+  const sync = async () => {
+    let rows: CollectionInfo[] = []
+    try {
+      rows = await loadCollections()
+    } catch {
+      return
+    }
+    await runSync(rows)
+  }
+
   ctx.effect(() => () => {
+    stopped = true
     for (const dispose of mounted.values()) dispose()
     mounted.clear()
     setNavErrors([])
   })
   ctx.inject(['snapshot'], (inner) => {
     const snapshot = inner.get('snapshot') as SnapshotService
+    let debounce = 0
     const off = snapshot.onMessage(DATABASE_CHANNEL, () => {
       window.dispatchEvent(new Event('fsdb:change'))
-      void sync()
+      window.clearTimeout(debounce)
+      debounce = window.setTimeout(() => void sync(), 40)
     })
-    return off
+    return () => {
+      window.clearTimeout(debounce)
+      off()
+    }
+  })
+  void bootLoadCollections(loadCollections, { stopped: () => stopped }).then((rows) => {
+    if (!stopped) return runSync(rows)
   })
 }
 

--- a/packages/core-file-system/src/web/nav-boot.test.ts
+++ b/packages/core-file-system/src/web/nav-boot.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { bootLoadCollections, collectionNavKey } from './nav-boot.ts'
+import type { CollectionInfo } from '@biu/type-file-system'
+
+function row(id: string): CollectionInfo {
+  return { id, path: `/${id}`, kind: 'collection', label: id, view: { moduleId: id, route: `/${id}` } }
+}
+
+test('collectionNavKey ignores tables without a nav view', () => {
+  assert.equal(collectionNavKey([row('b'), row('a'), { id: 'hidden', path: '/hidden', kind: 'collection', label: 'x', view: null }]), 'a,b')
+})
+
+test('bootLoadCollections retries empty/failed loads until the nav set is stable', async () => {
+  const calls: string[] = []
+  const waits: number[] = []
+  const load = async () => {
+    calls.push('load')
+    if (calls.length === 1) throw new Error('host down')
+    if (calls.length === 2) return []
+    if (calls.length === 3) return [row('plugins')]
+    return [row('plugins'), row('page')]
+  }
+  const listed = await bootLoadCollections(load, {
+    attempts: 8,
+    delayMs: 5,
+    wait: async (ms) => {
+      waits.push(ms)
+    },
+  })
+  assert.deepEqual(
+    listed.map((item) => item.id),
+    ['plugins', 'page'],
+  )
+  assert.ok(calls.length >= 5)
+  assert.ok(waits.length >= 1)
+})

--- a/packages/core-file-system/src/web/nav-boot.ts
+++ b/packages/core-file-system/src/web/nav-boot.ts
@@ -1,0 +1,40 @@
+import type { CollectionInfo } from '@biu/type-file-system'
+
+export function collectionNavKey(rows: CollectionInfo[]) {
+  return rows
+    .filter((row) => row.view?.moduleId && row.view.route)
+    .map((row) => row.view!.moduleId)
+    .sort()
+    .join(',')
+}
+
+/** Host 插件登记表会晚于 UI apply；失败或空列表时短轮询，避免导航一直空白。 */
+export async function bootLoadCollections(
+  load: () => Promise<CollectionInfo[]>,
+  opts?: { attempts?: number; delayMs?: number; stopped?: () => boolean; wait?: (ms: number) => Promise<void> },
+): Promise<CollectionInfo[]> {
+  const attempts = opts?.attempts ?? 30
+  const delayMs = opts?.delayMs ?? 100
+  const wait = opts?.wait ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)))
+  let last: CollectionInfo[] = []
+  let stable = 0
+  let prev = ''
+  for (let i = 0; i < attempts; i++) {
+    if (opts?.stopped?.()) return last
+    try {
+      last = await load()
+    } catch {
+      last = last.length ? last : []
+    }
+    const key = collectionNavKey(last)
+    if (key && key === prev) {
+      stable += 1
+      if (stable >= 2) return last
+    } else {
+      stable = 0
+      prev = key
+    }
+    if (i + 1 < attempts) await wait(delayMs)
+  }
+  return last
+}

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -143,6 +143,7 @@ function parseState(raw: unknown): StoreState {
 
 export class PluginStoreService extends Service {
   private state: StoreState = emptyState()
+  private listCache: StoreListing[] | null = null
 
   constructor(
     ctx: Context,
@@ -173,8 +174,13 @@ export class PluginStoreService extends Service {
   }
 
   private writeState() {
+    this.invalidateList()
     mkdirSync(dirname(this.statePath), { recursive: true })
     writeFileSync(this.statePath, `${JSON.stringify(this.state, null, 2)}\n`)
+  }
+
+  private invalidateList() {
+    this.listCache = null
   }
 
   private isEnabled(id: string) {
@@ -211,6 +217,7 @@ export class PluginStoreService extends Service {
     const hostJs = String(input.hostJs ?? '').trim()
     const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     if (!hostJs && !webSrc) throw new Error('plugin_create needs hostJs and/or webJs')
+    this.invalidateList()
     const dest = this.pluginPath(id)
     mkdirSync(dest, { recursive: true })
     const existing = existsSync(join(dest, 'manifest.json')) ? await readManifest(dest).catch(() => undefined) : undefined
@@ -251,6 +258,7 @@ export class PluginStoreService extends Service {
     const hostEntry = findEntry(sandbox, HOST_ENTRIES)
     const webEntry = findEntry(sandbox, WEB_ENTRIES)
     if (!hostEntry && !webEntry) throw new Error('sandbox needs host.ts/js or web.tsx/ts/js')
+    this.invalidateList()
     const dest = this.pluginPath(manifest.id)
     mkdirSync(dest, { recursive: true })
     await writeFile(join(dest, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
@@ -263,6 +271,7 @@ export class PluginStoreService extends Service {
   }
 
   async list(): Promise<StoreListing[]> {
+    if (this.listCache) return this.listCache
     const names = existsSync(this.pluginDir) ? await readdir(this.pluginDir) : []
     const running = new Set(
       this.hub()
@@ -290,6 +299,7 @@ export class PluginStoreService extends Service {
         hasWeb: stats.hasWeb,
       })
     }
+    this.listCache = items
     return items
   }
 
@@ -318,6 +328,7 @@ export class PluginStoreService extends Service {
     this.setEnabled(id, false)
     const hit = await this.findPluginDir(id)
     if (hit) await rm(hit, { recursive: true, force: true })
+    this.invalidateList()
     const lastRunAt = { ...this.state.lastRunAt }
     delete lastRunAt[id]
     this.state = { ...this.state, lastRunAt }

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -349,13 +349,12 @@ function PluginModuleStage({
       {sorted.map((entry) => {
         const extra = entry.props?.() ?? {}
         const moduleId = String(extra.moduleId ?? extra.id ?? entry.id)
-        const show = moduleId === activeId
+        if (moduleId !== activeId) return null
         const Component = entry.Component
         return (
           <div
             key={entry.id}
-            className={show ? 'flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden' : 'hidden'}
-            aria-hidden={!show}
+            className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
             data-testid={`${moduleId}-module`}
           >
             <Component {...extra} renderSlot={renderSlot} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

File System 启动慢、界面卡，主要不是「表引擎算不过来」，而是启动路径叠了几层浪费：

1. **导航登记有竞态**  
   `core-file-system` 的 web 插件 `apply()` 时立刻打 `/api/db/stat?path=/`。host 侧各表（插件 / 任务 / Page）往往还没 `database.register`。失败会被吞掉，之后只靠 WebSocket `database` 频道补登。若 snapshot 还没订上，广播已经发出去，导航会空很久。

2. **壳把所有模块一起挂上**  
   `PluginModuleStage` 用 CSS `hidden` 藏非当前页，React 树仍在。于是一进应用就会同时 `stat` + `list` 所有 File System 页，并跑 20s 轮询。

3. **Page 压测封面走 picsum.photos**  
   默认表会渲染封面缩略图，每行一张外网图，隐藏页也会加载。

4. **列表请求是瀑布**  
   先 `stat` 再 `list`；挂载时还会打两次。插件表每次 `list()` 都会扫 `.plugin` 目录。

## 改动

- 导航启动改为短轮询，直到视图集合连续两次稳定；WS 推送做了 40ms 合并。
- 壳层只挂载当前活动模块。
- `stat` / `list` 并行；去掉挂载时的重复 reload。
- Page 封面改为本地 SVG data URI。
- 插件 store `list()` 加缓存；host `broadcast` 合并同 tick 的多次登记。

无法在本环境用浏览器点一遍完整应用（无已运行的 host+web）。相关单测已过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

