### PR TITLE
test(file-system): 侧栏展开与路由切换压测

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -47,6 +47,7 @@ import {
   toggleStarredView,
 } from './view-storage.ts'
 import { pickDomAttrs, recordPickKind, viewPickId } from './pick-dom.ts'
+import { toggleExpandedViewKey } from './sidebar-nav.ts'
 
 const SIDEBAR_BRAND_GRADIENT =
   'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
@@ -412,7 +413,7 @@ export const DataSidebar = memo(function DataSidebar({
   }
 
   function toggleViewPreview(key: string) {
-    const next = expandedViewKey === key ? null : key
+    const next = toggleExpandedViewKey(expandedViewKey, key)
     if (onExpandedViewKeyChange) onExpandedViewKeyChange(next)
     else setExpandedViewKeyLocal(next)
   }

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -5,7 +5,8 @@ import { CircleStackIcon } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/type-slots'
 import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
-import { buildAppPath, isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
+import { isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
+import { pathForCenter } from './sidebar-nav.ts'
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseUiService } from './database-ui.ts'
 import {
@@ -93,26 +94,11 @@ function CollectionPage(props: SlotProps) {
     next: { collection: string; viewId?: string; recordId?: string | null },
     opts?: { replace?: boolean },
   ) => {
-    if (next.recordId) {
-      navigate(
-        buildAppPath({
-          kind: 'record',
-          moduleId: DATA_MODULE_ID,
-          path: DATA_MODULE_PATH,
-          collection: next.collection,
-          recordId: next.recordId,
-        }),
-        opts,
-      )
-      return
-    }
     navigate(
-      buildAppPath({
-        kind: 'collection-view',
-        moduleId: DATA_MODULE_ID,
-        path: DATA_MODULE_PATH,
+      pathForCenter({
         collection: next.collection,
         viewId: next.viewId,
+        recordId: next.recordId ?? undefined,
       }),
       opts,
     )

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -1,0 +1,151 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { parseAppPath } from '@biu/web-session-view'
+import {
+  applySidebarAction,
+  assertSidebarInvariants,
+  parseCenterPath,
+  pathForCenter,
+  previewKey,
+  starPreviewKey,
+  toggleExpandedViewKey,
+  type SidebarNavAction,
+  type SidebarNavState,
+} from './sidebar-nav.ts'
+
+const plugins = [{ id: 'database', label: '数据', path: '/database' }]
+
+const TABLES = ['/tasks', '/pages'] as const
+const VIEWS: Record<(typeof TABLES)[number], string[]> = {
+  '/tasks': ['1787983501816', 'board'],
+  '/pages': ['default', 'list'],
+}
+const RECORDS: Record<(typeof TABLES)[number], string[]> = {
+  '/tasks': ['task_mtdbgnqj_5022je', 'task_other'],
+  '/pages': ['page-1', 'page-2'],
+}
+
+function seedState(): SidebarNavState {
+  return {
+    collection: '/tasks',
+    viewId: '1787983501816',
+    lastViewId: '1787983501816',
+    viewsOpen: true,
+    expandedViewKey: null,
+    openTables: { '/tasks': true },
+  }
+}
+
+function randomOf<T>(rand: () => number, items: readonly T[]) {
+  return items[Math.floor(rand() * items.length)]!
+}
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0
+  return () => {
+    a += 0x6d2b79f5
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function randomAction(rand: () => number, state: SidebarNavState): SidebarNavAction {
+  const table = randomOf(rand, TABLES)
+  const viewId = randomOf(rand, VIEWS[table])
+  const recordId = randomOf(rand, RECORDS[table])
+  const kinds: SidebarNavAction['type'][] = [
+    'toggle-preview',
+    'toggle-sidebar',
+    'toggle-table',
+    'open-view',
+    'open-record',
+    'close-record',
+    'open-table',
+  ]
+  const type = randomOf(rand, kinds)
+  if (type === 'toggle-preview') {
+    const key = rand() < 0.5 ? previewKey(table, viewId) : starPreviewKey(table, viewId)
+    return { type, key }
+  }
+  if (type === 'toggle-sidebar') return { type }
+  if (type === 'toggle-table') return { type, path: table }
+  if (type === 'open-view') return { type, path: table, viewId }
+  if (type === 'open-record') return { type, path: table, viewId, recordId }
+  if (type === 'close-record') return { type }
+  return { type: 'open-table', path: table, viewId }
+}
+
+test('toggleExpandedViewKey 点两次回到原状，不会卡在展开', () => {
+  const key = previewKey('/tasks', 'board')
+  assert.equal(toggleExpandedViewKey(null, key), key)
+  assert.equal(toggleExpandedViewKey(key, key), null)
+  assert.equal(toggleExpandedViewKey(key, previewKey('/pages', 'default')), previewKey('/pages', 'default'))
+})
+
+test('点记录只换记录路由，不带 view，也不收起预览', () => {
+  const before: SidebarNavState = {
+    ...seedState(),
+    expandedViewKey: previewKey('/tasks', '1787983501816'),
+  }
+  const action: SidebarNavAction = {
+    type: 'open-record',
+    path: '/tasks',
+    viewId: 'board',
+    recordId: 'task_mtdbgnqj_5022je',
+  }
+  const after = applySidebarAction(before, action)
+  assertSidebarInvariants(before, action, after)
+  assert.equal(after.expandedViewKey, before.expandedViewKey)
+  assert.equal(pathForCenter(after), '/database/tasks/record/task_mtdbgnqj_5022je')
+  assert.equal(parseAppPath(pathForCenter(after), plugins).kind, 'record')
+})
+
+test('点展开箭头不改路由；点侧栏开关不改路由', () => {
+  const before = seedState()
+  const expand = applySidebarAction(before, { type: 'toggle-preview', key: previewKey('/tasks', 'board') })
+  assertSidebarInvariants(before, { type: 'toggle-preview', key: previewKey('/tasks', 'board') }, expand)
+  const fold = applySidebarAction(expand, { type: 'toggle-preview', key: previewKey('/tasks', 'board') })
+  assert.equal(fold.expandedViewKey, null)
+  const hidden = applySidebarAction(expand, { type: 'toggle-sidebar' })
+  assertSidebarInvariants(expand, { type: 'toggle-sidebar' }, hidden)
+  assert.equal(pathForCenter(hidden), pathForCenter(expand))
+})
+
+test('从记录返回回到上次视图，展开状态仍在', () => {
+  let state = { ...seedState(), expandedViewKey: previewKey('/tasks', '1787983501816') }
+  state = applySidebarAction(state, {
+    type: 'open-record',
+    path: '/tasks',
+    viewId: 'board',
+    recordId: 'task_mtdbgnqj_5022je',
+  })
+  const closed = applySidebarAction(state, { type: 'close-record' })
+  assertSidebarInvariants(state, { type: 'close-record' }, closed)
+  assert.equal(closed.recordId, undefined)
+  assert.equal(closed.viewId, '1787983501816')
+  assert.equal(closed.expandedViewKey, previewKey('/tasks', '1787983501816'))
+  assert.equal(pathForCenter(closed), '/database/tasks/view/1787983501816')
+})
+
+test('压测：随机切换表/视图/记录/展开，路由与展开不串台', () => {
+  const seeds = [1, 7, 42, 99, 20260830]
+  const steps = 400
+  for (const seed of seeds) {
+    const rand = mulberry32(seed)
+    let state = seedState()
+    for (let i = 0; i < steps; i++) {
+      const action = randomAction(rand, state)
+      const next = applySidebarAction(state, action)
+      try {
+        assertSidebarInvariants(state, action, next)
+      } catch (err) {
+        throw new Error(`seed=${seed} step=${i} action=${JSON.stringify(action)}: ${String(err)}`)
+      }
+      const parsed = parseCenterPath(pathForCenter(next))
+      assert.ok(parsed, `seed=${seed} 路径解析失败 ${pathForCenter(next)}`)
+      state = next
+    }
+  }
+})

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -1,0 +1,145 @@
+/** 侧栏展开/收起与数据路由切换的纯逻辑，UI 和压测共用。 */
+import { parseAppPath } from '@biu/web-session-view'
+import { databaseRecordPath, databaseViewPath } from './inspector-nav.ts'
+
+const DATABASE = [{ id: 'database', label: '数据', path: '/database' }]
+
+export type DataCenter = {
+  collection: string
+  viewId?: string
+  recordId?: string
+  lastViewId?: string
+}
+
+export type SidebarChrome = {
+  viewsOpen: boolean
+  expandedViewKey: string | null
+  openTables: Record<string, boolean>
+}
+
+export type SidebarNavState = DataCenter & SidebarChrome
+
+export type SidebarNavAction =
+  | { type: 'toggle-preview'; key: string }
+  | { type: 'toggle-sidebar' }
+  | { type: 'toggle-table'; path: string }
+  | { type: 'open-view'; path: string; viewId: string }
+  | { type: 'open-record'; path: string; viewId: string; recordId: string }
+  | { type: 'close-record' }
+  | { type: 'open-table'; path: string; viewId?: string }
+
+export function previewKey(path: string, viewId: string) {
+  return `${path}:${viewId}`
+}
+
+export function starPreviewKey(path: string, viewId: string) {
+  return `star:${path}:${viewId}`
+}
+
+/** 点箭头：只切这一个 key。点记录不得走这里。 */
+export function toggleExpandedViewKey(current: string | null, key: string) {
+  return current === key ? null : key
+}
+
+export function pathForCenter(center: Pick<DataCenter, 'collection' | 'viewId' | 'recordId'>) {
+  if (center.recordId) return databaseRecordPath(center.collection, center.recordId)
+  return databaseViewPath(center.collection, center.viewId)
+}
+
+export function parseCenterPath(pathname: string): DataCenter | null {
+  const parsed = parseAppPath(pathname, DATABASE)
+  if (parsed.kind === 'record') {
+    return { collection: parsed.collection, recordId: parsed.recordId }
+  }
+  if (parsed.kind === 'collection-view') {
+    return { collection: parsed.collection, viewId: parsed.viewId }
+  }
+  return null
+}
+
+export function applySidebarAction(state: SidebarNavState, action: SidebarNavAction): SidebarNavState {
+  if (action.type === 'toggle-preview') {
+    return { ...state, expandedViewKey: toggleExpandedViewKey(state.expandedViewKey, action.key) }
+  }
+  if (action.type === 'toggle-sidebar') {
+    return { ...state, viewsOpen: !state.viewsOpen }
+  }
+  if (action.type === 'toggle-table') {
+    return {
+      ...state,
+      openTables: { ...state.openTables, [action.path]: !state.openTables[action.path] },
+    }
+  }
+  if (action.type === 'open-table') {
+    return {
+      ...state,
+      collection: action.path,
+      viewId: action.viewId,
+      recordId: undefined,
+      lastViewId: action.viewId ?? state.lastViewId,
+      openTables: { ...state.openTables, [action.path]: true },
+    }
+  }
+  if (action.type === 'open-view') {
+    return {
+      ...state,
+      collection: action.path,
+      viewId: action.viewId,
+      recordId: undefined,
+      lastViewId: action.viewId,
+      openTables: { ...state.openTables, [action.path]: true },
+    }
+  }
+  if (action.type === 'open-record') {
+    const sameCollection = action.path === state.collection
+    return {
+      ...state,
+      collection: action.path,
+      recordId: action.recordId,
+      viewId: undefined,
+      lastViewId: sameCollection ? (state.recordId ? state.lastViewId : state.viewId) : undefined,
+      openTables: { ...state.openTables, [action.path]: true },
+    }
+  }
+  const backTo = state.lastViewId
+  return {
+    ...state,
+    recordId: undefined,
+    viewId: backTo,
+  }
+}
+
+export function assertSidebarInvariants(before: SidebarNavState, action: SidebarNavAction, after: SidebarNavState) {
+  const path = pathForCenter(after)
+  const parsed = parseCenterPath(path)
+  if (!parsed) throw new Error(`无法解析路径 ${path}`)
+  if (after.recordId) {
+    if (path.includes('/view/')) throw new Error(`记录路径不应带 view：${path}`)
+    if (parsed.recordId !== after.recordId) throw new Error(`记录 id 与路径不一致：${path}`)
+    if (parsed.collection !== after.collection) throw new Error(`记录集合与路径不一致：${path}`)
+  } else if (after.viewId) {
+    if (path.includes('/record/')) throw new Error(`视图路径不应带 record：${path}`)
+    if (parsed.viewId !== after.viewId) throw new Error(`视图 id 与路径不一致：${path}`)
+  }
+  if (action.type === 'open-record' || action.type === 'close-record') {
+    if (after.expandedViewKey !== before.expandedViewKey) {
+      throw new Error('点记录或返回不得改展开状态')
+    }
+    if (after.viewsOpen !== before.viewsOpen) {
+      throw new Error('点记录或返回不得改侧栏开关')
+    }
+  }
+  if (action.type === 'toggle-preview') {
+    if (after.expandedViewKey !== toggleExpandedViewKey(before.expandedViewKey, action.key)) {
+      throw new Error('展开切换结果不对')
+    }
+    if (pathForCenter(after) !== pathForCenter(before)) {
+      throw new Error('点展开箭头不得改路由')
+    }
+  }
+  if (action.type === 'toggle-sidebar') {
+    if (after.viewsOpen === before.viewsOpen) throw new Error('侧栏开关未翻转')
+    if (pathForCenter(after) !== pathForCenter(before)) throw new Error('收起侧栏不得改路由')
+    if (after.expandedViewKey !== before.expandedViewKey) throw new Error('收起整栏不得改视图展开')
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
单独抽了侧栏展开和数据路由的纯逻辑，并加了压测：

- 点记录：路径只有 `/database/类型/record/id`，不带 view，展开状态不变
- 点箭头：只切展开，不改路由
- 收起整栏：不改路由、不改某个视图的展开
- 5 组随机种子 × 400 步，连打切表 / 切视图 / 开记录 / 展开收起

跑法：`npx vitest run packages/core-file-system/src/web/sidebar-nav.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

