### PR TITLE
fix(fs): 禁止重复挂载检查器 pane，避免切任务表黑屏

### DIFF
--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -45,3 +45,16 @@ test('record focus and inspector host notify subscribers', () => {
   off()
   assert.equal(ui.getRecordFocus(), null)
 })
+
+test('decorate panes with the same id keep a single pane', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  const PaneA = () => null
+  const PaneB = () => null
+  ui.decorate('/tasks', { panes: [{ id: 'script', label: '脚本 A', Pane: PaneA }] })
+  ui.decorate('/tasks', { panes: [{ id: 'script', label: '脚本 B', Pane: PaneB }] })
+  const panes = ui.chrome('/tasks').panes ?? []
+  assert.equal(panes.length, 1)
+  assert.equal(panes[0]?.label, '脚本 B')
+  assert.equal(panes[0]?.Pane, PaneB)
+})

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -22,7 +22,13 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
     if (layer.Action) Action = layer.Action
     if (layer.Title) Title = layer.Title
     if (layer.Content) Content = layer.Content
-    if (layer.panes?.length) panes.push(...layer.panes)
+    if (layer.panes?.length) {
+      for (const pane of layer.panes) {
+        const i = panes.findIndex((item) => item.id === pane.id)
+        if (i >= 0) panes[i] = pane
+        else panes.push(pane)
+      }
+    }
   }
   return { cells, Action, Title, Content, panes: panes.length ? panes : undefined }
 }

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -139,27 +139,35 @@ function CollectionPage(props: SlotProps) {
     go({ collection: first.path, viewId: defaultViewId(first.path) }, { replace: true })
   }, [collectionFromRoute, tables])
 
+  const paneIds = (chrome.panes ?? []).map((pane) => pane.id).filter(Boolean)
+  const paneKey = [...new Set(paneIds)].join('\0')
+
   useEffect(() => {
     if (!slots || !ui || !currentPath) return
     if (parsed.kind !== 'collection-view' && parsed.kind !== 'record') return
-    const panes = chrome.panes ?? []
-    const placed = panes.map((pane) =>
-      slots.place('inspector-panels', RecordPanePanel, {
-        key: `fsdb-pane-${pane.id}`,
-        order: 20,
-        props: () => ({
-          tabId: pane.id,
-          tabLabel: pane.label,
-          tabIcon: CircleStackIcon,
-          centerKinds: ['collection-view', 'record'],
-          paneId: pane.id,
+    const seen = new Set<string>()
+    const placed = []
+    for (const pane of ui.chrome(currentPath).panes ?? []) {
+      if (!pane.id || seen.has(pane.id)) continue
+      seen.add(pane.id)
+      placed.push(
+        slots.place('inspector-panels', RecordPanePanel, {
+          key: `fsdb-pane-${pane.id}`,
+          order: 20,
+          props: () => ({
+            tabId: pane.id,
+            tabLabel: pane.label,
+            tabIcon: CircleStackIcon,
+            centerKinds: ['collection-view', 'record'],
+            paneId: pane.id,
+          }),
         }),
-      }),
-    )
+      )
+    }
     return () => {
       for (const item of placed) void item.dispose?.()
     }
-  }, [chrome.panes, currentPath, parsed.kind, slots, ui])
+  }, [currentPath, paneKey, parsed.kind, slots, ui])
 
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -28,6 +28,7 @@ test('database does not auto-open inspector content; panes follow the current ta
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.doesNotMatch(page, /biu:inspector-open/)
   assert.match(page, /centerKinds: \['collection-view', 'record'\]/)
+  assert.match(page, /if \(!pane.id \|\| seen.has\(pane.id\)\) continue/)
 })
 
 test('database can be added to the inspector and browsed by crumbs', () => {

--- a/packages/web-slots/src/web/index.test.ts
+++ b/packages/web-slots/src/web/index.test.ts
@@ -30,6 +30,22 @@ test('place waits for open; close clears fills', async () => {
   assert.equal(ctx.slots.list('stage').length, 0)
 })
 
+test('inject re-open detaches before filling again', async () => {
+  const ctx = await boot()
+  ctx.slots.place('stage', Dummy, { key: 'c' })
+  const first = await ctx.plugin({
+    inject: ['slots'],
+    apply: (c: Context) => c.slots.fill('root', Dummy, { children: { stage: { kind: 'list' } } }),
+  })
+  assert.equal(ctx.slots.list('stage').length, 1)
+  await first.dispose()
+  await ctx.plugin({
+    inject: ['slots'],
+    apply: (c: Context) => c.slots.fill('root', Dummy, { children: { stage: { kind: 'list' } } }),
+  })
+  assert.equal(ctx.slots.list('stage').length, 1)
+})
+
 test('duplicate key throws', async () => {
   const ctx = await boot()
   ctx.slots.fill('root', Dummy, { children: { stage: { kind: 'list' } } })

--- a/packages/web-slots/src/web/service.ts
+++ b/packages/web-slots/src/web/service.ts
@@ -64,6 +64,7 @@ export class SlotsService extends Service {
     return this.ctx.effect(() => {
       let inner: (() => void) | undefined
       const attach = () => {
+        detach()
         const result = callback()
         inner = typeof result === 'function' ? result : undefined
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
切到任务表时检查器会把 `script` 面板挂两次，`slots.place` 抛 `already has "fsdb-pane-script"`，`CollectionPage` 整页白屏。

- chrome 合并 pane 按 id 去重（后写覆盖）
- CollectionPage 同一 id 只 place 一次
- 槽位再次 Open 时先 detach 再 fill

`vite build` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

