### PR TITLE
fix(chat): 模块页悬浮最近对话，右下角可切换 Agent

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1562,6 +1562,7 @@ export function CollectionBrowser({
                               setCrumbOpen(null)
                             }}
                           >
+                            <CrumbGlyph kind={choice.target.kind} />
                             {choice.label}
                           </button>
                         ))}
@@ -2268,7 +2269,7 @@ if (typeof document !== 'undefined') {
 .fsdb-crumb-btn:hover,.fsdb-crumb-btn.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
 .fsdb-crumb-pick{position:relative;flex:none}
 .fsdb-crumb-menu{position:absolute;left:0;top:calc(100% + 4px);z-index:20;min-width:160px;max-height:240px;overflow:auto;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-surface);padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.16)}
-.fsdb-crumb-option{display:block;width:100%;border:0;border-radius:6px;background:transparent;padding:6px 8px;color:var(--dsw-label);font:inherit;font-size:13px;text-align:left;cursor:pointer}
+.fsdb-crumb-option{display:flex;width:100%;min-width:0;align-items:center;gap:6px;border:0;border-radius:6px;background:transparent;padding:6px 8px;color:var(--dsw-label);font:inherit;font-size:13px;text-align:left;cursor:pointer}
 .fsdb-crumb-option:hover,.fsdb-crumb-option.is-active{background:var(--dsw-hover)}
 .fsdb-inspector-panel{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden;background:var(--dsw-bg)}
 .fsdb-inspector-host{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -10,5 +10,6 @@ describe('顶栏三级标题', () => {
     expect(nav).toBeTruthy()
     expect(nav).not.toContain('ChevronDownIcon')
     expect(nav).toContain('aria-haspopup={canPick ? \'menu\' : undefined}')
+    expect(nav).toContain('<CrumbGlyph kind={choice.target.kind} />')
   })
 })

--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -8,7 +8,11 @@ const chat = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'u
 
 test('brand mascot lives at the corner; sidebar head is title plus collapse', () => {
   assert.match(shell, /BrandCornerMascot/)
+  assert.match(shell, /onSelect/)
   assert.match(chat, /data-testid="sidebar-collapse"/)
   assert.match(chat, /Biu Agent OS/)
   assert.doesNotMatch(chat, /SidebarBrandMascot/)
+  const mascot = readFileSync(resolve(import.meta.dirname, '../../../web-mascot/src/web/brand-mascot.tsx'), 'utf8')
+  assert.match(mascot, /brand-agent-menu/)
+  assert.match(mascot, /brand-corner-mascot-toggle/)
 })

--- a/packages/web-app-shell/src/web/chat-decouple.test.ts
+++ b/packages/web-app-shell/src/web/chat-decouple.test.ts
@@ -5,9 +5,9 @@ import assert from 'node:assert/strict'
 
 const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
 
-test('overlay chat coexists with the center chat and has no enlarge or sidebar buttons', () => {
+test('overlay chat is off on the agent page and on elsewhere', () => {
   assert.match(shell, /showCenter=\{activeModule === 'agent'\}/)
-  assert.match(shell, /floating/)
+  assert.match(shell, /floating=\{activeModule !== 'agent'\}/)
   assert.doesNotMatch(shell, /chat-overlay-toggle/)
   assert.doesNotMatch(shell, /toggleChatOverlay/)
   assert.doesNotMatch(shell, /放大聊天窗口/)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -705,7 +705,14 @@ function Shell(props: SlotProps) {
       />
 
       <DanceStage sessions={danceSessions} on={dancing} shape={danceShape} />
-      <BrandCornerMascot />
+      <BrandCornerMascot
+        agents={danceSessions}
+        activeId={sessionId}
+        onSelect={(id) => {
+          if (activeModule === 'agent') navigate(`/s/${encodeURIComponent(id)}`)
+          else void sessionView.load(id, { view: 'chat' })
+        }}
+      />
 
       <main className="flex min-h-0 min-w-0 flex-col overflow-hidden">
         <div
@@ -715,7 +722,7 @@ function Shell(props: SlotProps) {
           <AgentMainPanels
             renderSlot={props.renderSlot}
             header={overlayHeader}
-            floating
+            floating={activeModule !== 'agent'}
             showCenter={activeModule === 'agent'}
             withSidebar={showChatSidebar}
             railOpen={railOpen || railPinned}

--- a/packages/web-mascot/src/web/brand-mascot.tsx
+++ b/packages/web-mascot/src/web/brand-mascot.tsx
@@ -1,4 +1,14 @@
-import { useId } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { SidebarMascot } from './sidebar-mascot.tsx'
+import { resolveSessionMascot } from './session-mascot.ts'
+
+export type CornerAgent = {
+  id: string
+  title: string
+  updatedAt?: number
+  type?: string
+  mascot?: { shape: string; color: string; eye?: number }
+}
 
 export function BrandMascot({ className }: { className?: string }) {
   const uid = useId().replace(/:/g, '')
@@ -29,10 +39,82 @@ export function BrandMascot({ className }: { className?: string }) {
   )
 }
 
-export function BrandCornerMascot() {
+export function BrandCornerMascot({
+  agents = [],
+  activeId,
+  onSelect,
+}: {
+  agents?: CornerAgent[]
+  activeId?: string | null
+  onSelect?: (id: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const ranked = useMemo(
+    () => [...agents].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0) || a.id.localeCompare(b.id)),
+    [agents],
+  )
+  const current = ranked.find((item) => item.id === activeId) ?? ranked[0]
+  const identity = current ? resolveSessionMascot(current.id, current.mascot) : undefined
+
+  useEffect(() => {
+    if (!open) return
+    function onPointer(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false)
+    }
+    window.addEventListener('mousedown', onPointer)
+    return () => window.removeEventListener('mousedown', onPointer)
+  }, [open])
+
   return (
-    <div className="brand-corner-mascot" data-testid="brand-corner-mascot" aria-hidden>
-      <BrandMascot className="size-9" />
+    <div className="brand-corner-mascot" ref={rootRef} data-testid="brand-corner-mascot">
+      <button
+        type="button"
+        className="brand-corner-mascot-btn"
+        title={current ? current.title : '选择 Agent'}
+        aria-label={current ? `当前 Agent：${current.title}` : '选择 Agent'}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="brand-corner-mascot-toggle"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {identity && current ? (
+          <SidebarMascot size={36} sessionId={current.id} identity={identity} animate={false} title={current.title} />
+        ) : (
+          <BrandMascot className="size-9" />
+        )}
+      </button>
+      {open ? (
+        <div className="brand-agent-menu" role="menu" data-testid="brand-agent-menu">
+          {ranked.length ? (
+            ranked.map((item) => {
+              const face = resolveSessionMascot(item.id, item.mascot)
+              const active = item.id === (activeId ?? current?.id)
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  role="menuitem"
+                  className={`inspector-catalog-item${active ? ' is-active' : ''}`}
+                  data-testid={`brand-agent-${item.id}`}
+                  onClick={() => {
+                    onSelect?.(item.id)
+                    setOpen(false)
+                  }}
+                >
+                  <SidebarMascot size={24} sessionId={item.id} identity={face} animate={false} title={item.title} />
+                  <span className="min-w-0 flex-1 truncate">
+                    {(item.type ?? 'chat') === 'live' ? <span className="mr-1 text-[9px] font-semibold tracking-wide uppercase">live</span> : null}
+                    {item.title}
+                  </span>
+                </button>
+              )
+            })
+          ) : (
+            <p className="inspector-catalog-empty">还没有 Agent</p>
+          )}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -11,6 +11,7 @@ import {
   type TrajectoryUsage,
 } from './session-project.ts'
 import type { AppRoute } from './session-route.ts'
+import { mostRecentSessionId } from './session-groups.ts'
 import { markSidebarMascotFresh } from './session-mascot-fresh.ts'
 
 export type { AppRoute, RouteView, InspectorCenterKind } from './session-route.ts'
@@ -46,6 +47,7 @@ export {
   UNGROUPED_PROJECT_KEY,
   UNGROUPED_TAG_KEY,
   PINNED_GROUP_KEY,
+  mostRecentSessionId,
   groupSessionsByProject,
   groupSessionsByTag,
   buildSidebarGroups,
@@ -343,66 +345,49 @@ export class SessionViewService extends Service {
     void this.ensureTrajectory()
   }
 
-  /** URL → 状态：只由路由层调用，不回写 URL */
+  /** URL → 状态：只由路由层调用，不回写 URL。
+   * `/s/:id` 打开该会话；其它页面（含首页、数据库等）打开最近一条对话，供全局悬浮窗使用。 */
   async applyRoute(route: AppRoute) {
-    if (route.kind !== 'home' && route.kind !== 'session') {
-      return
-    }
-    if (route.kind === 'home') {
-      if (!this.value.sessionId && this.value.view === 'chat') return
-      this.stashCurrent()
-      this.loadGen += 1
-      this.trajectoryLive = false
-      this.trajGen += 1
-      this.replace({
-        sessionId: null,
-        events: [],
-        nodes: [],
-        trajectory: [],
-        view: 'chat',
-        focusCallId: undefined,
-        pending: false,
-        agentStatus: 'idle',
-        inbox: [],
-        project: undefined,
-        hasMoreOlder: false,
-        loadingOlder: false,
-        trajectoryHasMore: false,
-        trajectoryLoading: false,
-        totalTurns: 0,
-        switchingSession: false,
-        error: undefined,
-      })
-      return
-    }
-    if (this.value.sessionId !== route.sessionId) {
-      try {
-        await this.load(route.sessionId, { view: route.view })
-      } catch (error) {
+    if (route.kind === 'session') {
+      if (this.value.sessionId !== route.sessionId) {
+        try {
+          await this.load(route.sessionId, { view: route.view })
+        } catch (error) {
+          this.replace({
+            error: String(error),
+            sessionId: null,
+            events: [],
+            nodes: [],
+            trajectory: [],
+            view: 'chat',
+            focusCallId: undefined,
+            hasMoreOlder: false,
+            loadingOlder: false,
+            trajectoryHasMore: false,
+            trajectoryLoading: false,
+            totalTurns: 0,
+            switchingSession: false,
+          })
+          throw error
+        }
+      } else if (this.value.view !== route.view) {
         this.replace({
-          error: String(error),
-          sessionId: null,
-          events: [],
-          nodes: [],
-          trajectory: [],
-          view: 'chat',
-          focusCallId: undefined,
-          hasMoreOlder: false,
-          loadingOlder: false,
-          trajectoryHasMore: false,
-          trajectoryLoading: false,
-          totalTurns: 0,
-          switchingSession: false,
+          view: route.view,
+          focusCallId: route.view === 'chat' ? undefined : this.value.focusCallId,
         })
-        throw error
       }
-    } else if (this.value.view !== route.view) {
-      this.replace({
-        view: route.view,
-        focusCallId: route.view === 'chat' ? undefined : this.value.focusCallId,
-      })
+      if (this.wantsTrajectory(route.view)) await this.ensureTrajectory()
+      return
     }
-    if (this.wantsTrajectory(route.view)) await this.ensureTrajectory()
+    await this.loadMostRecentSession()
+  }
+
+  private async loadMostRecentSession() {
+    if (!this.value.sessions.length) await this.refreshSessions()
+    const latest = mostRecentSessionId(this.value.sessions)
+    if (!latest) return
+    if (this.value.sessionId === latest) return
+    await this.load(latest, { view: 'chat' })
   }
 
   ingest(sessionId: string, event: SessionEvent) {

--- a/packages/web-session-view/src/web/session-groups.test.ts
+++ b/packages/web-session-view/src/web/session-groups.test.ts
@@ -9,6 +9,7 @@ import {
   folderNameFromPath,
   groupSessionsByProject,
   groupSessionsByTag,
+  mostRecentSessionId,
 } from './session-groups.ts'
 import type { SessionListItem } from './index.ts'
 
@@ -171,5 +172,16 @@ test('buildSidebarSections keeps a pinned section that holds pinned rows', () =>
   assert.deepEqual(
     sections[0]?.sessions?.map((r) => r.id),
     ['a'],
+  )
+})
+
+test('mostRecentSessionId prefers newest chat and ignores pin', () => {
+  assert.equal(
+    mostRecentSessionId([
+      item({ id: 'old', updatedAt: 1, pinned: true }),
+      item({ id: 'new', updatedAt: 9 }),
+      item({ id: 'live', updatedAt: 99, type: 'live' }),
+    ]),
+    'new',
   )
 })

--- a/packages/web-session-view/src/web/session-groups.ts
+++ b/packages/web-session-view/src/web/session-groups.ts
@@ -22,6 +22,23 @@ export function compareSessionRows(a: SessionListItem, b: SessionListItem) {
   return b.updatedAt - a.updatedAt || a.id.localeCompare(b.id)
 }
 
+/** 悬浮聊天用：按更新时间取最近一条对话（忽略置顶；优先普通 chat）。 */
+export function mostRecentSessionId(sessions: SessionListItem[]): string | undefined {
+  const chats = sessions.filter((item) => (item.type ?? 'chat') !== 'live')
+  const pool = chats.length ? chats : sessions
+  let best: SessionListItem | undefined
+  for (const item of pool) {
+    if (
+      !best ||
+      item.updatedAt > best.updatedAt ||
+      (item.updatedAt === best.updatedAt && item.id.localeCompare(best.id) < 0)
+    ) {
+      best = item
+    }
+  }
+  return best?.id
+}
+
 function sortGroupSessions(group: SessionSidebarGroup) {
   group.sessions.sort(compareSessionRows)
   group.updatedAt = group.sessions.reduce((max, item) => Math.max(max, item.updatedAt), 0)

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -684,3 +684,29 @@ test('forkCurrent inserts the child into the sidebar list', async () => {
   assert.equal(view.get().sessionId, 's2')
   assert.equal(view.get().sessions.some((item) => item.id === 's2'), true)
 })
+
+test('home and module routes open the most recently updated chat', async () => {
+  mockFetch({
+    '/api/sessions': () => ({
+      sessions: [
+        { id: 'old', title: 'old', eventCount: 1, updatedAt: 1 },
+        { id: 'new', title: 'new', eventCount: 1, updatedAt: 9 },
+      ],
+    }),
+    '/api/sessions/new?turns=': () => ({
+      id: 'new',
+      events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+      hasMore: false,
+      totalTurns: 0,
+    }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  await view.applyRoute({ kind: 'home' })
+  assert.equal(view.get().sessionId, 'new')
+  await view.applyRoute({ kind: 'module', moduleId: 'database', path: '/database' })
+  assert.equal(view.get().sessionId, 'new')
+})

--- a/web/style.css
+++ b/web/style.css
@@ -289,8 +289,35 @@ body {
   position: fixed;
   right: 16px;
   bottom: 16px;
-  z-index: 40;
-  pointer-events: none;
+  z-index: 90;
+  pointer-events: auto;
+}
+
+.brand-corner-mascot-btn {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 12px;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+
+.brand-agent-menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  z-index: 21;
+  min-width: 200px;
+  max-height: 280px;
+  overflow: auto;
+  border: 1px solid var(--dsw-border);
+  border-radius: 8px;
+  background: var(--dsw-surface);
+  padding: 4px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
 }
 
 /* 右侧检查器 tab：选中态与顶栏收起检查器按钮相同，无底边指示条 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- 聊天（Agent）页不再挂悬浮窗，中间已经是完整对话。
- 其它页面显示悬浮窗，默认打开最近更新的一条对话。
- 点右下角小人弹出 Agent 列表，聊天页会跳到该会话，其它页只切换悬浮窗里的对话。
- 数据页左上角面包屑下拉每一项带上表/视图/记录图标。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

