### PR TITLE
feat(file-system): 顶栏面包屑可切换，去掉关闭叉

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -39,7 +39,6 @@ import {
   TableCellsIcon,
   TrashIcon,
   ViewColumnsIcon,
-  XMarkIcon,
 } from '@heroicons/react/16/solid'
 import type { CollectionActionInfo, CollectionInfo, CollectionSchema, DbRecord, FieldSpec, FieldType } from '@biu/type-file-system'
 import { asAttachment, asHttpHref, asImageSrc } from '@biu/type-file-system'
@@ -65,6 +64,7 @@ import {
 } from './fields'
 import { AppDialog, CellSelect, CheckRow, LocalText, TokenMultiSelect } from './controls.tsx'
 import { DataSidebar } from './data-sidebar.tsx'
+import { buildCrumbs, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 import { pickDomAttrs, recordPickKind } from './pick-dom.ts'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
 import {
@@ -152,6 +152,14 @@ function viewForPath(collectionPath: string, routeViewId?: string): SavedView | 
 
 function isListColumn(key: string) {
   return key !== 'description' && key !== 'notes' && key !== 'content' && key !== 'emoji'
+}
+
+function CrumbGlyph({ kind }: { kind: Crumb['kind'] }) {
+  const cls = 'chat-view-project-icon'
+  if (kind === 'record') return <DocumentTextIcon aria-hidden className={cls} />
+  if (kind === 'view') return <Squares2X2Icon aria-hidden className={cls} />
+  if (kind === 'collection') return <TableCellsIcon aria-hidden className={cls} />
+  return <CircleStackIcon aria-hidden className={cls} />
 }
 
 function toDatetimeLocal(value: unknown) {
@@ -452,6 +460,7 @@ export function CollectionBrowser({
   onOpenView,
   onOpenRecord,
   onCloseRecord,
+  onCrumbTarget,
 }: {
   moduleId?: string
   collectionPath: string
@@ -468,6 +477,7 @@ export function CollectionBrowser({
   onOpenView?: (viewId: string) => void
   onOpenRecord?: (recordId: string, viewId?: string | null, collection?: string) => void
   onCloseRecord?: () => void
+  onCrumbTarget?: (target: CrumbTarget) => void
 }) {
   const [stat, setStat] = useState<StatResult | null>(null)
   const [items, setItems] = useState<Array<DbRecord & { path?: string }>>([])
@@ -536,6 +546,8 @@ export function CollectionBrowser({
     | null
   >(null)
   const [dlgError, setDlgError] = useState('')
+  const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
+  const crumbRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<HTMLDivElement>(null)
   const modeRef = useRef<HTMLDivElement>(null)
   const sortRef = useRef<HTMLDivElement>(null)
@@ -589,6 +601,7 @@ export function CollectionBrowser({
       const target = event.target as Node
       if (!searchRef.current?.contains(target) && !query) setSearchOpen(false)
       if (
+        crumbRef.current?.contains(target) ||
         viewRef.current?.contains(target) ||
         modeRef.current?.contains(target) ||
         sortRef.current?.contains(target) ||
@@ -599,6 +612,7 @@ export function CollectionBrowser({
       ) {
         return
       }
+      setCrumbOpen(null)
       setViewMenuOpen(false)
       setModeMenuOpen(false)
       setSortMenuOpen(false)
@@ -1156,6 +1170,21 @@ export function CollectionBrowser({
   }
 
   const labelOf = (row: DbRecord) => String(row[schema?.labelField ?? 'id'] ?? row.id)
+  const crumbs = useMemo(
+    () =>
+      buildCrumbs({
+        collection: collectionPath,
+        collectionLabel: title,
+        tables: tables.map((table) => ({ path: table.path, label: table.view?.title ?? table.label })),
+        viewId: selected ? undefined : routeViewId,
+        viewName: selected ? undefined : activeView?.name,
+        views: views.map((view) => ({ id: view.id, name: view.name })),
+        recordId: selected?.id,
+        recordLabel: selected ? labelOf(selected) : undefined,
+        records: items.map((row) => ({ id: row.id, label: labelOf(row) })),
+      }),
+    [activeView?.name, collectionPath, items, routeViewId, selected, tables, title, views],
+  )
   const currentTable = tables.find((item) => item.path === collectionPath)
   const recordKind = recordPickKind(currentTable?.view?.moduleId)
   const recordPick = (row: DbRecord) => pickDomAttrs(recordKind, row.id, labelOf(row))
@@ -1493,15 +1522,56 @@ export function CollectionBrowser({
       <div className="fsdb-right">
         <header className="chat-view-header" data-biu-ignore>
           <div className="chat-view-header-left">
-            <div
-              className="chat-view-project"
-              title={selected ? labelOf(selected) : (blurb || title)}
-            >
-              <CircleStackIcon aria-hidden className="chat-view-project-icon" />
-              <span className="chat-view-project-name">
-                {selected ? labelOf(selected) : (activeView?.name ?? title)}
-              </span>
-            </div>
+            <nav className="fsdb-crumbs" aria-label="位置" ref={crumbRef}>
+              {crumbs.map((crumb, index) => (
+                <span key={crumb.id} className="fsdb-crumb">
+                  {index ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
+                  <button
+                    type="button"
+                    className="fsdb-crumb-btn"
+                    title={crumb.label}
+                    onClick={() => {
+                      onCrumbTarget?.(crumb.target)
+                      setCrumbOpen(null)
+                    }}
+                  >
+                    <CrumbGlyph kind={crumb.kind} />
+                    <span className="chat-view-project-name">{crumb.label}</span>
+                  </button>
+                  {crumb.choices.length > 1 ? (
+                    <span className="fsdb-crumb-pick">
+                      <button
+                        type="button"
+                        className="chat-view-header-expand"
+                        aria-label={`切换${crumb.label}`}
+                        aria-expanded={crumbOpen === crumb.id}
+                        onClick={() => setCrumbOpen((prev) => (prev === crumb.id ? null : crumb.id))}
+                      >
+                        <ChevronDownIcon aria-hidden className="size-4" />
+                      </button>
+                      {crumbOpen === crumb.id ? (
+                        <div className="fsdb-crumb-menu" role="menu">
+                          {crumb.choices.map((choice) => (
+                            <button
+                              key={choice.id}
+                              type="button"
+                              className={`fsdb-crumb-option${choice.id === crumb.id ? ' is-active' : ''}`}
+                              role="menuitem"
+                              onClick={() => {
+                                onCrumbTarget?.(choice.target)
+                                setCrumbOpen(null)
+                              }}
+                            >
+                              {choice.label}
+                            </button>
+                          ))}
+                        </div>
+                      ) : null}
+                    </span>
+                  ) : null}
+                </span>
+              ))}
+            </nav>
           </div>
           <div className="chat-view-header-right">
             {selected ? <RecordActions row={selected} place="detail" /> : null}
@@ -1532,17 +1602,6 @@ export function CollectionBrowser({
                 <ChevronDoubleLeftIcon aria-hidden className="size-4" />
               )}
             </button>
-            {selected ? (
-              <button
-                type="button"
-                className="chat-view-header-expand"
-                title="返回视图 (Esc)"
-                aria-label="返回视图"
-                onClick={() => setDetailId(null)}
-              >
-                <XMarkIcon aria-hidden className="size-4" />
-              </button>
-            ) : null}
           </div>
         </header>
         <div className="fsdb-right-body">
@@ -2202,6 +2261,15 @@ if (typeof document !== 'undefined') {
 .fsdb-page{display:flex;min-width:0;min-height:0;flex:1;flex-direction:row;overflow:hidden;background:var(--dsw-bg);color:var(--dsw-label);font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji";font-size:14px;letter-spacing:-.011em}
 .fsdb-right{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-right .chat-view-header{flex:none}
+.fsdb-crumbs{display:flex;min-width:0;align-items:center;gap:2px}
+.fsdb-crumb{display:inline-flex;min-width:0;align-items:center;gap:2px}
+.fsdb-crumb-sep{flex:none;padding:0 4px;color:var(--dsw-label-3);font-size:13px}
+.fsdb-crumb-btn{display:inline-flex;min-width:0;max-width:180px;align-items:center;gap:6px;border:0;border-radius:6px;background:transparent;padding:4px 6px;color:var(--dsw-sidebar-fg);cursor:pointer}
+.fsdb-crumb-btn:hover{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
+.fsdb-crumb-pick{position:relative;flex:none}
+.fsdb-crumb-menu{position:absolute;left:0;top:calc(100% + 4px);z-index:20;min-width:160px;max-height:240px;overflow:auto;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-surface);padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.16)}
+.fsdb-crumb-option{display:block;width:100%;border:0;border-radius:6px;background:transparent;padding:6px 8px;color:var(--dsw-label);font:inherit;font-size:13px;text-align:left;cursor:pointer}
+.fsdb-crumb-option:hover,.fsdb-crumb-option.is-active{background:var(--dsw-hover)}
 .fsdb-inspector-panel{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden;background:var(--dsw-bg)}
 .fsdb-inspector-host{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-inspector-host:empty{display:none}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -501,6 +501,13 @@ export function CollectionBrowser({
       return true
     }
   })
+  const [inspectorOpen, setInspectorOpen] = useState(() => {
+    try {
+      return localStorage.getItem('cordis.inspector.open') === '1'
+    } catch {
+      return false
+    }
+  })
   const [viewMenuOpen, setViewMenuOpen] = useState(false)
   const [modeMenuOpen, setModeMenuOpen] = useState(false)
   const [sortMenuOpen, setSortMenuOpen] = useState(false)
@@ -561,6 +568,21 @@ export function CollectionBrowser({
     window.addEventListener('biu:toggle-module-sidebar', onToggle)
     return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
   }, [collectionPath, moduleId])
+
+  useEffect(() => {
+    const sync = (open: boolean) => setInspectorOpen(open)
+    const onOpen = () => sync(true)
+    const onClose = () => sync(false)
+    const onToggle = () => setInspectorOpen((prev) => !prev)
+    window.addEventListener('biu:inspector-open', onOpen)
+    window.addEventListener('biu:inspector-close', onClose)
+    window.addEventListener('biu:inspector-toggle', onToggle)
+    return () => {
+      window.removeEventListener('biu:inspector-open', onOpen)
+      window.removeEventListener('biu:inspector-close', onClose)
+      window.removeEventListener('biu:inspector-toggle', onToggle)
+    }
+  }, [])
 
   useEffect(() => {
     function onPointer(event: MouseEvent) {
@@ -1497,16 +1519,17 @@ export function CollectionBrowser({
             ) : null}
             <button
               type="button"
-              className={`chat-view-header-expand${viewsOpen ? ' is-active' : ''}`}
-              title={viewsOpen ? '收起左侧边栏' : '展开左侧边栏'}
-              aria-label={viewsOpen ? '收起左侧边栏' : '展开左侧边栏'}
-              aria-pressed={viewsOpen}
-              onClick={toggleViewsOpen}
+              className={`chat-view-header-expand${inspectorOpen ? ' is-active' : ''}`}
+              title={inspectorOpen ? '收起检查器' : '打开检查器'}
+              aria-label={inspectorOpen ? '收起检查器' : '打开检查器'}
+              aria-pressed={inspectorOpen}
+              data-testid="fsdb-inspector-toggle"
+              onClick={() => window.dispatchEvent(new Event('biu:inspector-toggle'))}
             >
-              {viewsOpen ? (
-                <ChevronDoubleLeftIcon aria-hidden className="size-4" />
-              ) : (
+              {inspectorOpen ? (
                 <ChevronDoubleRightIcon aria-hidden className="size-4" />
+              ) : (
+                <ChevronDoubleLeftIcon aria-hidden className="size-4" />
               )}
             </button>
             {selected ? (

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -6,7 +6,7 @@ import type { SlotProps } from '@biu/type-slots'
 import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import { isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
-import { pathForCenter } from './sidebar-nav.ts'
+import { pathForCenter, pathForCrumbTarget, type CrumbTarget } from './sidebar-nav.ts'
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseUiService } from './database-ui.ts'
 import {
@@ -125,7 +125,7 @@ function CollectionPage(props: SlotProps) {
     if (!tables.length) return
     if (parsed.kind === 'module' && parsed.moduleId === DATA_MODULE_ID) {
       const first = tables[0]!
-      go({ collection: first.path, viewId: defaultViewId(first.path) }, { replace: true })
+      go({ collection: first.path }, { replace: true })
     }
   }, [parsed.kind, parsed.moduleId, tables])
 
@@ -183,6 +183,7 @@ function CollectionPage(props: SlotProps) {
       onCloseRecord={() =>
         go({ collection: currentPath, viewId: defaultViewId(currentPath) }, { replace: true })
       }
+      onCrumbTarget={(target: CrumbTarget) => navigate(pathForCrumbTarget(target))}
     />
   )
 }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+
+test('filesystem header toggles the right inspector, not the left data sidebar', () => {
+  assert.match(browser, /data-testid="fsdb-inspector-toggle"/)
+  assert.match(browser, /biu:inspector-toggle/)
+  assert.match(
+    browser,
+    /inspectorOpen \?\s*\(\s*<ChevronDoubleRightIcon[\s\S]*:\s*\(\s*<ChevronDoubleLeftIcon/,
+  )
+  assert.doesNotMatch(browser, /收起左侧边栏/)
+  assert.doesNotMatch(browser, /展开左侧边栏/)
+})

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -4,8 +4,10 @@ import { parseAppPath } from '@biu/web-session-view'
 import {
   applySidebarAction,
   assertSidebarInvariants,
+  buildCrumbs,
   parseCenterPath,
   pathForCenter,
+  pathForCrumbTarget,
   previewKey,
   starPreviewKey,
   toggleExpandedViewKey,
@@ -127,6 +129,49 @@ test('从记录返回回到上次视图，展开状态仍在', () => {
   assert.equal(closed.viewId, '1787983501816')
   assert.equal(closed.expandedViewKey, previewKey('/tasks', '1787983501816'))
   assert.equal(pathForCenter(closed), '/database/tasks/view/1787983501816')
+})
+
+test('面包屑点上级会清掉后面几级', () => {
+  const crumbs = buildCrumbs({
+    collection: '/tasks',
+    collectionLabel: 'Task',
+    tables: [
+      { path: '/tasks', label: 'Task' },
+      { path: '/pages', label: 'Page' },
+    ],
+    viewId: '1787983501816',
+    viewName: '默认视图',
+    views: [
+      { id: '1787983501816', name: '默认视图' },
+      { id: 'board', name: '看板' },
+    ],
+  })
+  assert.deepEqual(
+    crumbs.map((item) => item.kind),
+    ['root', 'collection', 'view'],
+  )
+  assert.equal(pathForCrumbTarget(crumbs[0]!.target), '/database')
+  assert.equal(pathForCrumbTarget(crumbs[1]!.target), '/database/tasks')
+  assert.equal(pathForCrumbTarget(crumbs[2]!.target), '/database/tasks/view/1787983501816')
+  const pages = crumbs[1]!.choices.find((item) => item.id === '/pages')
+  assert.equal(pathForCrumbTarget(pages!.target), '/database/pages')
+})
+
+test('记录页面包屑第三级是记录，点表只回到表', () => {
+  const crumbs = buildCrumbs({
+    collection: '/tasks',
+    collectionLabel: 'Task',
+    tables: [{ path: '/tasks', label: 'Task' }],
+    recordId: 'task_mtdbgnqj_5022je',
+    recordLabel: '写文档',
+    records: [{ id: 'task_mtdbgnqj_5022je', label: '写文档' }],
+  })
+  assert.deepEqual(
+    crumbs.map((item) => item.kind),
+    ['root', 'collection', 'record'],
+  )
+  assert.equal(pathForCrumbTarget(crumbs[1]!.target), '/database/tasks')
+  assert.ok(!pathForCrumbTarget(crumbs[1]!.target).includes('/record/'))
 })
 
 test('压测：随机切换表/视图/记录/展开，路由与展开不串台', () => {

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -41,9 +41,98 @@ export function toggleExpandedViewKey(current: string | null, key: string) {
   return current === key ? null : key
 }
 
+export const DATABASE_ROOT_PATH = '/database'
+
+export type CrumbKind = 'root' | 'collection' | 'view' | 'record'
+
+export type CrumbTarget =
+  | { kind: 'root' }
+  | { kind: 'collection'; collection: string }
+  | { kind: 'view'; collection: string; viewId: string }
+  | { kind: 'record'; collection: string; recordId: string }
+
+export type CrumbChoice = { id: string; label: string; target: CrumbTarget }
+
+export type Crumb = {
+  kind: CrumbKind
+  id: string
+  label: string
+  target: CrumbTarget
+  choices: CrumbChoice[]
+}
+
 export function pathForCenter(center: Pick<DataCenter, 'collection' | 'viewId' | 'recordId'>) {
   if (center.recordId) return databaseRecordPath(center.collection, center.recordId)
   return databaseViewPath(center.collection, center.viewId)
+}
+
+export function pathForCrumbTarget(target: CrumbTarget) {
+  if (target.kind === 'root') return DATABASE_ROOT_PATH
+  if (target.kind === 'collection') return pathForCenter({ collection: target.collection })
+  if (target.kind === 'view') return pathForCenter({ collection: target.collection, viewId: target.viewId })
+  return pathForCenter({ collection: target.collection, recordId: target.recordId })
+}
+
+export function buildCrumbs(input: {
+  collection: string
+  collectionLabel: string
+  tables: Array<{ path: string; label: string }>
+  viewId?: string
+  viewName?: string
+  views?: Array<{ id: string; name: string }>
+  recordId?: string
+  recordLabel?: string
+  records?: Array<{ id: string; label: string }>
+}): Crumb[] {
+  const crumbs: Crumb[] = [
+    {
+      kind: 'root',
+      id: 'database',
+      label: '数据',
+      target: { kind: 'root' },
+      choices: [{ id: 'database', label: '数据', target: { kind: 'root' } }],
+    },
+  ]
+  if (!input.collection) return crumbs
+  crumbs.push({
+    kind: 'collection',
+    id: input.collection,
+    label: input.collectionLabel,
+    target: { kind: 'collection', collection: input.collection },
+    choices: input.tables.map((table) => ({
+      id: table.path,
+      label: table.label,
+      target: { kind: 'collection', collection: table.path },
+    })),
+  })
+  if (input.recordId) {
+    crumbs.push({
+      kind: 'record',
+      id: input.recordId,
+      label: input.recordLabel || input.recordId,
+      target: { kind: 'record', collection: input.collection, recordId: input.recordId },
+      choices: (input.records ?? [{ id: input.recordId, label: input.recordLabel || input.recordId }]).map((row) => ({
+        id: row.id,
+        label: row.label,
+        target: { kind: 'record', collection: input.collection, recordId: row.id },
+      })),
+    })
+    return crumbs
+  }
+  if (input.viewId) {
+    crumbs.push({
+      kind: 'view',
+      id: input.viewId,
+      label: input.viewName || input.viewId,
+      target: { kind: 'view', collection: input.collection, viewId: input.viewId },
+      choices: (input.views ?? [{ id: input.viewId, name: input.viewName || input.viewId }]).map((view) => ({
+        id: view.id,
+        label: view.name,
+        target: { kind: 'view', collection: input.collection, viewId: view.id },
+      })),
+    })
+  }
+  return crumbs
 }
 
 export function parseCenterPath(pathname: string): DataCenter | null {

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -518,8 +518,36 @@ function Shell(props: SlotProps) {
         /* ignore */
       }
     }
+    const persist = (next: boolean) => {
+      setInspectorOpen(next)
+      try {
+        localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
+      } catch {
+        /* ignore */
+      }
+    }
+    const onOpen = () => persist(true)
+    const onClose = () => persist(false)
+    const onToggle = () => {
+      setInspectorOpen((prev) => {
+        const next = !prev
+        try {
+          localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
+        } catch {
+          /* ignore */
+        }
+        if (!next) queueMicrotask(() => requestInspectorClose())
+        return next
+      })
+    }
     window.addEventListener('biu:inspector-open', onOpen)
-    return () => window.removeEventListener('biu:inspector-open', onOpen)
+    window.addEventListener('biu:inspector-close', onClose)
+    window.addEventListener('biu:inspector-toggle', onToggle)
+    return () => {
+      window.removeEventListener('biu:inspector-open', onOpen)
+      window.removeEventListener('biu:inspector-close', onClose)
+      window.removeEventListener('biu:inspector-toggle', onToggle)
+    }
   }, [])
   const appRoute = parseAppPath(location.pathname, pluginModules)
   const centerKind = centerKindFromRoute(appRoute)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
中间顶栏左上角改成可点面包屑：`数据 / 表 / 视图或记录`。

- 点某一级：跳到那一级，后面几级清掉
- 某一级有多个选项时，旁边箭头可选别的表/视图/记录，同样会清掉后面
- 右上角关闭叉已去掉，回退靠点面包屑
- 双箭头是右侧检查器，不是左侧数据栏
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

