### PR TITLE
feat(file-system): 中间顶栏加上侧栏展开/收起，布局对齐聊天

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -11,6 +11,8 @@ import {
   CalendarDaysIcon,
   CheckCircleIcon,
   CheckIcon,
+  ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -538,19 +540,23 @@ export function CollectionBrowser({
   const searchInputRef = useRef<HTMLInputElement>(null)
   const searchExpanded = searchOpen || query.length > 0
 
+  function toggleViewsOpen() {
+    setViewsOpen((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem(`fsdb.viewsOpen:${moduleId || collectionPath}`, next ? '1' : '0')
+      } catch {
+        /* ignore */
+      }
+      return next
+    })
+  }
+
   useEffect(() => {
     function onToggle(event: Event) {
       const id = (event as CustomEvent<{ id?: string }>).detail?.id
       if (!id || (moduleId && id !== moduleId)) return
-      setViewsOpen((prev) => {
-        const next = !prev
-        try {
-          localStorage.setItem(`fsdb.viewsOpen:${moduleId || collectionPath}`, next ? '1' : '0')
-        } catch {
-          /* ignore */
-        }
-        return next
-      })
+      toggleViewsOpen()
     }
     window.addEventListener('biu:toggle-module-sidebar', onToggle)
     return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
@@ -1465,9 +1471,15 @@ export function CollectionBrowser({
       <div className="fsdb-right">
         <header className="chat-view-header" data-biu-ignore>
           <div className="chat-view-header-left">
-            <span className="min-w-0 truncate text-[13px] font-semibold">
-              {selected ? labelOf(selected) : (activeView?.name ?? title)}
-            </span>
+            <div
+              className="chat-view-project"
+              title={selected ? labelOf(selected) : (blurb || title)}
+            >
+              <CircleStackIcon aria-hidden className="chat-view-project-icon" />
+              <span className="chat-view-project-name">
+                {selected ? labelOf(selected) : (activeView?.name ?? title)}
+              </span>
+            </div>
           </div>
           <div className="chat-view-header-right">
             {selected ? <RecordActions row={selected} place="detail" /> : null}
@@ -1483,6 +1495,20 @@ export function CollectionBrowser({
                 <StarIcon aria-hidden className={`size-4${viewStarred ? ' text-[#f5b700]' : ''}`} />
               </button>
             ) : null}
+            <button
+              type="button"
+              className={`chat-view-header-expand${viewsOpen ? ' is-active' : ''}`}
+              title={viewsOpen ? '收起左侧边栏' : '展开左侧边栏'}
+              aria-label={viewsOpen ? '收起左侧边栏' : '展开左侧边栏'}
+              aria-pressed={viewsOpen}
+              onClick={toggleViewsOpen}
+            >
+              {viewsOpen ? (
+                <ChevronDoubleLeftIcon aria-hidden className="size-4" />
+              ) : (
+                <ChevronDoubleRightIcon aria-hidden className="size-4" />
+              )}
+            </button>
             {selected ? (
               <button
                 type="button"
@@ -1499,12 +1525,6 @@ export function CollectionBrowser({
         <div className="fsdb-right-body">
         {!selected ? (
         <div className="tasks-main fsdb-main">
-        {!viewsOpen ? (
-          <div className="fsdb-collection-head is-inline">
-            <div className="fsdb-collection-name">{title}</div>
-            {blurb ? <p className="fsdb-footnote">{blurb}</p> : null}
-          </div>
-        ) : null}
         <div className="tasks-toolbar" data-biu-ignore>
           <div className="tasks-toolbar-left">
             <div className="tasks-viewdd-wrap" ref={viewRef}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
文件系统中间顶栏按聊天窗口同一套布局：

- 左边：当前视图或记录的说明文字
- 右边：收藏等配置，以及展开/收起左侧数据边栏的按钮

收起侧栏后，点双箭头还能再打开。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

