### PR TITLE
切回会话：滚到当时贴顶的那条消息

### DIFF
--- a/packages/cap-chat/src/web/thread-reveal.test.ts
+++ b/packages/cap-chat/src/web/thread-reveal.test.ts
@@ -100,33 +100,39 @@ function box(top: number, height: number): DOMRect {
 
 describe('chat scroll memory per session', () => {
   it('keeps an independent reading position for each session', () => {
-    rememberChatScroll('s-a', { kind: 'anchor', nodeId: 'u-3', offset: 24 })
+    rememberChatScroll('s-a', { kind: 'pin', nodeId: 'u-3' })
     rememberChatScroll('s-b', { kind: 'bottom' })
-    expect(recalledChatScroll('s-a')).toEqual({ kind: 'anchor', nodeId: 'u-3', offset: 24 })
+    expect(recalledChatScroll('s-a')).toEqual({ kind: 'pin', nodeId: 'u-3' })
     expect(recalledChatScroll('s-b')).toEqual({ kind: 'bottom' })
   })
 
-  it('mounts from the remembered turn instead of only the tail', () => {
+  it('mounts from the pinned turn instead of only the tail', () => {
     const nodes = longThread()
     expect(turnIndexContaining(nodes, 'u-3')).toBe(3)
-    expect(revealStartForMemory(nodes, { kind: 'anchor', nodeId: 'u-3', offset: 12 }, 10)).toBe(3)
+    expect(revealStartForMemory(nodes, { kind: 'pin', nodeId: 'u-3' }, 10)).toBe(3)
     expect(revealStartForMemory(nodes, { kind: 'bottom' }, 10)).toBe(10 - CHAT_FIRST_PAINT_TURNS)
   })
 
-  it('captures the first visible node when not pinned to the bottom', () => {
+  it('captures the user message currently stuck to the top', () => {
     const parent = document.createElement('div')
     Object.defineProperty(parent, 'scrollHeight', { value: 4000, configurable: true })
     Object.defineProperty(parent, 'scrollTop', { value: 1200, writable: true, configurable: true })
     Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
     parent.getBoundingClientRect = () => box(0, 800)
-    const above = document.createElement('div')
-    above.dataset.nodeId = 'u-2'
-    above.getBoundingClientRect = () => box(-80, 40)
-    const visible = document.createElement('div')
-    visible.dataset.nodeId = 'u-3'
-    visible.getBoundingClientRect = () => box(40, 80)
-    parent.append(above, visible)
-    expect(captureChatScroll(parent)).toEqual({ kind: 'anchor', nodeId: 'u-3', offset: -40 })
+    const passed = document.createElement('div')
+    passed.dataset.nodeId = 'u-2'
+    passed.dataset.chatKind = 'user'
+    passed.getBoundingClientRect = () => box(-80, 40)
+    const sticky = document.createElement('div')
+    sticky.dataset.nodeId = 'u-3'
+    sticky.dataset.chatKind = 'user'
+    sticky.getBoundingClientRect = () => box(0, 40)
+    const later = document.createElement('div')
+    later.dataset.nodeId = 'u-4'
+    later.dataset.chatKind = 'user'
+    later.getBoundingClientRect = () => box(200, 40)
+    parent.append(passed, sticky, later)
+    expect(captureChatScroll(parent)).toEqual({ kind: 'pin', nodeId: 'u-3' })
   })
 
   it('captures bottom when close to the latest messages', () => {
@@ -137,7 +143,7 @@ describe('chat scroll memory per session', () => {
     expect(captureChatScroll(parent)).toEqual({ kind: 'bottom' })
   })
 
-  it('restores the saved offset onto the same node', () => {
+  it('restores by aligning that message to the top of the viewport', () => {
     const parent = document.createElement('div')
     Object.defineProperty(parent, 'scrollTop', { value: 500, writable: true, configurable: true })
     parent.getBoundingClientRect = () => box(0, 800)
@@ -145,7 +151,7 @@ describe('chat scroll memory per session', () => {
     row.dataset.nodeId = 'u-3'
     row.getBoundingClientRect = () => box(120, 80)
     parent.append(row)
-    expect(restoreChatScroll(parent, { kind: 'anchor', nodeId: 'u-3', offset: -40 })).toBe(true)
-    expect(parent.scrollTop).toBe(500 + 120 + -40)
+    expect(restoreChatScroll(parent, { kind: 'pin', nodeId: 'u-3' })).toBe(true)
+    expect(parent.scrollTop).toBe(620)
   })
 })

--- a/packages/cap-chat/src/web/thread-reveal.ts
+++ b/packages/cap-chat/src/web/thread-reveal.ts
@@ -37,11 +37,12 @@ export function bumpRevealStart(startIndex: number, batch = CHAT_REVEAL_BATCH): 
 }
 
 export const CHAT_NEAR_BOTTOM_PX = 96
+const PIN_TOP_SLACK_PX = 8
 
-/** 贴底，或某条消息相对视口顶的偏移。切回会话时按这个还原进度条。 */
+/** 贴底，或当时贴在视口顶的那条用户消息。回来滚到它重新贴顶。 */
 export type ChatScrollMemory =
   | { kind: 'bottom' }
-  | { kind: 'anchor'; nodeId: string; offset: number }
+  | { kind: 'pin'; nodeId: string }
 
 const chatScrollBySession = new Map<string, ChatScrollMemory>()
 
@@ -62,7 +63,7 @@ export function turnIndexContaining(nodes: ChatNode[], nodeId: string): number {
   return groupNodesIntoTurns(nodes).findIndex((turn) => turn.some((node) => node.id === nodeId))
 }
 
-/** 回到中间阅读位置时，从那一回合挂到最新；贴底则仍只先挂尾巴。 */
+/** 回到中间阅读位置时，从贴顶那一回合挂到最新；贴底则仍只先挂尾巴。 */
 export function revealStartForMemory(
   nodes: ChatNode[],
   memory: ChatScrollMemory | undefined,
@@ -73,20 +74,25 @@ export function revealStartForMemory(
   return index < 0 ? 0 : index
 }
 
+function nodeSelector(nodeId: string) {
+  const escaped =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(nodeId) : nodeId
+  return `[data-node-id="${escaped}"]`
+}
+
+/** 当前贴顶的用户消息：已经顶到视口上沿的最后一条。 */
 export function captureChatScroll(parent: HTMLElement): ChatScrollMemory {
   const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
   if (distance <= CHAT_NEAR_BOTTOM_PX) return { kind: 'bottom' }
   const parentTop = parent.getBoundingClientRect().top
-  const rows = parent.querySelectorAll<HTMLElement>('[data-node-id]')
-  for (const el of rows) {
-    const id = el.dataset.nodeId
-    if (!id) continue
-    const rect = el.getBoundingClientRect()
-    if (rect.bottom > parentTop + 1) {
-      return { kind: 'anchor', nodeId: id, offset: parentTop - rect.top }
-    }
+  const users = parent.querySelectorAll<HTMLElement>('[data-chat-kind="user"][data-node-id]')
+  let pin: HTMLElement | null = null
+  for (const el of users) {
+    if (el.getBoundingClientRect().top <= parentTop + PIN_TOP_SLACK_PX) pin = el
   }
-  return { kind: 'bottom' }
+  const id = pin?.dataset.nodeId ?? users[0]?.dataset.nodeId
+  if (!id) return { kind: 'bottom' }
+  return { kind: 'pin', nodeId: id }
 }
 
 export function restoreChatScroll(parent: HTMLElement, memory: ChatScrollMemory): boolean {
@@ -94,13 +100,9 @@ export function restoreChatScroll(parent: HTMLElement, memory: ChatScrollMemory)
     parent.scrollTop = parent.scrollHeight
     return true
   }
-  const escaped =
-    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(memory.nodeId) : memory.nodeId
-  const el = parent.querySelector(`[data-node-id="${escaped}"]`)
+  const el = parent.querySelector(nodeSelector(memory.nodeId))
   if (!(el instanceof HTMLElement)) return false
-  const parentTop = parent.getBoundingClientRect().top
-  const top = el.getBoundingClientRect().top
-  parent.scrollTop += top - parentTop + memory.offset
+  parent.scrollTop += el.getBoundingClientRect().top - parent.getBoundingClientRect().top
   return true
 }
 

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -917,7 +917,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     const parent = scrollRef.current
     if (!parent) return
     const mem = recalledChatScroll(sessionId)
-    if (sessionId && restoredForRef.current !== sessionId && mem?.kind === 'anchor') {
+    if (sessionId && restoredForRef.current !== sessionId && mem?.kind === 'pin') {
       if (restoreChatScroll(parent, mem)) {
         restoredForRef.current = sessionId
         stickToBottomRef.current = false


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
切会话只记当时贴在视口顶的那条用户消息（`u-{seq}`）。切回来把这条滚到视口顶对齐，不再记像素偏移。贴在最新则仍记贴底。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

