### PR TITLE
fix(inspector): 右侧栏能打开，默认只列出可开项

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1017,6 +1017,16 @@ export function CollectionBrowser({
     )
   }
 
+  useEffect(() => {
+    const onAction = (event: Event) => {
+      const detail = (event as CustomEvent<string>).detail
+      if (detail === 'add-view') addEmptyView()
+      if (detail === 'copy-view') copyView()
+    }
+    window.addEventListener('biu:inspector-action', onAction)
+    return () => window.removeEventListener('biu:inspector-action', onAction)
+  })
+
   function patchActiveView(patch: Partial<SavedView>) {
     if (!activeViewId) return
     persistViews(views.map((view) => (view.id === activeViewId ? { ...view, ...patch } : view)))

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -137,7 +137,8 @@ function CollectionPage(props: SlotProps) {
   }, [collectionFromRoute, tables])
 
   useEffect(() => {
-    if (parsed.kind !== 'record' || !slots || !ui) return
+    if (!slots || !ui || !currentPath) return
+    if (parsed.kind !== 'collection-view' && parsed.kind !== 'record') return
     const panes = chrome.panes ?? []
     const placed = panes.map((pane) =>
       slots.place('inspector-panels', RecordPanePanel, {
@@ -147,17 +148,16 @@ function CollectionPage(props: SlotProps) {
           tabId: pane.id,
           tabLabel: pane.label,
           tabIcon: CircleStackIcon,
-          centerKinds: ['record'],
+          centerKinds: ['collection-view', 'record'],
           paneId: pane.id,
           databaseUi: ui,
         }),
       }),
     )
-    if (panes.length) window.dispatchEvent(new Event('biu:inspector-open'))
     return () => {
       for (const item of placed) void item.dispose?.()
     }
-  }, [chrome, parsed.kind, slots, ui])
+  }, [chrome, currentPath, parsed.kind, slots, ui])
 
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -15,3 +15,9 @@ test('filesystem header toggles the right inspector, not the left data sidebar',
   assert.doesNotMatch(browser, /收起左侧边栏/)
   assert.doesNotMatch(browser, /展开左侧边栏/)
 })
+
+test('database does not auto-open inspector content; panes follow the current table', () => {
+  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.doesNotMatch(page, /biu:inspector-open/)
+  assert.match(page, /centerKinds: \['collection-view', 'record'\]/)
+})

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -21,3 +21,10 @@ test('database does not auto-open inspector content; panes follow the current ta
   assert.doesNotMatch(page, /biu:inspector-open/)
   assert.match(page, /centerKinds: \['collection-view', 'record'\]/)
 })
+
+test('common inspector actions add or copy a view', () => {
+  const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+  assert.match(browser, /biu:inspector-action/)
+  assert.match(browser, /add-view/)
+  assert.match(browser, /copy-view/)
+})

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -14,7 +14,9 @@ import {
   clampOverlayChatHeight,
   OVERLAY_CHAT_HEIGHT_MIN,
   inspectorTabFromEvent,
+  inspectorActionFromEvent,
   requestInspectorTab,
+  requestInspectorAction,
 } from './chat-overlay.ts'
 
 test('chat column subtracts rail, sidebar and inspector', () => {
@@ -100,4 +102,15 @@ test('requestInspectorTab dispatches tab id', () => {
   requestInspectorTab('database')
   window.removeEventListener('biu:inspector-tab', onTab)
   assert.equal(seen, 'database')
+})
+
+test('requestInspectorAction dispatches tool id', () => {
+  let seen = ''
+  const onAction = (event: Event) => {
+    seen = inspectorActionFromEvent(event) ?? ''
+  }
+  window.addEventListener('biu:inspector-action', onAction)
+  requestInspectorAction('add-view')
+  window.removeEventListener('biu:inspector-action', onAction)
+  assert.equal(seen, 'add-view')
 })

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -129,6 +129,16 @@ export function requestInspectorTab(tabId: string) {
   window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
 }
 
+export function requestInspectorAction(action: string) {
+  if (!action) return
+  window.dispatchEvent(new CustomEvent('biu:inspector-action', { detail: action }))
+}
+
+export function inspectorActionFromEvent(event: Event): string | undefined {
+  const detail = (event as CustomEvent).detail
+  return typeof detail === 'string' && detail ? detail : undefined
+}
+
 export function inspectorTabFromEvent(event: Event): string | undefined {
   const detail = (event as CustomEvent).detail
   if (typeof detail === 'string' && detail) return detail

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -26,4 +26,8 @@ test('declares generic module slots, not plugin ids', async () => {
   assert.equal(ctx.slots.specOf('channels'), undefined)
   assert.equal(ctx.slots.specOf('dashboard'), undefined)
   assert.equal(ctx.slots.list('root').length, 1)
+  const addView = ctx.slots.list('inspector-panels').find((item) => item.id === 'common-add-view')
+  assert.equal(addView?.props?.().common, true)
+  assert.equal(addView?.props?.().action, 'add-view')
+  assert.equal(addView?.props?.().tabLabel, '添加视图')
 })

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { memo, useCallback, useEffect, useRef, useState, useSyncExternalStore, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import {
   chatColumnWidth,
@@ -27,7 +27,7 @@ import { bindSnapshot, type SnapshotService } from '@biu/web-snapshot'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 import { centerKindFromRoute, parseAppPath } from '@biu/web-session-view'
-import { inspectorPanelMatches } from './inspector-panels.ts'
+import { placeCommonInspectorTools } from './inspector-common.tsx'
 import {
   isMascotDancing,
   mascotDanceShape,
@@ -543,11 +543,6 @@ function Shell(props: SlotProps) {
   }, [])
   const appRoute = parseAppPath(location.pathname, pluginModules)
   const centerKind = centerKindFromRoute(appRoute)
-  const inspectorExtras = useSlotEntries(slots, 'inspector-panels')
-  const inspectorTabCount = useMemo(
-    () => inspectorExtras.filter((entry) => inspectorPanelMatches(entry.props?.() ?? {}, centerKind, sessionId)).length,
-    [centerKind, inspectorExtras, sessionId],
-  )
   const inspectorVisible = inspectorOpen
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
@@ -660,23 +655,21 @@ function Shell(props: SlotProps) {
             <MapPinIcon {...chromeIcon} />
           </button>
         ) : null}
-        {inspectorTabCount > 0 ? (
-          <button
-            type="button"
-            className={`chat-view-header-expand${inspectorOpen ? ' is-active' : ''}`}
-            title={inspectorOpen ? '收起检查器' : '打开检查器'}
-            aria-label={inspectorOpen ? '收起检查器' : '打开检查器'}
-            aria-pressed={inspectorOpen}
-            data-testid="inspector-toggle"
-            onClick={toggleInspector}
-          >
-            {inspectorOpen ? (
-              <ChevronDoubleRightIcon {...chromeIcon} />
-            ) : (
-              <ChevronDoubleLeftIcon {...chromeIcon} />
-            )}
-          </button>
-        ) : null}
+        <button
+          type="button"
+          className={`chat-view-header-expand${inspectorOpen ? ' is-active' : ''}`}
+          title={inspectorOpen ? '收起检查器' : '打开检查器'}
+          aria-label={inspectorOpen ? '收起检查器' : '打开检查器'}
+          aria-pressed={inspectorOpen}
+          data-testid="inspector-toggle"
+          onClick={toggleInspector}
+        >
+          {inspectorOpen ? (
+            <ChevronDoubleRightIcon {...chromeIcon} />
+          ) : (
+            <ChevronDoubleLeftIcon {...chromeIcon} />
+          )}
+        </button>
       </div>
     </header>
   )
@@ -864,4 +857,5 @@ export function apply(ctx: Context) {
     },
     props: () => shellProps,
   })
+  placeCommonInspectorTools(ctx.slots as SlotsService)
 }

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -548,7 +548,7 @@ function Shell(props: SlotProps) {
     () => inspectorExtras.filter((entry) => inspectorPanelMatches(entry.props?.() ?? {}, centerKind, sessionId)).length,
     [centerKind, inspectorExtras, sessionId],
   )
-  const inspectorVisible = inspectorOpen && inspectorTabCount > 0
+  const inspectorVisible = inspectorOpen
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}` : '/'

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+const inspector = readFileSync(resolve(import.meta.dirname, './session-inspector.tsx'), 'utf8')
+
+test('inspector starts as a catalog and only renders a panel after a pick', () => {
+  assert.match(inspector, /useState\(''\)/)
+  assert.match(inspector, /data-testid="inspector-catalog"/)
+  assert.match(inspector, /可打开/)
+  assert.match(inspector, /setTab\(active \? '' : item\.id\)/)
+})

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -8,6 +8,7 @@ const inspector = readFileSync(resolve(import.meta.dirname, './session-inspector
 test('inspector starts as a catalog and only renders a panel after a pick', () => {
   assert.match(inspector, /useState\(''\)/)
   assert.match(inspector, /data-testid="inspector-catalog"/)
-  assert.match(inspector, /可打开/)
+  assert.match(inspector, /工具/)
+  assert.match(inspector, /requestInspectorAction/)
   assert.match(inspector, /setTab\(active \? '' : item\.id\)/)
 })

--- a/packages/web-app-shell/src/web/inspector-common.tsx
+++ b/packages/web-app-shell/src/web/inspector-common.tsx
@@ -1,0 +1,31 @@
+import { PlusIcon, Square2StackIcon } from '@heroicons/react/16/solid'
+import type { SlotsService } from '@biu/web-slots'
+
+function InspectorActionStub() {
+  return null
+}
+
+export function placeCommonInspectorTools(slots: SlotsService) {
+  slots.place('inspector-panels', InspectorActionStub, {
+    key: 'common-add-view',
+    order: -20,
+    props: () => ({
+      tabId: 'add-view',
+      tabLabel: '添加视图',
+      tabIcon: PlusIcon,
+      common: true,
+      action: 'add-view',
+    }),
+  })
+  slots.place('inspector-panels', InspectorActionStub, {
+    key: 'common-copy-view',
+    order: -19,
+    props: () => ({
+      tabId: 'copy-view',
+      tabLabel: '拷贝视图',
+      tabIcon: Square2StackIcon,
+      common: true,
+      action: 'copy-view',
+    }),
+  })
+}

--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { inspectorPanelMatches } from './inspector-panels.ts'
+import { inspectorPanelMatches, resolveInspectorTab } from './inspector-panels.ts'
 
 test('session-only panels stay on chat and hide on database/task', () => {
   const extra = { centerKinds: ['session'], requiresSession: true }
@@ -11,10 +11,10 @@ test('session-only panels stay on chat and hide on database/task', () => {
   assert.equal(inspectorPanelMatches(extra, 'task', 's1'), false)
 })
 
-test('record panes only appear when a record is the center', () => {
-  const extra = { centerKinds: ['record'] }
+test('record panes are offered on the table and the record, not on chat', () => {
+  const extra = { centerKinds: ['collection-view', 'record'] }
   assert.equal(inspectorPanelMatches(extra, 'record', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'collection-view', null), false)
+  assert.equal(inspectorPanelMatches(extra, 'collection-view', null), true)
   assert.equal(inspectorPanelMatches(extra, 'session', 's1'), false)
 })
 
@@ -23,6 +23,12 @@ test('task inspector only appears on the tasks module', () => {
   assert.equal(inspectorPanelMatches(extra, 'task', null), true)
   assert.equal(inspectorPanelMatches(extra, 'session', 's1'), false)
   assert.equal(inspectorPanelMatches(extra, 'record', null), false)
+})
+
+test('inspector does not auto-open the first available tab', () => {
+  assert.equal(resolveInspectorTab('', ['script', 'reports']), '')
+  assert.equal(resolveInspectorTab('script', ['script', 'reports']), 'script')
+  assert.equal(resolveInspectorTab('gone', ['script', 'reports']), '')
 })
 
 test('legacy untagged panels stay off session and database centers', () => {

--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -25,6 +25,15 @@ test('task inspector only appears on the tasks module', () => {
   assert.equal(inspectorPanelMatches(extra, 'record', null), false)
 })
 
+test('common tools stay available on every center', () => {
+  const extra = { common: true, action: 'add-view' }
+  assert.equal(inspectorPanelMatches(extra, 'collection-view', null), true)
+  assert.equal(inspectorPanelMatches(extra, 'record', null), true)
+  assert.equal(inspectorPanelMatches(extra, 'session', 's1'), true)
+  assert.equal(inspectorPanelMatches(extra, 'session', null), true)
+  assert.equal(inspectorPanelMatches(extra, 'module', null), true)
+})
+
 test('inspector does not auto-open the first available tab', () => {
   assert.equal(resolveInspectorTab('', ['script', 'reports']), '')
   assert.equal(resolveInspectorTab('script', ['script', 'reports']), 'script')

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -23,3 +23,9 @@ export function inspectorPanelMatches(
   if (extra.requiresSession && !sessionId) return false
   return true
 }
+
+/** 不自动打开任何分区：只有用户点过、且该项仍可用时才保持。 */
+export function resolveInspectorTab(current: string, allowed: string[]) {
+  if (current && allowed.includes(current)) return current
+  return ''
+}

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -3,6 +3,8 @@ import type { InspectorCenterKind } from '@biu/web-session-view'
 export type InspectorPanelExtra = {
   centerKinds?: unknown
   requiresSession?: unknown
+  common?: unknown
+  action?: unknown
 }
 
 export function inspectorPanelMatches(
@@ -10,6 +12,10 @@ export function inspectorPanelMatches(
   centerKind: InspectorCenterKind,
   sessionId: string | null,
 ): boolean {
+  if (extra.common) {
+    if (extra.requiresSession && !sessionId) return false
+    return true
+  }
   const kinds = Array.isArray(extra.centerKinds)
     ? extra.centerKinds.filter((item): item is InspectorCenterKind => typeof item === 'string')
     : []

--- a/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
+++ b/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
@@ -11,6 +11,11 @@ describe('panel collapse chevrons follow panel state', () => {
     )
   })
 
+  it('opens the inspector rail even when no tab is selected yet', () => {
+    expect(shell).toMatch(/const inspectorVisible = inspectorOpen/)
+    expect(shell).not.toMatch(/inspectorVisible = inspectorOpen && inspectorTabCount/)
+  })
+
   it('declares inspector persist helpers once (no duplicate onOpen)', () => {
     const persistBlock = shell.match(
       /const persist = \(next: boolean\) => \{[\s\S]*?window\.addEventListener\('biu:inspector-toggle', onToggle\)/,

--- a/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
+++ b/packages/web-app-shell/src/web/panel-toggle-chevrons.test.ts
@@ -14,6 +14,7 @@ describe('panel collapse chevrons follow panel state', () => {
   it('opens the inspector rail even when no tab is selected yet', () => {
     expect(shell).toMatch(/const inspectorVisible = inspectorOpen/)
     expect(shell).not.toMatch(/inspectorVisible = inspectorOpen && inspectorTabCount/)
+    expect(shell).not.toMatch(/inspectorTabCount > 0/)
   })
 
   it('declares inspector persist helpers once (no duplicate onOpen)', () => {

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -9,7 +9,7 @@ import {
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 import { inspectorTabFromEvent } from './chat-overlay.ts'
-import { inspectorPanelMatches } from './inspector-panels.ts'
+import { inspectorPanelMatches, resolveInspectorTab } from './inspector-panels.ts'
 
 export type SessionInspectorProps = {
   open: boolean
@@ -24,16 +24,6 @@ export type SessionInspectorProps = {
 
 function inspectorTabStorageKey(sid: string | null | undefined) {
   return sid ? `inspector.tab:${sid}` : 'inspector.tab:home'
-}
-
-function inspectorStoredTab(sid: string | null | undefined, allowed: string[]): string | undefined {
-  try {
-    const raw = localStorage.getItem(inspectorTabStorageKey(sid))
-    if (raw && allowed.includes(raw)) return raw
-  } catch {
-    /* ignore */
-  }
-  return undefined
 }
 
 export const SessionInspector = memo(function SessionInspector({
@@ -66,9 +56,8 @@ export const SessionInspector = memo(function SessionInspector({
       })
   }, [centerKind, extras, sessionId])
   const allowedTabs = useMemo(() => extraTabs.map((item) => item.id), [extraTabs])
-  const defaultTab = extraTabs[0]?.id ?? ''
 
-  const [tab, setTabState] = useState(() => inspectorStoredTab(sessionId, allowedTabs) ?? defaultTab)
+  const [tab, setTabState] = useState('')
   const setTab = useCallback(
     (next: string) => {
       setTabState(next)
@@ -89,13 +78,8 @@ export const SessionInspector = memo(function SessionInspector({
       return
     }
     // 无 session 时没有可用的 stored key 旧逻辑会每次 extras 刷新都打回 defaultTab，任务/插件点了等于没点。
-    setTabState((current) => {
-      const stored = inspectorStoredTab(sessionId, allowedTabs)
-      if (stored) return stored
-      if (current && allowedTabs.includes(current)) return current
-      return defaultTab
-    })
-  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), defaultTab, setTab])
+    setTabState((current) => resolveInspectorTab(current, allowedTabs))
+  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), setTab])
 
   useEffect(() => {
     const onTab = (event: Event) => {
@@ -156,35 +140,57 @@ export const SessionInspector = memo(function SessionInspector({
         }}
       />
 
-      <div className="app-side-bar-head">
-        <div className="inspector-tabs" role="tablist" aria-label="检查器分区">
-          {extraTabs.map((item) => {
-            const active = tab === item.id
-            return (
-              <button
-                key={item.id}
-                type="button"
-                role="tab"
-                aria-selected={active}
-                className={`inspector-tab${active ? ' is-active' : ''}`}
-                onClick={() => setTab(item.id)}
-                data-testid={`inspector-tab-${item.id}`}
-              >
-                <span className="inspector-tab-indicator" aria-hidden />
-                {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
-                {item.label}
-              </button>
-            )
-          })}
+      {extraActive ? (
+        <div className="app-side-bar-head">
+          <div className="inspector-tabs" role="tablist" aria-label="检查器分区">
+            {extraTabs.map((item) => {
+              const active = tab === item.id
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  className={`inspector-tab${active ? ' is-active' : ''}`}
+                  onClick={() => setTab(active ? '' : item.id)}
+                  data-testid={`inspector-tab-${item.id}`}
+                >
+                  <span className="inspector-tab-indicator" aria-hidden />
+                  {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
+                  {item.label}
+                </button>
+              )
+            })}
+          </div>
         </div>
-      </div>
+      ) : null}
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {extraActive && ExtraComponent ? (
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid={`inspector-${extraActive.id}`}>
             <ExtraComponent {...(extraActive.entry.props?.() ?? {})} renderSlot={renderSlot} />
           </div>
-        ) : null}
+        ) : (
+          <div className="inspector-catalog" data-testid="inspector-catalog">
+            <p className="inspector-catalog-lead">可打开</p>
+            {extraTabs.length ? (
+              extraTabs.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  className="inspector-catalog-item"
+                  onClick={() => setTab(item.id)}
+                  data-testid={`inspector-offer-${item.id}`}
+                >
+                  {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
+                  <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                </button>
+              ))
+            ) : (
+              <p className="inspector-catalog-empty">当前中间页没有可打开的内容</p>
+            )}
+          </div>
+        )}
       </div>
     </aside>
   )

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -8,7 +8,7 @@ import {
 } from '@biu/web-session-view'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
-import { inspectorTabFromEvent } from './chat-overlay.ts'
+import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts'
 import { inspectorPanelMatches, resolveInspectorTab } from './inspector-panels.ts'
 
 export type SessionInspectorProps = {
@@ -52,6 +52,8 @@ export const SessionInspector = memo(function SessionInspector({
           Icon: extra.tabIcon as ComponentType<{ className?: string }> | undefined,
           ensureTrajectory: Boolean(extra.ensureTrajectory),
           focusOnCall: Boolean(extra.focusOnCall),
+          common: Boolean(extra.common),
+          action: typeof extra.action === 'string' ? extra.action : '',
         }]
       })
   }, [centerKind, extras, sessionId])
@@ -118,8 +120,18 @@ export const SessionInspector = memo(function SessionInspector({
 
   if (!open) return null
 
-  const extraActive = extraTabs.find((item) => item.id === tab)
+  const extraActive = extraTabs.find((item) => item.id === tab && !item.action)
   const ExtraComponent = extraActive?.entry.Component
+  const commonTabs = extraTabs.filter((item) => item.common)
+  const pageTabs = extraTabs.filter((item) => !item.common)
+
+  function pickOffer(item: (typeof extraTabs)[number]) {
+    if (item.action) {
+      requestInspectorAction(item.action)
+      return
+    }
+    setTab(item.id)
+  }
 
   return (
     <aside
@@ -172,23 +184,36 @@ export const SessionInspector = memo(function SessionInspector({
           </div>
         ) : (
           <div className="inspector-catalog" data-testid="inspector-catalog">
-            <p className="inspector-catalog-lead">可打开</p>
-            {extraTabs.length ? (
-              extraTabs.map((item) => (
-                <button
-                  key={item.id}
-                  type="button"
-                  className="inspector-catalog-item"
-                  onClick={() => setTab(item.id)}
-                  data-testid={`inspector-offer-${item.id}`}
-                >
-                  {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
-                  <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                </button>
-              ))
-            ) : (
-              <p className="inspector-catalog-empty">当前中间页没有可打开的内容</p>
-            )}
+            <p className="inspector-catalog-lead">工具</p>
+            {commonTabs.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="inspector-catalog-item"
+                onClick={() => pickOffer(item)}
+                data-testid={`inspector-offer-${item.id}`}
+              >
+                {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
+                <span className="min-w-0 flex-1 truncate">{item.label}</span>
+              </button>
+            ))}
+            {pageTabs.length ? (
+              <>
+                <p className="inspector-catalog-lead">此页</p>
+                {pageTabs.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className="inspector-catalog-item"
+                    onClick={() => pickOffer(item)}
+                    data-testid={`inspector-offer-${item.id}`}
+                  >
+                    {item.Icon ? <item.Icon {...chromeIcon} /> : <Squares2X2Icon {...chromeIcon} />}
+                    <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                  </button>
+                ))}
+              </>
+            ) : null}
           </div>
         )}
       </div>

--- a/web/style.css
+++ b/web/style.css
@@ -324,6 +324,52 @@ body {
   display: none;
 }
 
+.inspector-catalog {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+}
+
+.inspector-catalog-lead {
+  margin: 0 0 4px;
+  color: var(--dsw-label-3);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.inspector-catalog-item {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  padding: 8px 10px;
+  color: var(--dsw-sidebar-fg);
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.inspector-catalog-item:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-sidebar-fg-active);
+}
+
+.inspector-catalog-empty {
+  margin: 8px 0 0;
+  color: var(--dsw-label-3);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .chat-view-header-left,
 .chat-view-header-right {
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器任何中间页都能打开，不再因为没有分区就藏按钮或画空白。

**公共工具（始终在）：**
- 添加视图
- 拷贝视图

**此页：** 中间页自己的可开项（例如 Task 的脚本 / 进度汇报），没有就不列，但不影响栏本身。

默认仍不自动打开某一项。测试 24 项通过，`vite build` 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

