### PR TITLE
fix(file-system): Page 封面图改为 base64 并去掉 lazy

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -40,7 +40,7 @@ test('page plugin registers every field type on /pages without a web module', as
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
   const listed = await registered[0]!.list()
   assert.equal(listed.length, page.ROW_COUNT)
-  assert.equal(String(listed[0]?.cover).startsWith('data:image/svg+xml;charset=utf-8,'), true)
+  assert.equal(String(listed[0]?.cover).startsWith('data:image/svg+xml;base64,'), true)
   assert.ok(asImageSrc(listed[0]?.cover))
   const written = await registered[0]!.write!('p000', { enabled: false })
   assert.equal(written.enabled, false)

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -14,8 +14,8 @@ const COLOR_HEX: Record<(typeof COLORS)[number], string> = {
 }
 
 function seedCover(id: string, color: (typeof COLORS)[number]) {
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect fill="${COLOR_HEX[color]}" width="100%" height="100%"/><text x="50%" y="54%" fill="#fff" font-size="28" text-anchor="middle" font-family="sans-serif">${id}</text></svg>`
-  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><rect fill="${COLOR_HEX[color]}" width="100%" height="100%"/><text x="160" y="104" fill="#fff" font-size="28" text-anchor="middle" font-family="sans-serif">${id}</text></svg>`
+  return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`
 }
 
 type PageRow = DbRecord & {

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -284,7 +284,7 @@ function ImageThumb({ src }: { src: string }) {
           setOpen(true)
         }}
       >
-        <img className="fsdb-thumb" src={src} alt="" loading="lazy" decoding="async" />
+        <img className="fsdb-thumb" src={src} alt="" decoding="async" />
       </button>
       {open
         ? createPortal(
@@ -332,7 +332,7 @@ function FilePreview({ value, compact = false }: { value: unknown; compact?: boo
   const src = asImageSrc(value)
   if (src) {
     if (compact) return <ImageThumb src={src} />
-    return <img className="fsdb-fileview-img" src={src} alt="" loading="lazy" decoding="async" />
+    return <img className="fsdb-fileview-img" src={src} alt="" decoding="async" />
   }
   const file = asAttachment(value)
   if (file) {
@@ -2256,7 +2256,7 @@ if (typeof document !== 'undefined') {
 .fsdb-link{color:inherit;text-underline-offset:2px;overflow-wrap:anywhere}
 .fsdb-link:hover{text-decoration:underline}
 .fsdb-thumb-link,.fsdb-thumb-btn{display:inline-flex;align-items:center;justify-content:center;line-height:0;border:0;padding:0;background:transparent;cursor:zoom-in;vertical-align:middle}
-.fsdb-thumb{display:block;width:18px;height:18px;object-fit:cover;border-radius:4px;background:var(--dsw-hover);flex:none}
+.fsdb-thumb{display:block;width:28px;height:16px;object-fit:cover;border-radius:4px;background:var(--dsw-hover);flex:none}
 .fsdb-lightbox{position:fixed;inset:0;z-index:140;display:flex;align-items:center;justify-content:center;padding:28px;background:rgba(0,0,0,.72);cursor:zoom-out}
 .fsdb-lightbox img{max-width:min(92vw,1100px);max-height:88vh;object-fit:contain;border-radius:10px;box-shadow:0 16px 48px rgba(0,0,0,.45);cursor:default}
 .fsdb-file{display:inline-flex;align-items:center;gap:6px;min-width:0;color:inherit;text-underline-offset:2px}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一版封面是 `data:image/svg+xml;charset=utf-8,` + URL 编码，很多浏览器的 `<img>` 画不出来；表格又在 overflow 里还加了 `loading=lazy`，缩略图更容易一直空白。

改成 `base64` SVG，缩略图改为立即加载。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

