### PR TITLE
面包屑：悬停出展开按钮，点标题不打开菜单

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2347,6 +2347,9 @@ if (typeof document !== 'undefined') {
 .fsdb-crumb-btn:hover,.fsdb-crumb-btn.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
 .fsdb-crumb-btn .chat-view-project-name,.fsdb-crumb-option .chat-view-project-name{font-size:14px;font-weight:600;color:inherit}
 .fsdb-crumb-pick{position:relative;flex:none}
+.fsdb-crumb-expand{position:absolute;right:-2px;top:50%;z-index:2;display:grid;place-items:center;width:16px;height:16px;margin:0;border:0;border-radius:4px;background:var(--dsw-surface);box-shadow:0 0 0 1px var(--dsw-border);color:var(--dsw-sidebar-fg);opacity:0;pointer-events:none;transform:translateY(-50%);cursor:pointer}
+.fsdb-crumb-pick:hover .fsdb-crumb-expand,.fsdb-crumb-pick.is-open .fsdb-crumb-expand,.fsdb-crumb-pick:focus-within .fsdb-crumb-expand{opacity:1;pointer-events:auto}
+.fsdb-crumb-expand:hover,.fsdb-crumb-expand.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
 .fsdb-crumb-menu{position:absolute;left:0;top:calc(100% + 4px);z-index:80;min-width:160px;max-height:240px;overflow:auto;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-surface);padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.16)}
 .fsdb-crumb-menu.is-fixed{position:fixed;z-index:140}
 .fsdb-crumb-option{display:flex;width:100%;min-width:0;align-items:center;gap:6px;border:0;border-radius:6px;background:transparent;padding:6px 8px;color:var(--dsw-sidebar-fg);font:inherit;font-size:14px;font-weight:600;text-align:left;cursor:pointer}

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -7,13 +7,16 @@ const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf
 const inspector = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
 
 describe('顶栏三级标题', () => {
-  it('没有单独的下拉箭头，点标题本身出菜单', () => {
-    expect(trail).not.toContain('ChevronDownIcon')
-    expect(trail).toContain("aria-haspopup={canPick ? 'menu' : undefined}")
+  it('悬停才露出右侧展开按钮，点标题本身不打开菜单', () => {
+    expect(trail).toContain('ChevronDownIcon')
+    expect(trail).toContain('data-testid="crumb-expand"')
+    expect(trail).toContain('crumbLabelAction')
+    expect(trail).toContain("aria-haspopup=\"menu\"")
     expect(trail).toContain('<CrumbItemGlyph kind={crumb.kind}')
     expect(trail).toContain('createPortal')
     expect(trail).toContain('data-fsdb-crumb-menu')
-    expect(trail).toContain('<CrumbItemGlyph kind={openCrumb.kind} icon={choice.icon} mode={choice.mode} emoji={choice.emoji} />')
+    expect(trail).not.toContain('onMouseEnter')
+    expect(browser).toContain('.fsdb-crumb-expand{position:absolute')
     expect(browser).toContain('<CrumbTrail')
   })
 
@@ -24,7 +27,7 @@ describe('顶栏三级标题', () => {
     expect(browser).toMatch(/\.fsdb-crumb-option\{[^}]*font-weight:600/)
   })
 
-  it('右侧检查器面包屑同样用下拉切换，不靠点回去退', () => {
+  it('右侧检查器面包屑同样用展开按钮切换，不靠悬停自动展开', () => {
     expect(inspector).toContain('<CrumbTrail')
     expect(inspector).toContain('onOpenId={setCrumbOpen}')
     expect(inspector).toContain('onActivate={onActivate}')

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -1,7 +1,8 @@
 import { useLayoutEffect, useRef, useState, type MouseEvent, type Ref } from 'react'
 import { createPortal } from 'react-dom'
+import { ChevronDownIcon } from '@heroicons/react/16/solid'
 import { CrumbItemGlyph } from './nav-glyphs.tsx'
-import { crumbButtonAction, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
+import { crumbLabelAction, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 
 export function CrumbTrail({
   crumbs,
@@ -45,33 +46,45 @@ export function CrumbTrail({
         return (
           <span key={crumb.id} className="fsdb-crumb">
             {index ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
-            <span className="fsdb-crumb-pick">
+            <span className={`fsdb-crumb-pick${open ? ' is-open' : ''}`}>
               <button
                 type="button"
-                ref={(el) => {
-                  if (el) btnRefs.current.set(crumb.id, el)
-                  else btnRefs.current.delete(crumb.id)
-                }}
                 className={`fsdb-crumb-btn${open ? ' is-open' : ''}`}
                 title={crumb.label}
-                aria-haspopup={canPick ? 'menu' : undefined}
-                aria-expanded={canPick ? open : undefined}
                 onClick={(event: MouseEvent) => {
                   event.preventDefault()
                   event.stopPropagation()
                   onActivate?.()
-                  const action = crumbButtonAction(crumb, index ? crumbs[index - 1] : undefined)
-                  if (action === 'menu') {
-                    onOpenId(open ? null : crumb.id)
-                    return
-                  }
-                  onPick(action)
+                  onPick(crumbLabelAction(crumb, index ? crumbs[index - 1] : undefined))
                   onOpenId(null)
                 }}
               >
                 <CrumbItemGlyph kind={crumb.kind} icon={current?.icon} mode={current?.mode} emoji={current?.emoji} />
                 <span className="chat-view-project-name">{crumb.label}</span>
               </button>
+              {canPick ? (
+                <button
+                  type="button"
+                  ref={(el) => {
+                    if (el) btnRefs.current.set(crumb.id, el)
+                    else btnRefs.current.delete(crumb.id)
+                  }}
+                  className={`fsdb-crumb-expand${open ? ' is-open' : ''}`}
+                  title="展开选择"
+                  aria-label={`展开 ${crumb.label}`}
+                  aria-haspopup="menu"
+                  aria-expanded={open}
+                  data-testid="crumb-expand"
+                  onClick={(event: MouseEvent) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    onActivate?.()
+                    onOpenId(open ? null : crumb.id)
+                  }}
+                >
+                  <ChevronDownIcon aria-hidden className="size-3" />
+                </button>
+              ) : null}
             </span>
           </span>
         )

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -6,6 +6,7 @@ import {
   assertSidebarInvariants,
   buildCrumbs,
   crumbButtonAction,
+  crumbLabelAction,
   parseCenterPath,
   pathForCenter,
   pathForCrumbTarget,
@@ -209,6 +210,7 @@ test('一项时点面包屑回到上一级，多项出菜单', () => {
     ],
   })
   assert.equal(crumbButtonAction(many[1]!, many[0]!), 'menu')
+  assert.equal(crumbLabelAction(many[1]!, many[0]!), many[0]!.target)
 })
 
 test('压测：随机切换表/视图/记录/展开，路由与展开不串台', () => {

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -138,11 +138,16 @@ export function buildCrumbs(input: {
   return crumbs
 }
 
+/** 点标题：回到上一级。多项选择改走右侧展开按钮，避免和标题点击抢手。 */
+export function crumbLabelAction(crumb: Crumb, parent?: Crumb): CrumbTarget {
+  if (parent) return parent.target
+  return { kind: 'root' }
+}
+
 /** 多项则出菜单；只有一项时点这一级回到上一级。 */
 export function crumbButtonAction(crumb: Crumb, parent?: Crumb): 'menu' | CrumbTarget {
   if (crumb.choices.length > 1) return 'menu'
-  if (parent) return parent.target
-  return { kind: 'root' }
+  return crumbLabelAction(crumb, parent)
 }
 
 export function parseCenterPath(pathname: string): DataCenter | null {

--- a/web/style.css
+++ b/web/style.css
@@ -494,6 +494,14 @@ body {
   max-width: 140px;
 }
 
+.inspector-crumb-full .fsdb-crumb-pick {
+  overflow: visible;
+}
+
+.inspector-crumb-full .fsdb-crumb-expand {
+  z-index: 4;
+}
+
 .inspector-crumb-full .fsdb-crumb-menu {
   z-index: 90;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
面包屑悬停时不自动展开。有多个表/视图时，右侧浮一个小展开按钮，点按钮才出菜单选不同项；点标题文字仍是原来的跳转（回到上一级），两者不再抢点击。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

