### PR TITLE
docs(brand): 品牌名改为 Biu Agent OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 <div align="center">
 
 <p>
-  <img src="public/brand-lockup.svg" width="268" height="54" alt="biu harness" />
+  <img src="public/brand-lockup.svg" width="300" height="54" alt="Biu Agent OS" />
 </p>
 
-# biu-harness
+# Biu Agent OS
 
 **English** · [简体中文](README.zh-CN.md)
 
-A pluggable, self-hosted agent harness.  
+A pluggable, self-hosted agent OS.  
 
 </div>
 
@@ -19,13 +19,13 @@ A pluggable, self-hosted agent harness.
   <img alt="node" src="https://img.shields.io/node/v/cordis" />
 </p>
 
-**biu-harness** is a local workbench that treats agents as processes and the task board as the bus between them. Agents run as independent sessions — each with its own workspace, model, and tool set — while a board coordinates multi-agent work. The kernel is Cordis: HTTP, sessions, LLM, chat, and the board are all plugins loaded from a single manifest, [`cordis.plugins.json`](cordis.plugins.json).
+**Biu Agent OS** is a local workbench that treats agents as processes and the task board as the bus between them. Agents run as independent sessions — each with its own workspace, model, and tool set — while a board coordinates multi-agent work. The kernel is Cordis: HTTP, sessions, LLM, chat, and the board are all plugins loaded from a single manifest, [`cordis.plugins.json`](cordis.plugins.json).
 
 ---
 
 ## Table of Contents
 
-- [biu-harness](#biu-harness)
+- [Biu Agent OS](#biu-agent-os)
   - [Table of Contents](#table-of-contents)
   - [Design Principles](#design-principles)
     - [1. Everything is a plugin](#1-everything-is-a-plugin)
@@ -229,7 +229,7 @@ biu-harness
 │   └── link-cordis-plugins.mjs
 ├── public/
 │   ├── favicon.svg            # Brand mascot (sidebar gradient)
-│   ├── brand-lockup.svg       # README: mascot + biu harness tag
+│   ├── brand-lockup.svg       # README: mascot + Biu Agent OS tag
 │   ├── mascot-blue.svg        # README mascots (BMW M tricolor)
 │   ├── mascot-violet.svg
 │   ├── mascot-red.svg
@@ -338,7 +338,7 @@ Alternatively: `npm run dev:host` and `npm run dev:web`.
 
 ## License
 
-Code and docs written by biu-harness are under the [MIT License](LICENSE): learn, modify, distribute, and use commercially, provided the copyright notice and license text are retained.
+Code and docs written by Biu Agent OS are under the [MIT License](LICENSE): learn, modify, distribute, and use commercially, provided the copyright notice and license text are retained.
 
 **Exception: the Grok Bot.** `public/grok-bot/` — its geometry, animation, and character design — is **not MIT**. It is adapted from a learning extraction of Grok Bot.app and rights belong to xAI and other holders. It may be used for cloning and demos; before redistributing, shipping, or adopting it as a product mascot, assess the trademark/copyright risk yourself or replace it with your own character. This project grants no rights to this part. See [NOTICE.md](NOTICE.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,14 +1,14 @@
 <div align="center">
 
 <p>
-  <img src="public/brand-lockup.svg" width="268" height="54" alt="biu harness" />
+  <img src="public/brand-lockup.svg" width="300" height="54" alt="Biu Agent OS" />
 </p>
 
-# biu-harness
+# Biu Agent OS
 
 [English](README.md) · **简体中文**
 
-可插拔、自托管的 Agent Harness。
+可插拔、自托管的 Agent OS。
 
 </div>
 
@@ -19,7 +19,7 @@
   <img alt="node" src="https://img.shields.io/node/v/cordis" />
 </p>
 
-**biu-harness** 是一套把 Agent 当进程、把任务看板当协作总线的本地工作台。每个 Agent 是独立 session（各自拥有工作区、模型、工具集），由看板协调多 Agent 协作。内核基于 Cordis：HTTP、会话、LLM、对话、看板……一律是插件，由一份清单 [`cordis.plugins.json`](cordis.plugins.json) 承载。
+**Biu Agent OS** 是一套把 Agent 当进程、把任务看板当协作总线的本地工作台。每个 Agent 是独立 session（各自拥有工作区、模型、工具集），由看板协调多 Agent 协作。内核基于 Cordis：HTTP、会话、LLM、对话、看板……一律是插件，由一份清单 [`cordis.plugins.json`](cordis.plugins.json) 承载。
 
 ---
 
@@ -221,7 +221,7 @@ biu-harness
 │   └── link-cordis-plugins.mjs
 ├── public/
 │   ├── favicon.svg            # 品牌小人（侧栏同款渐变）
-│   ├── brand-lockup.svg       # README：小人 + biu harness tag
+│   ├── brand-lockup.svg       # README：小人 + Biu Agent OS tag
 │   ├── mascot-blue.svg        # README 吉祥物（BMW M 三色）
 │   ├── mascot-violet.svg
 │   ├── mascot-red.svg
@@ -330,7 +330,7 @@ export CHAT_MODEL=deepseek-chat # 可选
 
 ## 许可
 
-仓库里 **biu-harness 自己写的代码和文档** 使用 [MIT License](LICENSE)：可以学习、修改、分发，**也可以商用**，保留版权声明和许可文本即可。
+仓库里 **Biu Agent OS 自己写的代码和文档** 使用 [MIT License](LICENSE)：可以学习、修改、分发，**也可以商用**，保留版权声明和许可文本即可。
 
 **例外：Grok Bot 机器人。** `public/grok-bot/` 里的几何、动画和角色外形 **不是 MIT**。它们改编自对 Grok Bot.app 的学习向抽取，权利属于 xAI 等权利人。可用于克隆与演示；二次分发、打包上线或当产品吉祥物前，**有商标 / 版权侵权风险**，请自行评估，或替换为自有角色。本项目不授予这部分的任何权利。说明见 [NOTICE.md](NOTICE.md)。
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <title>Biu</title>
+    <title>Biu Agent OS</title>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "biu",
   "version": "0.1.0",
   "private": true,
-  "description": "一切即插件的 Agent Harness：多 Agent 不靠群聊，而是通过任务看板协作。基于 Cordis，事件流驱动，一切可溯源。",
+  "description": "Biu Agent OS：一切即插件，多 Agent 不靠群聊，而是通过任务看板协作。基于 Cordis，事件流驱动，一切可溯源。",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -434,7 +434,7 @@ export const DataSidebar = memo(function DataSidebar({
             className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
             style={{ background: SIDEBAR_BRAND_GRADIENT }}
           >
-            biu harness
+            Biu Agent OS
           </span>
         </span>
       </div>

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -307,7 +307,7 @@ export const ChatSidebar = memo(function ChatSidebar({
             className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
             style={{ background: SIDEBAR_BRAND_GRADIENT }}
           >
-            biu harness
+            Biu Agent OS
           </span>
         </span>
       </div>

--- a/public/brand-lockup.svg
+++ b/public/brand-lockup.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 268 54" width="268" height="54" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 54" width="300" height="54" fill="none">
   <defs>
     <linearGradient id="brandLockup" x1="0" y1="0.15" x2="1" y2="0.85">
       <stop offset="0%" stop-color="#1A4464"/>
@@ -13,6 +13,6 @@
       <path d="M108.97 125.73L111.9 126.2L114.63 127.37L117 129.16L118.84 131.49L119.99 134.23L120.32 137.18L119.85 140.11L118.59 142.8L116.78 145.16L114.84 147.42L112.89 149.67L110.93 151.92L108.97 154.16L107.01 156.39L105.03 158.62L103.05 160.85L101.07 163.06L99.07 165.28L97.09 167.5L95.09 169.71L93.05 171.88L90.69 173.67L87.89 174.66L84.93 174.81L82.02 174.22L79.31 173L76.92 171.24L74.99 168.98L73.7 166.3L73.26 163.37L73.74 160.45L75.2 157.86L77.17 155.63L79.18 153.43L81.18 151.23L83.17 149.02L85.16 146.8L87.14 144.58L89.11 142.35L91.08 140.11L93.04 137.87L95 135.63L96.95 133.38L98.89 131.12L100.87 128.89L103.25 127.12L106.02 126.04Z" fill="#ffffff"/>
     </g>
   </svg>
-  <rect x="60" y="11" width="202" height="32" rx="6" fill="url(#brandLockup)"/>
-  <text x="161" y="32.5" text-anchor="middle" fill="#ffffff" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" font-weight="600">biu harness</text>
+  <rect x="60" y="11" width="234" height="32" rx="6" fill="url(#brandLockup)"/>
+  <text x="177" y="32.5" text-anchor="middle" fill="#ffffff" font-family="ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="14" font-weight="600">Biu Agent OS</text>
 </svg>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把界面和 README 上的品牌文案从 biu harness 改成 **Biu Agent OS**。

包括：聊天侧栏、数据侧栏、README 中英、品牌 lockup 图、浏览器标题。仓库目录名和 clone 地址仍是 biu-harness。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

