### PR TITLE
fix(file-system): 左侧导航一起出现，并修好封面图

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context, Service } from 'cordis'
-import type { CollectionSpec, FieldType } from '@biu/type-file-system'
+import { asImageSrc, type CollectionSpec, type FieldType } from '@biu/type-file-system'
 import * as page from './index.ts'
 
 const FIELD_TYPES: FieldType[] = [
@@ -40,7 +40,8 @@ test('page plugin registers every field type on /pages without a web module', as
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
   const listed = await registered[0]!.list()
   assert.equal(listed.length, page.ROW_COUNT)
-  assert.equal(String(listed[0]?.cover).startsWith('data:image/svg+xml'), true)
+  assert.equal(String(listed[0]?.cover).startsWith('data:image/svg+xml;charset=utf-8,'), true)
+  assert.ok(asImageSrc(listed[0]?.cover))
   const written = await registered[0]!.write!('p000', { enabled: false })
   assert.equal(written.enabled, false)
   assert.equal(written.score, listed[0]?.score)

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -15,7 +15,7 @@ const COLOR_HEX: Record<(typeof COLORS)[number], string> = {
 
 function seedCover(id: string, color: (typeof COLORS)[number]) {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect fill="${COLOR_HEX[color]}" width="100%" height="100%"/><text x="50%" y="54%" fill="#fff" font-size="28" text-anchor="middle" font-family="sans-serif">${id}</text></svg>`
-  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
 }
 
 type PageRow = DbRecord & {

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -11,7 +11,7 @@ import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu
 import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseUiService } from './database-ui.ts'
-import { bootLoadCollections } from './nav-boot.ts'
+import { bootLoadCollections, collectionNavKey } from './nav-boot.ts'
 
 type SlotsService = {
   place: (slot: string, view: unknown, opts: { key: string; order?: number; props?: () => Record<string, unknown> }) => { dispose?: () => unknown }
@@ -33,10 +33,13 @@ type AppModulesService = {
     order?: number
     Icon?: ComponentType<{ className?: string }>
   }) => { dispose?: () => unknown }
+  markNavReady?: () => void
 }
 
 type SnapshotService = {
   onMessage: (type: string, handler: (payload: unknown) => void) => () => void
+  get?: () => { collections?: CollectionInfo[] }
+  subscribe?: (fn: () => void) => () => void
 }
 
 const ICONS: Record<string, ComponentType<{ className?: string }>> = {
@@ -138,6 +141,7 @@ export function apply(ctx: Context) {
 
   slots.place('root-overlays', RegisterErrorBanner, { key: 'fsdb-nav-errors', order: 80 })
   let stopped = false
+  let readyTimer = 0
   const runSync = async (rows: CollectionInfo[]) => {
     const views = rows.filter((row) => row.view?.moduleId && row.view.route)
     const live = new Set(views.map((row) => row.view!.moduleId))
@@ -193,24 +197,40 @@ export function apply(ctx: Context) {
     setNavErrors(errors)
   }
 
-  const sync = async () => {
-    let rows: CollectionInfo[] = []
-    try {
-      rows = await loadCollections()
-    } catch {
-      return
+  const sync = async (rows?: CollectionInfo[]) => {
+    let next = rows
+    if (!next) {
+      try {
+        next = await loadCollections()
+      } catch {
+        return
+      }
     }
-    await runSync(rows)
+    await runSync(next)
+    if (!collectionNavKey(next)) return
+    window.clearTimeout(readyTimer)
+    readyTimer = window.setTimeout(() => appModules.markNavReady?.(), 80)
   }
 
   ctx.effect(() => () => {
     stopped = true
+    window.clearTimeout(readyTimer)
     for (const dispose of mounted.values()) dispose()
     mounted.clear()
     setNavErrors([])
   })
   ctx.inject(['snapshot'], (inner) => {
     const snapshot = inner.get('snapshot') as SnapshotService
+    let lastKey = ''
+    const fromSnap = () => {
+      const rows = snapshot.get?.().collections ?? []
+      const key = collectionNavKey(rows)
+      if (!key || key === lastKey) return
+      lastKey = key
+      void sync(rows)
+    }
+    fromSnap()
+    const offSnap = snapshot.subscribe?.(fromSnap)
     let debounce = 0
     const off = snapshot.onMessage(DATABASE_CHANNEL, () => {
       window.dispatchEvent(new Event('fsdb:change'))
@@ -219,11 +239,19 @@ export function apply(ctx: Context) {
     })
     return () => {
       window.clearTimeout(debounce)
+      offSnap?.()
       off()
     }
   })
-  void bootLoadCollections(loadCollections, { stopped: () => stopped }).then((rows) => {
-    if (!stopped) return runSync(rows)
+  void bootLoadCollections(loadCollections, {
+    stopped: () => stopped,
+    onUpdate: (rows) => {
+      if (stopped || !collectionNavKey(rows)) return
+      void sync(rows)
+    },
+  }).then((rows) => {
+    if (stopped) return
+    return sync(rows)
   })
 }
 

--- a/packages/core-file-system/src/web/nav-boot.test.ts
+++ b/packages/core-file-system/src/web/nav-boot.test.ts
@@ -21,13 +21,16 @@ test('bootLoadCollections retries empty/failed loads until the nav set is stable
     if (calls.length === 3) return [row('plugins')]
     return [row('plugins'), row('page')]
   }
+  const updates: string[] = []
   const listed = await bootLoadCollections(load, {
     attempts: 8,
     delayMs: 5,
     wait: async (ms) => {
       waits.push(ms)
     },
+    onUpdate: (rows) => updates.push(rows.map((item) => item.id).join(',')),
   })
+  assert.ok(updates.includes('plugins,page'))
   assert.deepEqual(
     listed.map((item) => item.id),
     ['plugins', 'page'],

--- a/packages/core-file-system/src/web/nav-boot.ts
+++ b/packages/core-file-system/src/web/nav-boot.ts
@@ -11,7 +11,13 @@ export function collectionNavKey(rows: CollectionInfo[]) {
 /** Host 插件登记表会晚于 UI apply；失败或空列表时短轮询，避免导航一直空白。 */
 export async function bootLoadCollections(
   load: () => Promise<CollectionInfo[]>,
-  opts?: { attempts?: number; delayMs?: number; stopped?: () => boolean; wait?: (ms: number) => Promise<void> },
+  opts?: {
+    attempts?: number
+    delayMs?: number
+    stopped?: () => boolean
+    wait?: (ms: number) => Promise<void>
+    onUpdate?: (rows: CollectionInfo[]) => void
+  },
 ): Promise<CollectionInfo[]> {
   const attempts = opts?.attempts ?? 30
   const delayMs = opts?.delayMs ?? 100
@@ -23,6 +29,7 @@ export async function bootLoadCollections(
     if (opts?.stopped?.()) return last
     try {
       last = await load()
+      opts?.onUpdate?.(last)
     } catch {
       last = last.length ? last : []
     }

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -89,10 +89,11 @@ export class HubService extends Service {
       routes: this.ctx.http.listRoutes(),
       events: this.events,
       tools: this.ctx.tools.names(),
+      collections: listSnapshotCollections(this.ctx),
       services: [
         'http', 'hub', 'tools', 'llm', 'agentLoop', 'agents', 'approvals',
         'sessionStore', 'sessions', 'systemPrompt', 'fs', 'subprocess', 'sandbox',
-        'shell', 'jobs', 'mcp', 'terminals', 'lsp', 'subagents', 'chat',
+        'shell', 'jobs', 'mcp', 'terminals', 'lsp', 'subagents', 'chat', 'database',
       ].filter((name) => Boolean(this.ctx.get(name))),
     }
   }
@@ -169,6 +170,20 @@ export function skipHubEvent(name: string, args?: unknown[]) {
     if (payload?.event?.type === 'assistant/chunk') return true
   }
   return false
+}
+
+function listSnapshotCollections(ctx: Context) {
+  const db = ctx.get('database') as
+    | { collectionsList?: () => Array<{ id: string; path: string; label?: string; view?: unknown }> }
+    | undefined
+  if (!db?.collectionsList) return []
+  return db.collectionsList().map((item) => ({
+    id: item.id,
+    path: item.path,
+    kind: 'collection' as const,
+    label: item.label ?? item.id,
+    view: item.view ?? null,
+  }))
 }
 
 function isStorePackage(packageName?: string) {

--- a/packages/web-app-modules/src/web/index.test.ts
+++ b/packages/web-app-modules/src/web/index.test.ts
@@ -26,4 +26,7 @@ test('plugins register routes; shell does not hardcode them', async () => {
   assert.equal(moduleIdFromPath('/dashboard', plugins), 'dashboard')
   assert.equal(isAgentPath('/tasks', plugins), false)
   assert.equal(svc.list().map((item) => item.id).join(','), 'agent,tasks,dashboard')
+  assert.equal(svc.isNavReady(), false)
+  svc.markNavReady()
+  assert.equal(svc.isNavReady(), true)
 })

--- a/packages/web-app-modules/src/web/index.ts
+++ b/packages/web-app-modules/src/web/index.ts
@@ -38,6 +38,7 @@ export class AppModulesService extends Service {
   private extras = new Map<string, AppModule>()
   private listeners = new Set<() => void>()
   private seq = 0
+  private navReady = false
 
   constructor(ctx: Context) {
     super(ctx, 'appModules')
@@ -58,6 +59,17 @@ export class AppModulesService extends Service {
 
   list(): AppModule[] {
     return [AGENT, ...this.plugins()]
+  }
+
+  isNavReady() {
+    return this.navReady
+  }
+
+  /** 左侧栏等齐：File System 表入口和其它模块一起亮。 */
+  markNavReady() {
+    if (this.navReady) return
+    this.navReady = true
+    this.bump()
   }
 
   register(mod: AppModule) {
@@ -87,6 +99,13 @@ export function bindAppModules(source: AppModulesService) {
   }
 }
 
+export function bindAppModulesNavReady(source: AppModulesService) {
+  return function useAppModulesNavReady(): boolean {
+    useSyncExternalStore(source.subscribe, source.version, source.version)
+    return source.isNavReady()
+  }
+}
+
 export function moduleById(id: string, modules: AppModule[] = BUILTIN_MODULES): AppModule {
   return modules.find((item) => item.id === id) ?? AGENT
 }
@@ -106,5 +125,9 @@ export const name = 'appModules'
 export const inject = [] as const
 
 export function apply(ctx: Context) {
-  new AppModulesService(ctx)
+  const svc = new AppModulesService(ctx)
+  ctx.effect(() => {
+    const timer = setTimeout(() => svc.markNavReady(), 2500)
+    return () => clearTimeout(timer)
+  }, 'appModules.navReady.timeout')
 }

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -32,6 +32,7 @@ import {
 } from '@biu/web-mascot'
 import {
   bindAppModules,
+  bindAppModulesNavReady,
   moduleIdFromPath,
   type AppModule,
   type AppModulesService,
@@ -369,6 +370,7 @@ function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const useAppModules = props.useAppModules as ReturnType<typeof bindAppModules>
+  const useAppModulesNavReady = props.useAppModulesNavReady as ReturnType<typeof bindAppModulesNavReady> | undefined
   const appModules = props.appModules as AppModulesService
   const sessionView = props.sessionView as SessionViewService
   const projectView = props.projectView as ProjectViewService
@@ -376,7 +378,9 @@ function Shell(props: SlotProps) {
   const navigate = useNavigate()
   const location = useLocation()
   const modules = useAppModules()
+  const navReady = useAppModulesNavReady ? useAppModulesNavReady() : true
   const pluginModules = modules.filter((item) => item.id !== 'agent')
+  const railModules = navReady ? modules : []
   const sessionId = useSessionView((state) => state.sessionId)
   const danceSessions = useSessionView((state) => state.sessions)
   const dancing = useSyncExternalStore(
@@ -660,7 +664,7 @@ function Shell(props: SlotProps) {
           <ModuleRail
             active={activeModule}
             agentHref={agentHref}
-            modules={modules}
+            modules={railModules}
             pinned={railPinned}
             onTogglePin={toggleRailPin}
             onSettings={() => setSettingsOpen(true)}
@@ -782,6 +786,7 @@ export function apply(ctx: Context) {
     useSnapshot: bindSnapshot(ctx.snapshot as SnapshotService),
     useSessionView: bindSessionView(ctx.sessionView as SessionViewService),
     useAppModules: bindAppModules(ctx.appModules as AppModulesService),
+    useAppModulesNavReady: bindAppModulesNavReady(ctx.appModules as AppModulesService),
     sessionView: ctx.sessionView as SessionViewService,
     projectView: ctx.projectView as ProjectViewService,
     useProjectView: bindProjectView(ctx.projectView as ProjectViewService),

--- a/packages/web-snapshot/src/web/index.ts
+++ b/packages/web-snapshot/src/web/index.ts
@@ -27,6 +27,14 @@ export interface Snapshot {
   clockIso?: string
   lastSessionId?: string
   lastSessionEvent?: string
+  /** File System 已登记表，启动时随 snapshot 一起到，导航不必再等一轮 /api/db/stat。 */
+  collections?: Array<{
+    id: string
+    path: string
+    kind?: string
+    label: string
+    view?: { moduleId?: string; route?: string; title?: string; blurb?: string; order?: number; icon?: string } | null
+  }>
 }
 
 const empty: Snapshot = { seq: 0, plugins: [], pages: [], routes: [], events: [], services: [] }

--- a/packages/web-ui-hub/src/web/index.ts
+++ b/packages/web-ui-hub/src/web/index.ts
@@ -45,11 +45,13 @@ export function apply(ctx: Context) {
     running = true
     try {
       const rows = ctx.snapshot.get().plugins
-      const enabledRows = rows.filter((plugin) => {
-        if (!plugin.web) return false
-        if (plugin.enabled) return true
-        return plugin.state === 'pending' || plugin.state === 'loading' || plugin.state === 'active'
-      })
+      const enabledRows = rows
+        .filter((plugin) => {
+          if (!plugin.web) return false
+          if (plugin.enabled) return true
+          return plugin.state === 'pending' || plugin.state === 'loading' || plugin.state === 'active'
+        })
+        .sort((a, b) => Number(b.id === 'core-file-system') - Number(a.id === 'core-file-system'))
       const enabledIds = new Set(enabledRows.map((plugin) => plugin.id))
 
       for (const row of enabledRows) {
@@ -69,6 +71,16 @@ export function apply(ctx: Context) {
         if (enabledIds.has(id)) continue
         await fiber.dispose()
         forks.delete(id)
+      }
+      const fsUi = rows.some(
+        (plugin) =>
+          plugin.id === 'core-file-system' &&
+          plugin.web &&
+          (plugin.enabled || plugin.state === 'pending' || plugin.state === 'loading' || plugin.state === 'active'),
+      )
+      if (!fsUi) {
+        const appModules = ctx.get('appModules') as { markNavReady?: () => void } | undefined
+        appModules?.markNavReady?.()
       }
     } finally {
       running = false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
左侧栏以前 Agent/Tasks 先亮，File System 表入口要再等 `/api/db/stat` 轮询，所以会一个一个蹦出来。

现在登记表写进 snapshot，File System UI 先挂；导航栏等入口齐了再一起画。另外把 Page 封面 `data:image/svg+xml;utf8` 改成带 `charset=utf-8` 的合法 data URI，缩略图能显示。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

