### PR TITLE
切回会话时还原阅读进度，不要跳到最新

### DIFF
--- a/packages/cap-chat/src/web/thread-reveal.test.ts
+++ b/packages/cap-chat/src/web/thread-reveal.test.ts
@@ -1,13 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import type { ChatNode } from '@biu/web-session-view'
 import {
   bumpRevealStart,
+  captureChatScroll,
   CHAT_FIRST_PAINT_TURNS,
   firstPaintStartIndex,
   groupNodesIntoTurns,
+  recalledChatScroll,
+  rememberChatScroll,
+  resetChatScrollMemoryForTests,
+  restoreChatScroll,
+  revealStartForMemory,
   shouldRevealFast,
   sliceTurnsFrom,
+  turnIndexContaining,
 } from './thread-reveal.ts'
+
+afterEach(() => {
+  resetChatScrollMemoryForTests()
+})
 
 function user(id: string): ChatNode {
   return { id, kind: 'user', text: id }
@@ -68,5 +79,73 @@ describe('thread reveal (visible first, then older)', () => {
     expect(
       shouldRevealFast({ scrollTop: 40, scrollHeight: 4000, clientHeight: 800 }),
     ).toBe(true)
+  })
+})
+
+function box(top: number, height: number): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 400,
+    width: 400,
+    height,
+    toJSON() {
+      return {}
+    },
+  }
+}
+
+describe('chat scroll memory per session', () => {
+  it('keeps an independent reading position for each session', () => {
+    rememberChatScroll('s-a', { kind: 'anchor', nodeId: 'u-3', offset: 24 })
+    rememberChatScroll('s-b', { kind: 'bottom' })
+    expect(recalledChatScroll('s-a')).toEqual({ kind: 'anchor', nodeId: 'u-3', offset: 24 })
+    expect(recalledChatScroll('s-b')).toEqual({ kind: 'bottom' })
+  })
+
+  it('mounts from the remembered turn instead of only the tail', () => {
+    const nodes = longThread()
+    expect(turnIndexContaining(nodes, 'u-3')).toBe(3)
+    expect(revealStartForMemory(nodes, { kind: 'anchor', nodeId: 'u-3', offset: 12 }, 10)).toBe(3)
+    expect(revealStartForMemory(nodes, { kind: 'bottom' }, 10)).toBe(10 - CHAT_FIRST_PAINT_TURNS)
+  })
+
+  it('captures the first visible node when not pinned to the bottom', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollHeight', { value: 4000, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 1200, writable: true, configurable: true })
+    Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
+    parent.getBoundingClientRect = () => box(0, 800)
+    const above = document.createElement('div')
+    above.dataset.nodeId = 'u-2'
+    above.getBoundingClientRect = () => box(-80, 40)
+    const visible = document.createElement('div')
+    visible.dataset.nodeId = 'u-3'
+    visible.getBoundingClientRect = () => box(40, 80)
+    parent.append(above, visible)
+    expect(captureChatScroll(parent)).toEqual({ kind: 'anchor', nodeId: 'u-3', offset: -40 })
+  })
+
+  it('captures bottom when close to the latest messages', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 1180, writable: true, configurable: true })
+    Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
+    expect(captureChatScroll(parent)).toEqual({ kind: 'bottom' })
+  })
+
+  it('restores the saved offset onto the same node', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollTop', { value: 500, writable: true, configurable: true })
+    parent.getBoundingClientRect = () => box(0, 800)
+    const row = document.createElement('div')
+    row.dataset.nodeId = 'u-3'
+    row.getBoundingClientRect = () => box(120, 80)
+    parent.append(row)
+    expect(restoreChatScroll(parent, { kind: 'anchor', nodeId: 'u-3', offset: -40 })).toBe(true)
+    expect(parent.scrollTop).toBe(500 + 120 + -40)
   })
 })

--- a/packages/cap-chat/src/web/thread-reveal.ts
+++ b/packages/cap-chat/src/web/thread-reveal.ts
@@ -36,6 +36,74 @@ export function bumpRevealStart(startIndex: number, batch = CHAT_REVEAL_BATCH): 
   return Math.max(0, startIndex - Math.max(1, batch))
 }
 
+export const CHAT_NEAR_BOTTOM_PX = 96
+
+/** 贴底，或某条消息相对视口顶的偏移。切回会话时按这个还原进度条。 */
+export type ChatScrollMemory =
+  | { kind: 'bottom' }
+  | { kind: 'anchor'; nodeId: string; offset: number }
+
+const chatScrollBySession = new Map<string, ChatScrollMemory>()
+
+export function rememberChatScroll(sessionId: string, memory: ChatScrollMemory) {
+  chatScrollBySession.set(sessionId, memory)
+}
+
+export function recalledChatScroll(sessionId: string | null | undefined): ChatScrollMemory | undefined {
+  if (!sessionId) return undefined
+  return chatScrollBySession.get(sessionId)
+}
+
+export function resetChatScrollMemoryForTests() {
+  chatScrollBySession.clear()
+}
+
+export function turnIndexContaining(nodes: ChatNode[], nodeId: string): number {
+  return groupNodesIntoTurns(nodes).findIndex((turn) => turn.some((node) => node.id === nodeId))
+}
+
+/** 回到中间阅读位置时，从那一回合挂到最新；贴底则仍只先挂尾巴。 */
+export function revealStartForMemory(
+  nodes: ChatNode[],
+  memory: ChatScrollMemory | undefined,
+  totalTurns: number,
+): number {
+  if (!memory || memory.kind === 'bottom') return firstPaintStartIndex(totalTurns)
+  const index = turnIndexContaining(nodes, memory.nodeId)
+  return index < 0 ? 0 : index
+}
+
+export function captureChatScroll(parent: HTMLElement): ChatScrollMemory {
+  const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
+  if (distance <= CHAT_NEAR_BOTTOM_PX) return { kind: 'bottom' }
+  const parentTop = parent.getBoundingClientRect().top
+  const rows = parent.querySelectorAll<HTMLElement>('[data-node-id]')
+  for (const el of rows) {
+    const id = el.dataset.nodeId
+    if (!id) continue
+    const rect = el.getBoundingClientRect()
+    if (rect.bottom > parentTop + 1) {
+      return { kind: 'anchor', nodeId: id, offset: parentTop - rect.top }
+    }
+  }
+  return { kind: 'bottom' }
+}
+
+export function restoreChatScroll(parent: HTMLElement, memory: ChatScrollMemory): boolean {
+  if (memory.kind === 'bottom') {
+    parent.scrollTop = parent.scrollHeight
+    return true
+  }
+  const escaped =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(memory.nodeId) : memory.nodeId
+  const el = parent.querySelector(`[data-node-id="${escaped}"]`)
+  if (!(el instanceof HTMLElement)) return false
+  const parentTop = parent.getBoundingClientRect().top
+  const top = el.getBoundingClientRect().top
+  parent.scrollTop += top - parentTop + memory.offset
+  return true
+}
+
 /** 视口还没被尾巴填满，或用户已经滑到顶等更早内容：用 rAF 快补。 */
 export function shouldRevealFast(opts: {
   scrollTop: number

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -39,15 +39,21 @@ import { LiveDispatchTable } from './live-dispatch-table.tsx'
 import { UsageInline } from './usage-inline.tsx'
 import {
   bumpRevealStart,
+  captureChatScroll,
+  CHAT_NEAR_BOTTOM_PX,
   firstPaintStartIndex,
   groupNodesIntoTurns,
+  recalledChatScroll,
+  rememberChatScroll,
+  restoreChatScroll,
+  revealStartForMemory,
   shouldRevealFast,
   sliceTurnsFrom,
 } from './thread-reveal.ts'
 
 export { groupNodesIntoTurns } from './thread-reveal.ts'
 
-const NEAR_BOTTOM_PX = 96
+const NEAR_BOTTOM_PX = CHAT_NEAR_BOTTOM_PX
 /** 提早预取更早消息，避免滑到顶才开始请求 */
 const PREFETCH_OLDER_PX = 720
 
@@ -769,11 +775,11 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   if (sessionId !== sessionKeyRef.current) {
     sessionKeyRef.current = sessionId
     prevTotalRef.current = totalTurns
-    const next = firstPaintStartIndex(totalTurns)
+    const next = revealStartForMemory(nodes, recalledChatScroll(sessionId), totalTurns)
     if (next !== revealStart) setRevealStart(next)
   } else if (prevTotalRef.current === 0 && totalTurns > 0) {
     prevTotalRef.current = totalTurns
-    const next = firstPaintStartIndex(totalTurns)
+    const next = revealStartForMemory(nodes, recalledChatScroll(sessionId), totalTurns)
     if (next !== revealStart) setRevealStart(next)
   } else {
     prevTotalRef.current = totalTurns
@@ -791,6 +797,10 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const rootRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLElement | null>(null)
   const stickToBottomRef = useRef(true)
+  const sessionIdRef = useRef(sessionId)
+  sessionIdRef.current = sessionId
+  const restoredForRef = useRef<string | null>(null)
+  const prependHeightRef = useRef(0)
   const prefetchingRef = useRef(false)
   const [scrollEpoch, setScrollEpoch] = useState(0)
 
@@ -815,9 +825,20 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
   }, [sessionId])
 
-  useEffect(() => {
-    stickToBottomRef.current = true
+  useLayoutEffect(() => {
+    const mem = recalledChatScroll(sessionId)
+    stickToBottomRef.current = !mem || mem.kind === 'bottom'
+    restoredForRef.current = null
+    prependHeightRef.current = 0
   }, [sessionId])
+
+  useEffect(() => {
+    return () => {
+      const parent = scrollRef.current
+      const id = sessionIdRef.current
+      if (id && parent) rememberChatScroll(id, captureChatScroll(parent))
+    }
+  }, [])
 
   useEffect(() => {
     if (pending) stickToBottomRef.current = true
@@ -851,10 +872,15 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       stickToBottomRef.current = distance <= NEAR_BOTTOM_PX
       maybePrefetchOlder()
     }
+    const onUserScroll = () => {
+      onScroll()
+      const id = sessionIdRef.current
+      if (id && restoredForRef.current === id) rememberChatScroll(id, captureChatScroll(parent))
+    }
     onScroll()
-    parent.addEventListener('scroll', onScroll, { passive: true })
+    parent.addEventListener('scroll', onUserScroll, { passive: true })
     return () => {
-      parent.removeEventListener('scroll', onScroll)
+      parent.removeEventListener('scroll', onUserScroll)
     }
   }, [sessionId, scrollEpoch, hasMoreOlder, loadingOlder, sessionView])
 
@@ -887,10 +913,20 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       ? `${lastNode.id}:${Math.floor(lastNode.copyText.length / 96)}:1`
       : `${mountedNodes.length}:${pending ? 1 : 0}:${error ?? ''}`
 
-  const prependHeightRef = useRef(0)
   useLayoutEffect(() => {
     const parent = scrollRef.current
     if (!parent) return
+    const mem = recalledChatScroll(sessionId)
+    if (sessionId && restoredForRef.current !== sessionId && mem?.kind === 'anchor') {
+      if (restoreChatScroll(parent, mem)) {
+        restoredForRef.current = sessionId
+        stickToBottomRef.current = false
+        prependHeightRef.current = parent.scrollHeight
+        return
+      }
+      return
+    }
+    if (sessionId) restoredForRef.current = sessionId
     if (stickToBottomRef.current) {
       if (mountedNodes.length > 0) parent.scrollTop = parent.scrollHeight
     } else if (prependHeightRef.current) {
@@ -898,7 +934,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       if (delta) parent.scrollTop += delta
     }
     prependHeightRef.current = parent.scrollHeight
-  }, [stickKey, mountedNodes.length, revealStart])
+  }, [stickKey, mountedNodes.length, revealStart, sessionId])
 
   if (nodes.length === 0 && !pending && !error && !switchingSession) {
     const session = sessions.find((item) => item.id === sessionId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
切会话时记住每个会话的阅读位置：贴底则回来仍贴底；停在中间则记下视口里那条消息和偏移，切回来滚到同一处，并从该回合开始挂载，而不是又跳到最新。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

