### PR TITLE
fix(web-app-shell): 修复 Identifier 'onOpen' has already been declared

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -510,14 +510,6 @@ function Shell(props: SlotProps) {
     return () => window.removeEventListener('biu:inspector-width', onWidth)
   }, [onInspectorWidthChange])
   useEffect(() => {
-    const onOpen = () => {
-      setInspectorOpen(true)
-      try {
-        localStorage.setItem('cordis.inspector.open', '1')
-      } catch {
-        /* ignore */
-      }
-    }
     const persist = (next: boolean) => {
       setInspectorOpen(next)
       try {

--- a/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
+++ b/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
@@ -10,4 +10,14 @@ describe('panel collapse chevrons follow panel state', () => {
       /inspectorOpen \?\s*\(\s*<ChevronDoubleRightIcon[\s\S]*:\s*\(\s*<ChevronDoubleLeftIcon/,
     )
   })
+
+  it('declares inspector persist helpers once (no duplicate onOpen)', () => {
+    const persistBlock = shell.match(
+      /const persist = \(next: boolean\) => \{[\s\S]*?window\.addEventListener\('biu:inspector-toggle', onToggle\)/,
+    )
+    expect(persistBlock?.[0]).toBeTruthy()
+    expect(persistBlock?.[0].match(/const onOpen =/g)?.length).toBe(1)
+    expect(persistBlock?.[0]).toContain('const persist = (next: boolean)')
+    expect(persistBlock?.[0]).toContain('const onClose = () => persist(false)')
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
已快进合入 `file-system`（`5f9d407`）。

检查器 `useEffect` 去掉重复的 `onOpen`/`onClose`，只保留 `persist` 一套监听。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

