### PR TITLE
fix: 数据模块空白，补上导航 moduleId

### DIFF
--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -7,6 +7,12 @@ test('file-system web is the implementation plugin, not a domain module', () => 
   assert.equal(typeof apply, 'function')
 })
 
+test('app-modules slot matches rail id via extra.moduleId, not the slot key', () => {
+  const extra = { moduleId: 'database', collections: [] }
+  const slotKey = 'fsdb-database'
+  assert.equal(String(extra.moduleId ?? extra.id ?? slotKey), 'database')
+})
+
 test('navConflict flags duplicate route and display name against existing modules', () => {
   const modules = [{ id: 'tasks', label: 'Tasks', path: '/tasks' }]
   assert.match(navConflict({ moduleId: 'x', route: '/tasks' }, 'X', modules, 'x') ?? '', /路由重复/)

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -151,6 +151,7 @@ export function apply(ctx: Context) {
           key: 'fsdb-database',
           order,
           props: () => ({
+            moduleId: DATABASE_MODULE_ID,
             collections: views,
             databaseUi: ctx.get('databaseUi') as DatabaseUi,
           }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据图标能点，但中间是空白。壳用 `extra.moduleId` 决定画哪个模块，登记时只传了 collections，slot key 是 `fsdb-database`，对不上 `database` 就整页不渲染。

已补上 `moduleId: 'database'`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

