### PR TITLE
聊天悬浮窗在所有页面置顶

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState, useSyncExternalStore, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import {
   chatColumnWidth,
   setChatOverlay,
@@ -197,15 +198,21 @@ function UpdateButton() {
   )
 }
 
-/** 主区固定聊天；轨迹改在右侧检查器。 */
+/** 主区固定聊天；轨迹改在右侧检查器。悬浮形态可挂到任意页面最顶层。 */
 const AgentMainPanels = memo(function AgentMainPanels({
   renderSlot,
   header,
+  floating,
+  withSidebar,
+  railOpen,
 }: {
   renderSlot: SlotProps['renderSlot']
   header: ReactNode
+  floating: boolean
+  withSidebar: boolean
+  railOpen: boolean
 }) {
-  const overlay = useSyncExternalStore(subscribeChatOverlay, getChatOverlay, () => false)
+  const overlay = floating
   const hidden = useSyncExternalStore(subscribeOverlayAutohide, getOverlayAutohide, () => false)
   const stageRef = useRef<HTMLDivElement>(null)
   const heightRef = useRef(OVERLAY_CHAT_HEIGHT_DEFAULT)
@@ -288,29 +295,33 @@ const AgentMainPanels = memo(function AgentMainPanels({
   )
 
   if (overlay) {
-    return (
-      <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+    const panel = (
+      <div
+        className={`chat-overlay-panel${hidden ? ' is-autohide' : ''}`}
+        data-with-sidebar={withSidebar ? '1' : '0'}
+        data-testid="chat-overlay-panel"
+        style={{
+          ['--overlay-chat-height' as string]: `${overlayChatHeight}px`,
+          ['--rail-w' as string]: railOpen ? '48px' : '0px',
+        } as CSSProperties}
+        onMouseEnter={() => {
+          if (hidden) return
+          keepVisible()
+        }}
+        onMouseLeave={hideIfIdle}
+      >
         <div
-          className="chat-overlay-panel"
-          style={{ ['--overlay-chat-height' as string]: `${overlayChatHeight}px` } as CSSProperties}
-          onMouseEnter={() => {
-            if (hidden) return
-            keepVisible()
-          }}
-          onMouseLeave={hideIfIdle}
-        >
-          <div
-            className="chat-overlay-resize"
-            data-testid="chat-overlay-resize"
-            title="拖动调节聊天高度"
-            onPointerDown={onResizeHeight}
-          />
-          {header}
-          <div className="chat-overlay-thread">{stage}</div>
-          <div className="chat-composer-dock pointer-events-none">{dockInner}</div>
-        </div>
+          className="chat-overlay-resize"
+          data-testid="chat-overlay-resize"
+          title="拖动调节聊天高度"
+          onPointerDown={onResizeHeight}
+        />
+        {header}
+        <div className="chat-overlay-thread">{stage}</div>
+        <div className="chat-composer-dock pointer-events-none">{dockInner}</div>
       </div>
     )
+    return createPortal(panel, document.body)
   }
 
   return (
@@ -467,7 +478,9 @@ function Shell(props: SlotProps) {
       /* ignore */
     }
   }, [])
+  const activeModule = moduleIdFromPath(location.pathname, pluginModules)
   const syncChatOverlay = useCallback(() => {
+    if (activeModule !== 'agent') return
     if (!inspectorOpen) {
       setChatOverlay(false)
       return
@@ -479,7 +492,7 @@ function Shell(props: SlotProps) {
       sidebarCollapsed,
     })
     if (width < CHAT_OVERLAY_ENTER) setChatOverlay(true)
-  }, [inspectorOpen, inspectorWidth, sidebarCollapsed])
+  }, [activeModule, inspectorOpen, inspectorWidth, sidebarCollapsed])
   useEffect(() => {
     syncChatOverlay()
     window.addEventListener('resize', syncChatOverlay)
@@ -505,16 +518,20 @@ function Shell(props: SlotProps) {
     window.addEventListener('biu:inspector-open', onOpen)
     return () => window.removeEventListener('biu:inspector-open', onOpen)
   }, [])
-  const activeModule = moduleIdFromPath(location.pathname, pluginModules)
   const appRoute = parseAppPath(location.pathname, pluginModules)
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}` : '/'
   const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
+  const chatFloating = chatOverlay || activeModule !== 'agent'
   const onAgentRailClick = useCallback((alreadyActive: boolean) => {
     if (alreadyActive) setSidebarCollapsed((prev) => !prev)
     else setSidebarCollapsed(false)
   }, [])
+
+  useEffect(() => {
+    if (activeModule !== 'agent') setChatOverlay(true)
+  }, [activeModule])
 
   // 工具检查 /debuginspect：打开右侧轨迹 Tab（主区不再切 Debug 页）
   useEffect(() => {
@@ -640,7 +657,7 @@ function Shell(props: SlotProps) {
           }`
           : ' app-shell-module'
         }${railOpen || railPinned ? ' is-rail-open' : ''}`}
-      data-testid={chatOverlay ? 'chat-overlay' : undefined}
+      data-testid={chatFloating ? 'chat-overlay' : undefined}
       style={
         inspectorOpen
           ? ({ ['--inspector-width' as string]: `${inspectorWidth}px` } as CSSProperties)
@@ -684,11 +701,16 @@ function Shell(props: SlotProps) {
 
       <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
         <div
-          className={`min-h-0 min-w-0 flex-col overflow-hidden ${activeModule === 'agent' ? 'flex flex-1' : 'hidden'}`}
-          aria-hidden={activeModule !== 'agent'}
+          className={`min-h-0 min-w-0 flex-col overflow-hidden ${activeModule === 'agent' && !chatFloating ? 'flex flex-1' : 'contents'}`}
         >
-          {chatOverlay ? null : chatHeader}
-          <AgentMainPanels renderSlot={props.renderSlot} header={chatHeader} />
+          {chatFloating ? null : chatHeader}
+          <AgentMainPanels
+            renderSlot={props.renderSlot}
+            header={chatHeader}
+            floating={chatFloating}
+            withSidebar={showChatSidebar}
+            railOpen={railOpen || railPinned}
+          />
         </div>
         <PluginModuleStage
           slots={slots}

--- a/web/style.css
+++ b/web/style.css
@@ -431,15 +431,15 @@ body {
   overflow: visible;
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-panel {
+.chat-overlay-panel {
   position: fixed;
-  left: calc(var(--rail-w) + 280px);
+  left: var(--rail-w);
   right: 0;
   bottom: 20px;
-  z-index: 40;
+  z-index: 80;
   display: flex;
   flex-direction: column;
-  width: min(var(--dsw-chat-width), calc(100vw - var(--rail-w) - 280px - 40px));
+  width: min(var(--dsw-chat-width), calc(100vw - var(--rail-w) - 40px));
   margin-inline: auto;
   padding: 0 12px 12px;
   border-radius: 14px;
@@ -449,17 +449,17 @@ body {
   transition: left .16s ease, width .16s ease;
 }
 
-.app-shell-agent.is-sidebar-collapsed.is-chat-overlay .chat-overlay-panel {
-  left: var(--rail-w);
-  width: min(var(--dsw-chat-width), calc(100vw - var(--rail-w) - 40px));
+.chat-overlay-panel[data-with-sidebar="1"] {
+  left: calc(var(--rail-w) + 280px);
+  width: min(var(--dsw-chat-width), calc(100vw - var(--rail-w) - 280px - 40px));
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-thread {
+.chat-overlay-thread {
   position: relative;
   flex: none;
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-resize {
+.chat-overlay-resize {
   position: absolute;
   top: 0;
   left: 50%;
@@ -471,7 +471,7 @@ body {
   touch-action: none;
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-resize::after {
+.chat-overlay-resize::after {
   content: '';
   display: block;
   width: 36px;
@@ -481,11 +481,11 @@ body {
   background: var(--dsw-border);
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-panel .chat-view-header {
+.chat-overlay-panel .chat-view-header {
   padding-inline: 4px;
 }
 
-.app-shell-agent.is-chat-overlay .chat-stage {
+.chat-overlay-panel .chat-stage {
   visibility: visible;
   flex: none;
   height: var(--overlay-chat-height, 200px);
@@ -493,11 +493,11 @@ body {
   overflow-y: auto;
 }
 
-.app-shell-agent.is-chat-overlay .chat-stage .sticky {
+.chat-overlay-panel .chat-stage .sticky {
   position: static;
 }
 
-.app-shell-agent.is-chat-overlay .chat-overlay-panel .chat-composer-dock {
+.chat-overlay-panel .chat-composer-dock {
   position: relative;
   inset: auto;
   width: 100%;
@@ -508,7 +508,7 @@ body {
   box-shadow: none;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .chat-overlay-panel {
+.chat-overlay-panel.is-autohide {
   bottom: 10px;
   padding: 0;
   background: transparent;
@@ -516,42 +516,42 @@ body {
   pointer-events: none !important;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .chat-overlay-resize,
-.app-shell-agent.is-chat-overlay-autohide .chat-overlay-thread,
-.app-shell-agent.is-chat-overlay-autohide .chat-view-header,
-.app-shell-agent.is-chat-overlay-autohide .chat-stage {
+.chat-overlay-panel.is-autohide .chat-overlay-resize,
+.chat-overlay-panel.is-autohide .chat-overlay-thread,
+.chat-overlay-panel.is-autohide .chat-view-header,
+.chat-overlay-panel.is-autohide .chat-stage {
   display: none !important;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .chat-composer-dock {
+.chat-overlay-panel.is-autohide .chat-composer-dock {
   pointer-events: none !important;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .chat-composer-dock > * {
+.chat-overlay-panel.is-autohide .chat-composer-dock > * {
   pointer-events: none !important;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .composer-pill,
-.app-shell-agent.is-chat-overlay-autohide .chat-live-hud,
-.app-shell-agent.is-chat-overlay-autohide .chat-live-hud-metrics,
-.app-shell-agent.is-chat-overlay-autohide .dock-approval-hint,
-.app-shell-agent.is-chat-overlay-autohide .chat-dock-toolbar-end,
-.app-shell-agent.is-chat-overlay-autohide .chat-dock-toolbar-start > :not(.dock-agent-stack) {
+.chat-overlay-panel.is-autohide .composer-pill,
+.chat-overlay-panel.is-autohide .chat-live-hud,
+.chat-overlay-panel.is-autohide .chat-live-hud-metrics,
+.chat-overlay-panel.is-autohide .dock-approval-hint,
+.chat-overlay-panel.is-autohide .chat-dock-toolbar-end,
+.chat-overlay-panel.is-autohide .chat-dock-toolbar-start > :not(.dock-agent-stack) {
   display: none !important;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .chat-dock-toolbar,
-.app-shell-agent.is-chat-overlay-autohide .chat-dock-toolbar-start {
+.chat-overlay-panel.is-autohide .chat-dock-toolbar,
+.chat-overlay-panel.is-autohide .chat-dock-toolbar-start {
   justify-content: center;
   width: 100%;
 }
 
-.app-shell-agent.is-chat-overlay-autohide .dock-agent-stack,
-.app-shell-agent.is-chat-overlay-autohide .dock-agent-stack * {
+.chat-overlay-panel.is-autohide .dock-agent-stack,
+.chat-overlay-panel.is-autohide .dock-agent-stack * {
   pointer-events: auto !important;
 }
 
-.app-shell-agent.is-chat-overlay .chat-composer-dock > * {
+.chat-overlay-panel .chat-composer-dock > * {
   width: 100%;
   max-width: none;
 }
@@ -578,7 +578,7 @@ body {
   pointer-events: none;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud-metrics {
+.chat-overlay-panel .chat-live-hud-metrics {
   display: flex;
   max-width: min(100%, 28rem);
   align-items: center;
@@ -597,21 +597,21 @@ body {
   gap: 8px;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud-metrics .chat-reply-meta-icon svg {
+.chat-overlay-panel .chat-live-hud-metrics .chat-reply-meta-icon svg {
   width: 12px;
   height: 12px;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud-metrics .traj-usage-ring {
+.chat-overlay-panel .chat-live-hud-metrics .traj-usage-ring {
   width: 12px;
   height: 12px;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud-metrics .traj-usage {
+.chat-overlay-panel .chat-live-hud-metrics .traj-usage {
   font-size: 11px;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud-metrics .traj-usage-arrow {
+.chat-overlay-panel .chat-live-hud-metrics .traj-usage-arrow {
   color: var(--dsw-sidebar-fg);
   opacity: 1;
 }
@@ -620,7 +620,7 @@ body {
   display: none;
 }
 
-.app-shell-agent.is-chat-overlay .chat-live-hud {
+.chat-overlay-panel .chat-live-hud {
   display: none !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Session 页仍可缩小/放大；切到数据等其它模块时聊天改为全局悬浮窗（portal 到 `document.body`，`z-index: 80`），盖在页面内容之上，低于详情弹层（100）。

离开 Session 时自动进入悬浮，避免检查器关闭把 overlay 关掉。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

