### PR TITLE
fix(router): 刷新时不要把未登记完的路由踢回首页

### DIFF
--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -1,5 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { Context } from 'cordis'
 import * as slots from '@biu/web-slots'
 import * as appModules from '@biu/web-app-modules'
@@ -30,4 +32,10 @@ test('declares generic module slots, not plugin ids', async () => {
   assert.equal(addView?.props?.().common, true)
   assert.equal(addView?.props?.().action, 'add-view')
   assert.equal(addView?.props?.().tabLabel, '添加视图')
+})
+
+test('refresh does not send unfinished plugin routes home', () => {
+  const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.doesNotMatch(shell, /navigate\('\/', \{ replace: true \}\)/)
+  assert.match(shell, /waitingOnNav/)
 })

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -569,13 +569,14 @@ function Shell(props: SlotProps) {
     }
   }, [focusCallId, routeView])
 
-  // 单向：URL → sessionView。回写只靠 Link / navigate，不做 state→URL。
+  // 单向：URL → sessionView。插件还没挂上时不要把 /database 当成首页。
   useEffect(() => {
+    const waitingOnNav =
+      !navReady && location.pathname !== '/' && !location.pathname.startsWith('/s/')
+    if (waitingOnNav) return
     const route = parseAppPath(location.pathname, pluginModules)
-    void sessionView.applyRoute(route).catch(() => {
-      if (location.pathname !== '/') navigate('/', { replace: true })
-    })
-  }, [location.pathname, navigate, sessionView, appModules.version()])
+    void sessionView.applyRoute(route).catch(() => undefined)
+  }, [location.pathname, navReady, sessionView, appModules.version()])
 
   // /debug 兼容：主区仍聊天，轨迹在右侧；URL 收成 /s/:id
   useEffect(() => {

--- a/packages/web-react-host/src/web/renderer-keep-route.test.ts
+++ b/packages/web-react-host/src/web/renderer-keep-route.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+const renderer = readFileSync(resolve(import.meta.dirname, './renderer.tsx'), 'utf8')
+
+test('unknown paths do not bounce to home before plugins register', () => {
+  assert.doesNotMatch(renderer, /Navigate to="\/"/)
+  assert.doesNotMatch(renderer, /isKnownAppPath/)
+})

--- a/packages/web-react-host/src/web/renderer.tsx
+++ b/packages/web-react-host/src/web/renderer.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useSyncExternalStore, type ReactNode } from 'react'
-import { BrowserRouter, Navigate, useLocation } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { SlotEvent, type SlotEntry, type SlotKind, type SlotsService } from '@biu/web-slots'
 import type { AppModulesService } from '@biu/web-app-modules'
-import { isKnownAppPath } from '@biu/web-session-view'
 
 function Outlet({ slots, name, kind }: { slots: SlotsService; name: string; kind?: SlotKind }) {
   useSyncExternalStore(
@@ -39,9 +38,8 @@ function AppShell({ slots }: { slots: SlotsService }) {
   return <Outlet slots={slots} name="root" kind="single" />
 }
 
-/** 单壳常驻：路由变化不卸载 Shell，避免 Chat/Debug/模块切换整树重挂。 */
+/** 单壳常驻：路由变化不卸载 Shell，避免 Chat/Debug/模块切换整树重挂。未知路径也不踢回首页，等插件登记完再认。 */
 function Root({ slots, modules }: { slots: SlotsService; modules?: AppModulesService }) {
-  const location = useLocation()
   useSyncExternalStore(
     modules?.subscribe ?? ((fn: () => void) => {
       void fn
@@ -50,10 +48,6 @@ function Root({ slots, modules }: { slots: SlotsService; modules?: AppModulesSer
     modules?.version ?? (() => 0),
     modules?.version ?? (() => 0),
   )
-  const plugins = modules?.plugins() ?? []
-  if (!isKnownAppPath(location.pathname, plugins)) {
-    return <Navigate to="/" replace />
-  }
   return <AppShell slots={slots} />
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
刷新时插件还没 register，`/database/...` 会被当成未知路径并 `Navigate` 到 `/`。

已关掉这条默认回首页：URL 先留着，等导航登记完再认。编译通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

