### PR TITLE
fix(file-system): 右侧整块替换，详情不再出现在视图下面

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1489,7 +1489,9 @@ export function CollectionBrowser({
             ) : null}
           </div>
         </header>
-        <div className={`tasks-main fsdb-main${selected ? ' hidden' : ''}`} aria-hidden={Boolean(selected)}>
+        <div className="fsdb-right-body">
+        {!selected ? (
+        <div className="tasks-main fsdb-main">
         {!viewsOpen ? (
           <div className="fsdb-collection-head is-inline">
             <div className="fsdb-collection-name">{title}</div>
@@ -1991,7 +1993,7 @@ export function CollectionBrowser({
           </div>
         </div>
       </div>
-      {selected && schema ? (
+        ) : selected && schema ? (
         <div className="fsdb-detail-stage">
           <div className="fsdb-detail-screen" role="main" aria-label="记录详情">
             {detailTab !== 'overview' && chrome?.panes?.some((pane) => pane.id === detailTab) ? (
@@ -2109,6 +2111,7 @@ export function CollectionBrowser({
           </div>
         </div>
       ) : null}
+        </div>
       </div>
       {dlg?.kind === 'rename' ? (
         <AppDialog
@@ -2158,6 +2161,7 @@ if (typeof document !== 'undefined') {
 .fsdb-page{display:flex;min-width:0;min-height:0;flex:1;flex-direction:row;overflow:hidden;background:var(--dsw-bg);color:var(--dsw-label);font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji";font-size:14px;letter-spacing:-.011em}
 .fsdb-right{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-right .chat-view-header{flex:none}
+.fsdb-right-body{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-views{display:flex;width:280px;flex:none;flex-direction:column;min-height:0;overflow:hidden}
 .fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点侧栏或表格里的数据项时，右侧顶栏以下整块换成该项详情，不再把详情挂在当前视图（表格/列表）下面。

点视图或顶栏返回时，右侧再整块换回该视图。

根因：`.fsdb-main { display: flex }` 盖过了 Tailwind `hidden`，视图关不掉，详情只能叠在下面。现在改为互斥渲染，同一时间只挂视图或详情。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

