### PR TITLE
fix(shell): 侧栏 Biu Agent OS 与下方列表左对齐

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -373,7 +373,7 @@ export const DataSidebar = memo(function DataSidebar({
       className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
       aria-label="数据"
     >
-      <div className="app-side-bar-head">
+      <div className="app-side-bar-head app-side-bar-head-brand">
         <span
           className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
           style={{ background: SIDEBAR_BRAND_GRADIENT }}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -7,7 +7,7 @@ const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf
 
 test('data sidebar brand sits left with a collapse control on the right', () => {
   const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
-  assert.match(sidebar, /Biu Agent OS/)
+  assert.match(sidebar, /app-side-bar-head-brand/)
   assert.match(sidebar, /data-testid="sidebar-collapse"/)
   assert.doesNotMatch(sidebar, /SidebarBrandMascot/)
   assert.match(browser, /onCollapse=\{toggleViewsOpen\}/)

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -11,4 +11,9 @@ describe('sidebar text colors', () => {
     expect(css).toMatch(/\.app-side-bar\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg\)/s)
     expect(css).toMatch(/\.chat-session-row\.is-active\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg-active\)/s)
   })
+
+  it('left-aligns the sidebar brand with the list below', () => {
+    expect(css).toMatch(/\.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*flex-start/s)
+    expect(css).not.toMatch(/\.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*center/s)
+  })
 })

--- a/web/style.css
+++ b/web/style.css
@@ -292,12 +292,14 @@ body {
 }
 
 .app-side-bar-head-brand {
-  justify-content: center;
+  justify-content: flex-start;
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .app-side-bar-head-brand .chat-view-header-expand {
   position: absolute;
-  right: 12px;
+  right: 8px;
 }
 
 .brand-corner-cluster {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
左侧顶栏「Biu Agent OS」原先在标题栏里居中，和下面「添加聊天」等行对不齐。改为靠左，内边距与列表的 `px-2` 对齐；收起按钮仍在右侧。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

