### PR TITLE
侧栏行背景与 Icon 间距对齐聊天

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -167,16 +167,16 @@ function ViewRecordPreview({
   return (
     <div className="fsdb-view-preview" role="list">
       {state.items.map((row) => (
-        <button
-          key={row.id}
-          type="button"
-          role="listitem"
-          className="fsdb-view-preview-row"
-          title={recordPreviewLabel(row)}
-          onClick={() => onOpenRecord?.(row.id)}
-        >
-          <span className="min-w-0 flex-1 truncate">{recordPreviewLabel(row)}</span>
-        </button>
+        <div key={row.id} className="chat-session-row" role="listitem">
+          <button
+            type="button"
+            className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
+            title={recordPreviewLabel(row)}
+            onClick={() => onOpenRecord?.(row.id)}
+          >
+            <span className="min-w-0 flex-1 truncate font-medium">{recordPreviewLabel(row)}</span>
+          </button>
+        </div>
       ))}
       {state.loading && !state.items.length ? (
         <div className="fsdb-view-preview-hint">加载中…</div>
@@ -393,32 +393,36 @@ export const DataSidebar = memo(function DataSidebar({
                     return (
                       <div key={previewKey} className="min-w-0">
                         <div className={`chat-session-row group${active ? ' is-active' : ''} is-pinned`}>
-                          <button
-                            type="button"
-                            className="sidebar-rail-icon sidebar-group-fold"
-                            title={expanded ? '收起记录' : '展开记录'}
-                            aria-expanded={expanded}
-                            onClick={() => toggleViewPreview(previewKey)}
-                          >
-                            <span className="sidebar-group-fold-face">
-                              <ViewModeGlyph mode={view.mode} />
-                            </span>
-                            <span className="sidebar-group-fold-chevron">
-                              {expanded ? (
-                                <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
-                              ) : (
-                                <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
-                              )}
-                            </span>
-                          </button>
-                          <button
-                            type="button"
-                            className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                            onClick={() => openView(table.path, view.id)}
-                          >
-                            <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
+                          <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+                            <button
+                              type="button"
+                              className="grid size-6 shrink-0 place-items-center border-0 bg-transparent p-0 text-inherit"
+                              title={expanded ? '收起记录' : '展开记录'}
+                              aria-expanded={expanded}
+                              onClick={() => toggleViewPreview(previewKey)}
+                            >
+                              <span className="sidebar-rail-icon sidebar-group-fold">
+                                <span className="sidebar-group-fold-face">
+                                  <ViewModeGlyph mode={view.mode} />
+                                </span>
+                                <span className="sidebar-group-fold-chevron">
+                                  {expanded ? (
+                                    <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
+                                  ) : (
+                                    <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
+                                  )}
+                                </span>
+                              </span>
+                            </button>
+                            <button
+                              type="button"
+                              className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                              onClick={() => openView(table.path, view.id)}
+                            >
+                              {view.name}
+                            </button>
                             <span className="shrink-0 text-[14px] leading-5 opacity-70">{tableName}</span>
-                          </button>
+                          </div>
                           <ChatCount count={getPreviewTotal(viewTotalKey(table.path, view))} />
                           <button
                             type="button"
@@ -516,31 +520,35 @@ export const DataSidebar = memo(function DataSidebar({
                               <div
                                 className={`chat-session-row group${active ? ' is-active' : ''}${starred ? ' is-pinned' : ''}`}
                               >
-                                <button
-                                  type="button"
-                                  className="sidebar-rail-icon sidebar-group-fold"
-                                  title={expanded ? '收起记录' : '展开记录'}
-                                  aria-expanded={expanded}
-                                  onClick={() => toggleViewPreview(previewKey)}
-                                >
-                                  <span className="sidebar-group-fold-face">
-                                    <ViewModeGlyph mode={view.mode} />
-                                  </span>
-                                  <span className="sidebar-group-fold-chevron">
-                                    {expanded ? (
-                                      <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
-                                    ) : (
-                                      <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
-                                    )}
-                                  </span>
-                                </button>
-                                <button
-                                  type="button"
-                                  className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-                                  onClick={() => openView(table.path, view.id)}
-                                >
-                                  <span className="min-w-0 flex-1 truncate font-medium">{view.name}</span>
-                                </button>
+                                <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+                                  <button
+                                    type="button"
+                                    className="grid size-6 shrink-0 place-items-center border-0 bg-transparent p-0 text-inherit"
+                                    title={expanded ? '收起记录' : '展开记录'}
+                                    aria-expanded={expanded}
+                                    onClick={() => toggleViewPreview(previewKey)}
+                                  >
+                                    <span className="sidebar-rail-icon sidebar-group-fold">
+                                      <span className="sidebar-group-fold-face">
+                                        <ViewModeGlyph mode={view.mode} />
+                                      </span>
+                                      <span className="sidebar-group-fold-chevron">
+                                        {expanded ? (
+                                          <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
+                                        ) : (
+                                          <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
+                                        )}
+                                      </span>
+                                    </span>
+                                  </button>
+                                  <button
+                                    type="button"
+                                    className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                                    onClick={() => openView(table.path, view.id)}
+                                  >
+                                    {view.name}
+                                  </button>
+                                </div>
                                 <ChatCount count={getPreviewTotal(viewTotalKey(table.path, view))} />
                                 {table.path === collectionPath ? (
                                   <>

--- a/web/style.css
+++ b/web/style.css
@@ -932,50 +932,32 @@ body {
   max-height: 256px;
   overflow-y: auto;
   overscroll-behavior: contain;
-  padding: 2px 0 6px 20px;
 }
 
-.fsdb-views .sidebar-session-list {
-  padding-left: 20px;
+.fsdb-view-preview .chat-session-row > .chat-session-row-main {
+  padding-left: 11px;
 }
 
-.fsdb-views .sidebar-session-list .chat-session-row > .chat-session-row-main {
-  padding-left: 0;
-}
-
-.fsdb-view-preview-row {
-  display: flex;
-  width: 100%;
-  min-height: 32px;
-  align-items: center;
-  padding: 4px 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--dsw-sidebar-fg);
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.25rem;
-  text-align: left;
-  cursor: pointer;
-}
-
-.fsdb-view-preview-row:hover {
-  background: var(--dsw-hover);
-  color: var(--dsw-sidebar-fg-active);
+.sidebar-session-list .fsdb-view-preview .chat-session-row > .chat-session-row-main {
+  padding-left: 22px;
 }
 
 .fsdb-view-preview-hint,
 .fsdb-view-preview-more {
   display: block;
   width: 100%;
-  padding: 4px 8px;
+  padding: 4px 8px 4px 19px;
   border: 0;
   background: transparent;
   color: var(--dsw-label-3);
   font-size: 14px;
   line-height: 1.25rem;
   text-align: left;
+}
+
+.sidebar-session-list .fsdb-view-preview-hint,
+.sidebar-session-list .fsdb-view-preview-more {
+  padding-left: 30px;
 }
 
 .fsdb-view-preview-more {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据侧栏改回和聊天同一套路：整行 `::before` 铺满高亮，缩进只加在内容上（11px / 再一层 22px）。视图 Icon 放进 24px 盒，和标题 `gap-1.5`，不再把 Icon 甩在主按钮外面。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

