### PR TITLE
修阅读位置：按回合容器滚，不被 sticky 骗到

### DIFF
--- a/packages/cap-chat/src/web/thread-reveal.test.ts
+++ b/packages/cap-chat/src/web/thread-reveal.test.ts
@@ -143,15 +143,21 @@ describe('chat scroll memory per session', () => {
     expect(captureChatScroll(parent)).toEqual({ kind: 'bottom' })
   })
 
-  it('restores by aligning that message to the top of the viewport', () => {
+  it('restores by scrolling the turn box to the top, ignoring sticky visual offset', () => {
     const parent = document.createElement('div')
-    Object.defineProperty(parent, 'scrollTop', { value: 500, writable: true, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 1800, writable: true, configurable: true })
+    const turn = document.createElement('div')
+    turn.dataset.turnAnchor = 'u-3'
+    turn.className = 'chat-turn'
+    Object.defineProperty(turn, 'offsetTop', { value: 640, configurable: true })
+    const sticky = document.createElement('div')
+    sticky.dataset.nodeId = 'u-3'
+    sticky.dataset.chatKind = 'user'
+    sticky.getBoundingClientRect = () => box(0, 40)
+    turn.append(sticky)
+    parent.append(turn)
     parent.getBoundingClientRect = () => box(0, 800)
-    const row = document.createElement('div')
-    row.dataset.nodeId = 'u-3'
-    row.getBoundingClientRect = () => box(120, 80)
-    parent.append(row)
     expect(restoreChatScroll(parent, { kind: 'pin', nodeId: 'u-3' })).toBe(true)
-    expect(parent.scrollTop).toBe(620)
+    expect(parent.scrollTop).toBe(640)
   })
 })

--- a/packages/cap-chat/src/web/thread-reveal.ts
+++ b/packages/cap-chat/src/web/thread-reveal.ts
@@ -80,6 +80,23 @@ function nodeSelector(nodeId: string) {
   return `[data-node-id="${escaped}"]`
 }
 
+function turnSelector(nodeId: string) {
+  const escaped =
+    typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(nodeId) : nodeId
+  return `[data-turn-anchor="${escaped}"]`
+}
+
+/** 相对滚动容器的文档坐标；走 offsetTop，不受 sticky 视觉位置干扰。 */
+export function offsetInScroller(el: HTMLElement, scroller: HTMLElement): number {
+  let y = 0
+  let node: HTMLElement | null = el
+  while (node && node !== scroller) {
+    y += node.offsetTop
+    node = node.parentElement
+  }
+  return y
+}
+
 /** 当前贴顶的用户消息：已经顶到视口上沿的最后一条。 */
 export function captureChatScroll(parent: HTMLElement): ChatScrollMemory {
   const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
@@ -100,9 +117,10 @@ export function restoreChatScroll(parent: HTMLElement, memory: ChatScrollMemory)
     parent.scrollTop = parent.scrollHeight
     return true
   }
-  const el = parent.querySelector(nodeSelector(memory.nodeId))
+  const turn = parent.querySelector(turnSelector(memory.nodeId))
+  const el = turn instanceof HTMLElement ? turn : parent.querySelector(nodeSelector(memory.nodeId))
   if (!(el instanceof HTMLElement)) return false
-  parent.scrollTop += el.getBoundingClientRect().top - parent.getBoundingClientRect().top
+  parent.scrollTop = offsetInScroller(el, parent)
   return true
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
还原阅读位置时不要用 sticky 用户气泡的 getBoundingClientRect（它视觉上已经贴顶，加 scrollTop 等于没动）。改为把 `.chat-turn` 的 offsetTop 设成滚动位置，让那条消息真正贴顶。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

