### PR TITLE
fix(inspector): 进聊天时右侧不要出现没有面包屑的数据库页

### DIFF
--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -12,6 +12,7 @@ import { loadActiveViewId, loadRecords, loadViews } from './view-storage.ts'
 import { databaseRecordPath, databaseViewPath } from './inspector-nav.ts'
 import {
   getInspectorDbPath,
+  isInspectorDatabasePath,
   seedInspectorDbPath,
   setInspectorDbPath,
   subscribeInspectorDbPath,
@@ -80,6 +81,29 @@ function useInspectorDbPath(paneId: string) {
   )
 }
 
+function defaultInspectorDbPath(tables: CollectionInfo[]) {
+  const first = tables[0]
+  if (!first?.path) return ''
+  return databaseViewPath(first.path, loadActiveViewId(first.path, loadViews(first.path)) ?? undefined)
+}
+
+function useBindInspectorDbPath(paneId: string, tables: CollectionInfo[]) {
+  const location = useLocation()
+  const inspectorPath = useInspectorDbPath(paneId)
+  useEffect(() => {
+    if (inspectorPath) return
+    if (isInspectorDatabasePath(location.pathname)) {
+      seedInspectorDbPath(paneId, location.pathname)
+      return
+    }
+    const fallback = defaultInspectorDbPath(tables)
+    if (fallback) setInspectorDbPath(paneId, fallback)
+  }, [inspectorPath, location.pathname, paneId, tables])
+  if (inspectorPath) return inspectorPath
+  if (isInspectorDatabasePath(location.pathname)) return location.pathname
+  return ''
+}
+
 function crumbsForRoute(
   pathname: string,
   tables: CollectionInfo[],
@@ -129,14 +153,15 @@ export function DatabaseInspectorTab({
   paneId?: string
 }) {
   const id = paneOf({ paneId })
-  const location = useLocation()
-  const inspectorPath = useInspectorDbPath(id)
+  const collections = useInspectorCollections()
+  const tables = useMemo(
+    () => collections.filter((row) => row.path && row.path !== '/'),
+    [collections],
+  )
+  const inspectorPath = useBindInspectorDbPath(id, tables)
   const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
   const crumbRef = useRef<HTMLElement>(null)
   useViewTick()
-  useEffect(() => {
-    seedInspectorDbPath(id, location.pathname)
-  }, [id, location.pathname])
   useEffect(() => {
     function onPointer(event: globalThis.MouseEvent) {
       const target = event.target as Node
@@ -147,12 +172,7 @@ export function DatabaseInspectorTab({
     document.addEventListener('mousedown', onPointer)
     return () => document.removeEventListener('mousedown', onPointer)
   }, [])
-  const collections = useInspectorCollections()
-  const tables = useMemo(
-    () => collections.filter((row) => row.path && row.path !== '/'),
-    [collections],
-  )
-  const { crumbs } = crumbsForRoute(inspectorPath || location.pathname, tables)
+  const { crumbs } = crumbsForRoute(inspectorPath, tables)
   const leaf = crumbs.at(-1)
   const leafChoice = leaf?.choices.find((item) => item.id === leaf.id)
   useEffect(() => {
@@ -207,20 +227,15 @@ export function DatabaseInspectorTab({
 export function DatabaseInspectorBrowse(props: SlotProps) {
   const id = paneOf(props)
   const ui = getDatabaseUi()
-  const location = useLocation()
-  const inspectorPath = useInspectorDbPath(id)
-  useViewTick()
-  useEffect(() => {
-    seedInspectorDbPath(id, location.pathname)
-  }, [id, location.pathname])
   const collections = useInspectorCollections()
   const tables = useMemo(
     () => collections.filter((row) => row.path && row.path !== '/'),
     [collections],
   )
-  const pathname = inspectorPath || location.pathname
-  const { collection, viewId, recordId } = crumbsForRoute(pathname, tables)
-  const currentPath = collection || tables[0]?.path || ''
+  const inspectorPath = useBindInspectorDbPath(id, tables)
+  useViewTick()
+  const { collection, viewId, recordId } = crumbsForRoute(inspectorPath, tables)
+  const currentPath = collection
   const table = tables.find((item) => item.path === currentPath)
   const title = table ? tableLabel(table) : '数据'
   const chrome = useSyncExternalStore(

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import {
   getInspectorDbPath,
+  isInspectorDatabasePath,
   seedInspectorDbPath,
   setInspectorDbPath,
 } from './inspector-db-route.ts'
@@ -14,6 +15,16 @@ test('inspector database path does not overwrite after first seed', () => {
   assert.equal(getInspectorDbPath(), '/database/pages')
   setInspectorDbPath('/database/tasks')
   assert.equal(getInspectorDbPath(), '/database/tasks')
+})
+
+test('chat routes are not seeded as inspector database paths', () => {
+  setInspectorDbPath('')
+  assert.equal(isInspectorDatabasePath('/s/abc'), false)
+  assert.equal(isInspectorDatabasePath('/database/pages'), true)
+  seedInspectorDbPath('/s/abc')
+  assert.equal(getInspectorDbPath(), '')
+  seedInspectorDbPath('/database/pages')
+  assert.equal(getInspectorDbPath(), '/database/pages')
 })
 
 test('each inspector database pane keeps its own path', () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -15,24 +15,35 @@ function bump() {
   for (const fn of listeners) fn()
 }
 
+export function isInspectorDatabasePath(pathname: string) {
+  const path = String(pathname || '').split('?')[0]
+  return path === '/database' || path.startsWith('/database/')
+}
+
+function panePath(paneId = DEFAULT_PANE) {
+  const path = paths.get(paneId) ?? ''
+  return isInspectorDatabasePath(path) ? path : ''
+}
+
 export function getInspectorDbPath(paneId = DEFAULT_PANE) {
-  return paths.get(paneId) ?? ''
+  return panePath(paneId)
 }
 
 export function setInspectorDbPath(paneId: string, next?: string) {
   const id = next === undefined ? DEFAULT_PANE : paneId
   const path = next === undefined ? paneId : next
-  if ((paths.get(id) ?? '') === path) return
-  if (!path) paths.delete(id)
-  else paths.set(id, path)
+  const stored = isInspectorDatabasePath(path) ? path : ''
+  if ((paths.get(id) ?? '') === stored) return
+  if (!stored) paths.delete(id)
+  else paths.set(id, stored)
   bump()
 }
 
 export function seedInspectorDbPath(paneId: string, pathname?: string) {
   const id = pathname === undefined ? DEFAULT_PANE : paneId
   const path = pathname === undefined ? paneId : pathname
-  if (paths.get(id)) return
-  if (!path) return
+  if (panePath(id)) return
+  if (!isInspectorDatabasePath(path)) return
   paths.set(id, path)
   bump()
 }

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -22,6 +22,7 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /slotTabId/)
   assert.match(inspector, /paneId=\{item.id\}/)
   assert.match(inspector, /paneId=\{extraActive.id\}/)
+  assert.doesNotMatch(inspector, /displayTabs.find\(\(item\) => item.id === tab\)/)
   assert.match(inspector, /inspector-add-trash/)
   assert.match(inspector, /closeOpenedTab/)
   assert.match(inspector, /item.repeatable/)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -146,6 +146,15 @@ export const SessionInspector = memo(function SessionInspector({
   )
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
 
+  useEffect(() => {
+    setOpened(readOpened(sessionId))
+    try {
+      setTabState(localStorage.getItem(inspectorTabStorageKey(sessionId)) ?? '')
+    } catch {
+      setTabState('')
+    }
+  }, [sessionId])
+
   const focusTabId = extraTabs.find((item) => item.focusOnCall)?.id
   useEffect(() => {
     if (focusCallId && focusTabId) {
@@ -227,7 +236,7 @@ export const SessionInspector = memo(function SessionInspector({
     if (!item) return []
     return [{ ...item, id: openedId }]
   })
-  const extraActive = headerTabs.find((item) => item.id === tab) ?? displayTabs.find((item) => item.id === tab)
+  const extraActive = headerTabs.find((item) => item.id === tab)
   const ExtraComponent = extraActive?.entry.Component
 
   function pickOffer(item: (typeof extraTabs)[number]) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
刚进聊天时，右侧检查器会把当前地址 `/s/...` 当成数据库路径。面包屑解析不到表（只显示一个没有下拉的「数据」），面板却回退到第一张表，看起来像数据库页但没有中间那种逐级面包屑。

改动：
- 只有 `/database...` 才写入检查器路径
- 没有合法路径就不渲染表
- 内容只跟已打开的 Tab 走，不会把目录里的数据库页偷偷当成当前页

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

