### PR TITLE
切进聊天先画可视区，再分帧挂上更早消息

### DIFF
--- a/packages/cap-chat/src/web/thread-reveal.test.ts
+++ b/packages/cap-chat/src/web/thread-reveal.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatNode } from '@biu/web-session-view'
+import {
+  bumpRevealStart,
+  CHAT_FIRST_PAINT_TURNS,
+  firstPaintStartIndex,
+  groupNodesIntoTurns,
+  shouldRevealFast,
+  sliceTurnsFrom,
+} from './thread-reveal.ts'
+
+function user(id: string): ChatNode {
+  return { id, kind: 'user', text: id }
+}
+
+function reply(id: string): ChatNode {
+  return {
+    id,
+    kind: 'reply',
+    parts: [{ id: `${id}-a`, kind: 'assistant', text: id }],
+    copyText: id,
+  }
+}
+
+function longThread(): ChatNode[] {
+  const nodes: ChatNode[] = []
+  for (let i = 0; i < 10; i += 1) {
+    nodes.push(user(`u-${i}`), reply(`r-${i}`))
+  }
+  return nodes
+}
+
+describe('thread reveal (visible first, then older)', () => {
+  it('first paint starts at the tail, not turn 0', () => {
+    expect(firstPaintStartIndex(10)).toBe(10 - CHAT_FIRST_PAINT_TURNS)
+    expect(firstPaintStartIndex(1)).toBe(0)
+    expect(firstPaintStartIndex(0)).toBe(0)
+  })
+
+  it('sliceTurnsFrom keeps later turns mounted when start decreases', () => {
+    const nodes = longThread()
+    const tail = sliceTurnsFrom(nodes, 8)
+    expect(tail.map((n) => n.id)).toEqual(['u-8', 'r-8', 'u-9', 'r-9'])
+    const more = sliceTurnsFrom(nodes, bumpRevealStart(8, 2))
+    expect(more.map((n) => n.id).slice(-4)).toEqual(['u-8', 'r-8', 'u-9', 'r-9'])
+    expect(more[0]?.id).toBe('u-6')
+  })
+
+  it('new message at the end stays in the mounted slice without remounting earlier tail', () => {
+    const nodes = [...longThread(), user('u-10'), reply('r-10')]
+    const start = firstPaintStartIndex(10)
+    const shown = sliceTurnsFrom(nodes, start)
+    expect(shown.at(-2)?.id).toBe('u-10')
+    expect(shown.some((n) => n.id === 'u-8')).toBe(true)
+  })
+
+  it('groupNodesIntoTurns still splits on user', () => {
+    expect(groupNodesIntoTurns(longThread())).toHaveLength(10)
+  })
+
+  it('reveals fast when the tail does not fill the viewport', () => {
+    expect(
+      shouldRevealFast({ scrollTop: 2000, scrollHeight: 400, clientHeight: 800 }),
+    ).toBe(true)
+    expect(
+      shouldRevealFast({ scrollTop: 2000, scrollHeight: 4000, clientHeight: 800 }),
+    ).toBe(false)
+    expect(
+      shouldRevealFast({ scrollTop: 40, scrollHeight: 4000, clientHeight: 800 }),
+    ).toBe(true)
+  })
+})

--- a/packages/cap-chat/src/web/thread-reveal.ts
+++ b/packages/cap-chat/src/web/thread-reveal.ts
@@ -1,0 +1,55 @@
+import type { ChatNode } from '@biu/web-session-view'
+
+/** 每个 user 与其后的回复合成一回合。 */
+export function groupNodesIntoTurns(nodes: ChatNode[]): ChatNode[][] {
+  const turns: ChatNode[][] = []
+  let current: ChatNode[] = []
+  for (const node of nodes) {
+    if (node.kind === 'user') {
+      if (current.length) turns.push(current)
+      current = [node]
+      continue
+    }
+    if (!current.length) {
+      turns.push([node])
+      continue
+    }
+    current.push(node)
+  }
+  if (current.length) turns.push(current)
+  return turns
+}
+
+/** 首帧只挂最近几回合，先画出视口里能看见的尾巴。 */
+export const CHAT_FIRST_PAINT_TURNS = 2
+/** 视口填满后，每帧/idle 再往上补的回合数。 */
+export const CHAT_REVEAL_BATCH = 4
+const VIEWPORT_SLACK_PX = 64
+const NEAR_TOP_PX = 720
+
+export function firstPaintStartIndex(totalTurns: number): number {
+  if (totalTurns <= 0) return 0
+  return Math.max(0, totalTurns - CHAT_FIRST_PAINT_TURNS)
+}
+
+export function bumpRevealStart(startIndex: number, batch = CHAT_REVEAL_BATCH): number {
+  return Math.max(0, startIndex - Math.max(1, batch))
+}
+
+/** 视口还没被尾巴填满，或用户已经滑到顶等更早内容：用 rAF 快补。 */
+export function shouldRevealFast(opts: {
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+}): boolean {
+  if (opts.scrollHeight <= opts.clientHeight + VIEWPORT_SLACK_PX) return true
+  if (opts.scrollTop <= NEAR_TOP_PX) return true
+  return false
+}
+
+export function sliceTurnsFrom(nodes: ChatNode[], startTurnIndex: number): ChatNode[] {
+  const turns = groupNodesIntoTurns(nodes)
+  if (startTurnIndex <= 0) return nodes
+  if (startTurnIndex >= turns.length) return []
+  return turns.slice(startTurnIndex).flat()
+}

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -37,6 +37,15 @@ import { UserBubbleEditor } from './user-bubble-editor.tsx'
 import { ToolCard } from './tool-card.tsx'
 import { LiveDispatchTable } from './live-dispatch-table.tsx'
 import { UsageInline } from './usage-inline.tsx'
+import {
+  bumpRevealStart,
+  firstPaintStartIndex,
+  groupNodesIntoTurns,
+  shouldRevealFast,
+  sliceTurnsFrom,
+} from './thread-reveal.ts'
+
+export { groupNodesIntoTurns } from './thread-reveal.ts'
 
 const NEAR_BOTTOM_PX = 96
 /** 提早预取更早消息，避免滑到顶才开始请求 */
@@ -522,26 +531,6 @@ function findReplyForUser(nodes: ChatNode[], userIndex: number): Extract<ChatNod
   return undefined
 }
 
-/** 每个 user 与其后的回复合成一回合，作为 sticky 的包含块，避免多条用户消息叠在顶部。 */
-export function groupNodesIntoTurns(nodes: ChatNode[]): ChatNode[][] {
-  const turns: ChatNode[][] = []
-  let current: ChatNode[] = []
-  for (const node of nodes) {
-    if (node.kind === 'user') {
-      if (current.length) turns.push(current)
-      current = [node]
-      continue
-    }
-    if (!current.length) {
-      turns.push([node])
-      continue
-    }
-    current.push(node)
-  }
-  if (current.length) turns.push(current)
-  return turns
-}
-
 const noopToggleDetails = (_replyId: string) => undefined
 
 function NodeView({
@@ -640,9 +629,8 @@ function NodeView({
 const NodeViewMemo = memo(NodeView)
 
 /**
- * 消息列表：会话内全部挂在 DOM 上（不虚表卸行）。
- * 屏外绘制交给 CSS content-visibility；来回滑不会整行 remount。
- * 导出供回归测试断言「跳回不重新挂载」。
+ * 消息列表：已交给本组件的节点常驻 DOM（不虚表卸行）。
+ * 更早回合由 ChatThread 分帧从上往下补挂；屏外绘制交给 content-visibility。
  */
 export const ChatNodeList = memo(function ChatNodeList({
   nodes,
@@ -772,10 +760,28 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const sessionView = props.sessionView as SessionViewService
   const navigate = useNavigate()
   const nodes = useSessionView((state) => state.nodes)
+  const sessionId = useSessionView((state) => state.sessionId)
+  const turns = useMemo(() => groupNodesIntoTurns(nodes), [nodes])
+  const totalTurns = turns.length
+  const [revealStart, setRevealStart] = useState(() => firstPaintStartIndex(totalTurns))
+  const sessionKeyRef = useRef(sessionId)
+  const prevTotalRef = useRef(totalTurns)
+  if (sessionId !== sessionKeyRef.current) {
+    sessionKeyRef.current = sessionId
+    prevTotalRef.current = totalTurns
+    const next = firstPaintStartIndex(totalTurns)
+    if (next !== revealStart) setRevealStart(next)
+  } else if (prevTotalRef.current === 0 && totalTurns > 0) {
+    prevTotalRef.current = totalTurns
+    const next = firstPaintStartIndex(totalTurns)
+    if (next !== revealStart) setRevealStart(next)
+  } else {
+    prevTotalRef.current = totalTurns
+  }
+  const mountedNodes = useMemo(() => sliceTurnsFrom(nodes, revealStart), [nodes, revealStart])
   const pending = useSessionView((state) => state.pending)
   const agentStatus = useSessionView((state) => state.agentStatus)
   const agentStep = useSessionView((state) => state.agentStep)
-  const sessionId = useSessionView((state) => state.sessionId)
   const sessions = useSessionView((state) => state.sessions)
   const error = useSessionView((state) => state.error)
   const switchingSession = useSessionView((state) => state.switchingSession)
@@ -852,17 +858,47 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
   }, [sessionId, scrollEpoch, hasMoreOlder, loadingOlder, sessionView])
 
-  const lastNode = nodes.at(-1)
+  useEffect(() => {
+    if (revealStart <= 0) return
+    const parent = scrollRef.current
+    const fast = parent
+      ? shouldRevealFast({
+          scrollTop: parent.scrollTop,
+          scrollHeight: parent.scrollHeight,
+          clientHeight: parent.clientHeight,
+        })
+      : true
+    const bump = () => setRevealStart((start) => bumpRevealStart(start))
+    if (fast) {
+      const id = requestAnimationFrame(bump)
+      return () => cancelAnimationFrame(id)
+    }
+    if (typeof requestIdleCallback === 'function') {
+      const id = requestIdleCallback(bump, { timeout: 90 })
+      return () => cancelIdleCallback(id)
+    }
+    const t = window.setTimeout(bump, 40)
+    return () => clearTimeout(t)
+  }, [revealStart, totalTurns, sessionId, scrollEpoch])
+
+  const lastNode = mountedNodes.at(-1)
   const stickKey =
     lastNode?.kind === 'reply' && lastNode.streaming
       ? `${lastNode.id}:${Math.floor(lastNode.copyText.length / 96)}:1`
-      : `${nodes.length}:${pending ? 1 : 0}:${error ?? ''}`
+      : `${mountedNodes.length}:${pending ? 1 : 0}:${error ?? ''}`
 
+  const prependHeightRef = useRef(0)
   useLayoutEffect(() => {
-    if (!stickToBottomRef.current || nodes.length === 0) return
     const parent = scrollRef.current
-    if (parent) parent.scrollTop = parent.scrollHeight
-  }, [stickKey, nodes.length])
+    if (!parent) return
+    if (stickToBottomRef.current) {
+      if (mountedNodes.length > 0) parent.scrollTop = parent.scrollHeight
+    } else if (prependHeightRef.current) {
+      const delta = parent.scrollHeight - prependHeightRef.current
+      if (delta) parent.scrollTop += delta
+    }
+    prependHeightRef.current = parent.scrollHeight
+  }, [stickKey, mountedNodes.length, revealStart])
 
   if (nodes.length === 0 && !pending && !error && !switchingSession) {
     const session = sessions.find((item) => item.id === sessionId)
@@ -883,6 +919,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       ref={rootRef}
       className="w-full"
       data-chat-virtual="0"
+      data-chat-reveal-start={revealStart}
       data-switching={switchingSession ? '1' : undefined}
       style={switchingSession ? { opacity: 0.72, transition: 'opacity 120ms ease' } : undefined}
     >
@@ -891,7 +928,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
         <div className="mb-3 text-center text-(length:--dsw-chat-ui-font-size) text-(--dsw-label-3)">加载更早消息…</div>
       ) : null}
       <ChatNodeList
-        nodes={nodes}
+        nodes={mountedNodes}
         onInspect={onInspect}
         onFork={onFork}
         sessions={sessions}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
切进长会话时，首帧只挂最近两回合（贴底能看见的尾巴），视口填满后用 rAF / idle 把更早回合往上补进去。已经挂上的行保持常驻，不是滑走就卸的虚表。

这是渲染侧的渐进挂载，不是滑到顶才请求的懒加载。网络仍一次拉全量。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

