### PR TITLE
视图右侧显示记录条数，数字字号统一

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useId, useState } from 'react'
+import { memo, useEffect, useId, useMemo, useState, useSyncExternalStore } from 'react'
 import {
   BoltIcon,
   ChatBubbleLeftRightIcon,
@@ -22,10 +22,18 @@ import type { ViewMode } from './fields.ts'
 import type { SavedView } from './saved-view.ts'
 import {
   fetchViewPreview,
+  fetchViewTotal,
+  getPreviewTotal,
+  getPreviewTotalsVersion,
   nextPreviewLimit,
   previewCacheKey,
   recordPreviewLabel,
+  rememberPreviewTotal,
   SIDEBAR_PREVIEW_MAX,
+  subscribePreviewTotals,
+  TABLE_TOTAL_VIEW,
+  tableTotalKey,
+  viewTotalKey,
 } from './sidebar-preview.ts'
 import {
   activeViewStorageKey,
@@ -124,6 +132,7 @@ function ViewRecordPreview({
       (page) => {
         if (cancelled) return
         previewCache.set(key, { items: page.items, total: page.total })
+        rememberPreviewTotal(key, page.total)
         setState({ items: page.items, total: page.total, loading: false, error: '' })
       },
       (err: unknown) => {
@@ -145,6 +154,7 @@ function ViewRecordPreview({
       const items = [...state.items, ...page.items]
       const total = page.total
       previewCache.set(key, { items, total })
+      rememberPreviewTotal(key, total)
       setState({ items, total, loading: false, error: '' })
     } catch (err) {
       setState((prev) => ({ ...prev, loading: false, error: String(err) }))
@@ -185,12 +195,17 @@ function ViewRecordPreview({
   )
 }
 
-function ChatCount({ count }: { count: number }) {
+function ChatCount({ count }: { count: number | undefined }) {
+  if (count == null) return null
   return (
-    <span className="sidebar-chat-count">
+    <span className="sidebar-chat-count" title={`${count} 条`}>
       <span className="sidebar-chat-count-num">{count}</span>
     </span>
   )
+}
+
+function usePreviewTotalsVersion() {
+  return useSyncExternalStore(subscribePreviewTotals, getPreviewTotalsVersion, () => 0)
 }
 
 export const DataSidebar = memo(function DataSidebar({
@@ -220,7 +235,10 @@ export const DataSidebar = memo(function DataSidebar({
   onCopyView: () => void
   onOpenRecord?: (path: string, view: SavedView, recordId: string) => void
 }) {
-  const listedTables = tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]
+  const listedTables = useMemo(
+    () => (tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]),
+    [collectionPath, tables, title],
+  )
   const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
   const [starredViews, setStarredViews] = useState(loadStarredViews)
   const [favOpen, setFavOpen] = useState(() => {
@@ -232,6 +250,7 @@ export const DataSidebar = memo(function DataSidebar({
   })
   const [dataOpen, setDataOpen] = useState(true)
   const [expandedViewKey, setExpandedViewKey] = useState<string | null>(null)
+  usePreviewTotalsVersion()
 
   function viewsFor(path: string) {
     return path === collectionPath ? views : loadViews(path)
@@ -243,6 +262,37 @@ export const DataSidebar = memo(function DataSidebar({
     if (!table || !view) return []
     return [{ table, view }]
   })
+
+  const countJobs = useMemo(() => {
+    const jobs: Array<{ path: string; view: typeof TABLE_TOTAL_VIEW | SavedView }> = []
+    if (favOpen) {
+      for (const { table, view } of starredRows) jobs.push({ path: table.path, view })
+    }
+    if (dataOpen) {
+      for (const table of listedTables) {
+        jobs.push({ path: table.path, view: TABLE_TOTAL_VIEW })
+        if (openTables[table.path]) {
+          for (const view of viewsFor(table.path)) jobs.push({ path: table.path, view })
+        }
+      }
+    }
+    return jobs
+  }, [dataOpen, favOpen, listedTables, openTables, starredRows, views, collectionPath])
+
+  const countJobKey = countJobs.map((job) => viewTotalKey(job.path, job.view)).join('|')
+  useEffect(() => {
+    let cancelled = false
+    void Promise.all(
+      countJobs.map((job) =>
+        fetchViewTotal(job.path, job.view).catch(() => {
+          if (cancelled) return
+        }),
+      ),
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [countJobKey, countJobs])
 
   function toggleStar(path: string, viewId: string) {
     setStarredViews((prev) => {
@@ -367,8 +417,9 @@ export const DataSidebar = memo(function DataSidebar({
                             onClick={() => openView(table.path, view.id)}
                           >
                             <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
-                            <span className="shrink-0 text-[11px] leading-3.75 opacity-70">{tableName}</span>
+                            <span className="shrink-0 text-[14px] leading-5 opacity-70">{tableName}</span>
                           </button>
+                          <ChatCount count={getPreviewTotal(viewTotalKey(table.path, view))} />
                           <button
                             type="button"
                             className="chat-session-row-star is-on"
@@ -406,7 +457,11 @@ export const DataSidebar = memo(function DataSidebar({
                   <span className="min-w-0 flex-1 truncate tracking-normal">数据</span>
                 </button>
               </div>
-              <ChatCount count={listedTables.length} />
+              <ChatCount
+                count={listedTables.every((table) => getPreviewTotal(tableTotalKey(table.path)) != null)
+                  ? listedTables.reduce((sum, table) => sum + (getPreviewTotal(tableTotalKey(table.path)) ?? 0), 0)
+                  : undefined}
+              />
             </div>
             {dataOpen ? (
               <div className="min-w-0 space-y-1.5 pt-0.5">
@@ -448,7 +503,7 @@ export const DataSidebar = memo(function DataSidebar({
                           </span>
                           <span className="min-w-0 flex-1 truncate">{name}</span>
                         </div>
-                        <ChatCount count={listed.length} />
+                        <ChatCount count={getPreviewTotal(tableTotalKey(table.path))} />
                       </div>
                       <div className={`sidebar-session-list min-w-0 ${open ? '' : 'hidden'}`} aria-hidden={!open}>
                         {listed.map((view) => {
@@ -486,6 +541,7 @@ export const DataSidebar = memo(function DataSidebar({
                                 >
                                   <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
                                 </button>
+                                <ChatCount count={getPreviewTotal(viewTotalKey(table.path, view))} />
                                 {table.path === collectionPath ? (
                                   <>
                                     <button

--- a/packages/core-file-system/src/web/sidebar-preview.test.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.test.ts
@@ -1,6 +1,15 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { nextPreviewLimit, previewCacheKey, recordPreviewLabel, SIDEBAR_PREVIEW_PAGE } from './sidebar-preview.ts'
+import {
+  getPreviewTotal,
+  nextPreviewLimit,
+  previewCacheKey,
+  recordPreviewLabel,
+  rememberPreviewTotal,
+  SIDEBAR_PREVIEW_PAGE,
+  tableTotalKey,
+  viewTotalKey,
+} from './sidebar-preview.ts'
 
 test('record preview prefers label field then title', () => {
   assert.equal(recordPreviewLabel({ id: '1', title: '封面' }, 'title'), '封面')
@@ -12,6 +21,13 @@ test('preview cache includes view query and filters', () => {
   const a = previewCacheKey('/tasks', { id: 'v1', sortField: 'id', sortDir: 'asc', filters: {}, query: '' })
   const b = previewCacheKey('/tasks', { id: 'v1', sortField: 'id', sortDir: 'asc', filters: { status: 'open' }, query: '' })
   assert.notEqual(a, b)
+})
+
+test('table total key is not a saved view key', () => {
+  const view = { id: 'v1', sortField: 'id', sortDir: 'asc' as const, filters: {}, query: '' }
+  assert.notEqual(tableTotalKey('/tasks'), viewTotalKey('/tasks', view))
+  rememberPreviewTotal(viewTotalKey('/tasks', view), 12)
+  assert.equal(getPreviewTotal(viewTotalKey('/tasks', view)), 12)
 })
 
 test('preview pages stay small and stop at max', () => {

--- a/packages/core-file-system/src/web/sidebar-preview.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.ts
@@ -30,6 +30,60 @@ export function nextPreviewLimit(loaded: number, total: number) {
   return Math.min(SIDEBAR_PREVIEW_PAGE, SIDEBAR_PREVIEW_MAX - loaded, total - loaded)
 }
 
+export const TABLE_TOTAL_VIEW = {
+  id: '__table__',
+  sortField: 'id',
+  sortDir: 'asc' as const,
+  filters: {} as Record<string, string>,
+  query: '',
+}
+
+const totalCache = new Map<string, number>()
+const totalListeners = new Set<() => void>()
+let totalsVersion = 0
+
+export function rememberPreviewTotal(key: string, total: number) {
+  if (totalCache.get(key) === total) return
+  totalCache.set(key, total)
+  totalsVersion += 1
+  for (const fn of totalListeners) fn()
+}
+
+export function getPreviewTotalsVersion() {
+  return totalsVersion
+}
+
+export function getPreviewTotal(key: string) {
+  return totalCache.get(key)
+}
+
+export function subscribePreviewTotals(fn: () => void) {
+  totalListeners.add(fn)
+  return () => {
+    totalListeners.delete(fn)
+  }
+}
+
+export function viewTotalKey(path: string, view: Pick<SavedView, 'id' | 'sortField' | 'sortDir' | 'filters' | 'query'>) {
+  return previewCacheKey(path, view)
+}
+
+export function tableTotalKey(path: string) {
+  return previewCacheKey(path, TABLE_TOTAL_VIEW)
+}
+
+export async function fetchViewTotal(
+  path: string,
+  view: Pick<SavedView, 'id' | 'sortField' | 'sortDir' | 'filters' | 'query'>,
+) {
+  const key = viewTotalKey(path, view)
+  const cached = totalCache.get(key)
+  if (cached != null) return cached
+  const page = await fetchViewPreview(path, view, 0, 1)
+  rememberPreviewTotal(key, page.total)
+  return page.total
+}
+
 export async function fetchViewPreview(
   path: string,
   view: Pick<SavedView, 'sortField' | 'sortDir' | 'filters' | 'query'>,

--- a/web/style.css
+++ b/web/style.css
@@ -1035,31 +1035,31 @@ body {
   display: inline-grid;
   flex-shrink: 0;
   place-items: center;
-  width: 24px;
+  min-width: 24px;
   height: 24px;
   grid-column: 2;
   justify-self: end;
   margin: 0;
-  padding: 0;
+  padding: 0 4px;
   border-radius: 6px;
   color: inherit;
-  font: inherit;
+  font-size: 14px;
+  font-weight: 500;
   line-height: 0;
 }
 
 .sidebar-chat-count-num {
   display: block;
+  font-size: 14px;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   line-height: 1;
   opacity: 1;
 }
 
-.sidebar-section-head .sidebar-chat-count {
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.sidebar-group-head .sidebar-chat-count {
+.sidebar-section-head .sidebar-chat-count,
+.sidebar-group-head .sidebar-chat-count,
+.chat-session-row .sidebar-chat-count {
   font-size: 14px;
   font-weight: 500;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
视图右侧显示该视图筛选后的记录总数（只打 limit=1 拿 total，不拉整表）。表行是全表条数，「数据」分组是各表合计。计数数字与名称统一 14px。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

