### PR TITLE
fix(shell): 聊天浮窗勿误收；左侧栏不够则整栏关掉

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2358,7 +2358,7 @@ if (typeof document !== 'undefined') {
 .fsdb-inspector-host:not(:empty) + .fsdb-inspector-empty{display:none}
 .fsdb-inspector-panel .fsdb-detail-stage{min-height:0;flex:1}
 .fsdb-right-body{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
-.fsdb-views{display:flex;width:var(--sidebar-col,280px);max-width:280px;min-width:0;flex:none;flex-direction:column;min-height:0;overflow:hidden}
+.fsdb-views{display:flex;width:var(--sidebar-col,280px);max-width:280px;min-width:0;flex:none;flex-direction:column;min-height:0;overflow:hidden;box-sizing:border-box}
 .inspector-database-page{width:100%;min-height:0;flex:1}
 .fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}

--- a/packages/web-app-shell/src/web/chat-decouple.test.ts
+++ b/packages/web-app-shell/src/web/chat-decouple.test.ts
@@ -17,4 +17,6 @@ test('overlay chat is off on the agent page and elsewhere until the corner dock 
   assert.doesNotMatch(overlayHead.slice(0, 1200), /inspector-toggle/)
   assert.match(shell, /overlayStillHoldsPointer/)
   assert.doesNotMatch(shell, /chat-composer-dock pointer-events-none">\{overlayDock\}/)
+  assert.match(shell, /is-left-hidden/)
+  assert.match(shell, /leftHidden/)
 })

--- a/packages/web-app-shell/src/web/chat-decouple.test.ts
+++ b/packages/web-app-shell/src/web/chat-decouple.test.ts
@@ -15,4 +15,6 @@ test('overlay chat is off on the agent page and elsewhere until the corner dock 
   assert.doesNotMatch(shell, /放大聊天窗口/)
   const overlayHead = shell.slice(shell.indexOf('const overlayHeader'))
   assert.doesNotMatch(overlayHead.slice(0, 1200), /inspector-toggle/)
+  assert.match(shell, /overlayStillHoldsPointer/)
+  assert.doesNotMatch(shell, /chat-composer-dock pointer-events-none">\{overlayDock\}/)
 })

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -13,6 +13,7 @@ import {
   getOverlayAutohide,
   setOverlayAutohide,
   requestOverlayAutohide,
+  overlayStillHoldsPointer,
   setOverlayResizing,
   setOverlayPinned,
   clampOverlayChatHeight,
@@ -119,6 +120,16 @@ test('autohide requires leaving and not resizing', () => {
   setOverlayResizing(false)
   requestOverlayAutohide()
   assert.equal(getOverlayAutohide(), true)
+})
+
+test('pointer still inside overlay when relatedTarget or hit is in the panel', () => {
+  const panel = document.createElement('div')
+  panel.setAttribute('data-testid', 'chat-overlay-panel')
+  const child = document.createElement('input')
+  panel.append(child)
+  document.body.append(panel)
+  assert.equal(overlayStillHoldsPointer(panel, child, 0, 0), true)
+  panel.remove()
 })
 
 test('autohide does not fire when overlay is pinned', () => {

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -31,7 +31,7 @@ test('chat column subtracts rail, sidebar and inspector', () => {
   )
 })
 
-test('narrow viewport shrinks left pane before inspector, then center last', () => {
+test('narrow viewport hides the left pane outright, then shrinks inspector, then center', () => {
   const wide = allocateShellColumns({
     viewportWidth: 1600,
     leftPane: true,
@@ -42,15 +42,15 @@ test('narrow viewport shrinks left pane before inspector, then center last', () 
   assert.equal(wide.inspector, 320)
   assert.equal(wide.center, 1600 - SIDEBAR_MAX - 320)
 
-  const stealLeft = allocateShellColumns({
+  const hideLeft = allocateShellColumns({
     viewportWidth: SIDEBAR_MAX + CENTER_MIN + 320 - 100,
     leftPane: true,
     inspectorOpen: true,
     inspectorWidth: 320,
   })
-  assert.equal(stealLeft.left, SIDEBAR_MAX - 100)
-  assert.equal(stealLeft.inspector, 320)
-  assert.equal(stealLeft.center, CENTER_MIN)
+  assert.equal(hideLeft.left, 0)
+  assert.equal(hideLeft.inspector, 320)
+  assert.equal(hideLeft.center, SIDEBAR_MAX + CENTER_MIN + 320 - 100 - 320)
 
   const stealInspector = allocateShellColumns({
     viewportWidth: CENTER_MIN + INSPECTOR_MIN,

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -140,6 +140,23 @@ export function setOverlayResizing(next: boolean) {
 }
 
 /** 仅在未钉住、未拖高度、且指针已离开时收起。 */
+/** 指针其实还在浮窗里（子节点重绘、composer 穿透）时不要收起。 */
+export function overlayStillHoldsPointer(
+  panel: EventTarget | null,
+  related: EventTarget | null,
+  clientX?: number,
+  clientY?: number,
+) {
+  const root = panel instanceof Element ? panel : null
+  if (!root) return false
+  if (related instanceof Node && root.contains(related)) return true
+  if (typeof clientX === 'number' && typeof clientY === 'number') {
+    const hit = document.elementFromPoint(clientX, clientY)
+    if (hit && (root.contains(hit) || hit.closest('[data-testid="chat-overlay-panel"]'))) return true
+  }
+  return false
+}
+
 export function requestOverlayAutohide() {
   if (!overlay || resizing || pinned) return
   setOverlayAutohide(true)

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -6,7 +6,7 @@ export const INSPECTOR_MIN = 240
 const RAIL = 0
 const SIDEBAR = SIDEBAR_MAX
 
-/** 窄屏时先压左侧栏，再压检查器（不低于 INSPECTOR_MIN），最后才压中间。 */
+/** 窄屏时先整栏关掉左侧（不要压成细条），再压检查器（不低于 INSPECTOR_MIN），最后才压中间。 */
 export function allocateShellColumns(opts: {
   viewportWidth: number
   railWidth?: number
@@ -20,9 +20,8 @@ export function allocateShellColumns(opts: {
   let inspector = opts.inspectorOpen ? Math.max(INSPECTOR_MIN, opts.inspectorWidth) : 0
   let center = available - left - inspector
   if (center < CENTER_MIN && left > 0) {
-    const take = Math.min(left, CENTER_MIN - center)
-    left -= take
-    center += take
+    center += left
+    left = 0
   }
   if (center < CENTER_MIN && inspector > INSPECTOR_MIN) {
     const take = Math.min(inspector - INSPECTOR_MIN, CENTER_MIN - center)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -565,6 +565,7 @@ function Shell(props: SlotProps) {
     inspectorOpen: inspectorVisible,
     inspectorWidth,
   })
+  const leftHidden = shellColumns.left <= 0
   const onAgentRailClick = useCallback((alreadyActive: boolean) => {
     if (alreadyActive) setSidebarCollapsed((prev) => !prev)
     else setSidebarCollapsed(false)
@@ -689,10 +690,10 @@ function Shell(props: SlotProps) {
   return (
     <div
       className={`app-shell${activeModule === 'agent'
-          ? ` app-shell-agent${sidebarCollapsed ? ' is-sidebar-collapsed' : ''}${inspectorVisible ? ' is-inspector-open' : ''}${overlayAutohide ? ' is-chat-overlay-autohide' : ''
+          ? ` app-shell-agent${sidebarCollapsed || leftHidden ? ' is-sidebar-collapsed' : ''}${inspectorVisible ? ' is-inspector-open' : ''}${overlayAutohide ? ' is-chat-overlay-autohide' : ''
           }`
           : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}`
-        }${railOpen || railPinned ? ' is-rail-open' : ''}`}
+        }${railOpen || railPinned ? ' is-rail-open' : ''}${leftHidden ? ' is-left-hidden' : ''}`}
       data-testid="app-shell"
       style={
         {
@@ -730,7 +731,7 @@ function Shell(props: SlotProps) {
       </div>
 
       <ChatSidebar
-        visible={showChatSidebar}
+        visible={showChatSidebar && !leftHidden}
         routeSessionId={routeSessionId}
         useSessionView={useSessionView}
         sessionView={sessionView}
@@ -760,7 +761,7 @@ function Shell(props: SlotProps) {
             header={overlayHeader}
             floating={activeModule !== 'agent'}
             showCenter={activeModule === 'agent'}
-            withSidebar={showChatSidebar}
+            withSidebar={showChatSidebar && !leftHidden}
             railOpen={railOpen || railPinned}
           />
         </div>

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -11,6 +11,7 @@ import {
   setOverlayAutohide,
   subscribeOverlayAutohide,
   requestOverlayAutohide,
+  overlayStillHoldsPointer,
   setOverlayResizing,
   getOverlayPinned,
   subscribeOverlayPinned,
@@ -235,10 +236,20 @@ const AgentMainPanels = memo(function AgentMainPanels({
   const keepVisible = useCallback(() => {
     setOverlayAutohide(false)
   }, [])
-  const hideIfIdle = useCallback(() => {
-    if (!overlay) return
-    requestOverlayAutohide()
-  }, [overlay])
+  const hideIfIdle = useCallback(
+    (event?: { currentTarget: EventTarget; relatedTarget: EventTarget | null; clientX: number; clientY: number }) => {
+      if (!overlay) return
+      const panel = event?.currentTarget ?? null
+      const related = event?.relatedTarget ?? null
+      const x = event?.clientX
+      const y = event?.clientY
+      queueMicrotask(() => {
+        if (overlayStillHoldsPointer(panel, related, x, y)) return
+        requestOverlayAutohide()
+      })
+    },
+    [overlay],
+  )
   useEffect(() => {
     if (!overlay) setOverlayAutohide(false)
   }, [overlay])
@@ -316,10 +327,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
             ['--overlay-chat-height' as string]: `${overlayChatHeight}px`,
             ['--rail-w' as string]: railOpen ? '48px' : '0px',
           } as CSSProperties}
-          onMouseEnter={() => {
-            if (hidden) return
-            keepVisible()
-          }}
+          onMouseEnter={keepVisible}
           onMouseLeave={hideIfIdle}
         >
           <div
@@ -330,7 +338,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
           />
           {header}
           <div className="chat-overlay-thread">{overlayStage}</div>
-          <div className="chat-composer-dock pointer-events-none">{overlayDock}</div>
+          <div className="chat-composer-dock">{overlayDock}</div>
         </div>,
         document.body,
       )

--- a/web/style.css
+++ b/web/style.css
@@ -867,6 +867,7 @@ body {
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+  pointer-events: auto;
 }
 
 .chat-overlay-panel.is-autohide {

--- a/web/style.css
+++ b/web/style.css
@@ -1045,6 +1045,10 @@ body {
   width: min(var(--dsw-chat-width), calc(100vw - var(--rail-w) - var(--inspector-width, 320px) - 40px));
 }
 
+.app-shell.is-left-hidden .fsdb-views {
+  display: none !important;
+}
+
 /* 侧栏独立合成层：右侧 Markdown 重绘时少拖累左侧 :hover */
 .app-side-bar {
   contain: layout paint style;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两处布局/浮窗：

**浮窗误收：** 输入栏 dock 的 `pointer-events-none` 会让命中穿到后面的页面，Tiptap 打字重绘也会误发 `mouseleave`。浮窗 dock 自己接收指针；离开后确认命中仍在面板内才收起。

**左侧细条：** 窄屏原先把 280px 侧栏一点点减宽，剩一条带边框的竖缝。现在要么满宽要么为 0，并隐藏聊天侧栏和数据 `.fsdb-views`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

