### PR TITLE
记录跟表用同一套图标；切回会话滚准贴顶回合

### DIFF
--- a/packages/cap-chat/src/web/thread-reveal.test.ts
+++ b/packages/cap-chat/src/web/thread-reveal.test.ts
@@ -109,7 +109,7 @@ describe('chat scroll memory per session', () => {
   it('mounts from the pinned turn instead of only the tail', () => {
     const nodes = longThread()
     expect(turnIndexContaining(nodes, 'u-3')).toBe(3)
-    expect(revealStartForMemory(nodes, { kind: 'pin', nodeId: 'u-3' }, 10)).toBe(3)
+    expect(revealStartForMemory(nodes, { kind: 'pin', nodeId: 'u-3' }, 10)).toBe(0)
     expect(revealStartForMemory(nodes, { kind: 'bottom' }, 10)).toBe(10 - CHAT_FIRST_PAINT_TURNS)
   })
 
@@ -146,18 +146,18 @@ describe('chat scroll memory per session', () => {
   it('restores by scrolling the turn box to the top, ignoring sticky visual offset', () => {
     const parent = document.createElement('div')
     Object.defineProperty(parent, 'scrollTop', { value: 1800, writable: true, configurable: true })
+    parent.getBoundingClientRect = () => box(0, 800)
     const turn = document.createElement('div')
     turn.dataset.turnAnchor = 'u-3'
     turn.className = 'chat-turn'
-    Object.defineProperty(turn, 'offsetTop', { value: 640, configurable: true })
+    turn.getBoundingClientRect = () => box(-80, 200)
     const sticky = document.createElement('div')
     sticky.dataset.nodeId = 'u-3'
     sticky.dataset.chatKind = 'user'
     sticky.getBoundingClientRect = () => box(0, 40)
     turn.append(sticky)
     parent.append(turn)
-    parent.getBoundingClientRect = () => box(0, 800)
     expect(restoreChatScroll(parent, { kind: 'pin', nodeId: 'u-3' })).toBe(true)
-    expect(parent.scrollTop).toBe(640)
+    expect(parent.scrollTop).toBe(1720)
   })
 })

--- a/packages/cap-chat/src/web/thread-reveal.ts
+++ b/packages/cap-chat/src/web/thread-reveal.ts
@@ -70,8 +70,7 @@ export function revealStartForMemory(
   totalTurns: number,
 ): number {
   if (!memory || memory.kind === 'bottom') return firstPaintStartIndex(totalTurns)
-  const index = turnIndexContaining(nodes, memory.nodeId)
-  return index < 0 ? 0 : index
+  return 0
 }
 
 function nodeSelector(nodeId: string) {
@@ -88,13 +87,7 @@ function turnSelector(nodeId: string) {
 
 /** 相对滚动容器的文档坐标；走 offsetTop，不受 sticky 视觉位置干扰。 */
 export function offsetInScroller(el: HTMLElement, scroller: HTMLElement): number {
-  let y = 0
-  let node: HTMLElement | null = el
-  while (node && node !== scroller) {
-    y += node.offsetTop
-    node = node.parentElement
-  }
-  return y
+  return el.getBoundingClientRect().top - scroller.getBoundingClientRect().top + scroller.scrollTop
 }
 
 /** 当前贴顶的用户消息：已经顶到视口上沿的最后一条。 */

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -800,6 +800,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const sessionIdRef = useRef(sessionId)
   sessionIdRef.current = sessionId
   const restoredForRef = useRef<string | null>(null)
+  const holdOlderRef = useRef(false)
+  const maxScrollRef = useRef(0)
   const prependHeightRef = useRef(0)
   const prefetchingRef = useRef(false)
   const [scrollEpoch, setScrollEpoch] = useState(0)
@@ -830,6 +832,8 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     stickToBottomRef.current = !mem || mem.kind === 'bottom'
     restoredForRef.current = null
     prependHeightRef.current = 0
+    holdOlderRef.current = mem?.kind === 'pin'
+    maxScrollRef.current = 0
   }, [sessionId])
 
   useEffect(() => {
@@ -874,6 +878,10 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
     const onUserScroll = () => {
       onScroll()
+      maxScrollRef.current = Math.max(maxScrollRef.current, parent.scrollTop)
+      if (holdOlderRef.current && maxScrollRef.current > PREFETCH_OLDER_PX && parent.scrollTop <= PREFETCH_OLDER_PX) {
+        holdOlderRef.current = false
+      }
       const id = sessionIdRef.current
       if (id && restoredForRef.current === id) rememberChatScroll(id, captureChatScroll(parent))
     }
@@ -886,6 +894,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
 
   useEffect(() => {
     if (revealStart <= 0) return
+    if (holdOlderRef.current) return
     const parent = scrollRef.current
     const fast = parent
       ? shouldRevealFast({

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -3,7 +3,6 @@ import {
   ChevronDoubleLeftIcon,
   ChevronDownIcon,
   ChevronRightIcon,
-  DocumentTextIcon,
   PencilSquareIcon,
   PlusIcon,
   Square2StackIcon,
@@ -55,12 +54,14 @@ function ViewRecordPreview({
   view,
   open,
   recordKind,
+  tableIcon,
   onOpenRecord,
 }: {
   path: string
   view: SavedView
   open: boolean
   recordKind: string
+  tableIcon?: string
   onOpenRecord?: (recordId: string) => void
 }) {
   const key = previewCacheKey(path, view)
@@ -166,7 +167,7 @@ function ViewRecordPreview({
                     setEmojiDraft(emoji)
                   }}
                 >
-                  {emoji ? <span className="fsdb-record-emoji">{emoji}</span> : <DocumentTextIcon aria-hidden className="size-4" />}
+                  <TableGlyph icon={tableIcon} />
                 </button>
                 {pickerId === row.id ? (
                   <div className="fsdb-emoji-picker" data-biu-ignore onClick={(event) => event.stopPropagation()}>
@@ -493,6 +494,7 @@ export const DataSidebar = memo(function DataSidebar({
                           view={view}
                           open={expanded}
                           recordKind={recordPickKind(table.view?.moduleId)}
+                          tableIcon={table.view?.icon}
                           onOpenRecord={(id) => openRecord(table.path, view, id)}
                         />
                       </div>
@@ -645,6 +647,7 @@ export const DataSidebar = memo(function DataSidebar({
                                 view={view}
                                 open={expanded}
                                 recordKind={recordPickKind(table.view?.moduleId)}
+                                tableIcon={table.view?.icon}
                                 onOpenRecord={(id) => openRecord(table.path, view, id)}
                               />
                             </div>

--- a/packages/core-file-system/src/web/nav-glyphs.tsx
+++ b/packages/core-file-system/src/web/nav-glyphs.tsx
@@ -4,7 +4,6 @@ import {
   ChatBubbleLeftRightIcon,
   BoltIcon,
   EyeIcon,
-  DocumentTextIcon,
   ListBulletIcon,
   PuzzlePieceIcon,
   Squares2X2Icon,
@@ -36,7 +35,7 @@ export function CrumbItemGlyph({
   kind,
   icon,
   mode,
-  emoji,
+  emoji: _emoji,
   className = 'chat-view-project-icon',
 }: {
   kind: CrumbKind
@@ -45,10 +44,7 @@ export function CrumbItemGlyph({
   emoji?: string
   className?: string
 }) {
-  if (kind === 'record') {
-    if (emoji) return <span className="fsdb-record-emoji" aria-hidden>{emoji}</span>
-    return <DocumentTextIcon aria-hidden className={className} />
-  }
+  if (kind === 'record') return <TableGlyph icon={icon} className={className} />
   if (kind === 'view') return <ViewModeGlyph mode={mode} className={className} />
   if (kind === 'collection') return <TableGlyph icon={icon} className={className} />
   return <CircleStackIcon aria-hidden className={className} />

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -186,7 +186,7 @@ test('一项时点面包屑回到上一级，多项出菜单', () => {
   const crumbs = buildCrumbs({
     collection: '/tasks',
     collectionLabel: 'Task',
-    tables: [{ path: '/tasks', label: 'Task' }],
+    tables: [{ path: '/tasks', label: 'Task', icon: 'clipboard' }],
     viewId: 'v1',
     viewName: '默认视图',
     views: [{ id: 'v1', name: '默认视图' }],
@@ -194,6 +194,7 @@ test('一项时点面包屑回到上一级，多项出菜单', () => {
     recordLabel: '打开一条事件',
     records: [{ id: 'evt-194', label: '打开一条事件' }],
   })
+  assert.equal(crumbs[2]!.choices[0]!.icon, 'clipboard')
   assert.equal(crumbButtonAction(crumbs[2]!, crumbs[1]!), crumbs[1]!.target)
   assert.equal(crumbButtonAction(crumbs[1]!, crumbs[0]!), crumbs[0]!.target)
   const many = buildCrumbs({

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -121,6 +121,7 @@ export function buildCrumbs(input: {
     })
   }
   if (input.recordId) {
+    const tableIcon = input.tables.find((item) => item.path === input.collection)?.icon
     crumbs.push({
       kind: 'record',
       id: input.recordId,
@@ -129,7 +130,7 @@ export function buildCrumbs(input: {
       choices: (input.records ?? [{ id: input.recordId, label: input.recordLabel || input.recordId }]).map((row) => ({
         id: row.id,
         label: row.label,
-        emoji: row.emoji,
+        icon: tableIcon,
         target: { kind: 'record', collection: input.collection, recordId: row.id },
       })),
     })

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -2,13 +2,17 @@ import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useStat
 import { createPortal } from 'react-dom'
 import {
   CheckCircleIcon,
-  DocumentTextIcon,
   ListBulletIcon,
   PlusIcon,
   Squares2X2Icon,
   TableCellsIcon,
   TrashIcon,
   ViewColumnsIcon,
+  ClipboardDocumentListIcon,
+  ChatBubbleLeftRightIcon,
+  PuzzlePieceIcon,
+  BoltIcon,
+  EyeIcon,
 } from '@heroicons/react/16/solid'
 import { chromeIcon } from './chrome-icon.ts'
 import {
@@ -22,20 +26,31 @@ import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts
 import { getInspectorCaption, getInspectorCaptionVersion, subscribeInspectorCaptions } from './inspector-captions.ts'
 import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
 
+function captionTableIcon(icon?: string) {
+  const name = (icon ?? '').trim().toLowerCase()
+  if (name === 'puzzle-piece' || name === 'puzzle') return PuzzlePieceIcon
+  if (name === 'clipboard-document-list' || name === 'clipboard') return ClipboardDocumentListIcon
+  if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return ChatBubbleLeftRightIcon
+  if (name === 'bolt') return BoltIcon
+  if (name === 'eye') return EyeIcon
+  return TableCellsIcon
+}
+
 function PaneLeafIcon({
   kind,
   mode,
-  emoji,
+  icon,
   Fallback,
 }: {
   kind?: string
   mode?: string
+  icon?: string
   emoji?: string
   Fallback?: ComponentType<{ className?: string }>
 }) {
-  if (kind === 'record') {
-    if (emoji) return <span className="fsdb-record-emoji" aria-hidden>{emoji}</span>
-    return <DocumentTextIcon {...chromeIcon} />
+  if (kind === 'record' || kind === 'collection') {
+    const Glyph = captionTableIcon(icon)
+    return <Glyph {...chromeIcon} />
   }
   if (kind === 'view') {
     if (mode === 'queue') return <ListBulletIcon {...chromeIcon} />
@@ -352,7 +367,7 @@ export const SessionInspector = memo(function SessionInspector({
                       onClick={() => setTab(item.id)}
                       data-testid={`inspector-offer-${item.id}`}
                     >
-                      <PaneLeafIcon kind={caption?.kind} mode={caption?.mode} emoji={caption?.emoji} Fallback={item.Icon} />
+                      <PaneLeafIcon kind={caption?.kind} mode={caption?.mode} icon={caption?.icon} Fallback={item.Icon} />
                       <span className="min-w-0 flex-1 truncate">{caption?.label || item.label}</span>
                       <CheckCircleIcon aria-hidden className="size-4 shrink-0 inspector-add-check" />
                     </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
记录行、面包屑和检查器标题改用所属数据表的图标（任务表/聊天表各自那套），不再用文档图标。

阅读位置：切回来先挂完整消息再把当时贴顶的回合滚到视口顶；不再在还原过程中分帧往上补历史（那会把进度条带偏）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

