### PR TITLE
fix: 压掉 File System 引入后控制台/EventLog 刷屏

### DIFF
--- a/packages/cap-logger/src/host/index.test.ts
+++ b/packages/cap-logger/src/host/index.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { shouldLogDispatch } from './index.ts'
+
+test('logger skips heartbeat and hub/change so the console stays readable', () => {
+  assert.equal(shouldLogDispatch('clock/tick'), false)
+  assert.equal(shouldLogDispatch('hub/change'), false)
+  assert.equal(shouldLogDispatch('internal/status'), false)
+  assert.equal(shouldLogDispatch('database/change'), true)
+})

--- a/packages/cap-logger/src/host/index.ts
+++ b/packages/cap-logger/src/host/index.ts
@@ -3,9 +3,17 @@ import type { Context } from 'cordis'
 export const name = 'logger'
 export const inject = ['http']
 
+/** 秒级心跳 / 路由登记会把控制台和 EventLog 打满，启动时尤其明显。 */
+export const NOISY_EVENTS = new Set(['clock/tick', 'hub/change'])
+
+export function shouldLogDispatch(name: string) {
+  if (name.startsWith('internal/')) return false
+  return !NOISY_EVENTS.has(name)
+}
+
 export function apply(ctx: Context) {
   ctx.on('internal/dispatch', (mode, name) => {
-    if (name.startsWith('internal/')) return
+    if (!shouldLogDispatch(name)) return
     ctx.logger('logger').info(`${mode} ${name}`)
   })
 }

--- a/packages/host-http/src/host/index.ts
+++ b/packages/host-http/src/host/index.ts
@@ -169,11 +169,16 @@ export class HttpService extends Service {
           res.end(JSON.stringify(body))
         },
       }
+      const started = Date.now()
       try {
         await match.handler(context)
       } catch (error) {
         this.ctx.logger('http').error(error)
         if (!res.headersSent) context.send(500, { error: String(error) })
+      }
+      const ms = Date.now() - started
+      if (ms >= 8 || url.pathname.startsWith('/api/db')) {
+        this.ctx.logger('http').info(`${method} ${url.pathname}${url.search} ${ms}ms`)
       }
       return
     }

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -25,23 +25,21 @@ export class HubService extends Service {
   constructor(ctx: Context, catalog: CatalogEntry[]) {
     super(ctx, 'hub')
     ctx.on('internal/dispatch', (mode, name, args) => {
-      if (name.startsWith('internal/')) return
-      // 流式 delta 极高频，不进 hub event 总线（避免 Settings EventLog 拖垮主线程）
-      if (name === 'llm/stream') return
-      if (name === 'session/event') {
-        const payload = args[0] as { event?: { type?: string } } | undefined
-        if (payload?.event?.type === 'assistant/chunk') return
-      }
+      if (skipHubEvent(name, args)) return
       this.events.unshift({ ts: Date.now(), mode, name, args: clone(args) })
       this.events.splice(80)
       ctx.http.broadcast(HUB_CHANNEL_EVENT, this.events[0])
     })
-    ctx.on('internal/status', () => {
-      ctx.http.broadcast(HUB_CHANNEL_SNAPSHOT, this.snapshot())
-    })
-    ctx.on(HUB_CHANGE, () => {
-      ctx.http.broadcast(HUB_CHANNEL_SNAPSHOT, this.snapshot())
-    })
+    let snapTimer: ReturnType<typeof setTimeout> | null = null
+    const pushSnapshot = () => {
+      if (snapTimer) return
+      snapTimer = setTimeout(() => {
+        snapTimer = null
+        ctx.http.broadcast(HUB_CHANNEL_SNAPSHOT, this.snapshot())
+      }, 40)
+    }
+    ctx.on('internal/status', pushSnapshot)
+    ctx.on(HUB_CHANGE, pushSnapshot)
     for (const entry of catalog) {
       this.forks.set(entry.id, { entry })
     }
@@ -160,6 +158,17 @@ function clone(value: unknown): unknown[] {
   } catch {
     return ['[unserializable]']
   }
+}
+
+/** 心跳和路由登记会把 EventLog / WS 打满；FS 登记多条 /api/db 路由后更明显。 */
+export function skipHubEvent(name: string, args?: unknown[]) {
+  if (name.startsWith('internal/')) return true
+  if (name === 'llm/stream' || name === 'clock/tick' || name === 'hub/change') return true
+  if (name === 'session/event') {
+    const payload = args?.[0] as { event?: { type?: string } } | undefined
+    if (payload?.event?.type === 'assistant/chunk') return true
+  }
+  return false
 }
 
 function isStorePackage(packageName?: string) {

--- a/packages/host-hub/src/host/skip-event.test.ts
+++ b/packages/host-hub/src/host/skip-event.test.ts
@@ -1,0 +1,13 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { skipHubEvent } from './index.ts'
+
+test('hub event bus drops heartbeat and route-register noise', () => {
+  assert.equal(skipHubEvent('clock/tick'), true)
+  assert.equal(skipHubEvent('hub/change'), true)
+  assert.equal(skipHubEvent('llm/stream'), true)
+  assert.equal(skipHubEvent('internal/status'), true)
+  assert.equal(skipHubEvent('database/change'), false)
+  assert.equal(skipHubEvent('session/event', [{ event: { type: 'assistant/chunk' } }]), true)
+  assert.equal(skipHubEvent('session/event', [{ event: { type: 'tool/call' } }]), false)
+})

--- a/packages/web-ui-hub/src/web/index.ts
+++ b/packages/web-ui-hub/src/web/index.ts
@@ -79,8 +79,20 @@ export function apply(ctx: Context) {
     }
   }
 
+  const mountKey = () =>
+    ctx.snapshot
+      .get()
+      .plugins.filter((plugin) => plugin.web)
+      .map((plugin) => `${plugin.id}\0${plugin.web}\0${plugin.enabled}\0${plugin.state}`)
+      .sort()
+      .join('|')
+  let lastMountKey = ''
   ctx.snapshot.subscribe(() => {
+    const key = mountKey()
+    if (key === lastMountKey) return
+    lastMountKey = key
     void sync()
   })
+  lastMountKey = mountKey()
   return sync()
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
实跑 `file-system` 后，host 控制台几乎被 `logger emit clock/tick`（每秒一条）和启动瞬间几十条 `hub/change` 占满。`/api/snapshot` 的 80 条事件里大部分是心跳，真正的 `database/change` 被挤掉。

File System 多登记了 7 条 `/api/db` 路由，每条路由都会 `hub/change` 并广播整份 snapshot；前端 `ui-hub` 订阅整表 snapshot，时钟一跳就重新 sync 插件。

本 PR：心跳/路由登记不再进 logger 和 EventLog；snapshot 广播 40ms 合并；ui-hub 按插件集合指纹才重挂；`/api/db` 请求打耗时日志，方便继续看 FS 性能。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

