### PR TITLE
登记 Session / Event 两张表，收藏改为视图

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -1,5 +1,7 @@
 import { memo, useId, useState } from 'react'
 import {
+  BoltIcon,
+  ChatBubbleLeftRightIcon,
   ChevronRightIcon,
   ClipboardDocumentListIcon,
   PencilSquareIcon,
@@ -14,10 +16,11 @@ import type { CollectionInfo } from '@biu/type-file-system'
 import type { SavedView } from './saved-view.ts'
 import {
   activeViewStorageKey,
-  loadStarredTables,
+  isViewStarred,
+  loadStarredViews,
   loadViews,
-  persistStarredTables,
-  toggleStarredTable,
+  persistStarredViews,
+  toggleStarredView,
 } from './view-storage.ts'
 
 const SIDEBAR_BRAND_GRADIENT =
@@ -47,6 +50,8 @@ function TableGlyph({ icon }: { icon?: string }) {
   const name = (icon ?? '').trim().toLowerCase()
   if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={cls} />
   if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={cls} />
+  if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return <ChatBubbleLeftRightIcon aria-hidden className={cls} />
+  if (name === 'bolt') return <BoltIcon aria-hidden className={cls} />
   return <TableCellsIcon aria-hidden className={cls} />
 }
 
@@ -77,7 +82,7 @@ export const DataSidebar = memo(function DataSidebar({
 }) {
   const listedTables = tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]
   const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
-  const [starredTables, setStarredTables] = useState(loadStarredTables)
+  const [starredViews, setStarredViews] = useState(loadStarredViews)
   const [favOpen, setFavOpen] = useState(() => {
     try {
       return localStorage.getItem('fsdb.favOpen') !== '0'
@@ -85,12 +90,22 @@ export const DataSidebar = memo(function DataSidebar({
       return true
     }
   })
-  const starredRows = listedTables.filter((table) => starredTables.includes(table.path))
 
-  function toggleStar(path: string) {
-    setStarredTables((prev) => {
-      const next = toggleStarredTable(prev, path)
-      persistStarredTables(next)
+  function viewsFor(path: string) {
+    return path === collectionPath ? views : loadViews(path)
+  }
+
+  const starredRows = starredViews.flatMap((item) => {
+    const table = listedTables.find((row) => row.path === item.path)
+    const view = viewsFor(item.path).find((row) => row.id === item.viewId)
+    if (!table || !view) return []
+    return [{ table, view }]
+  })
+
+  function toggleStar(path: string, viewId: string) {
+    setStarredViews((prev) => {
+      const next = toggleStarredView(prev, path, viewId)
+      persistStarredViews(next)
       return next
     })
   }
@@ -98,6 +113,21 @@ export const DataSidebar = memo(function DataSidebar({
   function openTable(path: string) {
     setOpenTables((prev) => ({ ...prev, [path]: true }))
     onOpenTable?.(path)
+  }
+
+  function openView(path: string, viewId: string) {
+    try {
+      localStorage.setItem(activeViewStorageKey(path), viewId)
+    } catch {
+      /* ignore */
+    }
+    const listed = viewsFor(path)
+    const view = listed.find((item) => item.id === viewId)
+    if (path === collectionPath && view) {
+      onApplyView(view)
+      return
+    }
+    openTable(path)
   }
 
   return (
@@ -160,30 +190,32 @@ export const DataSidebar = memo(function DataSidebar({
               </div>
               {favOpen ? (
                 <div className="sidebar-session-list mb-2">
-                  {starredRows.map((table) => {
-                    const name = table.view?.title ?? table.label
+                  {starredRows.map(({ table, view }) => {
+                    const tableName = table.view?.title ?? table.label
+                    const active = table.path === collectionPath && view.id === activeViewId
                     return (
                       <div
-                        key={`star:${table.path}`}
-                        className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''} is-pinned`}
+                        key={`star:${table.path}:${view.id}`}
+                        className={`chat-session-row group${active ? ' is-active' : ''} is-pinned`}
                       >
                         <button
                           type="button"
                           className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                          onClick={() => openTable(table.path)}
+                          onClick={() => openView(table.path, view.id)}
                         >
                           <span className="grid size-6 shrink-0 place-items-center">
                             <TableGlyph icon={table.view?.icon} />
                           </span>
-                          <span className="min-w-0 flex-1 truncate font-medium">{name}</span>
+                          <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
+                          <span className="shrink-0 text-[11px] opacity-70">{tableName}</span>
                         </button>
                         <button
                           type="button"
                           className="chat-session-row-star is-on"
                           aria-pressed
-                          aria-label={`取消收藏 ${name}`}
+                          aria-label={`取消收藏 ${view.name}`}
                           title="取消收藏"
-                          onClick={() => toggleStar(table.path)}
+                          onClick={() => toggleStar(table.path, view.id)}
                         >
                           <StarIcon className="size-4 text-[#f5b700]" />
                         </button>
@@ -204,11 +236,10 @@ export const DataSidebar = memo(function DataSidebar({
             {listedTables.map((table) => {
               const name = table.view?.title ?? table.label
               const open = openTables[table.path] ?? table.path === collectionPath
-              const listed = table.path === collectionPath ? views : loadViews(table.path)
-              const starred = starredTables.includes(table.path)
+              const listed = viewsFor(table.path)
               return (
                 <div key={table.path}>
-                  <div className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}>
+                  <div className={`chat-session-row group${table.path === collectionPath ? ' is-active' : ''}`}>
                     <button
                       type="button"
                       className="fsdb-nav-chevron"
@@ -231,40 +262,31 @@ export const DataSidebar = memo(function DataSidebar({
                     <span className="sidebar-chat-count" title="视图数量">
                       <span className="sidebar-chat-count-num">{listed.length}</span>
                     </span>
-                    <button
-                      type="button"
-                      className={`chat-session-row-star${starred ? ' is-on' : ''}`}
-                      aria-pressed={starred}
-                      aria-label={starred ? `取消收藏 ${name}` : `收藏 ${name}`}
-                      title={starred ? '取消收藏' : '收藏'}
-                      onClick={() => toggleStar(table.path)}
-                    >
-                      <StarIcon className={`size-4${starred ? ' text-[#f5b700]' : ''}`} />
-                    </button>
                   </div>
-                  {open
-                    ? listed.map((view) => (
+                    {open
+                      ? listed.map((view) => {
+                          const starred = isViewStarred(starredViews, table.path, view.id)
+                          return (
                         <div
                           key={view.id}
-                          className={`chat-session-row group${table.path === collectionPath && view.id === activeViewId ? ' is-active' : ''}`}
+                          className={`chat-session-row group${table.path === collectionPath && view.id === activeViewId ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}
                         >
                           <button
                             type="button"
                             className="flex min-w-0 flex-1 items-center gap-1.5 py-1 pl-7 text-left text-[14px] leading-5"
-                            onClick={() => {
-                              if (table.path !== collectionPath) {
-                                try {
-                                  localStorage.setItem(activeViewStorageKey(table.path), view.id)
-                                } catch {
-                                  /* ignore */
-                                }
-                                openTable(table.path)
-                                return
-                              }
-                              onApplyView(view)
-                            }}
+                            onClick={() => openView(table.path, view.id)}
                           >
                             <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
+                          </button>
+                          <button
+                            type="button"
+                            className={`chat-session-row-star${starred ? ' is-on' : ''}`}
+                            aria-pressed={starred}
+                            aria-label={starred ? `取消收藏 ${view.name}` : `收藏 ${view.name}`}
+                            title={starred ? '取消收藏' : '收藏'}
+                            onClick={() => toggleStar(table.path, view.id)}
+                          >
+                            <StarIcon className={`size-4${starred ? ' text-[#f5b700]' : ''}`} />
                           </button>
                           {table.path === collectionPath ? (
                             <>
@@ -289,8 +311,9 @@ export const DataSidebar = memo(function DataSidebar({
                             </>
                           ) : null}
                         </div>
-                      ))
-                    : null}
+                          )
+                        })
+                      : null}
                 </div>
               )
             })}

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -1,10 +1,13 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { loadStarredTables, persistStarredTables, toggleStarredTable } from './view-storage.ts'
+import { isViewStarred, loadStarredViews, persistStarredViews, toggleStarredView } from './view-storage.ts'
 
-test('toggleStarredTable adds and removes a table path', () => {
-  assert.deepEqual(toggleStarredTable([], '/pages'), ['/pages'])
-  assert.deepEqual(toggleStarredTable(['/pages'], '/pages'), [])
-  persistStarredTables(['/plugins'])
-  assert.deepEqual(loadStarredTables(), ['/plugins'])
+test('toggleStarredView stars a view, not a whole table', () => {
+  const next = toggleStarredView([], '/pages', 'v1')
+  assert.deepEqual(next, [{ path: '/pages', viewId: 'v1' }])
+  assert.equal(isViewStarred(next, '/pages', 'v1'), true)
+  assert.equal(isViewStarred(next, '/pages', 'v2'), false)
+  assert.deepEqual(toggleStarredView(next, '/pages', 'v1'), [])
+  persistStarredViews([{ path: '/tasks', viewId: 'a' }])
+  assert.deepEqual(loadStarredViews(), [{ path: '/tasks', viewId: 'a' }])
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -28,22 +28,36 @@ export function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
   return listed[0]?.id ?? null
 }
 
-const STARRED_TABLES_KEY = 'fsdb.starredTables'
+export type StarredView = { path: string; viewId: string }
 
-export function loadStarredTables(): string[] {
+const STARRED_VIEWS_KEY = 'fsdb.starredViews'
+
+export function loadStarredViews(): StarredView[] {
   try {
-    const raw = localStorage.getItem(STARRED_TABLES_KEY)
+    const raw = localStorage.getItem(STARRED_VIEWS_KEY)
     const parsed = raw ? (JSON.parse(raw) as unknown) : []
-    return Array.isArray(parsed) ? parsed.map((item) => String(item)).filter(Boolean) : []
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((item) => {
+      if (!item || typeof item !== 'object') return []
+      const rec = item as Record<string, unknown>
+      const path = String(rec.path ?? '').trim()
+      const viewId = String(rec.viewId ?? '').trim()
+      return path && viewId ? [{ path, viewId }] : []
+    })
   } catch {
     return []
   }
 }
 
-export function persistStarredTables(paths: string[]) {
-  localStorage.setItem(STARRED_TABLES_KEY, JSON.stringify(paths))
+export function persistStarredViews(items: StarredView[]) {
+  localStorage.setItem(STARRED_VIEWS_KEY, JSON.stringify(items))
 }
 
-export function toggleStarredTable(paths: string[], path: string) {
-  return paths.includes(path) ? paths.filter((item) => item !== path) : [...paths, path]
+export function isViewStarred(items: StarredView[], path: string, viewId: string) {
+  return items.some((item) => item.path === path && item.viewId === viewId)
+}
+
+export function toggleStarredView(items: StarredView[], path: string, viewId: string): StarredView[] {
+  if (isViewStarred(items, path, viewId)) return items.filter((item) => item.path !== path || item.viewId !== viewId)
+  return [...items, { path, viewId }]
 }

--- a/packages/host-hub/package.json
+++ b/packages/host-hub/package.json
@@ -9,5 +9,8 @@
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8"
+  },
+  "dependencies": {
+    "@biu/type-file-system": "0.1.0"
   }
 }

--- a/packages/host-hub/src/host/events-collection.test.ts
+++ b/packages/host-hub/src/host/events-collection.test.ts
@@ -1,0 +1,20 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { eventsCollection } from './events-collection.ts'
+
+test('eventsCollection is a read-only File System table over hub buffer', () => {
+  const spec = eventsCollection({
+    listEvents: () => [
+      { id: 'evt-1', ts: 42, mode: 'emit', name: 'session/event', args: [{ ok: true }] },
+    ],
+  })
+  assert.equal(spec.path, '/events')
+  assert.equal(spec.view?.moduleId, 'events-db')
+  assert.equal(spec.write, undefined)
+  const rows = spec.list()
+  assert.ok(Array.isArray(rows))
+  const listed = rows as Array<{ id: string; title: string; args: string }>
+  assert.equal(listed[0]?.id, 'evt-1')
+  assert.equal(listed[0]?.title, 'session/event')
+  assert.equal(listed[0]?.args, '[{"ok":true}]')
+})

--- a/packages/host-hub/src/host/events-collection.ts
+++ b/packages/host-hub/src/host/events-collection.ts
@@ -1,0 +1,59 @@
+import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+
+export type HubEventRow = {
+  id: string
+  ts: number
+  mode: string
+  name: string
+  args: unknown[]
+}
+
+type HubLike = {
+  listEvents: () => HubEventRow[]
+}
+
+function stringifyArgs(args: unknown[]) {
+  try {
+    return JSON.stringify(args)
+  } catch {
+    return '[unserializable]'
+  }
+}
+
+export function eventsCollection(hub: HubLike): CollectionSpec {
+  const asRecord = (row: HubEventRow): DbRecord => ({
+    id: row.id,
+    title: row.name,
+    ts: row.ts,
+    mode: row.mode,
+    name: row.name,
+    args: stringifyArgs(row.args),
+  })
+  const list = () => hub.listEvents().map(asRecord)
+  return {
+    id: 'events',
+    path: '/events',
+    label: 'Event',
+    view: {
+      moduleId: 'events-db',
+      route: '/db-events',
+      title: 'Event',
+      blurb: 'Hub 已缓冲的 internal/dispatch 事件（最多约 80 条），只读。',
+      order: 19,
+      icon: 'bolt',
+    },
+    schema: {
+      labelField: 'title',
+      columns: ['title', 'mode', 'ts', 'args'],
+      fields: {
+        title: { type: 'string', label: '事件' },
+        mode: { type: 'string', label: '模式' },
+        name: { type: 'string', label: '名称' },
+        ts: { type: 'datetime', label: '时间', sortable: true },
+        args: { type: 'string', label: '参数' },
+      },
+    },
+    list,
+    get: (id) => list().find((row) => row.id === id) ?? null,
+  }
+}

--- a/packages/host-hub/src/host/index.ts
+++ b/packages/host-hub/src/host/index.ts
@@ -6,6 +6,7 @@ import { resolveCatalog } from './resolve-catalog.ts'
 import type { PageSpec } from '@biu/type-http'
 import { HUB_CHANGE, HUB_CHANNEL_EVENT, HUB_CHANNEL_SNAPSHOT } from '@biu/type-http'
 import { runWithToolOrigin } from '@biu/host-tools'
+import { eventsCollection } from './events-collection.ts'
 
 export { HUB_CHANGE, HUB_CHANNEL_EVENT, HUB_CHANNEL_SNAPSHOT }
 
@@ -19,16 +20,27 @@ interface ForkRecord {
 export class HubService extends Service {
   private forks = new Map<string, ForkRecord>()
   private pages: PageSpec[] = []
-  private events: Array<{ ts: number; mode: string; name: string; args: unknown[] }> = []
+  private events: Array<{ id: string; ts: number; mode: string; name: string; args: unknown[] }> = []
   private seq = 0
+  private eventSeq = 0
 
   constructor(ctx: Context, catalog: CatalogEntry[]) {
     super(ctx, 'hub')
     ctx.on('internal/dispatch', (mode, name, args) => {
       if (skipHubEvent(name, args)) return
-      this.events.unshift({ ts: Date.now(), mode, name, args: clone(args) })
+      this.eventSeq += 1
+      this.events.unshift({
+        id: `evt-${this.eventSeq}`,
+        ts: Date.now(),
+        mode,
+        name,
+        args: clone(args),
+      })
       this.events.splice(80)
       ctx.http.broadcast(HUB_CHANNEL_EVENT, this.events[0])
+    })
+    ctx.inject(['database'], (inner) => {
+      inner.database.register(eventsCollection(this))
     })
     let snapTimer: ReturnType<typeof setTimeout> | null = null
     const pushSnapshot = () => {
@@ -62,6 +74,10 @@ export class HubService extends Service {
         this.ctx.emit(HUB_CHANGE)
       }
     }, `hub.registerPage ${page.id}`)
+  }
+
+  listEvents() {
+    return [...this.events]
   }
 
   snapshot() {
@@ -190,6 +206,7 @@ function isStorePackage(packageName?: string) {
   return typeof packageName === 'string' && packageName.startsWith('store:')
 }
 
+export { eventsCollection } from './events-collection.ts'
 export type { CatalogEntry } from './catalog.ts'
 
 export const name = 'hub'

--- a/packages/host-sessions/package.json
+++ b/packages/host-sessions/package.json
@@ -14,5 +14,8 @@
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8"
+  },
+  "dependencies": {
+    "@biu/type-file-system": "0.1.0"
   }
 }

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -26,6 +26,7 @@ import {
   type SessionMascot as AssignedMascot,
 } from './session-mascot.ts'
 import { rebuildHealedEvents } from './session-heal.ts'
+import { sessionsCollection } from './sessions-collection.ts'
 
 export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord, SessionMascot, SessionType, SessionConfig }
 export { SESSION_FORMAT_VERSION, normalizeSessionType, normalizeSessionConfig, mergeSessionConfig }
@@ -279,6 +280,9 @@ export class SessionsService extends Service {
 
   constructor(ctx: Context) {
     super(ctx, 'sessions')
+    ctx.inject(['database'], (inner) => {
+      inner.database.register(sessionsCollection(this))
+    })
   }
 
   async create(
@@ -564,6 +568,8 @@ async function resolveHostProject(input: string): Promise<SessionProject> {
   if (!info.isDirectory()) throw new Error(`project path is not a directory: ${real}`)
   return { name: basename(real) || real, path: real, boundAt: Date.now() }
 }
+
+export { sessionsCollection } from './sessions-collection.ts'
 
 export const name = 'sessions'
 export const inject = ['sessionStore']

--- a/packages/host-sessions/src/host/sessions-collection.test.ts
+++ b/packages/host-sessions/src/host/sessions-collection.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { sessionsCollection } from './sessions-collection.ts'
+
+test('sessionsCollection maps summaries and writes title/pinned/tags', async () => {
+  const calls: unknown[] = []
+  const spec = sessionsCollection({
+    listSummaries: async () => [
+      {
+        id: 's1',
+        version: 1,
+        eventCount: 3,
+        title: 'hello',
+        updatedAt: 100,
+        type: 'chat',
+        config: { pinned: false, tags: ['a'] },
+      },
+    ],
+    rename: async (id, title) => {
+      calls.push(['rename', id, title])
+    },
+    patchConfig: async (id, patch) => {
+      calls.push(['patch', id, patch])
+    },
+  })
+  assert.equal(spec.path, '/sessions')
+  assert.equal(spec.view?.moduleId, 'sessions-db')
+  const rows = await spec.list()
+  assert.equal(rows[0]?.id, 's1')
+  assert.equal(rows[0]?.title, 'hello')
+  assert.deepEqual(rows[0]?.tags, ['a'])
+  await spec.write?.('s1', { title: 'renamed', pinned: true, tags: ['b', 'c'] })
+  assert.deepEqual(calls, [
+    ['rename', 's1', 'renamed'],
+    ['patch', 's1', { pinned: true, tags: ['b', 'c'] }],
+  ])
+})

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -1,0 +1,63 @@
+import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import type { SessionConfig, SessionSummary } from '@biu/type-session'
+
+type SessionsLike = {
+  listSummaries: () => Promise<SessionSummary[]>
+  rename: (id: string, title: string) => Promise<unknown>
+  patchConfig: (id: string, patch: SessionConfig) => Promise<unknown>
+}
+
+function asRecord(row: SessionSummary): DbRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    type: row.type ?? 'chat',
+    pinned: Boolean(row.config?.pinned),
+    tags: Array.isArray(row.config?.tags) ? row.config.tags.map(String) : [],
+    eventCount: row.eventCount,
+    project: row.project?.name ?? '',
+    updatedAt: row.updatedAt,
+  }
+}
+
+export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
+  const list = async () => (await sessions.listSummaries()).map(asRecord)
+  return {
+    id: 'sessions',
+    path: '/sessions',
+    label: 'Session',
+    view: {
+      moduleId: 'sessions-db',
+      route: '/db-sessions',
+      title: 'Session',
+      blurb: '已有聊天 Session 的只读登记；改标题/置顶/标签会写回会话配置，不替代侧栏聊天。',
+      order: 18,
+      icon: 'chat-bubble',
+    },
+    schema: {
+      labelField: 'title',
+      columns: ['title', 'type', 'pinned', 'tags', 'eventCount', 'project', 'updatedAt'],
+      fields: {
+        title: { type: 'string', label: '标题', writable: true },
+        type: { type: 'select', label: '类型', enum: ['chat', 'live'] },
+        pinned: { type: 'boolean', label: '置顶', writable: true },
+        tags: { type: 'multi-select', label: '标签', writable: true },
+        eventCount: { type: 'number', label: '事件数', computed: true, sortable: true },
+        project: { type: 'string', label: '项目' },
+        updatedAt: { type: 'datetime', label: '更新时间', sortable: true },
+      },
+    },
+    list,
+    get: async (id) => (await list()).find((row) => row.id === id) ?? null,
+    write: async (id, patch) => {
+      if (typeof patch.title === 'string') await sessions.rename(id, patch.title)
+      const config: SessionConfig = {}
+      if (typeof patch.pinned === 'boolean') config.pinned = patch.pinned
+      if (Array.isArray(patch.tags)) config.tags = patch.tags.map((item) => String(item))
+      if (Object.keys(config).length) await sessions.patchConfig(id, config)
+      const next = (await list()).find((row) => row.id === id)
+      if (!next) throw new Error(`unknown session: ${id}`)
+      return next
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在已有聊天 Session 和 Hub 事件缓冲之上，额外往 File System Database 登记两张表，侧栏一共能看到 5 块数据。

## Session
- path `/sessions`，视图 `sessions-db` / `/db-sessions`
- 数据来自 `listSummaries()`，不替代聊天侧栏
- 可写标题、置顶、标签（写回 `rename` / `patchConfig`）

## Event
- path `/events`，视图 `events-db` / `/db-events`
- 数据来自 Hub 已缓冲的 `internal/dispatch`（最多约 80 条），只读

## 收藏
- 星星打在视图行上，不再收藏整张表

合进 `file-system` 后硬刷新 `/database` 即可看到 5 张表。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

