### PR TITLE
fix(file-system): 记录路由去掉多余的 view 段

### DIFF
--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -78,8 +78,7 @@ function CollectionPage(props: SlotProps) {
   const parsed = useMemo(() => parseAppPath(location.pathname, [DATA_MODULE]), [location.pathname])
   const collectionFromRoute =
     parsed.kind === 'collection-view' || parsed.kind === 'record' ? parsed.collection : ''
-  const viewFromRoute =
-    parsed.kind === 'collection-view' || parsed.kind === 'record' ? parsed.viewId : undefined
+  const viewFromRoute = parsed.kind === 'collection-view' ? parsed.viewId : undefined
   const recordFromRoute = parsed.kind === 'record' ? parsed.recordId : null
   const currentPath = collectionFromRoute || tables[0]?.path || ''
   const row = tables.find((item) => item.path === currentPath)
@@ -100,7 +99,6 @@ function CollectionPage(props: SlotProps) {
           moduleId: DATA_MODULE_ID,
           path: DATA_MODULE_PATH,
           collection: next.collection,
-          viewId: next.viewId,
           recordId: next.recordId,
         }),
         opts,
@@ -128,7 +126,7 @@ function CollectionPage(props: SlotProps) {
       go(
         {
           collection: parsed.collection,
-          viewId: parsed.viewId,
+          viewId: parsed.kind === 'collection-view' ? parsed.viewId : undefined,
           recordId: parsed.kind === 'record' ? parsed.recordId : null,
         },
         { replace: true },
@@ -190,10 +188,12 @@ function CollectionPage(props: SlotProps) {
       routeViewId={viewFromRoute}
       onOpenTable={(path, viewId) => go({ collection: path, viewId: viewId ?? defaultViewId(path) })}
       onOpenView={(viewId) => go({ collection: currentPath, viewId })}
-      onOpenRecord={(recordId, viewId, collection) =>
-        go({ collection: collection ?? currentPath, viewId: viewId ?? viewFromRoute, recordId })
+      onOpenRecord={(recordId, _viewId, collection) =>
+        go({ collection: collection ?? currentPath, recordId })
       }
-      onCloseRecord={() => go({ collection: currentPath, viewId: viewFromRoute }, { replace: true })}
+      onCloseRecord={() =>
+        go({ collection: currentPath, viewId: defaultViewId(currentPath) }, { replace: true })
+      }
     />
   )
 }

--- a/packages/core-file-system/src/web/inspector-nav.test.ts
+++ b/packages/core-file-system/src/web/inspector-nav.test.ts
@@ -7,7 +7,7 @@ const plugins = [{ id: 'database', label: '数据', path: '/database' }]
 
 test('view and record helpers match the database URL scheme', () => {
   assert.equal(databaseViewPath('/pages', 'default'), '/database/pages/view/default')
-  assert.equal(databaseRecordPath('/pages', 'rec-1', 'default'), '/database/pages/view/default/record/rec-1')
+  assert.equal(databaseRecordPath('/pages', 'rec-1'), '/database/pages/record/rec-1')
   assert.equal(parseAppPath(databaseViewPath('/pages', 'default'), plugins).kind, 'collection-view')
   assert.equal(parseAppPath(databaseRecordPath('/pages', 'rec-1'), plugins).kind, 'record')
 })

--- a/packages/core-file-system/src/web/inspector-nav.ts
+++ b/packages/core-file-system/src/web/inspector-nav.ts
@@ -11,12 +11,11 @@ export function databaseViewPath(collection: string, viewId?: string): string {
   })
 }
 
-export function databaseRecordPath(collection: string, recordId: string, viewId?: string): string {
+export function databaseRecordPath(collection: string, recordId: string): string {
   return buildAppPath({
     kind: 'record',
     ...DATABASE,
     collection,
-    viewId,
     recordId,
   } satisfies AppRoute)
 }

--- a/packages/web-session-view/src/web/session-route.test.ts
+++ b/packages/web-session-view/src/web/session-route.test.ts
@@ -61,7 +61,6 @@ test('database nested routes identify view vs record without touching /s/:id', (
     moduleId: 'database',
     path: '/database',
     collection: '/pages',
-    viewId: undefined,
     recordId: 'rec-1',
   })
   assert.deepEqual(parseAppPath('/database/pages/view/board/record/rec-1', plugins), {
@@ -69,7 +68,6 @@ test('database nested routes identify view vs record without touching /s/:id', (
     moduleId: 'database',
     path: '/database',
     collection: '/pages',
-    viewId: 'board',
     recordId: 'rec-1',
   })
   assert.deepEqual(parseAppPath('/database/c/pages/v/board/r/rec-1', plugins), {
@@ -77,11 +75,22 @@ test('database nested routes identify view vs record without touching /s/:id', (
     moduleId: 'database',
     path: '/database',
     collection: '/pages',
-    viewId: 'board',
     recordId: 'rec-1',
   })
   assert.equal(isLegacyDatabasePath('/database/c/pages/v/x'), true)
+  assert.equal(isLegacyDatabasePath('/database/pages/view/board/record/rec-1'), true)
   assert.equal(isLegacyDatabasePath('/database/pages/view/x'), false)
+  assert.equal(isLegacyDatabasePath('/database/pages/record/rec-1'), false)
+  assert.equal(
+    buildAppPath({
+      kind: 'record',
+      moduleId: 'database',
+      path: '/database',
+      collection: '/tasks',
+      recordId: 'task_mtdbgnqj_5022je',
+    }),
+    '/database/tasks/record/task_mtdbgnqj_5022je',
+  )
   assert.equal(parseAppPath('/s/rec-1', plugins).kind, 'session')
 })
 
@@ -116,7 +125,6 @@ test('buildAppPath round-trips with parseAppPath', () => {
       moduleId: 'database' as const,
       path: '/database',
       collection: '/pages',
-      viewId: 'v1',
       recordId: 'r1',
     },
   ]

--- a/packages/web-session-view/src/web/session-route.ts
+++ b/packages/web-session-view/src/web/session-route.ts
@@ -1,14 +1,12 @@
 /** URL = 中心舞台。
  * `/` | `/s/:id` | `/s/:id/debug` | 插件 path
  * 数据模块（默认 `/database`）：
- *   `/database` 集合入口
- *   `/database/:collection` 集合（默认/当前视图）
- *   `/database/:collection/view/:viewId` 已保存视图
- *   `/database/:collection/record/:recordId` 记录（中心页）
- *   `/database/:collection/view/:viewId/record/:recordId` 从某视图打开的记录（后退回视图）
- * 旧写法 `/database/c/.../v/.../r/...` 仍能解析，写入时改成上面这种。
- * `:collection` 为集合 path 去掉前导 `/` 再 encode（`/pages` → `pages`）。
- * 记录 id / 视图 id 不进聊天路由 `/s/:id`。
+ *   `/database` 入口
+ *   `/database/:type` 某张表
+ *   `/database/:type/view/:viewId` 某个视图（看记录时不要这一段）
+ *   `/database/:type/record/:recordId` 某条记录
+ * 旧写法 `/c/` `/v/` `/r/` 以及 view+record 叠在一起的路径仍能解析，写入时改成上面这种。
+ * `:type` 为集合 path 去掉前导 `/` 再 encode（`/pages` → `pages`）。
  */
 import { matchRegisteredModule, type AppModule } from '@biu/web-app-modules'
 
@@ -21,10 +19,11 @@ export type AppRoute =
   | { kind: 'session'; sessionId: string; view: RouteView }
   | { kind: 'module'; moduleId: string; path: string }
   | { kind: 'collection-view'; moduleId: string; path: string; collection: string; viewId?: string }
-  | { kind: 'record'; moduleId: string; path: string; collection: string; viewId?: string; recordId: string }
+  | { kind: 'record'; moduleId: string; path: string; collection: string; recordId: string }
 
-const DATABASE_SEG =
-  /^\/(?:c\/)?([^/]+)(?:\/(?:v|view)\/([^/]+))?(?:\/(?:r|record)\/([^/]+))?$/
+const DATABASE_FLAT = /^\/(?:c\/)?([^/]+)(?:\/(?:view|v)\/([^/]+)|\/(?:record|r)\/([^/]+))?$/
+const DATABASE_NESTED_RECORD =
+  /^\/(?:c\/)?([^/]+)\/(?:view|v)\/[^/]+\/(?:record|r)\/([^/]+)$/
 
 export function encodeCollectionSeg(path: string) {
   return encodeURIComponent(normalizeCollectionKey(path).replace(/^\//, ''))
@@ -48,7 +47,7 @@ export function isLegacyDatabasePath(pathname: string, modulePath = '/database')
   const base = normalizePath(modulePath)
   if (path === base || !path.startsWith(`${base}/`)) return false
   const rest = path.slice(base.length)
-  return /^\/c\//.test(rest) || /\/(?:v|r)\//.test(rest)
+  return /^\/c\//.test(rest) || /\/(?:v|r)\//.test(rest) || /\/view\/[^/]+\/record\//.test(rest)
 }
 
 export function parseDatabaseRest(pathname: string, module: AppModule): AppRoute | null {
@@ -57,13 +56,23 @@ export function parseDatabaseRest(pathname: string, module: AppModule): AppRoute
   if (path === base) return null
   if (!path.startsWith(`${base}/`)) return null
   const rest = path.slice(base.length)
-  const match = rest.match(DATABASE_SEG)
+  const nested = rest.match(DATABASE_NESTED_RECORD)
+  if (nested?.[1] && nested[2]) {
+    return {
+      kind: 'record',
+      moduleId: module.id,
+      path: base,
+      collection: decodeCollectionSeg(nested[1]),
+      recordId: decodeURIComponent(nested[2]),
+    }
+  }
+  const match = rest.match(DATABASE_FLAT)
   if (!match?.[1]) return { kind: 'module', moduleId: module.id, path: base }
   const collection = decodeCollectionSeg(match[1])
   const viewId = match[2] ? decodeURIComponent(match[2]) : undefined
   const recordId = match[3] ? decodeURIComponent(match[3]) : undefined
   if (recordId) {
-    return { kind: 'record', moduleId: module.id, path: base, collection, viewId, recordId }
+    return { kind: 'record', moduleId: module.id, path: base, collection, recordId }
   }
   return { kind: 'collection-view', moduleId: module.id, path: base, collection, viewId }
 }
@@ -99,9 +108,9 @@ export function buildAppPath(route: AppRoute): string {
   if (route.kind === 'module') return route.path || `/${route.moduleId}`
   if (route.kind === 'collection-view' || route.kind === 'record') {
     const base = route.path || `/${route.moduleId}`
-    let next = `${normalizePath(base)}/${encodeCollectionSeg(route.collection)}`
-    if (route.viewId) next += `/view/${encodeURIComponent(route.viewId)}`
-    if (route.kind === 'record') next += `/record/${encodeURIComponent(route.recordId)}`
+    const next = `${normalizePath(base)}/${encodeCollectionSeg(route.collection)}`
+    if (route.kind === 'record') return `${next}/record/${encodeURIComponent(route.recordId)}`
+    if (route.viewId) return `${next}/view/${encodeURIComponent(route.viewId)}`
     return next
   }
   if (route.view === 'debug') return `/s/${encodeURIComponent(route.sessionId)}/debug`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
看一条记录时地址不再夹一段无意义的 view id。

现在只有三种：

- `/database/tasks` 表
- `/database/tasks/view/…` 视图
- `/database/tasks/record/task_xxx` 记录

你举的 `/database/tasks/view/1787983501816/record/task_mtdbgnqj_5022je` 会自动收成 `/database/tasks/record/task_mtdbgnqj_5022je`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

