### PR TITLE
检查器数据库：只显示中间内页，与左侧解耦

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -455,6 +455,7 @@ export function CollectionBrowser({
   onOpenRecord,
   onCloseRecord,
   onCrumbTarget,
+  embed = false,
 }: {
   moduleId?: string
   collectionPath: string
@@ -472,6 +473,8 @@ export function CollectionBrowser({
   onOpenRecord?: (recordId: string, viewId?: string | null, collection?: string) => void
   onCloseRecord?: () => void
   onCrumbTarget?: (target: CrumbTarget) => void
+  /** 检查器内页：只有中间舞台，不写侧栏开关/视图存储，也不抢记录焦点。 */
+  embed?: boolean
 }) {
   const [stat, setStat] = useState<StatResult | null>(null)
   const [items, setItems] = useState<Array<DbRecord & { path?: string }>>([])
@@ -566,6 +569,7 @@ export function CollectionBrowser({
   }
 
   useEffect(() => {
+    if (embed) return
     function onToggle(event: Event) {
       const id = (event as CustomEvent<{ id?: string }>).detail?.id
       if (!id || (moduleId && id !== moduleId)) return
@@ -573,9 +577,10 @@ export function CollectionBrowser({
     }
     window.addEventListener('biu:toggle-module-sidebar', onToggle)
     return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
-  }, [collectionPath, moduleId])
+  }, [collectionPath, embed, moduleId])
 
   useEffect(() => {
+    if (embed) return
     const sync = (open: boolean) => setInspectorOpen(open)
     const onOpen = () => sync(true)
     const onClose = () => sync(false)
@@ -588,7 +593,7 @@ export function CollectionBrowser({
       window.removeEventListener('biu:inspector-close', onClose)
       window.removeEventListener('biu:inspector-toggle', onToggle)
     }
-  }, [])
+  }, [embed])
 
   useEffect(() => {
     function onPointer(event: MouseEvent) {
@@ -865,26 +870,28 @@ export function CollectionBrowser({
   }, [collectionPath, detailId])
 
   useEffect(() => {
-    if (!detailId) return
+    if (embed || !detailId) return
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setDetailId(null)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [detailId])
+  }, [detailId, embed])
 
   useEffect(() => {
+    if (embed) return
     if (!detailId) {
       databaseUi?.setRecordFocus(null)
       return
     }
     const row = items.find((item) => item.id === detailId)
     databaseUi?.setRecordFocus({ path: collectionPath, recordId: detailId, record: row })
-  }, [collectionPath, databaseUi, detailId, items])
+  }, [collectionPath, databaseUi, detailId, embed, items])
 
   useEffect(() => {
+    if (embed) return
     return () => databaseUi?.setRecordFocus(null)
-  }, [databaseUi])
+  }, [databaseUi, embed])
 
   useEffect(() => {
     if (dlg?.kind !== 'rename') return
@@ -894,6 +901,7 @@ export function CollectionBrowser({
   function persistViews(next: SavedView[]) {
     viewsRef.current = next
     setViews(next)
+    if (embed) return
     localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
     pushSavedViews(collectionPath, next)
     window.dispatchEvent(new Event('fsdb:change'))
@@ -901,6 +909,7 @@ export function CollectionBrowser({
 
   function rememberActiveView(id: string) {
     setActiveViewId(id)
+    if (embed) return
     try {
       localStorage.setItem(activeViewStorageKey(collectionPath), id)
     } catch {
@@ -1026,38 +1035,6 @@ export function CollectionBrowser({
     setViewMenuOpen(false)
     setDlg({ kind: 'delete', view })
   }
-
-  const addEmptyViewRef = useRef(addEmptyView)
-  const copyViewRef = useRef(copyView)
-  const renameViewRef = useRef(renameView)
-  const deleteViewRef = useRef(deleteView)
-  addEmptyViewRef.current = addEmptyView
-  copyViewRef.current = copyView
-  renameViewRef.current = renameView
-  deleteViewRef.current = deleteView
-
-  useEffect(() => {
-    const onAdd = () => addEmptyViewRef.current()
-    const onCopy = () => copyViewRef.current()
-    const onRename = (event: Event) => {
-      const view = (event as CustomEvent<SavedView>).detail
-      if (view?.id) renameViewRef.current(view)
-    }
-    const onDelete = (event: Event) => {
-      const view = (event as CustomEvent<SavedView>).detail
-      if (view?.id) deleteViewRef.current(view)
-    }
-    window.addEventListener('fsdb:add-view', onAdd)
-    window.addEventListener('fsdb:copy-view', onCopy)
-    window.addEventListener('fsdb:rename-view', onRename)
-    window.addEventListener('fsdb:delete-view', onDelete)
-    return () => {
-      window.removeEventListener('fsdb:add-view', onAdd)
-      window.removeEventListener('fsdb:copy-view', onCopy)
-      window.removeEventListener('fsdb:rename-view', onRename)
-      window.removeEventListener('fsdb:delete-view', onDelete)
-    }
-  }, [])
 
   function applyRename(name?: string) {
     if (!dlg || dlg.kind !== 'rename') return
@@ -1526,8 +1503,11 @@ export function CollectionBrowser({
   ])
 
   return (
-    <div className="fsdb-page tasks-root">
-      {viewsOpen ? (
+    <div
+      className={`fsdb-page tasks-root${embed ? ' inspector-database-page' : ''}`}
+      data-testid={embed ? 'inspector-database' : undefined}
+    >
+      {!embed && viewsOpen ? (
         <DataSidebar
           tables={tables}
           collectionPath={collectionPath}
@@ -1552,6 +1532,7 @@ export function CollectionBrowser({
         />
       ) : null}
       <div className="fsdb-right">
+        {embed ? null : (
         <header className="chat-view-header" data-biu-ignore>
           <div className="chat-view-header-left">
             <nav className="fsdb-crumbs" aria-label="位置" ref={crumbRef}>
@@ -1637,6 +1618,7 @@ export function CollectionBrowser({
             </button>
           </div>
         </header>
+        )}
         <div className="fsdb-right-body">
         {!selected ? (
         <div className="tasks-main fsdb-main">
@@ -2311,7 +2293,7 @@ if (typeof document !== 'undefined') {
 .fsdb-inspector-panel .fsdb-detail-stage{min-height:0;flex:1}
 .fsdb-right-body{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-views{display:flex;width:280px;flex:none;flex-direction:column;min-height:0;overflow:hidden}
-.inspector-database-rail.fsdb-views{width:100%;flex:1;border-right:0}
+.inspector-database-page{width:100%;min-height:0;flex:1}
 .fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}
 .fsdb-collection-head{flex:none;padding:4px 16px 10px;min-width:0}

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -260,7 +260,6 @@ export const DataSidebar = memo(function DataSidebar({
   expandedViewKey: expandedViewKeyProp,
   onExpandedViewKeyChange,
   onCollapse,
-  hideChrome = false,
 }: {
   tables: CollectionInfo[]
   collectionPath: string
@@ -277,7 +276,6 @@ export const DataSidebar = memo(function DataSidebar({
   expandedViewKey?: string | null
   onExpandedViewKeyChange?: (key: string | null) => void
   onCollapse?: () => void
-  hideChrome?: boolean
 }) {
   const listedTables = useMemo(
     () => (tables.length ? tables : [{ path: collectionPath, label: title, view: { title } } as CollectionInfo]),
@@ -372,11 +370,9 @@ export const DataSidebar = memo(function DataSidebar({
 
   return (
     <aside
-      className={`app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden bg-(--dsw-sidebar)${hideChrome ? ' inspector-database-rail' : ' border-r border-(--dsw-border)'}`}
+      className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
       aria-label="数据"
-      data-testid={hideChrome ? 'inspector-database' : undefined}
     >
-      {hideChrome ? null : (
       <div className="app-side-bar-head">
         <span
           className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
@@ -395,7 +391,6 @@ export const DataSidebar = memo(function DataSidebar({
           <ChevronDoubleLeftIcon aria-hidden className="size-4" />
         </button>
       </div>
-      )}
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="app-side-actions" role="navigation" aria-label="视图操作" data-biu-ignore>
           <button type="button" className="app-side-actions-item" title="添加视图" onClick={onAddView}>

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -357,6 +357,7 @@ export function apply(ctx: Context) {
         Tab: DatabaseInspectorTab,
         common: true,
         useSnapshot: bindSnapshot(snapshot),
+        databaseUi: ctx.get('databaseUi') as DatabaseUiService,
       }),
     })
     let lastKey = ''

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,18 +1,26 @@
-import { useMemo, useState, useSyncExternalStore, type MouseEvent } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore, type MouseEvent } from 'react'
 import { CircleStackIcon } from '@heroicons/react/16/solid'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
+import type { CollectionChrome } from '@biu/type-file-system/ui'
 import type { bindSnapshot } from '@biu/web-snapshot'
 import { parseAppPath } from '@biu/web-session-view'
 import { buildCrumbs, DATABASE_ROOT_PATH, pathForCrumbTarget, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 import { CrumbItemGlyph } from './nav-glyphs.tsx'
-import { DataSidebar } from './data-sidebar.tsx'
+import { CollectionBrowser } from './browser.tsx'
 import { loadActiveViewId, loadViews } from './view-storage.ts'
 import { databaseRecordPath, databaseViewPath } from './inspector-nav.ts'
-import type { SavedView } from './saved-view.ts'
+import {
+  getInspectorDbPath,
+  seedInspectorDbPath,
+  setInspectorDbPath,
+  subscribeInspectorDbPath,
+} from './inspector-db-route.ts'
+import type { DatabaseUiService } from './database-ui.ts'
 
 const DATA_MODULE = { id: 'database', label: '数据', path: '/database' }
+const EMPTY_CHROME: CollectionChrome = {}
 
 let viewTick = 0
 
@@ -37,6 +45,10 @@ function useViewTick() {
     () => viewTick,
     () => 0,
   )
+}
+
+function useInspectorDbPath() {
+  return useSyncExternalStore(subscribeInspectorDbPath, getInspectorDbPath, () => '')
 }
 
 function crumbsForRoute(
@@ -64,6 +76,14 @@ function crumbsForRoute(
   return { crumbs, collection, viewId: activeViewId, recordId }
 }
 
+function goInspector(target: CrumbTarget | { kind: 'root' }) {
+  if (target.kind === 'root') {
+    setInspectorDbPath(DATABASE_ROOT_PATH)
+    return
+  }
+  setInspectorDbPath(pathForCrumbTarget(target))
+}
+
 export function DatabaseInspectorTab({
   active,
   onActivate,
@@ -74,15 +94,18 @@ export function DatabaseInspectorTab({
   useSnapshot?: ReturnType<typeof bindSnapshot>
 }) {
   const location = useLocation()
-  const navigate = useNavigate()
+  const inspectorPath = useInspectorDbPath()
   const [hover, setHover] = useState(false)
   useViewTick()
+  useEffect(() => {
+    seedInspectorDbPath(location.pathname)
+  }, [location.pathname])
   const collections = (useSnapshot?.((state) => state.collections ?? []) ?? []) as CollectionInfo[]
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
     [collections],
   )
-  const { crumbs } = crumbsForRoute(location.pathname, tables)
+  const { crumbs } = crumbsForRoute(inspectorPath || location.pathname, tables)
   const leaf = crumbs.at(-1)
   const leafChoice = leaf?.choices.find((item) => item.id === leaf.id)
   const showTrail = hover && crumbs.length > 0
@@ -91,11 +114,7 @@ export function DatabaseInspectorTab({
     event.preventDefault()
     event.stopPropagation()
     onActivate?.()
-    if (target.kind === 'root') {
-      navigate(DATABASE_ROOT_PATH)
-      return
-    }
-    navigate(pathForCrumbTarget(target))
+    goInspector(target)
   }
 
   return (
@@ -143,47 +162,56 @@ export function DatabaseInspectorTab({
 
 export function DatabaseInspectorBrowse(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
+  const ui = props.databaseUi as DatabaseUiService | undefined
   const location = useLocation()
-  const navigate = useNavigate()
+  const inspectorPath = useInspectorDbPath()
   useViewTick()
+  useEffect(() => {
+    seedInspectorDbPath(location.pathname)
+  }, [location.pathname])
   const collections = (useSnapshot((state) => state.collections ?? []) ?? []) as CollectionInfo[]
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
     [collections],
   )
-  const { collection, viewId } = crumbsForRoute(location.pathname, tables)
-  const collectionPath = collection || tables[0]?.path || ''
-  const table = tables.find((item) => item.path === collectionPath)
-  const views = collectionPath ? loadViews(collectionPath) : []
-  const activeViewId = viewId || loadActiveViewId(collectionPath, views)
+  const pathname = inspectorPath || location.pathname
+  const { collection, viewId, recordId } = crumbsForRoute(pathname, tables)
+  const currentPath = collection || tables[0]?.path || ''
+  const table = tables.find((item) => item.path === currentPath)
   const title = table ? tableLabel(table) : '数据'
+  const chrome = useSyncExternalStore(
+    (fn) => (ui ? ui.subscribe(fn) : () => undefined),
+    () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
+    () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
+  )
 
-  function openTable(path: string, nextViewId?: string) {
-    navigate(databaseViewPath(path, nextViewId ?? loadActiveViewId(path, loadViews(path)) ?? undefined))
-  }
-
-  function applyView(view: SavedView) {
-    if (!collectionPath) return
-    navigate(databaseViewPath(collectionPath, view.id))
+  if (!currentPath) {
+    return <p className="fsdb-inspector-empty">没有数据表</p>
   }
 
   return (
-    <DataSidebar
-      hideChrome
-      tables={tables}
-      collectionPath={collectionPath}
+    <CollectionBrowser
+      embed
+      key={currentPath}
+      moduleId="database"
+      collectionPath={currentPath}
       title={title}
-      views={views}
-      activeViewId={activeViewId}
-      onOpenTable={openTable}
-      onApplyView={applyView}
-      onRenameView={(view) => window.dispatchEvent(new CustomEvent('fsdb:rename-view', { detail: view }))}
-      onDeleteView={(view) => window.dispatchEvent(new CustomEvent('fsdb:delete-view', { detail: view }))}
-      onAddView={() => window.dispatchEvent(new Event('fsdb:add-view'))}
-      onCopyView={() => window.dispatchEvent(new Event('fsdb:copy-view'))}
-      onOpenRecord={(path, view, recordId) => {
-        navigate(databaseRecordPath(path, recordId))
+      blurb={table?.view?.blurb ?? ''}
+      chrome={chrome}
+      tables={tables}
+      routeRecordId={recordId ?? null}
+      routeViewId={viewId}
+      onOpenTable={(path, nextViewId) => {
+        setInspectorDbPath(databaseViewPath(path, nextViewId ?? loadActiveViewId(path, loadViews(path)) ?? undefined))
       }}
+      onOpenView={(nextViewId) => setInspectorDbPath(databaseViewPath(currentPath, nextViewId))}
+      onOpenRecord={(id, _viewId, nextCollection) => {
+        setInspectorDbPath(databaseRecordPath(nextCollection ?? currentPath, id))
+      }}
+      onCloseRecord={() => {
+        setInspectorDbPath(databaseViewPath(currentPath, loadActiveViewId(currentPath, loadViews(currentPath)) ?? undefined))
+      }}
+      onCrumbTarget={(target) => goInspector(target)}
     />
   )
 }

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  getInspectorDbPath,
+  seedInspectorDbPath,
+  setInspectorDbPath,
+} from './inspector-db-route.ts'
+
+test('inspector database path does not overwrite after first seed', () => {
+  setInspectorDbPath('')
+  seedInspectorDbPath('/database/pages')
+  assert.equal(getInspectorDbPath(), '/database/pages')
+  seedInspectorDbPath('/database/tasks')
+  assert.equal(getInspectorDbPath(), '/database/pages')
+  setInspectorDbPath('/database/tasks')
+  assert.equal(getInspectorDbPath(), '/database/tasks')
+})

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,0 +1,28 @@
+/** 检查器里的数据库页有自己的路径，不改中间主界面。 */
+
+const listeners = new Set<() => void>()
+let current = ''
+
+export function subscribeInspectorDbPath(fn: () => void) {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+export function getInspectorDbPath() {
+  return current
+}
+
+export function setInspectorDbPath(next: string) {
+  if (current === next) return
+  current = next
+  for (const fn of listeners) fn()
+}
+
+export function seedInspectorDbPath(pathname: string) {
+  if (current) return
+  if (!pathname) return
+  current = pathname
+  for (const fn of listeners) fn()
+}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -38,9 +38,10 @@ test('database can be added to the inspector and browsed by crumbs', () => {
   const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
   assert.match(browse, /aria-label="数据库位置"/)
   assert.match(browse, /inspector-crumb-leaf/)
-  assert.match(browse, /hideChrome/)
-  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
-  assert.match(sidebar, /data-testid=\{hideChrome \? 'inspector-database' : undefined\}/)
+  assert.match(browse, /embed/)
+  assert.match(browse, /setInspectorDbPath/)
+  assert.doesNotMatch(browse, /DataSidebar/)
+  assert.match(browser, /embed = false/)
 })
 
 test('inspector no longer listens for add/copy view actions', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -384,6 +384,12 @@ body {
   border-right: 0;
 }
 
+.inspector-database-page {
+  width: 100%;
+  min-height: 0;
+  flex: 1;
+}
+
 .inspector-catalog {
   display: flex;
   min-height: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上次错把左侧数据栏塞进检查器，会改中间页的视图。这次改成：

- 右侧「数据库」只渲染中间内页（表格/看板/记录详情），没有左侧栏、没有顶栏收起检查器那些控制。
- Tab 仍是叶子标题，悬停展开面包屑。
- 点面包屑、开记录只改检查器自己的路径，不改中间主界面，也不写视图 localStorage、不抢记录焦点。

编译已通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

