### PR TITLE
feat: 数据侧栏收藏，展开不再卡顿

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   ArrowDownIcon,
@@ -29,12 +29,10 @@ import {
   PlayIcon,
   PhotoIcon,
   PlusIcon,
-  PuzzlePieceIcon,
   RectangleStackIcon,
   Square2StackIcon,
   Squares2X2Icon,
   StopIcon,
-  StarIcon,
   TableCellsIcon,
   TrashIcon,
   ViewColumnsIcon,
@@ -62,7 +60,14 @@ import {
   type ViewMode,
 } from './fields'
 import { AppDialog, CellSelect, CheckRow, LocalText, TokenMultiSelect } from './controls.tsx'
+import { DataSidebar } from './data-sidebar.tsx'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
+import {
+  activeViewStorageKey,
+  loadActiveViewId,
+  loadViews,
+  viewsKey,
+} from './view-storage.ts'
 
 type ListResult = { items: Array<DbRecord & { path?: string }>; total?: number; offset?: number; limit?: number }
 type StatResult = { schema?: CollectionSchema }
@@ -77,53 +82,12 @@ function actionIcon(id: string) {
   return null
 }
 
-function TableGlyph({ icon }: { icon?: string }) {
-  const cls = 'size-4'
-  const name = (icon ?? '').trim().toLowerCase()
-  if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={cls} />
-  if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={cls} />
-  if (name === 'folder') return <CircleStackIcon aria-hidden className={cls} />
-  return <TableCellsIcon aria-hidden className={cls} />
-}
-
 function ModeGlyph({ id }: { id: ViewMode }) {
   const cls = 'size-[14px]'
   if (id === 'queue') return <ListBulletIcon aria-hidden className={cls} />
   if (id === 'table') return <TableCellsIcon aria-hidden className={cls} />
   if (id === 'cards') return <Squares2X2Icon aria-hidden className={cls} />
   return <ViewColumnsIcon aria-hidden className={cls} />
-}
-
-const SIDEBAR_BRAND_GRADIENT =
-  'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
-
-function SidebarBrandMascot({ className }: { className?: string }) {
-  const uid = useId().replace(/:/g, '')
-  return (
-    <svg className={className} viewBox="-15 -15 259 259" width={30} height={30} fill="none" aria-hidden>
-      <defs>
-        <linearGradient id={uid} x1="0" y1="0.15" x2="1" y2="0.85">
-          <stop offset="0%" stopColor="color-mix(in srgb, #0066B0 42%, var(--dsw-hover))" />
-          <stop offset="52%" stopColor="color-mix(in srgb, #5B3E90 40%, var(--dsw-hover))" />
-          <stop offset="100%" stopColor="color-mix(in srgb, #E22726 42%, var(--dsw-hover))" />
-        </linearGradient>
-      </defs>
-      <path
-        d="M0.27 170.27C0.27 94.06 51.31 32.27 114.27 32.27C177.23 32.27 228.27 94.06 228.27 170.27L228.27 170.27C228.27 196.27 228.27 196.27 202.27 196.27L26.27 196.27C0.27 196.27 0.27 196.27 0.27 170.27Z"
-        fill={`url(#${uid})`}
-      />
-      <g transform="translate(114.2705 118.2705) scale(1.003 0.68) translate(-114.2705 -114.2705)">
-        <path
-          d="M39.78 104.3L42.64 105.01L45.03 106.74L46.73 109.15L47.75 111.93L48.35 114.83L48.81 117.76L49.31 120.68L49.87 123.6L50.48 126.5L51.15 129.39L51.86 132.27L52.63 135.13L53.44 137.98L54.3 140.82L55.19 143.65L56.13 146.46L57.1 149.26L58.1 152.05L58.86 154.92L58.96 157.87L58.18 160.72L56.43 163.09L53.84 164.48L50.9 164.62L48.08 163.75L45.58 162.16L43.51 160.05L41.89 157.57L40.67 154.87L39.67 152.08L38.73 149.26L37.81 146.44L36.94 143.61L36.11 140.76L35.34 137.9L34.61 135.03L33.92 132.14L33.28 129.24L32.7 126.34L32.16 123.42L31.67 120.5L31.23 117.57L31.14 114.61L31.65 111.69L32.74 108.94L34.47 106.54L36.89 104.86Z"
-          fill="#fff"
-        />
-        <path
-          d="M108.97 125.73L111.9 126.2L114.63 127.37L117 129.16L118.84 131.49L119.99 134.23L120.32 137.18L119.85 140.11L118.59 142.8L116.78 145.16L114.84 147.42L112.89 149.67L110.93 151.92L108.97 154.16L107.01 156.39L105.03 158.62L103.05 160.85L101.07 163.06L99.07 165.28L97.09 167.5L95.09 169.71L93.05 171.88L90.69 173.67L87.89 174.66L84.93 174.81L82.02 174.22L79.31 173L76.92 171.24L74.99 168.98L73.7 166.3L73.26 163.37L73.74 160.45L75.2 157.86L77.17 155.63L79.18 153.43L81.18 151.23L83.17 149.02L85.16 146.8L87.14 144.58L89.11 142.35L91.08 140.11L93.04 137.87L95 135.63L96.95 133.38L98.89 131.12L100.87 128.89L103.25 127.12L106.02 126.04Z"
-          fill="#fff"
-        />
-      </g>
-    </svg>
-  )
 }
 
 const VIEW_MODES: Array<{ id: ViewMode; label: string }> = [
@@ -165,54 +129,10 @@ function draftFromRecord(schema: CollectionSchema, row: DbRecord, bodyKey: strin
   return next
 }
 
-function viewsKey(collectionPath: string) {
-  return `fsdb.views:${collectionPath}`
-}
-
-function activeViewStorageKey(collectionPath: string) {
-  return `fsdb.activeView:${collectionPath}`
-}
-
-function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
-  try {
-    const id = localStorage.getItem(activeViewStorageKey(collectionPath))
-    if (id && listed.some((view) => view.id === id)) return id
-  } catch {
-    /* ignore */
-  }
-  return listed[0]?.id ?? null
-}
-
 function viewForPath(collectionPath: string): SavedView | null {
   const listed = loadViews(collectionPath)
   const view = listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ?? listed[0]
   return view ? normalizeSavedView(view) : null
-}
-
-function loadViews(collectionPath: string): SavedView[] {
-  try {
-    const raw = localStorage.getItem(viewsKey(collectionPath))
-    const parsed = raw ? (JSON.parse(raw) as SavedView[]) : []
-    return parsed.map((view) => normalizeSavedView(view))
-  } catch {
-    return []
-  }
-}
-
-const STARRED_TABLES_KEY = 'fsdb.starredTables'
-
-function loadStarredTables(): string[] {
-  try {
-    const raw = localStorage.getItem(STARRED_TABLES_KEY)
-    const parsed = raw ? (JSON.parse(raw) as unknown) : []
-    return Array.isArray(parsed) ? parsed.map((item) => String(item)).filter(Boolean) : []
-  } catch {
-    return []
-  }
-}
-
-function persistStarredTables(paths: string[]) {
-  localStorage.setItem(STARRED_TABLES_KEY, JSON.stringify(paths))
 }
 
 function isListColumn(key: string) {
@@ -542,15 +462,6 @@ export function CollectionBrowser({
   const [viewsOpen, setViewsOpen] = useState(() => {
     try {
       return localStorage.getItem(`fsdb.viewsOpen:${moduleId || collectionPath}`) !== '0'
-    } catch {
-      return true
-    }
-  })
-  const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
-  const [starredTables, setStarredTables] = useState<string[]>(() => loadStarredTables())
-  const [favOpen, setFavOpen] = useState(() => {
-    try {
-      return localStorage.getItem('fsdb.favOpen') !== '0'
     } catch {
       return true
     }
@@ -1367,22 +1278,6 @@ export function CollectionBrowser({
 
   viewsRef.current = views
 
-  const listedTables = tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]
-  const starredRows = listedTables.filter((table) => starredTables.includes(table.path))
-
-  function toggleStar(path: string) {
-    setStarredTables((prev) => {
-      const next = prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]
-      persistStarredTables(next)
-      return next
-    })
-  }
-
-  function openTable(path: string) {
-    setOpenTables((prev) => ({ ...prev, [path]: true }))
-    onOpenTable?.(path)
-  }
-
   useEffect(() => {
     if (!schema || !collectionPath) {
       hydratePath.current = ''
@@ -1418,6 +1313,7 @@ export function CollectionBrowser({
   useEffect(() => {
     if (!hydrated || !activeViewId) return
     const id = window.setTimeout(() => {
+      if (hydratePath.current !== collectionPath) return
       const current = viewsRef.current.find((view) => view.id === activeViewId)
       if (!current) return
       const next = normalizeSavedView({
@@ -1440,6 +1336,7 @@ export function CollectionBrowser({
     return () => window.clearTimeout(id)
   }, [
     activeViewId,
+    collectionPath,
     columnKeys,
     filters,
     groupBy,
@@ -1458,203 +1355,19 @@ export function CollectionBrowser({
   return (
     <div className="fsdb-page tasks-root">
       {viewsOpen ? (
-      <aside
-        className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
-        aria-label="数据"
-      >
-        <div className="app-side-bar-head">
-          <span className="flex min-w-0 items-center gap-1.5">
-            <SidebarBrandMascot className="size-8 shrink-0" />
-            <span
-              className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
-              style={{ background: SIDEBAR_BRAND_GRADIENT }}
-            >
-              biu harness
-            </span>
-          </span>
-        </div>
-        <div className="fsdb-collection-head">
-          <div className="fsdb-collection-name">数据</div>
-        </div>
-        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
-          <div className="app-side-actions" role="navigation" aria-label="视图操作">
-            <button type="button" className="app-side-actions-item" title="添加视图" onClick={addEmptyView}>
-              <span className="app-side-actions-icon" aria-hidden>
-                <PlusIcon className="size-4 shrink-0" />
-              </span>
-              <span className="app-side-actions-label">添加视图</span>
-            </button>
-            <button type="button" className="app-side-actions-item" title="拷贝视图" onClick={() => copyView()}>
-              <span className="app-side-actions-icon" aria-hidden>
-                <Square2StackIcon className="size-4 shrink-0" />
-              </span>
-              <span className="app-side-actions-label">拷贝视图</span>
-            </button>
-          </div>
-          <section className="mt-2 min-w-0">
-            {starredRows.length ? (
-              <>
-                <div className="sidebar-section-head min-w-0">
-                  <button
-                    type="button"
-                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
-                    aria-expanded={favOpen}
-                    onClick={() => {
-                      const next = !favOpen
-                      setFavOpen(next)
-                      try {
-                        localStorage.setItem('fsdb.favOpen', next ? '1' : '0')
-                      } catch {
-                        /* ignore */
-                      }
-                    }}
-                  >
-                    <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">收藏</span>
-                  </button>
-                  <span className="sidebar-chat-count">
-                    <span className="sidebar-chat-count-num">{starredRows.length}</span>
-                  </span>
-                </div>
-                {favOpen ? (
-                  <div className="sidebar-session-list mb-2">
-                    {starredRows.map((table) => {
-                      const name = table.view?.title ?? table.label
-                      return (
-                        <div
-                          key={`star:${table.path}`}
-                          className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''} is-pinned`}
-                        >
-                          <button
-                            type="button"
-                            className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                            onClick={() => openTable(table.path)}
-                          >
-                            <span className="grid size-6 shrink-0 place-items-center">
-                              <TableGlyph icon={table.view?.icon} />
-                            </span>
-                            <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
-                          </button>
-                          <button
-                            type="button"
-                            className="chat-session-row-star is-on"
-                            aria-pressed
-                            aria-label={`取消收藏 ${name}`}
-                            title="取消收藏"
-                            onClick={() => toggleStar(table.path)}
-                          >
-                            <StarIcon className="size-4 text-[#f5b700]" />
-                          </button>
-                        </div>
-                      )
-                    })}
-                  </div>
-                ) : null}
-              </>
-            ) : null}
-            <div className="sidebar-section-head min-w-0">
-              <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">数据</span>
-              <span className="sidebar-chat-count">
-                <span className="sidebar-chat-count-num">{listedTables.length}</span>
-              </span>
-            </div>
-            <div className="sidebar-session-list">
-              {listedTables.map((table) => {
-                const name = table.view?.title ?? table.label
-                const open = openTables[table.path] ?? table.path === collectionPath
-                const listed = table.path === collectionPath ? views : loadViews(table.path)
-                const starred = starredTables.includes(table.path)
-                return (
-                  <div key={table.path}>
-                    <div className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}>
-                      <button
-                        type="button"
-                        className="fsdb-nav-chevron"
-                        aria-expanded={open}
-                        aria-label={open ? `折叠 ${name}` : `展开 ${name}`}
-                        onClick={() => setOpenTables((prev) => ({ ...prev, [table.path]: !open }))}
-                      >
-                        <ChevronRightIcon className={`size-4${open ? ' rotate-90' : ''}`} />
-                      </button>
-                      <button
-                        type="button"
-                        className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                        onClick={() => openTable(table.path)}
-                      >
-                        <span className="grid size-6 shrink-0 place-items-center">
-                          <TableGlyph icon={table.view?.icon} />
-                        </span>
-                        <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
-                      </button>
-                      <span className="sidebar-chat-count" title="视图数量">
-                        <span className="sidebar-chat-count-num">{listed.length}</span>
-                      </span>
-                      <button
-                        type="button"
-                        className={`chat-session-row-star${starred ? ' is-on' : ''}`}
-                        aria-pressed={starred}
-                        aria-label={starred ? `取消收藏 ${name}` : `收藏 ${name}`}
-                        title={starred ? '取消收藏' : '收藏'}
-                        onClick={() => toggleStar(table.path)}
-                      >
-                        <StarIcon className={`size-4${starred ? ' text-[#f5b700]' : ''}`} />
-                      </button>
-                    </div>
-                    {open
-                      ? listed.map((view) => (
-                          <div
-                            key={view.id}
-                            className={`chat-session-row group${table.path === collectionPath && view.id === activeViewId ? ' is-active' : ''}`}
-                          >
-                            <button
-                              type="button"
-                              className="flex min-w-0 flex-1 items-center gap-1.5 py-1 pl-7 text-left text-[14px] leading-5"
-                              onClick={() => {
-                                if (table.path !== collectionPath) {
-                                  try {
-                                    localStorage.setItem(activeViewStorageKey(table.path), view.id)
-                                  } catch {
-                                    /* ignore */
-                                  }
-                                  openTable(table.path)
-                                  return
-                                }
-                                applyView(view)
-                              }}
-                            >
-                              <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
-                            </button>
-                            {table.path === collectionPath ? (
-                              <>
-                                <button
-                                  type="button"
-                                  className="chat-session-row-delete"
-                                  title="重命名"
-                                  aria-label={`重命名 ${view.name}`}
-                                  onClick={() => renameView(view)}
-                                >
-                                  <PencilSquareIcon className="size-4 shrink-0" />
-                                </button>
-                                <button
-                                  type="button"
-                                  className="chat-session-row-delete"
-                                  title="删除"
-                                  aria-label={`删除 ${view.name}`}
-                                  onClick={() => deleteView(view)}
-                                >
-                                  <TrashIcon className="size-4 shrink-0" />
-                                </button>
-                              </>
-                            ) : null}
-                          </div>
-                        ))
-                      : null}
-                  </div>
-                )
-              })}
-            </div>
-          </section>
-        </div>
-      </aside>
+        <DataSidebar
+          tables={tables}
+          collectionPath={collectionPath}
+          title={title}
+          views={views}
+          activeViewId={activeViewId}
+          onOpenTable={onOpenTable}
+          onApplyView={applyView}
+          onRenameView={renameView}
+          onDeleteView={deleteView}
+          onAddView={addEmptyView}
+          onCopyView={copyView}
+        />
       ) : null}
       <div className="tasks-main fsdb-main">
         {!viewsOpen ? (

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -34,6 +34,7 @@ import {
   Square2StackIcon,
   Squares2X2Icon,
   StopIcon,
+  StarIcon,
   TableCellsIcon,
   TrashIcon,
   ViewColumnsIcon,
@@ -196,6 +197,22 @@ function loadViews(collectionPath: string): SavedView[] {
   } catch {
     return []
   }
+}
+
+const STARRED_TABLES_KEY = 'fsdb.starredTables'
+
+function loadStarredTables(): string[] {
+  try {
+    const raw = localStorage.getItem(STARRED_TABLES_KEY)
+    const parsed = raw ? (JSON.parse(raw) as unknown) : []
+    return Array.isArray(parsed) ? parsed.map((item) => String(item)).filter(Boolean) : []
+  } catch {
+    return []
+  }
+}
+
+function persistStarredTables(paths: string[]) {
+  localStorage.setItem(STARRED_TABLES_KEY, JSON.stringify(paths))
 }
 
 function isListColumn(key: string) {
@@ -530,6 +547,14 @@ export function CollectionBrowser({
     }
   })
   const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
+  const [starredTables, setStarredTables] = useState<string[]>(() => loadStarredTables())
+  const [favOpen, setFavOpen] = useState(() => {
+    try {
+      return localStorage.getItem('fsdb.favOpen') !== '0'
+    } catch {
+      return true
+    }
+  })
   const [viewMenuOpen, setViewMenuOpen] = useState(false)
   const [modeMenuOpen, setModeMenuOpen] = useState(false)
   const [sortMenuOpen, setSortMenuOpen] = useState(false)
@@ -1342,6 +1367,22 @@ export function CollectionBrowser({
 
   viewsRef.current = views
 
+  const listedTables = tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]
+  const starredRows = listedTables.filter((table) => starredTables.includes(table.path))
+
+  function toggleStar(path: string) {
+    setStarredTables((prev) => {
+      const next = prev.includes(path) ? prev.filter((item) => item !== path) : [...prev, path]
+      persistStarredTables(next)
+      return next
+    })
+  }
+
+  function openTable(path: string) {
+    setOpenTables((prev) => ({ ...prev, [path]: true }))
+    onOpenTable?.(path)
+  }
+
   useEffect(() => {
     if (!schema || !collectionPath) {
       hydratePath.current = ''
@@ -1451,14 +1492,80 @@ export function CollectionBrowser({
             </button>
           </div>
           <section className="mt-2 min-w-0">
+            {starredRows.length ? (
+              <>
+                <div className="sidebar-section-head min-w-0">
+                  <button
+                    type="button"
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                    aria-expanded={favOpen}
+                    onClick={() => {
+                      const next = !favOpen
+                      setFavOpen(next)
+                      try {
+                        localStorage.setItem('fsdb.favOpen', next ? '1' : '0')
+                      } catch {
+                        /* ignore */
+                      }
+                    }}
+                  >
+                    <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">收藏</span>
+                  </button>
+                  <span className="sidebar-chat-count">
+                    <span className="sidebar-chat-count-num">{starredRows.length}</span>
+                  </span>
+                </div>
+                {favOpen ? (
+                  <div className="sidebar-session-list mb-2">
+                    {starredRows.map((table) => {
+                      const name = table.view?.title ?? table.label
+                      return (
+                        <div
+                          key={`star:${table.path}`}
+                          className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''} is-pinned`}
+                        >
+                          <button
+                            type="button"
+                            className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
+                            onClick={() => openTable(table.path)}
+                          >
+                            <span className="grid size-6 shrink-0 place-items-center">
+                              <TableGlyph icon={table.view?.icon} />
+                            </span>
+                            <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+                          </button>
+                          <button
+                            type="button"
+                            className="chat-session-row-star is-on"
+                            aria-pressed
+                            aria-label={`取消收藏 ${name}`}
+                            title="取消收藏"
+                            onClick={() => toggleStar(table.path)}
+                          >
+                            <StarIcon className="size-4 text-[#f5b700]" />
+                          </button>
+                        </div>
+                      )
+                    })}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+            <div className="sidebar-section-head min-w-0">
+              <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">数据</span>
+              <span className="sidebar-chat-count">
+                <span className="sidebar-chat-count-num">{listedTables.length}</span>
+              </span>
+            </div>
             <div className="sidebar-session-list">
-              {(tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]).map((table) => {
+              {listedTables.map((table) => {
                 const name = table.view?.title ?? table.label
                 const open = openTables[table.path] ?? table.path === collectionPath
                 const listed = table.path === collectionPath ? views : loadViews(table.path)
+                const starred = starredTables.includes(table.path)
                 return (
                   <div key={table.path}>
-                    <div className={`chat-session-row${table.path === collectionPath ? ' is-active' : ''}`}>
+                    <div className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}>
                       <button
                         type="button"
                         className="fsdb-nav-chevron"
@@ -1471,10 +1578,7 @@ export function CollectionBrowser({
                       <button
                         type="button"
                         className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                        onClick={() => {
-                          setOpenTables((prev) => ({ ...prev, [table.path]: true }))
-                          onOpenTable?.(table.path)
-                        }}
+                        onClick={() => openTable(table.path)}
                       >
                         <span className="grid size-6 shrink-0 place-items-center">
                           <TableGlyph icon={table.view?.icon} />
@@ -1484,6 +1588,16 @@ export function CollectionBrowser({
                       <span className="sidebar-chat-count" title="视图数量">
                         <span className="sidebar-chat-count-num">{listed.length}</span>
                       </span>
+                      <button
+                        type="button"
+                        className={`chat-session-row-star${starred ? ' is-on' : ''}`}
+                        aria-pressed={starred}
+                        aria-label={starred ? `取消收藏 ${name}` : `收藏 ${name}`}
+                        title={starred ? '取消收藏' : '收藏'}
+                        onClick={() => toggleStar(table.path)}
+                      >
+                        <StarIcon className={`size-4${starred ? ' text-[#f5b700]' : ''}`} />
+                      </button>
                     </div>
                     {open
                       ? listed.map((view) => (
@@ -1501,7 +1615,7 @@ export function CollectionBrowser({
                                   } catch {
                                     /* ignore */
                                   }
-                                  onOpenTable?.(table.path)
+                                  openTable(table.path)
                                   return
                                 }
                                 applyView(view)

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -1,0 +1,302 @@
+import { memo, useId, useState } from 'react'
+import {
+  ChevronRightIcon,
+  ClipboardDocumentListIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  PuzzlePieceIcon,
+  Square2StackIcon,
+  StarIcon,
+  TableCellsIcon,
+  TrashIcon,
+} from '@heroicons/react/16/solid'
+import type { CollectionInfo } from '@biu/type-file-system'
+import type { SavedView } from './saved-view.ts'
+import {
+  activeViewStorageKey,
+  loadStarredTables,
+  loadViews,
+  persistStarredTables,
+  toggleStarredTable,
+} from './view-storage.ts'
+
+const SIDEBAR_BRAND_GRADIENT =
+  'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
+
+function SidebarBrandMascot({ className }: { className?: string }) {
+  const uid = useId().replace(/:/g, '')
+  return (
+    <svg className={className} viewBox="-15 -15 259 259" width={30} height={30} fill="none" aria-hidden>
+      <defs>
+        <linearGradient id={uid} x1="0" y1="0.15" x2="1" y2="0.85">
+          <stop offset="0%" stopColor="color-mix(in srgb, #0066B0 42%, var(--dsw-hover))" />
+          <stop offset="52%" stopColor="color-mix(in srgb, #5B3E90 40%, var(--dsw-hover))" />
+          <stop offset="100%" stopColor="color-mix(in srgb, #E22726 42%, var(--dsw-hover))" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M0.27 170.27C0.27 94.06 51.31 32.27 114.27 32.27C177.23 32.27 228.27 94.06 228.27 170.27L228.27 170.27C228.27 196.27 228.27 196.27 202.27 196.27L26.27 196.27C0.27 196.27 0.27 196.27 0.27 170.27Z"
+        fill={`url(#${uid})`}
+      />
+    </svg>
+  )
+}
+
+function TableGlyph({ icon }: { icon?: string }) {
+  const cls = 'size-4'
+  const name = (icon ?? '').trim().toLowerCase()
+  if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={cls} />
+  if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={cls} />
+  return <TableCellsIcon aria-hidden className={cls} />
+}
+
+export const DataSidebar = memo(function DataSidebar({
+  tables,
+  collectionPath,
+  title,
+  views,
+  activeViewId,
+  onOpenTable,
+  onApplyView,
+  onRenameView,
+  onDeleteView,
+  onAddView,
+  onCopyView,
+}: {
+  tables: CollectionInfo[]
+  collectionPath: string
+  title: string
+  views: SavedView[]
+  activeViewId: string | null
+  onOpenTable?: (path: string) => void
+  onApplyView: (view: SavedView) => void
+  onRenameView: (view: SavedView) => void
+  onDeleteView: (view: SavedView) => void
+  onAddView: () => void
+  onCopyView: () => void
+}) {
+  const listedTables = tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]
+  const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
+  const [starredTables, setStarredTables] = useState(loadStarredTables)
+  const [favOpen, setFavOpen] = useState(() => {
+    try {
+      return localStorage.getItem('fsdb.favOpen') !== '0'
+    } catch {
+      return true
+    }
+  })
+  const starredRows = listedTables.filter((table) => starredTables.includes(table.path))
+
+  function toggleStar(path: string) {
+    setStarredTables((prev) => {
+      const next = toggleStarredTable(prev, path)
+      persistStarredTables(next)
+      return next
+    })
+  }
+
+  function openTable(path: string) {
+    setOpenTables((prev) => ({ ...prev, [path]: true }))
+    onOpenTable?.(path)
+  }
+
+  return (
+    <aside
+      className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
+      aria-label="数据"
+    >
+      <div className="app-side-bar-head">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <SidebarBrandMascot className="size-8 shrink-0" />
+          <span
+            className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
+            style={{ background: SIDEBAR_BRAND_GRADIENT }}
+          >
+            biu harness
+          </span>
+        </span>
+      </div>
+      <div className="fsdb-collection-head">
+        <div className="fsdb-collection-name">数据</div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
+        <div className="app-side-actions" role="navigation" aria-label="视图操作">
+          <button type="button" className="app-side-actions-item" title="添加视图" onClick={onAddView}>
+            <span className="app-side-actions-icon" aria-hidden>
+              <PlusIcon className="size-4 shrink-0" />
+            </span>
+            <span className="app-side-actions-label">添加视图</span>
+          </button>
+          <button type="button" className="app-side-actions-item" title="拷贝视图" onClick={onCopyView}>
+            <span className="app-side-actions-icon" aria-hidden>
+              <Square2StackIcon className="size-4 shrink-0" />
+            </span>
+            <span className="app-side-actions-label">拷贝视图</span>
+          </button>
+        </div>
+        <section className="mt-2 min-w-0">
+          {starredRows.length ? (
+            <>
+              <div className="sidebar-section-head min-w-0">
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                  aria-expanded={favOpen}
+                  onClick={() => {
+                    const next = !favOpen
+                    setFavOpen(next)
+                    try {
+                      localStorage.setItem('fsdb.favOpen', next ? '1' : '0')
+                    } catch {
+                      /* ignore */
+                    }
+                  }}
+                >
+                  <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">收藏</span>
+                </button>
+                <span className="sidebar-chat-count">
+                  <span className="sidebar-chat-count-num">{starredRows.length}</span>
+                </span>
+              </div>
+              {favOpen ? (
+                <div className="sidebar-session-list mb-2">
+                  {starredRows.map((table) => {
+                    const name = table.view?.title ?? table.label
+                    return (
+                      <div
+                        key={`star:${table.path}`}
+                        className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''} is-pinned`}
+                      >
+                        <button
+                          type="button"
+                          className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
+                          onClick={() => openTable(table.path)}
+                        >
+                          <span className="grid size-6 shrink-0 place-items-center">
+                            <TableGlyph icon={table.view?.icon} />
+                          </span>
+                          <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+                        </button>
+                        <button
+                          type="button"
+                          className="chat-session-row-star is-on"
+                          aria-pressed
+                          aria-label={`取消收藏 ${name}`}
+                          title="取消收藏"
+                          onClick={() => toggleStar(table.path)}
+                        >
+                          <StarIcon className="size-4 text-[#f5b700]" />
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+              ) : null}
+            </>
+          ) : null}
+          <div className="sidebar-section-head min-w-0">
+            <span className="min-w-0 flex-1 truncate text-[14px] font-bold tracking-normal">数据</span>
+            <span className="sidebar-chat-count">
+              <span className="sidebar-chat-count-num">{listedTables.length}</span>
+            </span>
+          </div>
+          <div className="sidebar-session-list">
+            {listedTables.map((table) => {
+              const name = table.view?.title ?? table.label
+              const open = openTables[table.path] ?? table.path === collectionPath
+              const listed = table.path === collectionPath ? views : loadViews(table.path)
+              const starred = starredTables.includes(table.path)
+              return (
+                <div key={table.path}>
+                  <div className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}>
+                    <button
+                      type="button"
+                      className="fsdb-nav-chevron"
+                      aria-expanded={open}
+                      aria-label={open ? `折叠 ${name}` : `展开 ${name}`}
+                      onClick={() => setOpenTables((prev) => ({ ...prev, [table.path]: !open }))}
+                    >
+                      <ChevronRightIcon className={`size-4${open ? ' rotate-90' : ''}`} />
+                    </button>
+                    <button
+                      type="button"
+                      className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
+                      onClick={() => openTable(table.path)}
+                    >
+                      <span className="grid size-6 shrink-0 place-items-center">
+                        <TableGlyph icon={table.view?.icon} />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+                    </button>
+                    <span className="sidebar-chat-count" title="视图数量">
+                      <span className="sidebar-chat-count-num">{listed.length}</span>
+                    </span>
+                    <button
+                      type="button"
+                      className={`chat-session-row-star${starred ? ' is-on' : ''}`}
+                      aria-pressed={starred}
+                      aria-label={starred ? `取消收藏 ${name}` : `收藏 ${name}`}
+                      title={starred ? '取消收藏' : '收藏'}
+                      onClick={() => toggleStar(table.path)}
+                    >
+                      <StarIcon className={`size-4${starred ? ' text-[#f5b700]' : ''}`} />
+                    </button>
+                  </div>
+                  {open
+                    ? listed.map((view) => (
+                        <div
+                          key={view.id}
+                          className={`chat-session-row group${table.path === collectionPath && view.id === activeViewId ? ' is-active' : ''}`}
+                        >
+                          <button
+                            type="button"
+                            className="flex min-w-0 flex-1 items-center gap-1.5 py-1 pl-7 text-left text-[14px] leading-5"
+                            onClick={() => {
+                              if (table.path !== collectionPath) {
+                                try {
+                                  localStorage.setItem(activeViewStorageKey(table.path), view.id)
+                                } catch {
+                                  /* ignore */
+                                }
+                                openTable(table.path)
+                                return
+                              }
+                              onApplyView(view)
+                            }}
+                          >
+                            <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
+                          </button>
+                          {table.path === collectionPath ? (
+                            <>
+                              <button
+                                type="button"
+                                className="chat-session-row-delete"
+                                title="重命名"
+                                aria-label={`重命名 ${view.name}`}
+                                onClick={() => onRenameView(view)}
+                              >
+                                <PencilSquareIcon className="size-4 shrink-0" />
+                              </button>
+                              <button
+                                type="button"
+                                className="chat-session-row-delete"
+                                title="删除"
+                                aria-label={`删除 ${view.name}`}
+                                onClick={() => onDeleteView(view)}
+                              >
+                                <TrashIcon className="size-4 shrink-0" />
+                              </button>
+                            </>
+                          ) : null}
+                        </div>
+                      ))
+                    : null}
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      </div>
+    </aside>
+  )
+})

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -77,7 +77,6 @@ function CollectionPage(props: SlotProps) {
   if (!row) return null
   return (
     <CollectionBrowser
-      key={row.path}
       moduleId={DATA_MODULE_ID}
       collectionPath={row.path}
       title={row.view?.title ?? row.label}

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -1,0 +1,10 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { loadStarredTables, persistStarredTables, toggleStarredTable } from './view-storage.ts'
+
+test('toggleStarredTable adds and removes a table path', () => {
+  assert.deepEqual(toggleStarredTable([], '/pages'), ['/pages'])
+  assert.deepEqual(toggleStarredTable(['/pages'], '/pages'), [])
+  persistStarredTables(['/plugins'])
+  assert.deepEqual(loadStarredTables(), ['/plugins'])
+})

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -1,0 +1,49 @@
+import { normalizeSavedView, type SavedView } from './saved-view.ts'
+
+export function viewsKey(collectionPath: string) {
+  return `fsdb.views:${collectionPath}`
+}
+
+export function activeViewStorageKey(collectionPath: string) {
+  return `fsdb.activeView:${collectionPath}`
+}
+
+export function loadViews(collectionPath: string): SavedView[] {
+  try {
+    const raw = localStorage.getItem(viewsKey(collectionPath))
+    const parsed = raw ? (JSON.parse(raw) as SavedView[]) : []
+    return parsed.map((view) => normalizeSavedView(view))
+  } catch {
+    return []
+  }
+}
+
+export function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
+  try {
+    const id = localStorage.getItem(activeViewStorageKey(collectionPath))
+    if (id && listed.some((view) => view.id === id)) return id
+  } catch {
+    /* ignore */
+  }
+  return listed[0]?.id ?? null
+}
+
+const STARRED_TABLES_KEY = 'fsdb.starredTables'
+
+export function loadStarredTables(): string[] {
+  try {
+    const raw = localStorage.getItem(STARRED_TABLES_KEY)
+    const parsed = raw ? (JSON.parse(raw) as unknown) : []
+    return Array.isArray(parsed) ? parsed.map((item) => String(item)).filter(Boolean) : []
+  } catch {
+    return []
+  }
+}
+
+export function persistStarredTables(paths: string[]) {
+  localStorage.setItem(STARRED_TABLES_KEY, JSON.stringify(paths))
+}
+
+export function toggleStarredTable(paths: string[], path: string) {
+  return paths.includes(path) ? paths.filter((item) => item !== path) : [...paths, path]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据侧栏仿聊天：每张表可以收藏（星星），上方出现「收藏」区。

展开/折叠状态放在独立侧栏组件里，不再带动右边整张表重绘。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

