### PR TITLE
fix(file-system): 点记录不收起侧栏展开的视图

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -445,6 +445,8 @@ export function CollectionBrowser({
   databaseUi,
   routeRecordId = null,
   routeViewId,
+  expandedViewKey,
+  onExpandedViewKeyChange,
   onOpenView,
   onOpenRecord,
   onCloseRecord,
@@ -459,6 +461,8 @@ export function CollectionBrowser({
   databaseUi?: DatabaseUiService
   routeRecordId?: string | null
   routeViewId?: string
+  expandedViewKey?: string | null
+  onExpandedViewKeyChange?: (key: string | null) => void
   onOpenView?: (viewId: string) => void
   onOpenRecord?: (recordId: string, viewId?: string | null, collection?: string) => void
   onCloseRecord?: () => void
@@ -677,7 +681,7 @@ export function CollectionBrowser({
       setQuery('')
       setFilters({})
     }
-  }, [collectionPath, routeViewId])
+  }, [collectionPath])
 
   useEffect(() => {
     let debounce = 0
@@ -1454,6 +1458,8 @@ export function CollectionBrowser({
           onOpenRecord={(path, view, recordId) => {
             onOpenRecord?.(recordId, view.id, path)
           }}
+          expandedViewKey={expandedViewKey}
+          onExpandedViewKeyChange={onExpandedViewKeyChange}
         />
       ) : null}
       <div className="fsdb-right">

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -312,6 +312,8 @@ export const DataSidebar = memo(function DataSidebar({
   onAddView,
   onCopyView,
   onOpenRecord,
+  expandedViewKey: expandedViewKeyProp,
+  onExpandedViewKeyChange,
 }: {
   tables: CollectionInfo[]
   collectionPath: string
@@ -325,6 +327,8 @@ export const DataSidebar = memo(function DataSidebar({
   onAddView: () => void
   onCopyView: () => void
   onOpenRecord?: (path: string, view: SavedView, recordId: string) => void
+  expandedViewKey?: string | null
+  onExpandedViewKeyChange?: (key: string | null) => void
 }) {
   const listedTables = useMemo(
     () => (tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]),
@@ -341,7 +345,9 @@ export const DataSidebar = memo(function DataSidebar({
     }
   })
   const [dataOpen, setDataOpen] = useState(true)
-  const [expandedViewKey, setExpandedViewKey] = useState<string | null>(null)
+  const [expandedViewKeyLocal, setExpandedViewKeyLocal] = useState<string | null>(null)
+  const expandedViewKey = expandedViewKeyProp !== undefined ? expandedViewKeyProp : expandedViewKeyLocal
+  const setExpandedViewKey = onExpandedViewKeyChange ?? setExpandedViewKeyLocal
   usePreviewTotalsVersion()
 
   function viewsFor(path: string) {

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useSyncExternalStore, type ComponentType } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore, type ComponentType } from 'react'
 import type { Context } from 'cordis'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CircleStackIcon } from '@heroicons/react/16/solid'
@@ -75,6 +75,7 @@ function CollectionPage(props: SlotProps) {
   const ui = props.databaseUi as DatabaseUiService | undefined
   const location = useLocation()
   const navigate = useNavigate()
+  const [expandedViewKey, setExpandedViewKey] = useState<string | null>(null)
   const parsed = useMemo(() => parseAppPath(location.pathname, [DATA_MODULE]), [location.pathname])
   const collectionFromRoute =
     parsed.kind === 'collection-view' || parsed.kind === 'record' ? parsed.collection : ''
@@ -186,6 +187,8 @@ function CollectionPage(props: SlotProps) {
       databaseUi={ui}
       routeRecordId={recordFromRoute}
       routeViewId={viewFromRoute}
+      expandedViewKey={expandedViewKey}
+      onExpandedViewKeyChange={setExpandedViewKey}
       onOpenTable={(path, viewId) => go({ collection: path, viewId: viewId ?? defaultViewId(path) })}
       onOpenView={(viewId) => go({ collection: currentPath, viewId })}
       onOpenRecord={(recordId, _viewId, collection) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点侧栏展开后的记录，只换右边详情，展开的视图列表保持开着。

展开状态提到数据页这一层保存，不再跟着右侧详情重挂一起丢掉。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

