### PR TITLE
检查器面包屑：悬停不撑开，一个按钮展开整条路径

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2347,9 +2347,6 @@ if (typeof document !== 'undefined') {
 .fsdb-crumb-btn:hover,.fsdb-crumb-btn.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
 .fsdb-crumb-btn .chat-view-project-name,.fsdb-crumb-option .chat-view-project-name{font-size:14px;font-weight:600;color:inherit}
 .fsdb-crumb-pick{position:relative;flex:none}
-.fsdb-crumb-expand{position:absolute;right:-2px;top:50%;z-index:2;display:grid;place-items:center;width:16px;height:16px;margin:0;border:0;border-radius:4px;background:var(--dsw-surface);box-shadow:0 0 0 1px var(--dsw-border);color:var(--dsw-sidebar-fg);opacity:0;pointer-events:none;transform:translateY(-50%);cursor:pointer}
-.fsdb-crumb-pick:hover .fsdb-crumb-expand,.fsdb-crumb-pick.is-open .fsdb-crumb-expand,.fsdb-crumb-pick:focus-within .fsdb-crumb-expand{opacity:1;pointer-events:auto}
-.fsdb-crumb-expand:hover,.fsdb-crumb-expand.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
 .fsdb-crumb-menu{position:absolute;left:0;top:calc(100% + 4px);z-index:80;min-width:160px;max-height:240px;overflow:auto;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-surface);padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.16)}
 .fsdb-crumb-menu.is-fixed{position:fixed;z-index:140}
 .fsdb-crumb-option{display:flex;width:100%;min-width:0;align-items:center;gap:6px;border:0;border-radius:6px;background:transparent;padding:6px 8px;color:var(--dsw-sidebar-fg);font:inherit;font-size:14px;font-weight:600;text-align:left;cursor:pointer}

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -5,18 +5,17 @@ import { describe, expect, it } from 'vitest'
 const trail = readFileSync(resolve(import.meta.dirname, './crumb-trail.tsx'), 'utf8')
 const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
 const inspector = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
+const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
 
 describe('顶栏三级标题', () => {
-  it('悬停才露出右侧展开按钮，点标题本身不打开菜单', () => {
-    expect(trail).toContain('ChevronDownIcon')
-    expect(trail).toContain('data-testid="crumb-expand"')
-    expect(trail).toContain('crumbLabelAction')
-    expect(trail).toContain("aria-haspopup=\"menu\"")
+  it('中间顶栏点标题出菜单；检查器不靠悬停把面包屑撑开', () => {
+    expect(trail).toContain("aria-haspopup={canPick ? 'menu' : undefined}")
+    expect(trail).toContain('allowMenu')
     expect(trail).toContain('<CrumbItemGlyph kind={crumb.kind}')
     expect(trail).toContain('createPortal')
     expect(trail).toContain('data-fsdb-crumb-menu')
-    expect(trail).not.toContain('onMouseEnter')
-    expect(browser).toContain('.fsdb-crumb-expand{position:absolute')
+    expect(trail).not.toContain('data-testid="crumb-expand"')
+    expect(browser).not.toContain('.fsdb-crumb-expand{position:absolute')
     expect(browser).toContain('<CrumbTrail')
   })
 
@@ -27,11 +26,12 @@ describe('顶栏三级标题', () => {
     expect(browser).toMatch(/\.fsdb-crumb-option\{[^}]*font-weight:600/)
   })
 
-  it('右侧检查器面包屑同样用展开按钮切换，不靠悬停自动展开', () => {
-    expect(inspector).toContain('<CrumbTrail')
-    expect(inspector).toContain('onOpenId={setCrumbOpen}')
-    expect(inspector).toContain('onActivate={onActivate}')
+  it('右侧检查器用一个展开按钮控制整条面包屑，悬停不自动变成多项', () => {
+    expect(inspector).toContain('data-testid="inspector-crumb-toggle"')
+    expect(inspector).toContain('allowMenu={trailOpen}')
     expect(inspector).not.toContain('onMouseEnter')
+    expect(css).toContain('.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:not(:last-child)')
+    expect(css).not.toContain('.inspector-crumb-tab:hover .inspector-crumb-full .fsdb-crumb:not(:last-child)')
   })
 
   it('右侧检查器面包屑用记录标题而不是 id', () => {

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -1,8 +1,7 @@
 import { useLayoutEffect, useRef, useState, type MouseEvent, type Ref } from 'react'
 import { createPortal } from 'react-dom'
-import { ChevronDownIcon } from '@heroicons/react/16/solid'
 import { CrumbItemGlyph } from './nav-glyphs.tsx'
-import { crumbLabelAction, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
+import { crumbButtonAction, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 
 export function CrumbTrail({
   crumbs,
@@ -13,6 +12,7 @@ export function CrumbTrail({
   navRef,
   className,
   label,
+  allowMenu = true,
 }: {
   crumbs: Crumb[]
   openId: string | null
@@ -22,6 +22,8 @@ export function CrumbTrail({
   navRef?: Ref<HTMLElement | null>
   className?: string
   label?: string
+  /** 收起时只激活面板，不弹出某一级的选择菜单 */
+  allowMenu?: boolean
 }) {
   const btnRefs = useRef(new Map<string, HTMLButtonElement>())
   const [menuPos, setMenuPos] = useState<{ left: number; top: number } | null>(null)
@@ -40,56 +42,48 @@ export function CrumbTrail({
   return (
     <nav className={className ?? 'fsdb-crumbs'} aria-label={label ?? '位置'} ref={navRef}>
       {crumbs.map((crumb, index) => {
-        const canPick = crumb.choices.length > 1
+        const canPick = allowMenu && crumb.choices.length > 1
         const open = openId === crumb.id
         const current = crumb.choices.find((item) => item.id === crumb.id)
         return (
           <span key={crumb.id} className="fsdb-crumb">
             {index ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
-            <span className={`fsdb-crumb-pick${open ? ' is-open' : ''}`}>
+            <span className="fsdb-crumb-pick">
               <button
                 type="button"
+                ref={(el) => {
+                  if (el) btnRefs.current.set(crumb.id, el)
+                  else btnRefs.current.delete(crumb.id)
+                }}
                 className={`fsdb-crumb-btn${open ? ' is-open' : ''}`}
                 title={crumb.label}
+                aria-haspopup={canPick ? 'menu' : undefined}
+                aria-expanded={canPick ? open : undefined}
                 onClick={(event: MouseEvent) => {
                   event.preventDefault()
                   event.stopPropagation()
                   onActivate?.()
-                  onPick(crumbLabelAction(crumb, index ? crumbs[index - 1] : undefined))
+                  if (!allowMenu) {
+                    onOpenId(null)
+                    return
+                  }
+                  const action = crumbButtonAction(crumb, index ? crumbs[index - 1] : undefined)
+                  if (action === 'menu') {
+                    onOpenId(open ? null : crumb.id)
+                    return
+                  }
+                  onPick(action)
                   onOpenId(null)
                 }}
               >
                 <CrumbItemGlyph kind={crumb.kind} icon={current?.icon} mode={current?.mode} emoji={current?.emoji} />
                 <span className="chat-view-project-name">{crumb.label}</span>
               </button>
-              {canPick ? (
-                <button
-                  type="button"
-                  ref={(el) => {
-                    if (el) btnRefs.current.set(crumb.id, el)
-                    else btnRefs.current.delete(crumb.id)
-                  }}
-                  className={`fsdb-crumb-expand${open ? ' is-open' : ''}`}
-                  title="展开选择"
-                  aria-label={`展开 ${crumb.label}`}
-                  aria-haspopup="menu"
-                  aria-expanded={open}
-                  data-testid="crumb-expand"
-                  onClick={(event: MouseEvent) => {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    onActivate?.()
-                    onOpenId(open ? null : crumb.id)
-                  }}
-                >
-                  <ChevronDownIcon aria-hidden className="size-3" />
-                </button>
-              ) : null}
             </span>
           </span>
         )
       })}
-      {openCrumb && openCrumb.choices.length > 1 && menuPos && typeof document !== 'undefined'
+      {allowMenu && openCrumb && openCrumb.choices.length > 1 && menuPos && typeof document !== 'undefined'
         ? createPortal(
             <div
               className="fsdb-crumb-menu is-fixed"

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import { CircleStackIcon } from '@heroicons/react/16/solid'
+import { ChevronDownIcon, CircleStackIcon } from '@heroicons/react/16/solid'
 import { useLocation } from 'react-router-dom'
 import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
@@ -160,14 +160,17 @@ export function DatabaseInspectorTab({
   )
   const inspectorPath = useBindInspectorDbPath(id, tables)
   const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
+  const [trailOpen, setTrailOpen] = useState(false)
   const crumbRef = useRef<HTMLElement>(null)
+  const tabRef = useRef<HTMLDivElement>(null)
   useViewTick()
   useEffect(() => {
     function onPointer(event: globalThis.MouseEvent) {
       const target = event.target as Node
-      if (crumbRef.current?.contains(target)) return
+      if (tabRef.current?.contains(target)) return
       if (target instanceof Element && target.closest('[data-fsdb-crumb-menu]')) return
       setCrumbOpen(null)
+      setTrailOpen(false)
     }
     document.addEventListener('mousedown', onPointer)
     return () => document.removeEventListener('mousedown', onPointer)
@@ -192,7 +195,8 @@ export function DatabaseInspectorTab({
 
   return (
     <div
-      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}`}
+      ref={tabRef}
+      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}${trailOpen ? ' is-crumb-open' : ''}`}
       role="tab"
       aria-selected={Boolean(active)}
       data-testid="inspector-tab-database"
@@ -206,6 +210,7 @@ export function DatabaseInspectorTab({
           openId={crumbOpen}
           onOpenId={setCrumbOpen}
           onActivate={onActivate}
+          allowMenu={trailOpen}
           onPick={(target) => {
             onActivate?.()
             goInspector(id, target)
@@ -220,6 +225,27 @@ export function DatabaseInspectorTab({
           <span className="chat-view-project-name">数据</span>
         </span>
       )}
+      {crumbs.length > 1 ? (
+        <button
+          type="button"
+          className={`inspector-crumb-toggle${trailOpen ? ' is-open' : ''}`}
+          title={trailOpen ? '收起面包屑' : '展开面包屑'}
+          aria-label={trailOpen ? '收起面包屑' : '展开面包屑'}
+          aria-expanded={trailOpen}
+          data-testid="inspector-crumb-toggle"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onActivate?.()
+            setTrailOpen((open) => {
+              if (open) setCrumbOpen(null)
+              return !open
+            })
+          }}
+        >
+          <ChevronDownIcon aria-hidden className="size-3" />
+        </button>
+      ) : null}
     </div>
   )
 }

--- a/web/style.css
+++ b/web/style.css
@@ -456,10 +456,12 @@ body {
 }
 
 .inspector-crumb-tab {
+  position: relative;
   flex: none;
   max-width: none;
   min-width: max-content;
   overflow: visible;
+  padding-right: 18px;
 }
 
 .inspector-crumb-tab .inspector-crumb-full .fsdb-crumb:not(:last-child) {
@@ -470,14 +472,50 @@ body {
   display: none;
 }
 
-.inspector-crumb-tab:hover .inspector-crumb-full .fsdb-crumb:not(:last-child),
-.inspector-crumb-tab:has(.is-open) .inspector-crumb-full .fsdb-crumb:not(:last-child) {
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:not(:last-child) {
   display: inline-flex;
 }
 
-.inspector-crumb-tab:hover .inspector-crumb-full .fsdb-crumb:last-child .fsdb-crumb-sep,
-.inspector-crumb-tab:has(.is-open) .inspector-crumb-full .fsdb-crumb:last-child .fsdb-crumb-sep {
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:last-child .fsdb-crumb-sep {
   display: inline;
+}
+
+.inspector-crumb-toggle {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  border: 0;
+  border-radius: 4px;
+  background: var(--dsw-surface);
+  box-shadow: 0 0 0 1px var(--dsw-border);
+  color: var(--dsw-sidebar-fg);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  cursor: pointer;
+}
+
+.inspector-crumb-tab:hover .inspector-crumb-toggle,
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-toggle,
+.inspector-crumb-tab:focus-within .inspector-crumb-toggle {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.inspector-crumb-toggle:hover,
+.inspector-crumb-toggle.is-open {
+  background: var(--dsw-hover);
+  color: var(--dsw-sidebar-fg-active);
+}
+
+.inspector-crumb-toggle.is-open {
+  transform: translateY(-50%) rotate(180deg);
 }
 
 .inspector-crumb-leaf,
@@ -492,14 +530,6 @@ body {
 
 .inspector-crumb-full .fsdb-crumb-btn {
   max-width: 140px;
-}
-
-.inspector-crumb-full .fsdb-crumb-pick {
-  overflow: visible;
-}
-
-.inspector-crumb-full .fsdb-crumb-expand {
-  z-index: 4;
 }
 
 .inspector-crumb-full .fsdb-crumb-menu {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器面包屑悬停时不再从一项突然变成三项。只在右侧浮一个总的展开/收起按钮；点它才展开整条路径，然后再选表或视图。点当前标题只激活面板，不撑开面包屑。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

