### PR TITLE
fix(pick): 悬浮框和右下角都保留圆形选取光标

### DIFF
--- a/packages/cap-pick/src/web/index.test.ts
+++ b/packages/cap-pick/src/web/index.test.ts
@@ -4,17 +4,19 @@ import { Context } from 'cordis'
 import * as slots from '@biu/web-slots'
 import * as pickUi from './index.tsx'
 
-test('places header toggle and overlay into generic slots', async () => {
+test('places header toggle, corner toggle and overlay into generic slots', async () => {
   const ctx = new Context()
   await ctx.plugin(slots)
   ctx.slots.fill('root', () => null, {
     children: {
+      'header-tools': { kind: 'list' },
       'corner-tools': { kind: 'list' },
       'root-overlays': { kind: 'list' },
     },
   })
   await ctx.plugin(pickUi)
   assert.ok(ctx.pick)
-  assert.equal(ctx.slots.list('corner-tools').some((item) => item.id === 'pick-toggle'), true)
+  assert.equal(ctx.slots.list('header-tools').some((item) => item.id === 'pick-toggle'), true)
+  assert.equal(ctx.slots.list('corner-tools').some((item) => item.id === 'pick-toggle-corner'), true)
   assert.equal(ctx.slots.list('root-overlays').some((item) => item.id === 'pick-overlay'), true)
 })

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -15,10 +15,15 @@ export const inject = ['slots']
 export function apply(ctx: Context) {
   const pick = new PickService(ctx)
   const slots = ctx.slots as SlotsService
-  slots.place('corner-tools', PickToggle, {
+  slots.place('header-tools', PickToggle, {
     key: 'pick-toggle',
     order: 10,
-    props: () => ({}),
+    props: () => ({ placement: 'header' }),
+  })
+  slots.place('corner-tools', PickToggle, {
+    key: 'pick-toggle-corner',
+    order: 10,
+    props: () => ({ placement: 'corner' }),
   })
   slots.place('root-overlays', PickOverlay, {
     key: 'pick-overlay',

--- a/packages/cap-pick/src/web/toggle.tsx
+++ b/packages/cap-pick/src/web/toggle.tsx
@@ -2,9 +2,10 @@ import { CursorArrowRaysIcon } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/type-slots'
 import { getPick, usePickState } from './service.ts'
 
-export function PickToggle(_props: SlotProps) {
+export function PickToggle(props: SlotProps) {
   const pick = getPick()
   const { picking } = usePickState(pick)
+  const placement = String(props.placement ?? 'header')
   return (
     <button
       type="button"
@@ -12,7 +13,7 @@ export function PickToggle(_props: SlotProps) {
       aria-label="选取对象"
       data-dock-tip="选取对象"
       aria-pressed={picking}
-      data-testid="corner-pick-toggle"
+      data-testid={placement === 'corner' ? 'corner-pick-toggle' : 'header-pick-toggle'}
       data-biu-ignore
       onClick={() => pick?.toggle()}
     >

--- a/web/style.css
+++ b/web/style.css
@@ -319,8 +319,7 @@ body {
 }
 
 .brand-corner-mascot-btn.is-active,
-.brand-corner-dock-btn.is-active,
-.brand-corner-leading .project-chip-icon-only.is-active {
+.brand-corner-dock-btn.is-active {
   background: var(--dsw-hover);
 }
 
@@ -358,15 +357,12 @@ body {
 
 .brand-corner-leading .project-chip,
 .brand-corner-leading .project-chip-icon-only {
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: 10px;
-  background: transparent;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--dsw-border);
+  border-radius: 999px;
+  background: #262626;
   color: var(--dsw-sidebar-fg);
-  cursor: pointer;
 }
 
 .brand-agent-menu {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取光标两处都在：聊天悬浮框工具栏（原来那颗圆形胶囊）和右下角人物左边（同样圆底、描边、深色背景）。不再只留右边、也不再改成方钮。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

