### PR TITLE
feat(inspector): 可重复添加数据库 Tab，各自独立路径

### DIFF
--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -365,6 +365,7 @@ export function apply(ctx: Context) {
         tabIcon: CircleStackIcon,
         Tab: DatabaseInspectorTab,
         common: true,
+        repeatable: true,
       }),
     })
     let lastKey = ''

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -70,8 +70,12 @@ function useViewTick() {
   )
 }
 
-function useInspectorDbPath() {
-  return useSyncExternalStore(subscribeInspectorDbPath, getInspectorDbPath, () => '')
+function useInspectorDbPath(paneId: string) {
+  return useSyncExternalStore(
+    subscribeInspectorDbPath,
+    () => getInspectorDbPath(paneId),
+    () => '',
+  )
 }
 
 function crumbsForRoute(
@@ -99,24 +103,31 @@ function crumbsForRoute(
   return { crumbs, collection, viewId: activeViewId, recordId }
 }
 
-function goInspector(target: CrumbTarget) {
-  setInspectorDbPath(pathForCrumbTarget(target))
+function goInspector(paneId: string, target: CrumbTarget) {
+  setInspectorDbPath(paneId, pathForCrumbTarget(target))
+}
+
+function paneOf(props: { paneId?: unknown }) {
+  return String(props.paneId || 'database')
 }
 
 export function DatabaseInspectorTab({
   active,
   onActivate,
+  paneId,
 }: {
   active?: boolean
   onActivate?: () => void
+  paneId?: string
 }) {
+  const id = paneOf({ paneId })
   const location = useLocation()
-  const inspectorPath = useInspectorDbPath()
+  const inspectorPath = useInspectorDbPath(id)
   const [hover, setHover] = useState(false)
   useViewTick()
   useEffect(() => {
-    seedInspectorDbPath(location.pathname)
-  }, [location.pathname])
+    seedInspectorDbPath(id, location.pathname)
+  }, [id, location.pathname])
   const collections = useInspectorCollections()
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
@@ -131,7 +142,7 @@ export function DatabaseInspectorTab({
     event.preventDefault()
     event.stopPropagation()
     onActivate?.()
-    goInspector(target)
+    goInspector(id, target)
   }
 
   return (
@@ -140,6 +151,7 @@ export function DatabaseInspectorTab({
       role="tab"
       aria-selected={Boolean(active)}
       data-testid="inspector-tab-database"
+      data-pane={id}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       onClick={() => onActivate?.()}
@@ -173,14 +185,15 @@ export function DatabaseInspectorTab({
   )
 }
 
-export function DatabaseInspectorBrowse(_props: SlotProps) {
+export function DatabaseInspectorBrowse(props: SlotProps) {
+  const id = paneOf(props)
   const ui = getDatabaseUi()
   const location = useLocation()
-  const inspectorPath = useInspectorDbPath()
+  const inspectorPath = useInspectorDbPath(id)
   useViewTick()
   useEffect(() => {
-    seedInspectorDbPath(location.pathname)
-  }, [location.pathname])
+    seedInspectorDbPath(id, location.pathname)
+  }, [id, location.pathname])
   const collections = useInspectorCollections()
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
@@ -213,16 +226,16 @@ export function DatabaseInspectorBrowse(_props: SlotProps) {
       routeRecordId={recordId ?? null}
       routeViewId={viewId}
       onOpenTable={(path, nextViewId) => {
-        setInspectorDbPath(databaseViewPath(path, nextViewId ?? loadActiveViewId(path, loadViews(path)) ?? undefined))
+        setInspectorDbPath(id, databaseViewPath(path, nextViewId ?? loadActiveViewId(path, loadViews(path)) ?? undefined))
       }}
-      onOpenView={(nextViewId) => setInspectorDbPath(databaseViewPath(currentPath, nextViewId))}
-      onOpenRecord={(id, _viewId, nextCollection) => {
-        setInspectorDbPath(databaseRecordPath(nextCollection ?? currentPath, id))
+      onOpenView={(nextViewId) => setInspectorDbPath(id, databaseViewPath(currentPath, nextViewId))}
+      onOpenRecord={(recordIdNext, _viewId, nextCollection) => {
+        setInspectorDbPath(id, databaseRecordPath(nextCollection ?? currentPath, recordIdNext))
       }}
       onCloseRecord={() => {
-        setInspectorDbPath(databaseViewPath(currentPath, loadActiveViewId(currentPath, loadViews(currentPath)) ?? undefined))
+        setInspectorDbPath(id, databaseViewPath(currentPath, loadActiveViewId(currentPath, loadViews(currentPath)) ?? undefined))
       }}
-      onCrumbTarget={(target) => goInspector(target)}
+      onCrumbTarget={(target) => goInspector(id, target)}
     />
   )
 }

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -15,3 +15,12 @@ test('inspector database path does not overwrite after first seed', () => {
   setInspectorDbPath('/database/tasks')
   assert.equal(getInspectorDbPath(), '/database/tasks')
 })
+
+test('each inspector database pane keeps its own path', () => {
+  setInspectorDbPath('database::a', '/database/pages')
+  setInspectorDbPath('database::b', '/database/tasks')
+  assert.equal(getInspectorDbPath('database::a'), '/database/pages')
+  assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
+  seedInspectorDbPath('database::a', '/database/events')
+  assert.equal(getInspectorDbPath('database::a'), '/database/pages')
+})

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,7 +1,8 @@
-/** 检查器里的数据库页有自己的路径，不改中间主界面。 */
+/** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
 
+const DEFAULT_PANE = 'database'
 const listeners = new Set<() => void>()
-let current = ''
+const paths = new Map<string, string>()
 
 export function subscribeInspectorDbPath(fn: () => void) {
   listeners.add(fn)
@@ -10,19 +11,28 @@ export function subscribeInspectorDbPath(fn: () => void) {
   }
 }
 
-export function getInspectorDbPath() {
-  return current
-}
-
-export function setInspectorDbPath(next: string) {
-  if (current === next) return
-  current = next
+function bump() {
   for (const fn of listeners) fn()
 }
 
-export function seedInspectorDbPath(pathname: string) {
-  if (current) return
-  if (!pathname) return
-  current = pathname
-  for (const fn of listeners) fn()
+export function getInspectorDbPath(paneId = DEFAULT_PANE) {
+  return paths.get(paneId) ?? ''
+}
+
+export function setInspectorDbPath(paneId: string, next?: string) {
+  const id = next === undefined ? DEFAULT_PANE : paneId
+  const path = next === undefined ? paneId : next
+  if ((paths.get(id) ?? '') === path) return
+  if (!path) paths.delete(id)
+  else paths.set(id, path)
+  bump()
+}
+
+export function seedInspectorDbPath(paneId: string, pathname?: string) {
+  const id = pathname === undefined ? DEFAULT_PANE : paneId
+  const path = pathname === undefined ? paneId : pathname
+  if (paths.get(id)) return
+  if (!path) return
+  paths.set(id, path)
+  bump()
 }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -36,6 +36,7 @@ test('database can be added to the inspector and browsed by crumbs', () => {
   assert.match(page, /fsdb-database-browse/)
   assert.match(page, /tabLabel: '数据库'/)
   assert.match(page, /Tab: DatabaseInspectorTab/)
+  assert.match(page, /repeatable: true/)
   const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
   assert.match(browse, /bindInspectorSnapshot/)
   assert.doesNotMatch(browse, /useSnapshot\?:/)

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -14,3 +14,11 @@ test('inspector header keeps opened tabs on top and a plus menu on the right', (
   assert.match(inspector, /item.Tab/)
   assert.match(inspector, /inspectorViewProps/)
 })
+
+test('plus menu can add another database tab', () => {
+  assert.match(inspector, /repeatable/)
+  assert.match(inspector, /nextRepeatableTabId/)
+  assert.match(inspector, /slotTabId/)
+  assert.match(inspector, /paneId=\{item.id\}/)
+  assert.match(inspector, /paneId=\{extraActive.id\}/)
+})

--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -38,6 +38,7 @@ test('inspector does not auto-open the first available tab', () => {
   assert.equal(resolveInspectorTab('', ['script', 'reports']), '')
   assert.equal(resolveInspectorTab('script', ['script', 'reports']), 'script')
   assert.equal(resolveInspectorTab('gone', ['script', 'reports']), '')
+  assert.equal(resolveInspectorTab('database::a1', ['database']), 'database::a1')
 })
 
 test('legacy untagged panels stay off session and database centers', () => {
@@ -56,6 +57,7 @@ test('inspector view props drop tab chrome and databaseUi', () => {
     databaseUi: { boom: true },
     useSnapshot: 1,
     paneId: 'x',
+    repeatable: true,
   })
   assert.deepEqual(next, { paneId: 'x' })
 })

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -46,6 +46,7 @@ const INSPECTOR_VIEW_OMIT = new Set([
   'useSnapshot',
   'slots',
   'sessionView',
+  'repeatable',
 ])
 
 export function inspectorViewProps(raw: Record<string, unknown>) {
@@ -56,7 +57,17 @@ export function inspectorViewProps(raw: Record<string, unknown>) {
   }
   return next
 }
+export function slotTabId(openedId: string) {
+  const split = openedId.indexOf('::')
+  return split === -1 ? openedId : openedId.slice(0, split)
+}
+
+export function nextRepeatableTabId(tabId: string) {
+  return `${tabId}::${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+}
+
 export function resolveInspectorTab(current: string, allowed: string[]) {
-  if (current && allowed.includes(current)) return current
+  if (!current) return ''
+  if (allowed.includes(current) || allowed.includes(slotTabId(current))) return current
   return ''
 }

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -9,7 +9,7 @@ import {
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts'
-import { inspectorPanelMatches, inspectorViewProps, resolveInspectorTab } from './inspector-panels.ts'
+import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
 
 export type SessionInspectorProps = {
   open: boolean
@@ -69,6 +69,7 @@ export const SessionInspector = memo(function SessionInspector({
           ensureTrajectory: Boolean(extra.ensureTrajectory),
           focusOnCall: Boolean(extra.focusOnCall),
           common: Boolean(extra.common),
+          repeatable: Boolean(extra.repeatable),
           action: typeof extra.action === 'string' ? extra.action : '',
         }]
       })
@@ -163,13 +164,24 @@ export const SessionInspector = memo(function SessionInspector({
 
   if (!open) return null
 
-  const headerTabs = displayTabs.filter((item) => opened.includes(item.id))
-  const extraActive = displayTabs.find((item) => item.id === tab)
+  const headerTabs = opened.flatMap((openedId) => {
+    const item = displayTabs.find((tabItem) => tabItem.id === slotTabId(openedId))
+    if (!item) return []
+    return [{ ...item, id: openedId }]
+  })
+  const extraActive = headerTabs.find((item) => item.id === tab) ?? displayTabs.find((item) => item.id === tab)
   const ExtraComponent = extraActive?.entry.Component
 
   function pickOffer(item: (typeof extraTabs)[number]) {
     if (item.action) {
       requestInspectorAction(item.action)
+      setPlusOpen(false)
+      return
+    }
+    if (item.repeatable) {
+      const instanceId = nextRepeatableTabId(item.id)
+      persistOpened([...opened, instanceId])
+      setTab(instanceId)
       setPlusOpen(false)
       return
     }
@@ -210,6 +222,7 @@ export const SessionInspector = memo(function SessionInspector({
                   active={active}
                   onActivate={() => setTab(item.id)}
                   {...inspectorViewProps(raw)}
+                  paneId={item.id}
                 />
               )
             }
@@ -248,7 +261,7 @@ export const SessionInspector = memo(function SessionInspector({
                 <button
                   key={item.id}
                   type="button"
-                  className={`inspector-catalog-item${item.id === tab ? ' is-active' : ''}`}
+                  className={`inspector-catalog-item${slotTabId(tab) === item.id ? ' is-active' : ''}`}
                   role="menuitem"
                   onClick={() => pickOffer(item)}
                   data-testid={`inspector-offer-${item.id}`}
@@ -278,7 +291,7 @@ export const SessionInspector = memo(function SessionInspector({
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {extraActive && ExtraComponent ? (
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden" data-testid={`inspector-${extraActive.id}`}>
-            <ExtraComponent {...inspectorViewProps((extraActive.entry.props?.() ?? {}) as Record<string, unknown>)} renderSlot={renderSlot} />
+            <ExtraComponent {...inspectorViewProps((extraActive.entry.props?.() ?? {}) as Record<string, unknown>)} paneId={extraActive.id} renderSlot={renderSlot} />
           </div>
         ) : (
           <p className="inspector-catalog-empty" data-testid="inspector-catalog">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器加号可以反复添加「数据库」。每一份 Tab 有自己的路径，点面包屑/记录只改这一份，中间主界面不动。用来同时看不同表、配不同内容。

`vite build` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

