### PR TITLE
检查器数据库 tab：叶子标题 + 悬停面包屑，内容与左侧数据栏一致

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -896,6 +896,7 @@ export function CollectionBrowser({
     setViews(next)
     localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
     pushSavedViews(collectionPath, next)
+    window.dispatchEvent(new Event('fsdb:change'))
   }
 
   function rememberActiveView(id: string) {
@@ -1025,6 +1026,38 @@ export function CollectionBrowser({
     setViewMenuOpen(false)
     setDlg({ kind: 'delete', view })
   }
+
+  const addEmptyViewRef = useRef(addEmptyView)
+  const copyViewRef = useRef(copyView)
+  const renameViewRef = useRef(renameView)
+  const deleteViewRef = useRef(deleteView)
+  addEmptyViewRef.current = addEmptyView
+  copyViewRef.current = copyView
+  renameViewRef.current = renameView
+  deleteViewRef.current = deleteView
+
+  useEffect(() => {
+    const onAdd = () => addEmptyViewRef.current()
+    const onCopy = () => copyViewRef.current()
+    const onRename = (event: Event) => {
+      const view = (event as CustomEvent<SavedView>).detail
+      if (view?.id) renameViewRef.current(view)
+    }
+    const onDelete = (event: Event) => {
+      const view = (event as CustomEvent<SavedView>).detail
+      if (view?.id) deleteViewRef.current(view)
+    }
+    window.addEventListener('fsdb:add-view', onAdd)
+    window.addEventListener('fsdb:copy-view', onCopy)
+    window.addEventListener('fsdb:rename-view', onRename)
+    window.addEventListener('fsdb:delete-view', onDelete)
+    return () => {
+      window.removeEventListener('fsdb:add-view', onAdd)
+      window.removeEventListener('fsdb:copy-view', onCopy)
+      window.removeEventListener('fsdb:rename-view', onRename)
+      window.removeEventListener('fsdb:delete-view', onDelete)
+    }
+  }, [])
 
   function applyRename(name?: string) {
     if (!dlg || dlg.kind !== 'rename') return
@@ -2278,6 +2311,7 @@ if (typeof document !== 'undefined') {
 .fsdb-inspector-panel .fsdb-detail-stage{min-height:0;flex:1}
 .fsdb-right-body{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-views{display:flex;width:280px;flex:none;flex-direction:column;min-height:0;overflow:hidden}
+.inspector-database-rail.fsdb-views{width:100%;flex:1;border-right:0}
 .fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}
 .fsdb-collection-head{flex:none;padding:4px 16px 10px;min-width:0}

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -260,6 +260,7 @@ export const DataSidebar = memo(function DataSidebar({
   expandedViewKey: expandedViewKeyProp,
   onExpandedViewKeyChange,
   onCollapse,
+  hideChrome = false,
 }: {
   tables: CollectionInfo[]
   collectionPath: string
@@ -276,6 +277,7 @@ export const DataSidebar = memo(function DataSidebar({
   expandedViewKey?: string | null
   onExpandedViewKeyChange?: (key: string | null) => void
   onCollapse?: () => void
+  hideChrome?: boolean
 }) {
   const listedTables = useMemo(
     () => (tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]),
@@ -370,9 +372,11 @@ export const DataSidebar = memo(function DataSidebar({
 
   return (
     <aside
-      className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
+      className={`app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden bg-(--dsw-sidebar)${hideChrome ? ' inspector-database-rail' : ' border-r border-(--dsw-border)'}`}
       aria-label="数据"
+      data-testid={hideChrome ? 'inspector-database' : undefined}
     >
+      {hideChrome ? null : (
       <div className="app-side-bar-head">
         <span
           className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
@@ -391,6 +395,7 @@ export const DataSidebar = memo(function DataSidebar({
           <ChevronDoubleLeftIcon aria-hidden className="size-4" />
         </button>
       </div>
+      )}
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="app-side-actions" role="navigation" aria-label="视图操作" data-biu-ignore>
           <button type="button" className="app-side-actions-item" title="添加视图" onClick={onAddView}>

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -15,7 +15,7 @@ import {
 } from './nav-boot.ts'
 import { loadActiveViewId, loadViews, pushAllSavedViews } from './view-storage.ts'
 import { bindSnapshot } from '@biu/web-snapshot'
-import { DatabaseInspectorBrowse } from './inspector-database.tsx'
+import { DatabaseInspectorBrowse, DatabaseInspectorTab } from './inspector-database.tsx'
 
 type SlotsService = {
   place: (slot: string, view: unknown, opts: { key: string; order?: number; props?: () => Record<string, unknown> }) => { dispose?: () => unknown }
@@ -354,6 +354,7 @@ export function apply(ctx: Context) {
         tabId: 'database',
         tabLabel: '数据库',
         tabIcon: CircleStackIcon,
+        Tab: DatabaseInspectorTab,
         common: true,
         useSnapshot: bindSnapshot(snapshot),
       }),

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,133 +1,189 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState, useSyncExternalStore, type MouseEvent } from 'react'
 import { CircleStackIcon } from '@heroicons/react/16/solid'
+import { useLocation, useNavigate } from 'react-router-dom'
 import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
 import type { bindSnapshot } from '@biu/web-snapshot'
-import { buildCrumbs, type CrumbTarget } from './sidebar-nav.ts'
+import { parseAppPath } from '@biu/web-session-view'
+import { buildCrumbs, DATABASE_ROOT_PATH, pathForCrumbTarget, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 import { CrumbItemGlyph } from './nav-glyphs.tsx'
-import { applyInspectorBrowse, emptyInspectorBrowse } from './inspector-browse.ts'
-import { loadViews } from './view-storage.ts'
-import { fetchViewPreview, recordPreviewEmoji, recordPreviewLabel } from './sidebar-preview.ts'
+import { DataSidebar } from './data-sidebar.tsx'
+import { loadActiveViewId, loadViews } from './view-storage.ts'
+import { databaseRecordPath, databaseViewPath } from './inspector-nav.ts'
+import type { SavedView } from './saved-view.ts'
+
+const DATA_MODULE = { id: 'database', label: '数据', path: '/database' }
+
+let viewTick = 0
 
 function tableLabel(table: CollectionInfo) {
   return table.view?.title ?? table.label ?? table.path.replace(/^\//, '')
 }
 
+function useViewTick() {
+  return useSyncExternalStore(
+    (fn) => {
+      const bump = () => {
+        viewTick += 1
+        fn()
+      }
+      window.addEventListener('fsdb:change', bump)
+      window.addEventListener('storage', bump)
+      return () => {
+        window.removeEventListener('fsdb:change', bump)
+        window.removeEventListener('storage', bump)
+      }
+    },
+    () => viewTick,
+    () => 0,
+  )
+}
+
+function crumbsForRoute(
+  pathname: string,
+  tables: CollectionInfo[],
+): { crumbs: Crumb[]; collection: string; viewId?: string; recordId?: string } {
+  const parsed = parseAppPath(pathname, [DATA_MODULE])
+  const collection = parsed.kind === 'collection-view' || parsed.kind === 'record' ? parsed.collection : ''
+  const viewId = parsed.kind === 'collection-view' ? parsed.viewId : undefined
+  const recordId = parsed.kind === 'record' ? parsed.recordId : undefined
+  const table = tables.find((item) => item.path === collection)
+  const views = collection ? loadViews(collection) : []
+  const activeViewId = viewId || (collection ? loadActiveViewId(collection, views) ?? undefined : undefined)
+  const view = views.find((item) => item.id === activeViewId)
+  const crumbs = buildCrumbs({
+    collection,
+    collectionLabel: table ? tableLabel(table) : collection,
+    tables: tables.map((item) => ({ path: item.path, label: tableLabel(item), icon: item.view?.icon })),
+    viewId: collection ? activeViewId : undefined,
+    viewName: view?.name,
+    views: views.map((item) => ({ id: item.id, name: item.name, mode: item.mode })),
+    recordId,
+    recordLabel: recordId,
+  })
+  return { crumbs, collection, viewId: activeViewId, recordId }
+}
+
+export function DatabaseInspectorTab({
+  active,
+  onActivate,
+  useSnapshot,
+}: {
+  active?: boolean
+  onActivate?: () => void
+  useSnapshot?: ReturnType<typeof bindSnapshot>
+}) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [hover, setHover] = useState(false)
+  useViewTick()
+  const collections = (useSnapshot?.((state) => state.collections ?? []) ?? []) as CollectionInfo[]
+  const tables = useMemo(
+    () => collections.filter((row) => row.path && row.path !== '/'),
+    [collections],
+  )
+  const { crumbs } = crumbsForRoute(location.pathname, tables)
+  const leaf = crumbs.at(-1)
+  const leafChoice = leaf?.choices.find((item) => item.id === leaf.id)
+  const showTrail = hover && crumbs.length > 0
+
+  function go(event: MouseEvent, target: CrumbTarget | { kind: 'root' }) {
+    event.preventDefault()
+    event.stopPropagation()
+    onActivate?.()
+    if (target.kind === 'root') {
+      navigate(DATABASE_ROOT_PATH)
+      return
+    }
+    navigate(pathForCrumbTarget(target))
+  }
+
+  return (
+    <div
+      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}`}
+      role="tab"
+      aria-selected={Boolean(active)}
+      data-testid="inspector-tab-database"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={() => onActivate?.()}
+    >
+      {showTrail ? (
+        <nav className="inspector-crumb-full" aria-label="数据库位置">
+          <button type="button" className="fsdb-crumb-btn" onClick={(event) => go(event, { kind: 'root' })}>
+            <CircleStackIcon aria-hidden className="chat-view-project-icon" />
+            <span className="chat-view-project-name">数据库</span>
+          </button>
+          {crumbs.map((crumb) => {
+            const current = crumb.choices.find((item) => item.id === crumb.id)
+            return (
+              <span key={crumb.id} className="fsdb-crumb">
+                <span className="fsdb-crumb-sep" aria-hidden>/</span>
+                <button type="button" className="fsdb-crumb-btn" onClick={(event) => go(event, crumb.target)}>
+                  <CrumbItemGlyph kind={crumb.kind} icon={current?.icon} mode={current?.mode} emoji={current?.emoji} />
+                  <span className="chat-view-project-name">{crumb.label}</span>
+                </button>
+              </span>
+            )
+          })}
+        </nav>
+      ) : (
+        <span className="inspector-crumb-leaf">
+          {leaf ? (
+            <CrumbItemGlyph kind={leaf.kind} icon={leafChoice?.icon} mode={leafChoice?.mode} emoji={leafChoice?.emoji} />
+          ) : (
+            <CircleStackIcon aria-hidden className="chat-view-project-icon" />
+          )}
+          <span className="chat-view-project-name">{leaf?.label ?? '数据库'}</span>
+        </span>
+      )}
+    </div>
+  )
+}
+
 export function DatabaseInspectorBrowse(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
+  const location = useLocation()
+  const navigate = useNavigate()
+  useViewTick()
   const collections = (useSnapshot((state) => state.collections ?? []) ?? []) as CollectionInfo[]
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
     [collections],
   )
-  const [browse, setBrowse] = useState(emptyInspectorBrowse)
-  const [records, setRecords] = useState<Array<{ id: string; label: string; emoji?: string }>>([])
-  const table = tables.find((item) => item.path === browse.collection)
-  const views = browse.collection ? loadViews(browse.collection) : []
-  const view = views.find((item) => item.id === browse.viewId)
-  const crumbs = buildCrumbs({
-    collection: browse.collection,
-    collectionLabel: table ? tableLabel(table) : browse.collection,
-    tables: tables.map((item) => ({ path: item.path, label: tableLabel(item), icon: item.view?.icon })),
-    viewId: browse.viewId,
-    viewName: view?.name,
-    views: views.map((item) => ({ id: item.id, name: item.name, mode: item.mode })),
-    recordId: browse.recordId,
-    recordLabel: records.find((row) => row.id === browse.recordId)?.label,
-    records,
-  })
+  const { collection, viewId } = crumbsForRoute(location.pathname, tables)
+  const collectionPath = collection || tables[0]?.path || ''
+  const table = tables.find((item) => item.path === collectionPath)
+  const views = collectionPath ? loadViews(collectionPath) : []
+  const activeViewId = viewId || loadActiveViewId(collectionPath, views)
+  const title = table ? tableLabel(table) : '数据'
 
-  useEffect(() => {
-    const current = browse.collection && browse.viewId
-      ? loadViews(browse.collection).find((item) => item.id === browse.viewId)
-      : undefined
-    if (!browse.collection || !current) {
-      setRecords([])
-      return
-    }
-    let cancelled = false
-    void fetchViewPreview(browse.collection, current, 0, 40).then((page) => {
-      if (cancelled) return
-      const labelField = undefined
-      setRecords(page.items.map((row) => ({
-        id: String(row.id),
-        label: recordPreviewLabel(row, labelField),
-        emoji: recordPreviewEmoji(row),
-      })))
-    }).catch(() => {
-      if (!cancelled) setRecords([])
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [browse.collection, browse.viewId])
-
-  function go(target: CrumbTarget | { kind: 'root' }) {
-    setBrowse((prev) => applyInspectorBrowse(prev, target))
+  function openTable(path: string, nextViewId?: string) {
+    navigate(databaseViewPath(path, nextViewId ?? loadActiveViewId(path, loadViews(path)) ?? undefined))
   }
 
-  const list = !browse.collection
-    ? tables.map((item) => ({
-        id: item.path,
-        label: tableLabel(item),
-        glyph: <CrumbItemGlyph kind="collection" icon={item.view?.icon} className="size-4 shrink-0" />,
-        onClick: () => go({ kind: 'collection', collection: item.path }),
-      }))
-    : !browse.viewId
-      ? views.map((item) => ({
-          id: item.id,
-          label: item.name,
-          glyph: <CrumbItemGlyph kind="view" mode={item.mode} className="size-4 shrink-0" />,
-          onClick: () => go({ kind: 'view', collection: browse.collection, viewId: item.id }),
-        }))
-      : !browse.recordId
-        ? records.map((item) => ({
-            id: item.id,
-            label: item.label,
-            glyph: <CrumbItemGlyph kind="record" emoji={item.emoji} className="size-4 shrink-0" />,
-            onClick: () => go({ kind: 'record', collection: browse.collection, recordId: item.id }),
-          }))
-        : []
+  function applyView(view: SavedView) {
+    if (!collectionPath) return
+    navigate(databaseViewPath(collectionPath, view.id))
+  }
 
   return (
-    <div className="inspector-catalog" data-testid="inspector-database">
-      <nav className="fsdb-crumbs" aria-label="数据库位置">
-        <span className="fsdb-crumb">
-          <button type="button" className="fsdb-crumb-btn" onClick={() => go({ kind: 'root' })}>
-            <CircleStackIcon aria-hidden className="chat-view-project-icon" />
-            <span className="chat-view-project-name">数据库</span>
-          </button>
-        </span>
-        {crumbs.map((crumb) => {
-          const current = crumb.choices.find((item) => item.id === crumb.id)
-          return (
-          <span key={crumb.id} className="fsdb-crumb">
-            <span className="fsdb-crumb-sep" aria-hidden>/</span>
-            <button type="button" className="fsdb-crumb-btn" onClick={() => go(crumb.target)}>
-              <CrumbItemGlyph kind={crumb.kind} icon={current?.icon} mode={current?.mode} emoji={current?.emoji} />
-              <span className="chat-view-project-name">{crumb.label}</span>
-            </button>
-          </span>
-          )
-        })}
-      </nav>
-      {list.length ? (
-        list.map((item) => (
-          <button
-            key={item.id}
-            type="button"
-            className="inspector-catalog-item"
-            onClick={item.onClick}
-          >
-            {item.glyph}
-            <span className="min-w-0 flex-1 truncate">{item.label}</span>
-          </button>
-        ))
-      ) : (
-        <p className="inspector-catalog-empty">
-          {browse.recordId ? records.find((row) => row.id === browse.recordId)?.label || browse.recordId : '没有可打开的项'}
-        </p>
-      )}
-    </div>
+    <DataSidebar
+      hideChrome
+      tables={tables}
+      collectionPath={collectionPath}
+      title={title}
+      views={views}
+      activeViewId={activeViewId}
+      onOpenTable={openTable}
+      onApplyView={applyView}
+      onRenameView={(view) => window.dispatchEvent(new CustomEvent('fsdb:rename-view', { detail: view }))}
+      onDeleteView={(view) => window.dispatchEvent(new CustomEvent('fsdb:delete-view', { detail: view }))}
+      onAddView={() => window.dispatchEvent(new Event('fsdb:add-view'))}
+      onCopyView={() => window.dispatchEvent(new Event('fsdb:copy-view'))}
+      onOpenRecord={(path, view, recordId) => {
+        navigate(databaseRecordPath(path, recordId))
+      }}
+    />
   )
 }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -34,9 +34,12 @@ test('database can be added to the inspector and browsed by crumbs', () => {
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.match(page, /fsdb-database-browse/)
   assert.match(page, /tabLabel: '数据库'/)
+  assert.match(page, /Tab: DatabaseInspectorTab/)
   const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
   assert.match(browse, /data-testid="inspector-database"/)
   assert.match(browse, /aria-label="数据库位置"/)
+  assert.match(browse, /inspector-crumb-leaf/)
+  assert.match(browse, /hideChrome/)
 })
 
 test('inspector no longer listens for add/copy view actions', () => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -36,10 +36,11 @@ test('database can be added to the inspector and browsed by crumbs', () => {
   assert.match(page, /tabLabel: '数据库'/)
   assert.match(page, /Tab: DatabaseInspectorTab/)
   const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
-  assert.match(browse, /data-testid="inspector-database"/)
   assert.match(browse, /aria-label="数据库位置"/)
   assert.match(browse, /inspector-crumb-leaf/)
   assert.match(browse, /hideChrome/)
+  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  assert.match(sidebar, /data-testid=\{hideChrome \? 'inspector-database' : undefined\}/)
 })
 
 test('inspector no longer listens for add/copy view actions', () => {

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -11,4 +11,5 @@ test('inspector header keeps opened tabs on top and a plus menu on the right', (
   assert.match(inspector, /className="app-side-bar-head"/)
   assert.match(inspector, /PlusIcon/)
   assert.match(inspector, /点右上角加号/)
+  assert.match(inspector, /item.Tab/)
 })

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -65,6 +65,7 @@ export const SessionInspector = memo(function SessionInspector({
           id: String(extra.tabId ?? entry.id),
           label: String(extra.tabLabel ?? '插件'),
           Icon: extra.tabIcon as ComponentType<{ className?: string }> | undefined,
+          Tab: extra.Tab as ComponentType<Record<string, unknown>> | undefined,
           ensureTrajectory: Boolean(extra.ensureTrajectory),
           focusOnCall: Boolean(extra.focusOnCall),
           common: Boolean(extra.common),
@@ -200,6 +201,17 @@ export const SessionInspector = memo(function SessionInspector({
         <div className="inspector-tabs" role="tablist" aria-label="检查器分区">
           {headerTabs.map((item) => {
             const active = tab === item.id
+            const Tab = item.Tab
+            if (Tab) {
+              return (
+                <Tab
+                  key={item.id}
+                  active={active}
+                  onActivate={() => setTab(item.id)}
+                  {...(item.entry.props?.() ?? {})}
+                />
+              )
+            }
             return (
               <button
                 key={item.id}

--- a/web/style.css
+++ b/web/style.css
@@ -359,6 +359,31 @@ body {
   display: none;
 }
 
+.inspector-crumb-tab {
+  max-width: min(100%, 420px);
+  min-width: 0;
+}
+
+.inspector-crumb-leaf,
+.inspector-crumb-full {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  gap: 2px;
+}
+
+.inspector-crumb-full .fsdb-crumb-btn {
+  max-width: 140px;
+}
+
+.inspector-database-rail.fsdb-views {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  border-right: 0;
+}
+
 .inspector-catalog {
   display: flex;
   min-height: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器里的「数据库」分区：

- Tab 默认只显示当前路径最深一层（叶子），鼠标悬停后展开成完整可点击面包屑（数据库 / 表 / 视图 / 记录）。
- 面板内容复用左侧数据栏（收藏、表、视图、记录预览、添加/拷贝视图、星标、计数），只去掉品牌头和收起左侧栏。
- 检查器里改视图会通过 `fsdb:*` 事件同步主界面。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

