### PR TITLE
feat: 左侧栏合并为数据图标，表与视图可展开

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -61,6 +61,13 @@ import {
 } from './fields'
 import { AppDialog, CellSelect, CheckRow, LocalText, TokenMultiSelect } from './controls.tsx'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
+import {
+  defaultViewStub,
+  loadActiveViewId,
+  loadViews,
+  persistViews as writeViews,
+  rememberActiveView as storeActiveView,
+} from './view-store.ts'
 
 type ListResult = { items: Array<DbRecord & { path?: string }>; total?: number; offset?: number; limit?: number }
 type StatResult = { schema?: CollectionSchema }
@@ -83,10 +90,10 @@ function ModeGlyph({ id }: { id: ViewMode }) {
   return <ViewColumnsIcon aria-hidden className={cls} />
 }
 
-const SIDEBAR_BRAND_GRADIENT =
+export const SIDEBAR_BRAND_GRADIENT =
   'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
 
-function SidebarBrandMascot({ className }: { className?: string }) {
+export function SidebarBrandMascot({ className }: { className?: string }) {
   const uid = useId().replace(/:/g, '')
   return (
     <svg className={className} viewBox="-15 -15 259 259" width={30} height={30} fill="none" aria-hidden>
@@ -154,38 +161,10 @@ function draftFromRecord(schema: CollectionSchema, row: DbRecord, bodyKey: strin
   return next
 }
 
-function viewsKey(collectionPath: string) {
-  return `fsdb.views:${collectionPath}`
-}
-
-function activeViewStorageKey(collectionPath: string) {
-  return `fsdb.activeView:${collectionPath}`
-}
-
-function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
-  try {
-    const id = localStorage.getItem(activeViewStorageKey(collectionPath))
-    if (id && listed.some((view) => view.id === id)) return id
-  } catch {
-    /* ignore */
-  }
-  return listed[0]?.id ?? null
-}
-
 function viewForPath(collectionPath: string): SavedView | null {
   const listed = loadViews(collectionPath)
   const view = listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ?? listed[0]
   return view ? normalizeSavedView(view) : null
-}
-
-function loadViews(collectionPath: string): SavedView[] {
-  try {
-    const raw = localStorage.getItem(viewsKey(collectionPath))
-    const parsed = raw ? (JSON.parse(raw) as SavedView[]) : []
-    return parsed.map((view) => normalizeSavedView(view))
-  } catch {
-    return []
-  }
 }
 
 function isListColumn(key: string) {
@@ -480,12 +459,14 @@ export function CollectionBrowser({
   title,
   blurb,
   chrome,
+  hideViewsSidebar = false,
 }: {
   moduleId?: string
   collectionPath: string
   title: string
   blurb: string
   chrome?: CollectionChrome
+  hideViewsSidebar?: boolean
 }) {
   const [stat, setStat] = useState<StatResult | null>(null)
   const [items, setItems] = useState<Array<DbRecord & { path?: string }>>([])
@@ -509,6 +490,7 @@ export function CollectionBrowser({
   const [activeViewId, setActiveViewId] = useState<string | null>(initialView?.id ?? null)
   const [hydrated, setHydrated] = useState(false)
   const [viewsOpen, setViewsOpen] = useState(() => {
+    if (hideViewsSidebar) return false
     try {
       return localStorage.getItem(`fsdb.viewsOpen:${moduleId || collectionPath}`) !== '0'
     } catch {
@@ -555,6 +537,7 @@ export function CollectionBrowser({
   const searchExpanded = searchOpen || query.length > 0
 
   useEffect(() => {
+    if (hideViewsSidebar) return
     function onToggle(event: Event) {
       const id = (event as CustomEvent<{ id?: string }>).detail?.id
       if (!id || (moduleId && id !== moduleId)) return
@@ -570,7 +553,7 @@ export function CollectionBrowser({
     }
     window.addEventListener('biu:toggle-module-sidebar', onToggle)
     return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
-  }, [collectionPath, moduleId])
+  }, [collectionPath, hideViewsSidebar, moduleId])
 
   useEffect(() => {
     function onPointer(event: MouseEvent) {
@@ -858,16 +841,12 @@ export function CollectionBrowser({
   function persistViews(next: SavedView[]) {
     viewsRef.current = next
     setViews(next)
-    localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
+    writeViews(collectionPath, next)
   }
 
   function rememberActiveView(id: string) {
     setActiveViewId(id)
-    try {
-      localStorage.setItem(activeViewStorageKey(collectionPath), id)
-    } catch {
-      /* ignore */
-    }
+    storeActiveView(collectionPath, id)
   }
 
   function applyView(view: SavedView) {
@@ -1337,20 +1316,11 @@ export function CollectionBrowser({
     let next = loadViews(collectionPath)
     if (!next.length) {
       next = [
-        normalizeSavedView({
-          id: `${Date.now()}`,
-          name: '默认视图',
-          mode: 'table',
+        {
+          ...defaultViewStub(`${Date.now()}`),
           sortField: schemaDefaultKeys[0] ?? 'id',
-          sortDir: 'asc',
-          filters: {},
           columns: [...schemaDefaultKeys],
-          groupBy: '',
-          tree: true,
-          wrap: false,
-          truncate: true,
-          query: '',
-        }),
+        },
       ]
     }
     persistViews(next)
@@ -1400,7 +1370,7 @@ export function CollectionBrowser({
   ])
 
   return (
-    <div className="fsdb-page tasks-root">
+    <div className={hideViewsSidebar ? 'contents' : 'fsdb-page tasks-root'}>
       {viewsOpen ? (
       <aside
         className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
@@ -2202,6 +2172,10 @@ if (typeof document !== 'undefined') {
   style.textContent = `
 .fsdb-page{display:flex;min-width:0;min-height:0;flex:1;flex-direction:row;overflow:hidden;background:var(--dsw-bg);color:var(--dsw-label);font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji";font-size:14px;letter-spacing:-.011em}
 .fsdb-views{display:flex;width:280px;flex:none;flex-direction:column;min-height:0;overflow:hidden}
+.fsdb-nav-group{min-width:0}
+.fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
+.fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}
+.fsdb-nav-view{margin-left:0}
 .fsdb-collection-head{flex:none;padding:4px 16px 10px;min-width:0}
 .fsdb-collection-head.is-inline{padding:0 0 2px}
 .fsdb-collection-name{font-size:14px;font-weight:650;color:var(--dsw-label);line-height:1.35;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}

--- a/packages/core-file-system/src/web/hub-nav.test.ts
+++ b/packages/core-file-system/src/web/hub-nav.test.ts
@@ -1,0 +1,32 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { collectionFromLocation, navCollections, normalizeNavPath } from './hub-nav.ts'
+import type { CollectionInfo } from '@biu/type-file-system'
+
+function row(id: string, order: number, route = `/${id}`): CollectionInfo {
+  return {
+    id,
+    path: `/${id}`,
+    kind: 'collection',
+    label: id,
+    view: { moduleId: id, route, title: id, order },
+  }
+}
+
+test('navCollections sorts by view order', () => {
+  assert.deepEqual(
+    navCollections([row('page', 25, '/pages'), row('plugins', 30, '/plugins'), row('tasks-2', 21, '/tasks-2')]).map((item) => item.id),
+    ['tasks-2', 'page', 'plugins'],
+  )
+})
+
+test('collectionFromLocation matches view route and falls back to first', () => {
+  const rows = [row('page', 25, '/pages'), row('plugins', 30, '/plugins')]
+  assert.equal(collectionFromLocation(rows, '/plugins')?.id, 'plugins')
+  assert.equal(collectionFromLocation(rows, '/pages/extra')?.id, 'page')
+  assert.equal(collectionFromLocation(rows, '/database')?.id, 'page')
+})
+
+test('normalizeNavPath strips trailing slash', () => {
+  assert.equal(normalizeNavPath('/pages/'), '/pages')
+})

--- a/packages/core-file-system/src/web/hub-nav.ts
+++ b/packages/core-file-system/src/web/hub-nav.ts
@@ -1,0 +1,46 @@
+import type { CollectionInfo } from '@biu/type-file-system'
+
+export function normalizeNavPath(path: string) {
+  const raw = String(path || '/').trim() || '/'
+  const withSlash = raw.startsWith('/') ? raw : `/${raw}`
+  if (withSlash === '/') return '/'
+  return withSlash.replace(/\/+$/, '') || '/'
+}
+
+export function navCollections(rows: CollectionInfo[]) {
+  return rows
+    .filter((row) => row.view?.moduleId && row.view.route)
+    .slice()
+    .sort((a, b) => (a.view!.order ?? 50) - (b.view!.order ?? 50) || a.path.localeCompare(b.path))
+}
+
+export function collectionFromLocation(rows: CollectionInfo[], pathname: string): CollectionInfo | undefined {
+  const listed = navCollections(rows)
+  const path = normalizeNavPath(pathname)
+  return (
+    listed.find((row) => {
+      const route = normalizeNavPath(row.view!.route)
+      return path === route || path.startsWith(`${route}/`)
+    }) ?? listed[0]
+  )
+}
+
+export const DATABASE_MODULE_ID = 'database'
+export const DATABASE_MODULE_PATH = '/database'
+
+let liveNavCollections: CollectionInfo[] = []
+const liveListeners = new Set<() => void>()
+
+export function setLiveNavCollections(next: CollectionInfo[]) {
+  liveNavCollections = next
+  for (const fn of liveListeners) fn()
+}
+
+export function subscribeLiveNavCollections(fn: () => void) {
+  liveListeners.add(fn)
+  return () => liveListeners.delete(fn)
+}
+
+export function getLiveNavCollections() {
+  return liveNavCollections
+}

--- a/packages/core-file-system/src/web/hub.tsx
+++ b/packages/core-file-system/src/web/hub.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState, useSyncExternalStore, type ComponentType } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import {
+  ChevronRightIcon,
+  ClipboardDocumentListIcon,
+  FolderIcon,
+  PuzzlePieceIcon,
+  TableCellsIcon,
+} from '@heroicons/react/16/solid'
+import type { CollectionInfo } from '@biu/type-file-system'
+import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
+import type { SlotProps } from '@biu/type-slots'
+import { CollectionBrowser, SidebarBrandMascot, SIDEBAR_BRAND_GRADIENT } from './browser.tsx'
+import {
+  collectionFromLocation,
+  DATABASE_MODULE_ID,
+  DATABASE_MODULE_PATH,
+  getLiveNavCollections,
+  navCollections,
+  normalizeNavPath,
+  subscribeLiveNavCollections,
+} from './hub-nav.ts'
+import {
+  ensureViews,
+  loadActiveViewId,
+  rememberActiveView,
+  viewCount,
+  VIEWS_EVENT,
+} from './view-store.ts'
+
+const EMPTY_CHROME: CollectionChrome = {}
+
+const ICONS: Record<string, ComponentType<{ className?: string }>> = {
+  'clipboard-document-list': ClipboardDocumentListIcon,
+  clipboard: ClipboardDocumentListIcon,
+  'puzzle-piece': PuzzlePieceIcon,
+  puzzle: PuzzlePieceIcon,
+  'table-cells': TableCellsIcon,
+  folder: FolderIcon,
+}
+
+function resolveIcon(name?: string) {
+  if (!name) return TableCellsIcon
+  return ICONS[name] ?? ICONS[name.trim().toLowerCase()] ?? TableCellsIcon
+}
+
+function openKey(path: string) {
+  return `fsdb.hubOpen:${path}`
+}
+
+function isOpen(path: string, fallback: boolean) {
+  try {
+    const raw = localStorage.getItem(openKey(path))
+    if (raw === '1') return true
+    if (raw === '0') return false
+  } catch {
+    /* ignore */
+  }
+  return fallback
+}
+
+function setOpen(path: string, next: boolean) {
+  try {
+    localStorage.setItem(openKey(path), next ? '1' : '0')
+  } catch {
+    /* ignore */
+  }
+}
+
+function subscribeViews(fn: () => void) {
+  window.addEventListener(VIEWS_EVENT, fn)
+  window.addEventListener('storage', fn)
+  return () => {
+    window.removeEventListener(VIEWS_EVENT, fn)
+    window.removeEventListener('storage', fn)
+  }
+}
+
+export function DatabaseHub({
+  collections,
+  databaseUi,
+}: {
+  collections: CollectionInfo[]
+  databaseUi?: DatabaseUi
+}) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const live = useSyncExternalStore(subscribeLiveNavCollections, getLiveNavCollections, getLiveNavCollections)
+  const listed = useMemo(() => navCollections(live.length ? live : collections), [collections, live])
+  const active = collectionFromLocation(listed, location.pathname)
+  const [tick, setTick] = useState(0)
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(() => {
+    const start: Record<string, boolean> = {}
+    for (const row of listed) start[row.path] = isOpen(row.path, false)
+    return start
+  })
+  const [hubOpen, setHubOpen] = useState(() => {
+    try {
+      return localStorage.getItem('fsdb.viewsOpen:database') !== '0'
+    } catch {
+      return true
+    }
+  })
+
+  useEffect(() => subscribeViews(() => setTick((n) => n + 1)), [])
+
+  useEffect(() => {
+    function onToggle(event: Event) {
+      const id = (event as CustomEvent<{ id?: string }>).detail?.id
+      if (id && id !== DATABASE_MODULE_ID) return
+      setHubOpen((prev) => {
+        const next = !prev
+        try {
+          localStorage.setItem('fsdb.viewsOpen:database', next ? '1' : '0')
+        } catch {
+          /* ignore */
+        }
+        return next
+      })
+    }
+    window.addEventListener('biu:toggle-module-sidebar', onToggle)
+    return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
+  }, [])
+
+  useEffect(() => {
+    if (!active) return
+    const route = normalizeNavPath(active.view!.route)
+    const here = normalizeNavPath(location.pathname)
+    if (here === DATABASE_MODULE_PATH || here === '/') {
+      navigate(route, { replace: true })
+    }
+  }, [active, location.pathname, navigate])
+
+  useEffect(() => {
+    if (!active) return
+    setExpanded((prev) => {
+      if (prev[active.path]) return prev
+      setOpen(active.path, true)
+      return { ...prev, [active.path]: true }
+    })
+  }, [active])
+
+  const path = active?.path ?? ''
+  const title = active?.view?.title ?? active?.label ?? '数据'
+  const blurb = active?.view?.blurb ?? ''
+  const chrome = useSyncExternalStore(
+    (fn) => (databaseUi ? databaseUi.subscribe(fn) : () => undefined),
+    () => (path ? databaseUi?.chrome(path) ?? EMPTY_CHROME : EMPTY_CHROME),
+    () => (path ? databaseUi?.chrome(path) ?? EMPTY_CHROME : EMPTY_CHROME),
+  )
+  const activeViewId = path ? loadActiveViewId(path, ensureViews(path)) : null
+
+  function toggleGroup(row: CollectionInfo) {
+    setExpanded((prev) => {
+      const next = !prev[row.path]
+      setOpen(row.path, next)
+      return { ...prev, [row.path]: next }
+    })
+  }
+
+  function openCollection(row: CollectionInfo) {
+    const route = normalizeNavPath(row.view!.route)
+    if (normalizeNavPath(location.pathname) !== route) navigate(route)
+    setExpanded((prev) => {
+      if (prev[row.path]) return prev
+      setOpen(row.path, true)
+      return { ...prev, [row.path]: true }
+    })
+  }
+
+  function openView(row: CollectionInfo, viewId: string) {
+    rememberActiveView(row.path, viewId)
+    setTick((n) => n + 1)
+    const route = normalizeNavPath(row.view!.route)
+    if (normalizeNavPath(location.pathname) !== route) navigate(route)
+  }
+
+  if (!active) {
+    return (
+      <div className="fsdb-page tasks-root">
+        <div className="tasks-main fsdb-main">
+          <p className="tasks-error">还没有登记到 File System 的数据表。</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="fsdb-page tasks-root">
+      {hubOpen ? (
+        <aside
+          className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
+          aria-label="数据"
+        >
+          <div className="app-side-bar-head">
+            <span className="flex min-w-0 items-center gap-1.5">
+              <SidebarBrandMascot className="size-8 shrink-0" />
+              <span
+                className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
+                style={{ background: SIDEBAR_BRAND_GRADIENT }}
+              >
+                biu harness
+              </span>
+            </span>
+          </div>
+          <div className="fsdb-collection-head">
+            <div className="fsdb-collection-name">数据</div>
+            <p className="fsdb-footnote">任务、页面和插件都在这里，展开即可看各表的视图。</p>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
+            <section className="mt-1 min-w-0" data-views-epoch={tick}>
+              <div className="sidebar-session-list">
+                {listed.map((row) => {
+                  const Icon = resolveIcon(row.view?.icon)
+                  const open = !!expanded[row.path]
+                  const views = ensureViews(row.path)
+                  const count = viewCount(row.path)
+                  const selected = row.path === active.path
+                  const name = row.view?.title ?? row.label
+                  return (
+                    <div key={row.path} className="fsdb-nav-group">
+                      <div className={`chat-session-row${selected ? ' is-active' : ''}`}>
+                        <button
+                          type="button"
+                          className="fsdb-nav-chevron"
+                          aria-expanded={open}
+                          aria-label={open ? `折叠 ${name}` : `展开 ${name}`}
+                          onClick={() => toggleGroup(row)}
+                        >
+                          <ChevronRightIcon className={`size-4${open ? ' rotate-90' : ''}`} />
+                        </button>
+                        <button
+                          type="button"
+                          className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
+                          onClick={() => openCollection(row)}
+                        >
+                          <span className="grid size-6 shrink-0 place-items-center">
+                            <Icon aria-hidden className="size-4" />
+                          </span>
+                          <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+                        </button>
+                        <span className="sidebar-chat-count" title="视图数量">
+                          <span className="sidebar-chat-count-num">{count}</span>
+                        </span>
+                      </div>
+                      {open
+                        ? views.map((view) => (
+                            <div
+                              key={view.id}
+                              className={`chat-session-row fsdb-nav-view${selected && view.id === activeViewId ? ' is-active' : ''}`}
+                            >
+                              <button
+                                type="button"
+                                className="flex min-w-0 flex-1 items-center gap-1.5 py-1 pl-7 text-left text-[14px] leading-5"
+                                onClick={() => openView(row, view.id)}
+                              >
+                                <span className="min-w-0 flex-1 truncate">{view.name}</span>
+                              </button>
+                            </div>
+                          ))
+                        : null}
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
+          </div>
+        </aside>
+      ) : null}
+      <CollectionBrowser
+        key={`${path}:${activeViewId ?? ''}`}
+        moduleId={DATABASE_MODULE_ID}
+        collectionPath={path}
+        title={title}
+        blurb={blurb}
+        chrome={chrome}
+        hideViewsSidebar
+      />
+    </div>
+  )
+}
+
+export function DatabaseHubPage(props: SlotProps) {
+  const ui = props.databaseUi as DatabaseUi | undefined
+  const collections = (props.collections as CollectionInfo[] | undefined) ?? []
+  return <DatabaseHub collections={collections} databaseUi={ui} />
+}

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -1,16 +1,11 @@
 import { useSyncExternalStore, type ComponentType } from 'react'
 import type { Context } from 'cordis'
-import {
-  ClipboardDocumentListIcon,
-  FolderIcon,
-  PuzzlePieceIcon,
-  TableCellsIcon,
-} from '@heroicons/react/16/solid'
-import type { SlotProps } from '@biu/type-slots'
+import { CircleStackIcon } from '@heroicons/react/16/solid'
 import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu/type-file-system'
-import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
-import { CollectionBrowser } from './browser.tsx'
+import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { DatabaseUiService } from './database-ui.ts'
+import { DatabaseHubPage } from './hub.tsx'
+import { DATABASE_MODULE_ID, DATABASE_MODULE_PATH, navCollections, normalizeNavPath, setLiveNavCollections } from './hub-nav.ts'
 import { bootLoadCollections, collectionNavKey } from './nav-boot.ts'
 
 type SlotsService = {
@@ -29,6 +24,7 @@ type AppModulesService = {
     id: string
     label: string
     path: string
+    aliases?: string[]
     description?: string
     order?: number
     Icon?: ComponentType<{ className?: string }>
@@ -42,27 +38,6 @@ type SnapshotService = {
   subscribe?: (fn: () => void) => () => void
 }
 
-const ICONS: Record<string, ComponentType<{ className?: string }>> = {
-  'clipboard-document-list': ClipboardDocumentListIcon,
-  clipboard: ClipboardDocumentListIcon,
-  'puzzle-piece': PuzzlePieceIcon,
-  puzzle: PuzzlePieceIcon,
-  'table-cells': TableCellsIcon,
-  folder: FolderIcon,
-}
-
-function resolveIcon(name?: string) {
-  if (!name) return TableCellsIcon
-  return ICONS[name] ?? ICONS[name.trim().toLowerCase()] ?? TableCellsIcon
-}
-
-function normalizeNavPath(path: string) {
-  const raw = String(path || '/').trim() || '/'
-  const withSlash = raw.startsWith('/') ? raw : `/${raw}`
-  if (withSlash === '/') return '/'
-  return withSlash.replace(/\/+$/, '') || '/'
-}
-
 export function navConflict(view: CollectionView, title: string, modules: AppModule[], selfId: string): string | null {
   const route = normalizeNavPath(view.route)
   const pathHit = modules.find((item) => item.id !== selfId && normalizeNavPath(item.path) === route)
@@ -72,25 +47,14 @@ export function navConflict(view: CollectionView, title: string, modules: AppMod
   return null
 }
 
-const EMPTY_CHROME: CollectionChrome = {}
-
-function CollectionPage(props: SlotProps) {
-  const path = String(props.collectionPath ?? '')
-  const ui = props.databaseUi as DatabaseUi | undefined
-  const chrome = useSyncExternalStore(
-    (fn) => (ui ? ui.subscribe(fn) : () => undefined),
-    () => ui?.chrome(path) ?? EMPTY_CHROME,
-    () => ui?.chrome(path) ?? EMPTY_CHROME,
-  )
-  return (
-    <CollectionBrowser
-      moduleId={String(props.moduleId ?? '')}
-      collectionPath={path}
-      title={String(props.title ?? '')}
-      blurb={String(props.blurb ?? '')}
-      chrome={chrome}
-    />
-  )
+function hubConflict(routes: string[], modules: AppModule[], selfId: string): string | null {
+  for (const route of routes) {
+    const pathHit = modules.find((item) => item.id !== selfId && normalizeNavPath(item.path) === route)
+    if (pathHit) return `路由重复：${route} 已被「${pathHit.label}」占用`
+  }
+  const nameHit = modules.find((item) => item.id !== selfId && item.label === '数据')
+  if (nameHit) return `名称重复：最左导航已有「数据」`
+  return null
 }
 
 async function loadCollections(): Promise<CollectionInfo[]> {
@@ -138,60 +102,65 @@ export function apply(ctx: Context) {
   const slots = ctx.get('slots') as SlotsService
   const appModules = ctx.get('appModules') as AppModulesService
   const mounted = new Map<string, () => void>()
+  let mountedAlias = ''
 
   slots.place('root-overlays', RegisterErrorBanner, { key: 'fsdb-nav-errors', order: 80 })
   let stopped = false
   let readyTimer = 0
   const runSync = async (rows: CollectionInfo[]) => {
-    const views = rows.filter((row) => row.view?.moduleId && row.view.route)
-    const live = new Set(views.map((row) => row.view!.moduleId))
+    const views = navCollections(rows)
+    setLiveNavCollections(views)
+    const live = views.length ? new Set([DATABASE_MODULE_ID]) : new Set<string>()
     for (const [id, dispose] of mounted) {
       if (live.has(id)) continue
       dispose()
       mounted.delete(id)
     }
     const errors: string[] = []
+    if (!views.length) {
+      setNavErrors(errors)
+      return
+    }
+    const aliases = views.map((row) => normalizeNavPath(row.view!.route)).filter((route) => route !== DATABASE_MODULE_PATH)
+    const aliasKey = aliases.slice().sort().join(',')
+    if (mounted.has(DATABASE_MODULE_ID) && mountedAlias !== aliasKey) {
+      mounted.get(DATABASE_MODULE_ID)!()
+      mounted.delete(DATABASE_MODULE_ID)
+    }
     const occupied = appModules.list()
-    for (const row of views) {
-      const view = row.view!
-      const title = view.title ?? row.label
-      const conflict = navConflict(view, title, occupied, view.moduleId)
-      if (conflict) {
-        errors.push(`「${title}」${conflict}`)
-        continue
-      }
-      if (mounted.has(view.moduleId)) continue
-      if (!resolveIcon(view.icon) || (view.icon && !ICONS[view.icon] && !ICONS[view.icon.trim().toLowerCase()])) {
-        if (view.icon) errors.push(`「${title}」未知图标：${view.icon}，已改用默认图标`)
-      }
-      const blurb = view.blurb ?? ''
-      const order = view.order ?? 50
+    const conflict = hubConflict([DATABASE_MODULE_PATH, ...aliases], occupied, DATABASE_MODULE_ID)
+    if (conflict) {
+      errors.push(conflict)
+      setNavErrors(errors)
+      return
+    }
+    if (!mounted.has(DATABASE_MODULE_ID)) {
+      mountedAlias = aliasKey
       try {
+        const order = Math.min(...views.map((row) => row.view?.order ?? 50))
         const mod = appModules.register({
-          id: view.moduleId,
-          label: title,
-          path: view.route,
-          description: blurb,
+          id: DATABASE_MODULE_ID,
+          label: '数据',
+          path: DATABASE_MODULE_PATH,
+          aliases,
+          description: '任务、页面和插件的数据表',
           order,
-          Icon: resolveIcon(view.icon),
+          Icon: CircleStackIcon,
         })
-        const slot = slots.place('app-modules', CollectionPage, {
-          key: `fsdb-${view.moduleId}`,
+        const slot = slots.place('app-modules', DatabaseHubPage, {
+          key: 'fsdb-database',
           order,
           props: () => ({
-            moduleId: view.moduleId,
-            collectionPath: row.path,
-            title,
-            blurb,
+            collections: views,
             databaseUi: ctx.get('databaseUi') as DatabaseUi,
           }),
         })
-        mounted.set(view.moduleId, () => {
+        mounted.set(DATABASE_MODULE_ID, () => {
           void mod.dispose?.()
           void slot.dispose?.()
         })
       } catch (err) {
-        errors.push(`「${title}」无法挂到导航：${String(err)}`)
+        errors.push(`无法挂到导航：${String(err)}`)
       }
     }
     setNavErrors(errors)

--- a/packages/core-file-system/src/web/view-store.test.ts
+++ b/packages/core-file-system/src/web/view-store.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { ensureViews, loadViews, persistViews, viewCount, viewsKey } from './view-store.ts'
+
+test('ensureViews seeds one default view and viewCount reads it', () => {
+  localStorage.removeItem(viewsKey('/pages'))
+  assert.equal(loadViews('/pages').length, 0)
+  assert.equal(viewCount('/pages'), 1)
+  assert.equal(ensureViews('/pages')[0]?.name, '默认视图')
+  persistViews('/pages', [
+    ...ensureViews('/pages'),
+    {
+      id: '2',
+      name: '副本',
+      mode: 'table',
+      sortField: 'id',
+      sortDir: 'asc',
+      filters: {},
+      columns: [],
+    },
+  ])
+  assert.equal(viewCount('/pages'), 2)
+})

--- a/packages/core-file-system/src/web/view-store.ts
+++ b/packages/core-file-system/src/web/view-store.ts
@@ -1,0 +1,75 @@
+import { normalizeSavedView, type SavedView } from './saved-view.ts'
+
+export const VIEWS_EVENT = 'fsdb:views'
+
+export function viewsKey(collectionPath: string) {
+  return `fsdb.views:${collectionPath}`
+}
+
+export function activeViewStorageKey(collectionPath: string) {
+  return `fsdb.activeView:${collectionPath}`
+}
+
+export function loadViews(collectionPath: string): SavedView[] {
+  try {
+    const raw = localStorage.getItem(viewsKey(collectionPath))
+    const parsed = raw ? (JSON.parse(raw) as SavedView[]) : []
+    return parsed.map((view) => normalizeSavedView(view))
+  } catch {
+    return []
+  }
+}
+
+export function persistViews(collectionPath: string, next: SavedView[]) {
+  localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(VIEWS_EVENT, { detail: { path: collectionPath } }))
+  }
+}
+
+export function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
+  try {
+    const id = localStorage.getItem(activeViewStorageKey(collectionPath))
+    if (id && listed.some((view) => view.id === id)) return id
+  } catch {
+    /* ignore */
+  }
+  return listed[0]?.id ?? null
+}
+
+export function rememberActiveView(collectionPath: string, id: string) {
+  try {
+    localStorage.setItem(activeViewStorageKey(collectionPath), id)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function defaultViewStub(id = `${Date.now()}`): SavedView {
+  return normalizeSavedView({
+    id,
+    name: '默认视图',
+    mode: 'table',
+    sortField: 'id',
+    sortDir: 'asc',
+    filters: {},
+    columns: [],
+    groupBy: '',
+    tree: true,
+    wrap: false,
+    truncate: true,
+    query: '',
+  })
+}
+
+export function ensureViews(collectionPath: string): SavedView[] {
+  const listed = loadViews(collectionPath)
+  if (listed.length) return listed
+  const next = [defaultViewStub(`${Date.now()}:${collectionPath}`)]
+  persistViews(collectionPath, next)
+  return next
+}
+
+export function viewCount(collectionPath: string) {
+  return ensureViews(collectionPath).length
+}

--- a/packages/web-app-modules/src/web/index.test.ts
+++ b/packages/web-app-modules/src/web/index.test.ts
@@ -22,10 +22,21 @@ test('plugins register routes; shell does not hardcode them', async () => {
   svc.register({ id: 'tasks', label: 'Tasks', path: '/tasks', order: 20 })
   svc.register({ id: 'dashboard', label: 'Dashboard', path: '/dashboard', order: 80 })
   const plugins = svc.plugins()
+  svc.register({
+    id: 'database',
+    label: '数据',
+    path: '/database',
+    aliases: ['/pages', '/plugins', '/tasks-2'],
+    order: 15,
+  })
+  const withDb = svc.plugins()
+  assert.equal(moduleIdFromPath('/pages', withDb), 'database')
+  assert.equal(moduleIdFromPath('/plugins', withDb), 'database')
+  assert.equal(moduleIdFromPath('/tasks-2', withDb), 'database')
   assert.equal(moduleIdFromPath('/tasks', plugins), 'tasks')
   assert.equal(moduleIdFromPath('/dashboard', plugins), 'dashboard')
   assert.equal(isAgentPath('/tasks', plugins), false)
-  assert.equal(svc.list().map((item) => item.id).join(','), 'agent,tasks,dashboard')
+  assert.equal(svc.list().map((item) => item.id).join(','), 'agent,database,tasks,dashboard')
   assert.equal(svc.isNavReady(), false)
   svc.markNavReady()
   assert.equal(svc.isNavReady(), true)

--- a/packages/web-app-modules/src/web/index.ts
+++ b/packages/web-app-modules/src/web/index.ts
@@ -11,6 +11,8 @@ export type AppModule = {
   id: string
   label: string
   path: string
+  /** 额外路径也点亮同一颗图标（例如 File System 各表的旧路由）。 */
+  aliases?: string[]
   description?: string
   order?: number
   Icon?: ComponentType<{ className?: string }>
@@ -26,12 +28,19 @@ const AGENT: AppModule = {
 
 export const BUILTIN_MODULES: AppModule[] = [AGENT]
 
+function moduleBases(item: AppModule) {
+  return [item.path, ...(item.aliases ?? [])].map((entry) => normalizePath(entry)).filter((entry) => entry !== '/')
+}
+
 export function matchRegisteredModule(pathname: string, plugins: AppModule[]) {
   const path = normalizePath(pathname)
-  return plugins.find((item) => {
-    const base = normalizePath(item.path)
-    return path === base || path.startsWith(`${base}/`)
-  })
+  const hits = plugins.flatMap((item) =>
+    moduleBases(item)
+      .filter((base) => path === base || path.startsWith(`${base}/`))
+      .map((base) => ({ item, base })),
+  )
+  hits.sort((a, b) => b.base.length - a.base.length)
+  return hits[0]?.item
 }
 
 export class AppModulesService extends Service {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
最左栏不再为任务2 / Page / 插件各挂一颗图标，改成一个「数据」（数据库）入口。

内栏按表分组（任务2号、Page、插件）：
- 右侧数字是该表的视图数量
- 可展开/折叠，展开后列出该表全部视图
- 点表或视图，右边直接出数据表

旧地址 `/pages`、`/plugins`、`/tasks-2` 仍会进这个模块。合入后刷新前端即可（纯 UI）。

日志里的 Vite `ws proxy` / `EPIPE` 是 host 或页面重连时 WebSocket 被掐断，和这次导航改动无关，重启后偶发一次即可忽略。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

