### PR TITLE
fix(file-system): 插件/表详情里打字不再卡顿

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -59,7 +59,7 @@ import {
   uniqueValues,
   type ViewMode,
 } from './fields'
-import { AppDialog, CellSelect, CheckRow, TokenMultiSelect } from './controls.tsx'
+import { AppDialog, CellSelect, CheckRow, LocalText, TokenMultiSelect } from './controls.tsx'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
 
 type ListResult = { items: Array<DbRecord & { path?: string }>; total?: number; offset?: number; limit?: number }
@@ -437,11 +437,11 @@ function FieldEditor({
   }
   if (kind === 'datetime') {
     return (
-      <input
+      <LocalText
         className="fsdb-plain-input"
         value={toDatetimeLocal(value)}
         placeholder="YYYY-MM-DDTHH:mm"
-        onChange={(e) => onChange(fromDatetimeLocal(e.target.value))}
+        onCommit={(next) => onChange(fromDatetimeLocal(next))}
       />
     )
   }
@@ -456,15 +456,15 @@ function FieldEditor({
   }
   if (kind === 'url' || kind === 'image' || kind === 'attachment') {
     return (
-      <input
+      <LocalText
         className="fsdb-plain-input"
         value={value}
         placeholder={kind === 'image' ? 'https://… 或 data:image' : 'https://'}
-        onChange={(e) => onChange(e.target.value)}
+        onCommit={onChange}
       />
     )
   }
-  return <input className="fsdb-plain-input" value={value} title={value} placeholder={fieldKey} onChange={(e) => onChange(e.target.value)} />
+  return <LocalText className="fsdb-plain-input" value={value} title={value} placeholder={fieldKey} onCommit={onChange} />
 }
 
 function visibleActions(schema: CollectionSchema | undefined, row: DbRecord, place: 'row' | 'detail') {
@@ -644,6 +644,8 @@ export function CollectionBrowser({
   }, [collectionPath, fetchQuery, filters, page, pageSize, sortDir, sortField])
   const reloadRef = useRef(reload)
   reloadRef.current = reload
+  const detailIdRef = useRef<string | null>(null)
+  detailIdRef.current = detailId
 
   useEffect(() => {
     const id = window.setTimeout(() => {
@@ -699,11 +701,15 @@ export function CollectionBrowser({
     }
     let debounce = 0
     const onChange = () => {
+      if (detailIdRef.current) return
       window.clearTimeout(debounce)
       debounce = window.setTimeout(() => void reloadRef.current(), 120)
     }
     window.addEventListener('fsdb:change', onChange)
-    const timer = window.setInterval(() => void reloadRef.current(), 20000)
+    const timer = window.setInterval(() => {
+      if (detailIdRef.current) return
+      void reloadRef.current()
+    }, 20000)
     return () => {
       window.clearTimeout(debounce)
       window.clearInterval(timer)
@@ -2046,13 +2052,14 @@ export function CollectionBrowser({
             <div className="fsdb-detail-split">
               <div className="fsdb-detail-main">
                 {schema.labelField && schema.fields[schema.labelField]?.writable ? (
-                  <textarea
+                  <LocalText
+                    as="textarea"
                     className="fsdb-detail-title-input"
                     value={draft[schema.labelField] ?? ''}
                     rows={(draft[schema.labelField] ?? '').length > 48 ? 2 : 1}
-                    onChange={(event) => setDraft((prev) => ({ ...prev, [schema.labelField!]: event.target.value }))}
-                    onBlur={() => {
-                      const next = (draft[schema.labelField!] ?? '').trim()
+                    onCommit={(raw) => {
+                      const next = raw.trim()
+                      setDraft((prev) => ({ ...prev, [schema.labelField!]: next }))
                       if (next && next !== String(selected[schema.labelField!] ?? '')) {
                         void writeOne(selected, schema.labelField!, schema.fields[schema.labelField!]!, next)
                       }
@@ -2089,9 +2096,7 @@ export function CollectionBrowser({
                             options={uniqueValues(items, key, field)}
                             onChange={(next) => {
                               setDraft((prev) => ({ ...prev, [key]: next }))
-                              if (kind === 'boolean' || kind === 'select' || kind === 'multi-select') {
-                                void writeOne(selected, key, field, next)
-                              }
+                              void writeOne(selected, key, field, next)
                             }}
                           />
                         ) : (
@@ -2121,19 +2126,20 @@ export function CollectionBrowser({
                     )
                   }
                   if (spec.writable) {
+                    const saved =
+                      typeof detailBody === 'string' || detailBody == null
+                        ? String(detailBody ?? '')
+                        : JSON.stringify(detailBody, null, 2)
                     return (
-                      <textarea
+                      <LocalText
+                        as="textarea"
                         className="fsdb-detail-doc"
-                        value={draft[key] ?? ''}
+                        value={draft[key] ?? saved}
                         rows={12}
                         placeholder="内容：文本，或 JSON 文件"
-                        onChange={(event) => setDraft((prev) => ({ ...prev, [key]: event.target.value }))}
-                        onBlur={() => {
-                          const prev =
-                            typeof detailBody === 'string' || detailBody == null
-                              ? String(detailBody ?? '')
-                              : JSON.stringify(detailBody, null, 2)
-                          if ((draft[key] ?? '') !== prev) void writeOne(selected, key, spec, draft[key] ?? '')
+                        onCommit={(next) => {
+                          setDraft((prev) => ({ ...prev, [key]: next }))
+                          if (next !== saved) void writeOne(selected, key, spec, next)
                         }}
                       />
                     )

--- a/packages/core-file-system/src/web/controls.test.tsx
+++ b/packages/core-file-system/src/web/controls.test.tsx
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { useState } from 'react'
 import { fireEvent, render, screen } from '@testing-library/react'
-import { AppDialog } from './controls.tsx'
+import { AppDialog, LocalText } from './controls.tsx'
 
 test('named AppDialog keeps draft local so the parent does not re-render while typing', () => {
   let parentRenders = 0
@@ -35,4 +35,22 @@ test('named AppDialog keeps draft local so the parent does not re-render while t
   assert.equal(confirmed, '')
   fireEvent.click(screen.getByRole('button', { name: '保存' }))
   assert.equal(confirmed, '列表改名')
+})
+
+test('LocalText keeps keystrokes inside the field and only commits on blur', () => {
+  let parentRenders = 0
+  let committed = ''
+  function Host() {
+    parentRenders += 1
+    return <LocalText as="textarea" value="旧正文" placeholder="内容：文本，或 JSON 文件" onCommit={(next) => { committed = next }} />
+  }
+  render(<Host />)
+  const box = screen.getByPlaceholderText('内容：文本，或 JSON 文件') as HTMLTextAreaElement
+  const before = parentRenders
+  fireEvent.change(box, { target: { value: '新正文一二三' } })
+  assert.equal(box.value, '新正文一二三')
+  assert.equal(parentRenders, before)
+  assert.equal(committed, '')
+  fireEvent.blur(box)
+  assert.equal(committed, '新正文一二三')
 })

--- a/packages/core-file-system/src/web/controls.tsx
+++ b/packages/core-file-system/src/web/controls.tsx
@@ -379,3 +379,42 @@ export function AppDialog({
   )
   return createPortal(dialog, document.body)
 }
+
+/** 详情正文/文本列：输入只更新自己，失焦才回传，避免整张表跟着每个按键重绘。 */
+export function LocalText({
+  as = 'input',
+  className,
+  value,
+  rows,
+  placeholder,
+  title,
+  onCommit,
+}: {
+  as?: 'input' | 'textarea'
+  className?: string
+  value: string
+  rows?: number
+  placeholder?: string
+  title?: string
+  onCommit: (next: string) => void
+}) {
+  const [draft, setDraft] = useState(value)
+  const draftRef = useRef(draft)
+  draftRef.current = draft
+  useEffect(() => {
+    setDraft(value)
+  }, [value])
+  const commit = () => {
+    if (draftRef.current !== value) onCommit(draftRef.current)
+  }
+  const shared = {
+    className,
+    value: draft,
+    title,
+    placeholder,
+    onChange: (event: { target: { value: string } }) => setDraft(event.target.value),
+    onBlur: commit,
+  }
+  if (as === 'textarea') return <textarea {...shared} rows={rows} />
+  return <input {...shared} />
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开 File System 记录详情后，标题、正文、文本列的 `onChange` 都写在 `CollectionBrowser` 上。这个组件同时还画整张表、分组、树和 20s 轮询，所以每敲一个字就全页重绘，输入会明显不跟手。

改动：文本框用 `LocalText` 自己扛草稿，失焦才写回；详情打开时不刷新列表。单测覆盖「输入时父组件不重渲染」。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

