### PR TITLE
fix(chat): 选取对象时不再刷 flushSync 警告

### DIFF
--- a/packages/cap-chat/src/web/composer-pick-node.tsx
+++ b/packages/cap-chat/src/web/composer-pick-node.tsx
@@ -1,23 +1,26 @@
 import { Node, mergeAttributes } from '@tiptap/core'
-import { NodeViewWrapper, ReactNodeViewRenderer } from '@tiptap/react'
-import { PickChipLabel, chipLabel } from '@biu/cap-pick/web'
+import { createRoot, type Root } from 'react-dom/client'
+import { PickChipLabel, chipLabel, type PickRef } from '@biu/cap-pick/web'
 
-function PickChipView({ node }: { node: { attrs: Record<string, string | null> } }) {
-  const kind = String(node.attrs.kind ?? '')
-  const id = String(node.attrs.id ?? '')
-  const label = String(node.attrs.label ?? id)
-  const route = String(node.attrs.route ?? '')
-  const action = node.attrs.action ? String(node.attrs.action) : undefined
+function refFromAttrs(attrs: Record<string, unknown>): PickRef {
+  const kind = String(attrs.kind ?? '')
+  const id = String(attrs.id ?? '')
+  const label = String(attrs.label ?? id)
+  const route = String(attrs.route ?? '')
+  const action = attrs.action ? String(attrs.action) : undefined
+  return { kind, id, label, route, ...(action ? { action } : {}) }
+}
+
+function PickChipView({ attrs }: { attrs: Record<string, unknown> }) {
+  const pick = refFromAttrs(attrs)
   return (
-    <NodeViewWrapper as="span" className="composer-inline-chip">
-      <span
-        className="composer-tool-chip is-pick"
-        data-testid="user-pick-chip"
-        title={`${kind} · ${chipLabel({ kind, id, label, route, action })}`}
-      >
-        <PickChipLabel pick={{ kind, id, label, route, ...(action ? { action } : {}) }} />
-      </span>
-    </NodeViewWrapper>
+    <span
+      className="composer-tool-chip is-pick"
+      data-testid="user-pick-chip"
+      title={`${pick.kind} · ${chipLabel(pick)}`}
+    >
+      <PickChipLabel pick={pick} />
+    </span>
   )
 }
 
@@ -50,6 +53,37 @@ export const PickChipNode = Node.create({
     ]
   },
   addNodeView() {
-    return ReactNodeViewRenderer(PickChipView, { as: 'span' })
+    return ({ node }) => {
+      const dom = document.createElement('span')
+      dom.className = 'composer-inline-chip'
+      dom.setAttribute('data-pick-chip', '')
+      let attrs = node.attrs as Record<string, unknown>
+      let root: Root | null = createRoot(dom)
+      let paintQueued = false
+      const paint = () => {
+        paintQueued = false
+        root?.render(<PickChipView attrs={attrs} />)
+      }
+      const schedulePaint = () => {
+        if (paintQueued || !root) return
+        paintQueued = true
+        queueMicrotask(paint)
+      }
+      schedulePaint()
+      return {
+        dom,
+        update(updated) {
+          if (updated.type.name !== 'pickChip') return false
+          attrs = updated.attrs as Record<string, unknown>
+          schedulePaint()
+          return true
+        },
+        destroy() {
+          const current = root
+          root = null
+          queueMicrotask(() => current?.unmount())
+        },
+      }
+    }
   },
 })

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -63,8 +63,12 @@ describe('composer dock stacking above sticky user', () => {
 
   it('uses Tiptap for inline pick chips in the composer', () => {
     const composer = readFileSync(resolve(root, 'packages/cap-chat/src/web/composer.tsx'), 'utf8')
+    const node = readFileSync(resolve(root, 'packages/cap-chat/src/web/composer-pick-node.tsx'), 'utf8')
     expect(composer).toMatch(/useEditor/)
     expect(composer).toMatch(/composerDocExtensions/)
     expect(composer).toMatch(/EditorContent/)
+    expect(composer).toMatch(/insertPickChips/)
+    expect(node).not.toMatch(/ReactNodeViewRenderer/)
+    expect(node).toMatch(/queueMicrotask/)
   })
 })

--- a/packages/cap-chat/src/web/composer-tiptap.ts
+++ b/packages/cap-chat/src/web/composer-tiptap.ts
@@ -95,21 +95,30 @@ export function collectPickKeys(editor: Editor | null) {
   return keys
 }
 
-export function insertPickChip(editor: Editor, ref: PickRef) {
+function chipContent(ref: PickRef) {
+  return {
+    type: 'pickChip',
+    attrs: {
+      kind: ref.kind,
+      id: ref.id,
+      label: ref.label,
+      route: ref.route,
+      action: ref.action ?? null,
+    },
+  }
+}
+
+export function insertPickChips(editor: Editor, refs: PickRef[]) {
+  if (!refs.length || editor.isDestroyed) return
   editor
     .chain()
     .focus()
-    .insertContent({
-        type: 'pickChip',
-        attrs: {
-          kind: ref.kind,
-          id: ref.id,
-          label: ref.label,
-          route: ref.route,
-          action: ref.action ?? null,
-        },
-      })
+    .insertContent(refs.map(chipContent))
     .run()
+}
+
+export function insertPickChip(editor: Editor, ref: PickRef) {
+  insertPickChips(editor, [ref])
 }
 
 export function editorCaretPlain(editor: Editor | null): { value: string; cursor: number } {

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -11,7 +11,7 @@ import {
   collectPickKeys,
   deletePlainRange,
   editorCaretPlain,
-  insertPickChip,
+  insertPickChips,
   jsonFromDraft,
   serializeComposer,
 } from './composer-tiptap.ts'
@@ -562,15 +562,15 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
 
   useEffect(() => {
     if (!editor) return
+    const missing = pickRefs.filter((ref) => !pickKeysRef.current.has(pickKey(ref)))
     const nextKeys = new Set(pickRefs.map((item) => pickKey(item)))
-    for (const ref of pickRefs) {
-      const key = pickKey(ref)
-      if (pickKeysRef.current.has(key)) continue
-      insertPickChip(editor, ref)
-    }
-    pickKeysRef.current = nextKeys
-    const packed = serializeComposer(editor)
-    scheduleCanSubmit(packed.plain, picked, packed.refs.length, pendingImages.length)
+    queueMicrotask(() => {
+      if (editor.isDestroyed) return
+      insertPickChips(editor, missing)
+      pickKeysRef.current = nextKeys
+      const packed = serializeComposer(editor)
+      scheduleCanSubmit(packed.plain, picked, packed.refs.length, pendingImages.length)
+    })
   }, [pickRefs, editor, picked.length, pendingImages.length])
 
   function clearInput() {

--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -5,9 +5,10 @@ import assert from 'node:assert/strict'
 
 const overlay = readFileSync(resolve(import.meta.dirname, './overlay.tsx'), 'utf8')
 
-test('pick capture does not eat sidebar, rail, or inspector clicks', () => {
+test('pick capture does not eat sidebar, rail, or inspector chrome clicks', () => {
   assert.match(overlay, /function ignorePickCapture/)
   assert.match(overlay, /\.app-side-bar/)
-  assert.match(overlay, /\.session-inspector/)
   assert.match(overlay, /\.app-rail/)
+  assert.match(overlay, /data-biu-ignore/)
+  assert.doesNotMatch(overlay, /\.session-inspector/)
 })

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -6,7 +6,7 @@ import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect } from './resolve
 const DRAG_PX = 6
 
 const PICK_NAV_GUARD =
-  '[data-biu-ignore], .app-side-bar, .app-rail, .session-inspector, .brand-corner-cluster, [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"]'
+  '[data-biu-ignore], .app-side-bar, .app-rail, .brand-corner-cluster, [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"]'
 
 function ignorePickCapture(target: Element) {
   return Boolean(target.closest(PICK_NAV_GUARD))

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -9,7 +9,7 @@ const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css
 test('inspector header keeps opened tabs on top and a plus menu on the right', () => {
   assert.match(inspector, /data-testid="inspector-add"/)
   assert.match(inspector, /data-testid="inspector-add-menu"/)
-  assert.match(inspector, /className="app-side-bar-head"/)
+  assert.match(inspector, /className="app-side-bar-head" data-biu-ignore/)
   assert.match(inspector, /PlusIcon/)
   assert.match(inspector, /点右上角加号/)
   assert.match(inspector, /item.Tab/)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -261,6 +261,7 @@ export const SessionInspector = memo(function SessionInspector({
     >
       <div
         className="inspector-resize"
+        data-biu-ignore
         data-testid="inspector-resize"
         title="拖动调整宽度"
         onPointerDown={(event) => {
@@ -272,7 +273,7 @@ export const SessionInspector = memo(function SessionInspector({
         }}
       />
 
-      <div className="app-side-bar-head">
+      <div className="app-side-bar-head" data-biu-ignore>
         <div className="inspector-tabs" ref={tabsRef} role="tablist" aria-label="检查器分区">
           {headerTabs.map((item) => {
             const active = tab === item.id
@@ -324,6 +325,7 @@ export const SessionInspector = memo(function SessionInspector({
               ref={plusMenuRef}
               className="inspector-add-menu is-fixed"
               role="menu"
+              data-biu-ignore
               data-testid="inspector-add-menu"
               data-caption-rev={captionRev}
               style={{ right: plusPos.right, top: plusPos.top }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
智能鼠标相关两处：

**flushSync：** 选中对象后输入栏插入 pick 芯片时，Tiptap `ReactNodeViewRenderer` 会对每个节点 `flushSync`，选中几个就报几次。芯片改在 microtask 里 `createRoot`，并一次插入全部新芯片。

**右侧检查器选不中：** 选取模式把整个 `.session-inspector` 当成禁区，按下直接忽略，所以中间列表能 pick、右侧同一套数据库浏览却点不到。现在只忽略检查器顶栏、拖宽条和加号菜单，面板里的表/记录走与中间相同的 `data-biu-*` 命中。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

