### PR TITLE
fix(fs): 切表不再整页重挂，避免文件系统页卡住

### DIFF
--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+const overlay = readFileSync(resolve(import.meta.dirname, './overlay.tsx'), 'utf8')
+
+test('pick capture does not eat sidebar, rail, or inspector clicks', () => {
+  assert.match(overlay, /function ignorePickCapture/)
+  assert.match(overlay, /\.app-side-bar/)
+  assert.match(overlay, /\.session-inspector/)
+  assert.match(overlay, /\.app-rail/)
+})

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -6,6 +6,13 @@ import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect } from './resolve
 
 const DRAG_PX = 6
 
+const PICK_NAV_GUARD =
+  '[data-biu-ignore], .app-side-bar, .app-rail, .session-inspector, .brand-corner-cluster, [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"]'
+
+function ignorePickCapture(target: Element) {
+  return Boolean(target.closest(PICK_NAV_GUARD))
+}
+
 function hoverBox(el: HTMLElement) {
   const box = el.getBoundingClientRect()
   return { top: box.top, left: box.left, width: box.width, height: box.height }
@@ -49,7 +56,7 @@ export function PickOverlay(props: SlotProps) {
     const onDown = (event: PointerEvent) => {
       if (event.button !== 0) return
       const target = event.target
-      if (target instanceof Element && target.closest('[data-biu-ignore]')) return
+      if (target instanceof Element && ignorePickCapture(target)) return
       event.preventDefault()
       drag = { x: event.clientX, y: event.clientY, boxed: false }
     }
@@ -69,7 +76,7 @@ export function PickOverlay(props: SlotProps) {
 
     const onClick = (event: MouseEvent) => {
       const target = event.target
-      if (target instanceof Element && target.closest('[data-biu-ignore]')) return
+      if (target instanceof Element && ignorePickCapture(target)) return
       event.preventDefault()
       event.stopPropagation()
     }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -701,6 +701,10 @@ export function CollectionBrowser({
     hydratePath.current = ''
     setCollapsed({})
     hydratedDetail.current = ''
+    setItems([])
+    setStat(null)
+    setError('')
+    setPage(0)
     const stored = viewForPath(collectionPath, routeViewId)
     if (stored) {
       setViews(loadViews(collectionPath))
@@ -731,16 +735,18 @@ export function CollectionBrowser({
       debounce = window.setTimeout(() => void reloadRef.current(), 120)
     }
     window.addEventListener('fsdb:change', onChange)
-    const timer = window.setInterval(() => {
-      if (detailIdRef.current) return
-      void reloadRef.current()
-    }, 20000)
+    const timer = embed
+      ? 0
+      : window.setInterval(() => {
+          if (detailIdRef.current) return
+          void reloadRef.current()
+        }, 20000)
     return () => {
       window.clearTimeout(debounce)
-      window.clearInterval(timer)
+      if (timer) window.clearInterval(timer)
       window.removeEventListener('fsdb:change', onChange)
     }
-  }, [collectionPath])
+  }, [collectionPath, embed])
 
   useEffect(() => {
     void reload()
@@ -965,9 +971,9 @@ export function CollectionBrowser({
 
   useEffect(() => {
     if (!routeViewId) return
-    const view = viewsRef.current.find((item) => item.id === routeViewId) ?? views.find((item) => item.id === routeViewId)
+    const view = viewsRef.current.find((item) => item.id === routeViewId)
     if (view) applyView(view)
-  }, [collectionPath, routeViewId, views])
+  }, [collectionPath, routeViewId])
 
   function commitView(view: SavedView) {
     persistViews([...views, view])

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -527,25 +527,19 @@ export const DataSidebar = memo(function DataSidebar({
                     <div key={table.path} className="min-w-0">
                       <div className="sidebar-group-head mb-0.5">
                         <div
-                          role="button"
-                          tabIndex={0}
-                          className="flex min-h-8 min-w-0 flex-1 cursor-pointer items-center gap-1.5 rounded-md text-left text-[14px] font-medium tracking-normal text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
+                          className="flex min-h-8 min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-[14px] font-medium tracking-normal text-inherit"
                           title={name}
                           aria-expanded={open}
                           {...pickDomAttrs('collection', table.path, name)}
-                          onClick={() => {
-                            setOpenTables((prev) => ({ ...prev, [table.path]: !open }))
-                            if (!listed.length) onOpenTable?.(table.path)
-                          }}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter' || event.key === ' ') {
-                              event.preventDefault()
-                              setOpenTables((prev) => ({ ...prev, [table.path]: !open }))
-                            }
-                          }}
                         >
-                          <span className="grid size-6 shrink-0 place-items-center" aria-hidden>
-                            <span className="sidebar-rail-icon sidebar-group-fold">
+                          <button
+                            type="button"
+                            className="grid size-6 shrink-0 place-items-center border-0 bg-transparent p-0 text-inherit"
+                            title={open ? '收起视图' : '展开视图'}
+                            aria-label={open ? '收起视图' : '展开视图'}
+                            onClick={() => setOpenTables((prev) => ({ ...prev, [table.path]: !open }))}
+                          >
+                            <span className="sidebar-rail-icon sidebar-group-fold" aria-hidden>
                               <span className="sidebar-group-fold-face">
                                 <TableGlyph icon={table.view?.icon} />
                               </span>
@@ -557,8 +551,17 @@ export const DataSidebar = memo(function DataSidebar({
                                 )}
                               </span>
                             </span>
-                          </span>
-                          <span className="min-w-0 flex-1 truncate">{name}</span>
+                          </button>
+                          <button
+                            type="button"
+                            className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
+                            onClick={() => {
+                              setOpenTables((prev) => ({ ...prev, [table.path]: true }))
+                              onOpenTable?.(table.path)
+                            }}
+                          >
+                            {name}
+                          </button>
                         </div>
                         <ChatCount count={listed.length} />
                       </div>

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -157,13 +157,12 @@ function CollectionPage(props: SlotProps) {
     return () => {
       for (const item of placed) void item.dispose?.()
     }
-  }, [chrome, currentPath, parsed.kind, slots, ui])
+  }, [chrome.panes, currentPath, parsed.kind, slots, ui])
 
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')
   return (
     <CollectionBrowser
-      key={currentPath}
       moduleId={DATA_MODULE_ID}
       collectionPath={currentPath}
       title={title}

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -204,7 +204,6 @@ export function DatabaseInspectorBrowse(_props: SlotProps) {
   return (
     <CollectionBrowser
       embed
-      key={currentPath}
       moduleId="database"
       collectionPath={currentPath}
       title={title}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -46,6 +46,18 @@ test('database can be added to the inspector and browsed by crumbs', () => {
   assert.match(browser, /embed = false/)
 })
 
+test('switching tables does not remount the whole browser', () => {
+  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.doesNotMatch(page, /key=\{currentPath\}/)
+  const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
+  assert.doesNotMatch(browse, /key=\{currentPath\}/)
+})
+
+test('inspector embed does not poll the collection every 20s', () => {
+  assert.match(browser, /const timer = embed/)
+  assert.match(browser, /}, 20000\)/)
+})
+
 test('inspector no longer listens for add/copy view actions', () => {
   assert.doesNotMatch(browser, /biu:inspector-action/)
   assert.doesNotMatch(browser, /detail === 'add-view'/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
针对文件系统页「点来点去切不过去 / 像卡死」：

- 切表、切检查器路径时不再用 `key={currentPath}` 整棵 `CollectionBrowser` 拆掉重装（侧栏折叠和计数会跟着一起没）。
- 检查器里的数据库内页不再 20 秒一轮询。
- 侧栏：点表名打开该表，点箭头只折叠。
- 选取光标打开时，不再拦截侧栏、最左轨道、检查器上的点击。

请在数据页多点侧栏表/视图、检查器开关、面包屑、记录进出压一轮。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

