### PR TITLE
数据项行对齐表/视图，支持配置 emoji

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -127,6 +127,7 @@ test('every collection schema includes id, title, createdAt and updatedAt', asyn
   assert.equal(stat.schema.fields.createdAt?.type, 'datetime')
   assert.equal(stat.schema.fields.updatedAt?.label, '更新时间')
   assert.equal(stat.schema.fields.content?.type, 'file')
+  assert.equal(stat.schema.fields.emoji?.writable, true)
   assert.equal(stat.schema.contentField, 'content')
   await assert.rejects(() => db.write('/notes/n1', { createdAt: Date.now() }), /not writable/)
   await assert.rejects(() => db.write('/notes/n1', { id: 'other' }), /not writable/)

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -137,7 +137,7 @@ function viewForPath(collectionPath: string): SavedView | null {
 }
 
 function isListColumn(key: string) {
-  return key !== 'description' && key !== 'notes' && key !== 'content'
+  return key !== 'description' && key !== 'notes' && key !== 'content' && key !== 'emoji'
 }
 
 function toDatetimeLocal(value: unknown) {

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   ClipboardDocumentListIcon,
+  DocumentTextIcon,
   EyeIcon,
   ListBulletIcon,
   PencilSquareIcon,
@@ -27,11 +28,13 @@ import {
   getPreviewTotalsVersion,
   nextPreviewLimit,
   previewCacheKey,
+  recordPreviewEmoji,
   recordPreviewLabel,
   rememberPreviewTotal,
   SIDEBAR_PREVIEW_MAX,
   subscribePreviewTotals,
   viewTotalKey,
+  writeRecordEmoji,
 } from './sidebar-preview.ts'
 import {
   activeViewStorageKey,
@@ -93,6 +96,8 @@ function ViewModeGlyph({ mode }: { mode: ViewMode }) {
   return <ViewColumnsIcon aria-hidden className={cls} />
 }
 
+const RECORD_EMOJI_PRESETS = ['⭐', '🔥', '✅', '📌', '💡', '🎯', '📦', '🧩', '📄', '⚡']
+
 type PreviewState = { items: DbRecord[]; total: number; loading: boolean; error: string }
 
 const previewCache = new Map<string, { items: DbRecord[]; total: number }>()
@@ -116,6 +121,8 @@ function ViewRecordPreview({
     loading: !cached,
     error: '',
   }))
+  const [pickerId, setPickerId] = useState<string | null>(null)
+  const [emojiDraft, setEmojiDraft] = useState('')
 
   useEffect(() => {
     if (!open) return
@@ -142,6 +149,16 @@ function ViewRecordPreview({
       cancelled = true
     }
   }, [key, open, path, view.query, view.sortField, view.sortDir, view.filters])
+  useEffect(() => {
+    if (!pickerId) return
+    const onPointer = (event: MouseEvent) => {
+      const target = event.target
+      if (target instanceof Element && target.closest('.fsdb-emoji-picker, .fsdb-record-icon')) return
+      setPickerId(null)
+    }
+    document.addEventListener('mousedown', onPointer)
+    return () => document.removeEventListener('mousedown', onPointer)
+  }, [pickerId])
 
   async function loadMore() {
     const more = nextPreviewLimit(state.items.length, state.total)
@@ -159,23 +176,89 @@ function ViewRecordPreview({
     }
   }
 
+  async function saveEmoji(row: DbRecord, next: string) {
+    try {
+      const emoji = await writeRecordEmoji(path, row.id, next)
+      const items = state.items.map((item) => (item.id === row.id ? { ...item, emoji } : item))
+      previewCache.set(key, { items, total: state.total })
+      setState((prev) => ({ ...prev, items }))
+      setPickerId(null)
+      window.dispatchEvent(new Event('fsdb:change'))
+    } catch (err) {
+      setState((prev) => ({ ...prev, error: String(err) }))
+    }
+  }
+
   if (!open) return null
   const remaining = Math.max(0, state.total - state.items.length)
   const capped = state.items.length >= SIDEBAR_PREVIEW_MAX && remaining > 0
   return (
     <div className="fsdb-view-preview" role="list">
-      {state.items.map((row) => (
-        <div key={row.id} className="chat-session-row" role="listitem">
-          <button
-            type="button"
-            className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5"
-            title={recordPreviewLabel(row)}
-            onClick={() => onOpenRecord?.(row.id)}
-          >
-            <span className="min-w-0 flex-1 truncate font-medium">{recordPreviewLabel(row)}</span>
-          </button>
-        </div>
-      ))}
+      {state.items.map((row) => {
+        const emoji = recordPreviewEmoji(row)
+        return (
+          <div key={row.id} className="chat-session-row" role="listitem">
+            <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+              <span className="fsdb-record-icon relative grid size-6 shrink-0 place-items-center">
+                <button
+                  type="button"
+                  className="grid size-6 place-items-center border-0 bg-transparent p-0 text-[16px] leading-none text-inherit"
+                  title={emoji ? '更换图标' : '设置图标'}
+                  aria-label={emoji ? `更换 ${recordPreviewLabel(row)} 的图标` : `设置 ${recordPreviewLabel(row)} 的图标`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    setPickerId((prev) => (prev === row.id ? null : row.id))
+                    setEmojiDraft(emoji)
+                  }}
+                >
+                  {emoji ? <span className="fsdb-record-emoji">{emoji}</span> : <DocumentTextIcon aria-hidden className="size-4" />}
+                </button>
+                {pickerId === row.id ? (
+                  <div className="fsdb-emoji-picker" onClick={(event) => event.stopPropagation()}>
+                    <div className="fsdb-emoji-picker-presets">
+                      {RECORD_EMOJI_PRESETS.map((item) => (
+                        <button
+                          key={item}
+                          type="button"
+                          className="fsdb-emoji-picker-item"
+                          onClick={() => void saveEmoji(row, item)}
+                        >
+                          {item}
+                        </button>
+                      ))}
+                    </div>
+                    <input
+                      className="fsdb-emoji-picker-input"
+                      value={emojiDraft}
+                      placeholder="输入 emoji"
+                      maxLength={8}
+                      onChange={(event) => setEmojiDraft(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                          event.preventDefault()
+                          void saveEmoji(row, emojiDraft)
+                        }
+                        if (event.key === 'Escape') setPickerId(null)
+                      }}
+                    />
+                    <button type="button" className="fsdb-emoji-picker-clear" onClick={() => void saveEmoji(row, '')}>
+                      恢复默认
+                    </button>
+                  </div>
+                ) : null}
+              </span>
+              <button
+                type="button"
+                className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                title={recordPreviewLabel(row)}
+                onClick={() => onOpenRecord?.(row.id)}
+              >
+                {recordPreviewLabel(row)}
+              </button>
+            </div>
+          </div>
+        )
+      })}
       {state.loading && !state.items.length ? (
         <div className="fsdb-view-preview-hint">加载中…</div>
       ) : null}
@@ -472,7 +555,7 @@ export const DataSidebar = memo(function DataSidebar({
                         <div
                           role="button"
                           tabIndex={0}
-                          className="flex min-h-8 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md text-left text-[14px] font-medium tracking-normal text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
+                          className="flex min-h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-md text-left text-[14px] font-medium tracking-normal text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
                           title={name}
                           aria-expanded={open}
                           onClick={() => {
@@ -486,16 +569,18 @@ export const DataSidebar = memo(function DataSidebar({
                             }
                           }}
                         >
-                          <span className="sidebar-rail-icon sidebar-group-fold" aria-hidden>
-                            <span className="sidebar-group-fold-face">
-                              <TableGlyph icon={table.view?.icon} />
-                            </span>
-                            <span className="sidebar-group-fold-chevron">
-                              {open ? (
-                                <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
-                              ) : (
-                                <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
-                              )}
+                          <span className="grid size-6 shrink-0 place-items-center" aria-hidden>
+                            <span className="sidebar-rail-icon sidebar-group-fold">
+                              <span className="sidebar-group-fold-face">
+                                <TableGlyph icon={table.view?.icon} />
+                              </span>
+                              <span className="sidebar-group-fold-chevron">
+                                {open ? (
+                                  <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
+                                ) : (
+                                  <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
+                                )}
+                              </span>
                             </span>
                           </span>
                           <span className="min-w-0 flex-1 truncate">{name}</span>

--- a/packages/core-file-system/src/web/sidebar-preview.test.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   getPreviewTotal,
   nextPreviewLimit,
+  normalizeRecordEmoji,
   previewCacheKey,
   recordPreviewLabel,
   rememberPreviewTotal,
@@ -10,6 +11,12 @@ import {
   tableTotalKey,
   viewTotalKey,
 } from './sidebar-preview.ts'
+
+test('record emoji keeps a short grapheme and clears empty', () => {
+  assert.equal(normalizeRecordEmoji(' 🔥 '), '🔥')
+  assert.equal(normalizeRecordEmoji(''), '')
+  assert.equal(normalizeRecordEmoji('⭐🚀💥'), '⭐🚀')
+})
 
 test('record preview prefers label field then title', () => {
   assert.equal(recordPreviewLabel({ id: '1', title: '封面' }, 'title'), '封面')

--- a/packages/core-file-system/src/web/sidebar-preview.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.ts
@@ -13,6 +13,16 @@ export function previewCacheKey(path: string, view: Pick<SavedView, 'id' | 'sort
   return `${path}\0${view.id}\0${view.sortField}\0${view.sortDir}\0${JSON.stringify(view.filters ?? {})}\0${view.query ?? ''}`
 }
 
+export function normalizeRecordEmoji(value: unknown) {
+  const text = String(value ?? '').trim()
+  if (!text) return ''
+  return [...text].slice(0, 2).join('')
+}
+
+export function recordPreviewEmoji(row: DbRecord) {
+  return normalizeRecordEmoji(row.emoji)
+}
+
 export function recordPreviewLabel(row: DbRecord, labelField?: string) {
   if (labelField) {
     const labeled = row[labelField]
@@ -82,6 +92,18 @@ export async function fetchViewTotal(
   const page = await fetchViewPreview(path, view, 0, 1)
   rememberPreviewTotal(key, page.total)
   return page.total
+}
+
+export async function writeRecordEmoji(path: string, recordId: string, emoji: string) {
+  const next = normalizeRecordEmoji(emoji)
+  const res = await fetch('/api/db/write', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path: `${path}/${recordId}`, content: { emoji: next } }),
+  })
+  const body = (await res.json()) as { value?: DbRecord; error?: string }
+  if (!res.ok) throw new Error(body.error || res.statusText)
+  return normalizeRecordEmoji(body.value?.emoji ?? next)
 }
 
 export async function fetchViewPreview(

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -80,9 +80,10 @@ export const BUILTIN_FIELDS = {
   createdAt: { type: 'datetime', label: '创建时间' },
   updatedAt: { type: 'datetime', label: '更新时间' },
   content: { type: 'file', label: '内容' },
+  emoji: { type: 'string', label: '图标', writable: true },
 } as const satisfies Record<string, FieldSpec>
 
-export const BUILTIN_FIELD_KEYS = ['id', 'createdAt', 'updatedAt', 'content'] as const
+export const BUILTIN_FIELD_KEYS = ['id', 'createdAt', 'updatedAt', 'content', 'emoji'] as const
 
 export function withBuiltinFields(
   fields: Record<string, FieldSpec>,
@@ -94,6 +95,7 @@ export function withBuiltinFields(
   if (!next[labelField]) next[labelField] = { ...BUILTIN_FIELDS.title, label: labelField === 'title' ? '标题' : labelField }
   if (!next.createdAt) next.createdAt = BUILTIN_FIELDS.createdAt
   if (!next.updatedAt) next.updatedAt = BUILTIN_FIELDS.updatedAt
+  if (!next.emoji) next.emoji = BUILTIN_FIELDS.emoji
   if (contentField === 'content' && !next.content) next.content = BUILTIN_FIELDS.content
   const ordered: Record<string, FieldSpec> = {
     id: next.id,

--- a/web/style.css
+++ b/web/style.css
@@ -968,6 +968,78 @@ body {
   color: var(--dsw-sidebar-fg-active);
 }
 
+.fsdb-record-emoji {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.fsdb-emoji-picker {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 30;
+  width: 168px;
+  padding: 8px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 10px;
+  background: var(--dsw-sidebar);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+}
+
+.fsdb-emoji-picker-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.fsdb-emoji-picker-item {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.fsdb-emoji-picker-item:hover {
+  background: var(--dsw-hover);
+}
+
+.fsdb-emoji-picker-input {
+  box-sizing: border-box;
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px 8px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 14px;
+}
+
+.fsdb-emoji-picker-clear {
+  display: block;
+  width: 100%;
+  margin-top: 6px;
+  padding: 4px 0;
+  border: 0;
+  background: transparent;
+  color: var(--dsw-label-3);
+  font-size: 14px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.fsdb-emoji-picker-clear:hover {
+  color: var(--dsw-sidebar-fg-active);
+}
+
 /* 不推整行背景，只给会话内容加约 2/3 图标宽的左内边距 */
 .sidebar-session-list {
   padding-left: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表 / 视图 / 数据项都是 24px 图标盒 + gap-1.5 + 14px 标题。数据项默认文档符号；点击图标可选预设或输入 emoji，写入内置 `emoji` 字段，空则恢复默认。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

