### PR TITLE
fix(file-system): 点记录不自动收起，点箭头仍能折叠

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -412,7 +412,9 @@ export const DataSidebar = memo(function DataSidebar({
   }
 
   function toggleViewPreview(key: string) {
-    setExpandedViewKey((prev) => (prev === key ? null : key))
+    const next = expandedViewKey === key ? null : key
+    if (onExpandedViewKeyChange) onExpandedViewKeyChange(next)
+    else setExpandedViewKeyLocal(next)
   }
 
   function openRecord(path: string, view: SavedView, recordId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点预览里的记录：只打开详情，视图保持展开（这是原来的 bug）。

点视图左边的折叠箭头：仍然可以手动展开/收起。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

