### PR TITLE
面包屑展开按钮改为向右箭头，无边框无底

### DIFF
--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -28,7 +28,12 @@ describe('顶栏三级标题', () => {
 
   it('右侧检查器用一个展开按钮控制整条面包屑，悬停不自动变成多项', () => {
     expect(inspector).toContain('data-testid="inspector-crumb-toggle"')
+    expect(inspector).toContain('ChevronRightIcon')
+    expect(inspector).not.toContain('ChevronDownIcon')
     expect(inspector).toContain('allowMenu={trailOpen}')
+    expect(css).toMatch(/\.inspector-crumb-toggle\s*\{[^}]*background:\s*transparent/s)
+    expect(css).toMatch(/\.inspector-crumb-toggle\s*\{[^}]*box-shadow:\s*none/s)
+    expect(css).not.toContain('inspector-crumb-toggle.is-open {\n  transform: translateY(-50%) rotate(180deg);')
     expect(inspector).not.toContain('onMouseEnter')
     expect(css).toContain('.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:not(:last-child)')
     expect(css).not.toContain('.inspector-crumb-tab:hover .inspector-crumb-full .fsdb-crumb:not(:last-child)')

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -349,7 +349,6 @@ export const DataSidebar = memo(function DataSidebar({
     } catch {
       /* ignore */
     }
-    setOpenTables((prev) => ({ ...prev, [path]: true }))
     const listed = viewsFor(path)
     const view = listed.find((item) => item.id === viewId)
     if (path !== collectionPath) {
@@ -558,7 +557,6 @@ export const DataSidebar = memo(function DataSidebar({
                             type="button"
                             className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
                             onClick={() => {
-                              setOpenTables((prev) => ({ ...prev, [table.path]: true }))
                               onOpenTable?.(table.path)
                             }}
                           >

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import { ChevronDownIcon, CircleStackIcon } from '@heroicons/react/16/solid'
+import { ChevronRightIcon, CircleStackIcon } from '@heroicons/react/16/solid'
 import { useLocation } from 'react-router-dom'
 import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
@@ -243,7 +243,7 @@ export function DatabaseInspectorTab({
             })
           }}
         >
-          <ChevronDownIcon aria-hidden className="size-3" />
+          <ChevronRightIcon aria-hidden className="size-3" />
         </button>
       ) : null}
     </div>

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -13,6 +13,16 @@ test('data sidebar brand sits left with a collapse control on the right', () => 
   assert.match(browser, /onCollapse=\{toggleViewsOpen\}/)
 })
 
+test('table and view rows only expand from the fold column', () => {
+  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  assert.match(sidebar, /onClick=\{\(\) => \{\s*onOpenTable\?\.\(table\.path\)/)
+  assert.doesNotMatch(sidebar, /\[table\.path\]: true/)
+  assert.doesNotMatch(sidebar, /setOpenTables\(\(prev\) => \(\{ \.\.\.prev, \[path\]: true \}\)\)/)
+  assert.match(css, /\.sidebar-group-fold:hover \.sidebar-group-fold-chevron/)
+  assert.doesNotMatch(css, /\.chat-session-row:hover \.sidebar-group-fold-chevron/)
+})
+
 test('filesystem header toggles the right inspector, not the left data sidebar', () => {
   assert.match(browser, /data-testid="fsdb-inspector-toggle"/)
   assert.match(browser, /biu:inspector-toggle/)

--- a/web/style.css
+++ b/web/style.css
@@ -1324,27 +1324,24 @@ body {
   display: none;
 }
 
-.sidebar-group-head:hover .sidebar-group-fold-face,
-.sidebar-group-head:focus-within .sidebar-group-fold-face,
-.tasks-queue-ghead:hover .sidebar-group-fold-face,
-.tasks-queue-ghead:focus-within .sidebar-group-fold-face {
+.sidebar-group-fold:hover .sidebar-group-fold-face,
+.sidebar-group-fold:focus-within .sidebar-group-fold-face,
+.sidebar-group-head:focus-within .sidebar-group-fold:focus-within .sidebar-group-fold-face {
   display: none;
 }
 
-.sidebar-group-head:hover .sidebar-group-fold-chevron,
-.sidebar-group-head:focus-within .sidebar-group-fold-chevron,
-.tasks-queue-ghead:hover .sidebar-group-fold-chevron,
-.tasks-queue-ghead:focus-within .sidebar-group-fold-chevron {
+.sidebar-group-fold:hover .sidebar-group-fold-chevron,
+.sidebar-group-fold:focus-within .sidebar-group-fold-chevron {
   display: grid;
 }
 
-.chat-session-row:hover .sidebar-group-fold-face,
-.chat-session-row:focus-within .sidebar-group-fold-face {
+.chat-session-row .sidebar-group-fold:hover .sidebar-group-fold-face,
+.chat-session-row .sidebar-group-fold:focus-within .sidebar-group-fold-face {
   display: none;
 }
 
-.chat-session-row:hover .sidebar-group-fold-chevron,
-.chat-session-row:focus-within .sidebar-group-fold-chevron {
+.chat-session-row .sidebar-group-fold:hover .sidebar-group-fold-chevron,
+.chat-session-row .sidebar-group-fold:focus-within .sidebar-group-fold-chevron {
   display: grid;
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -490,10 +490,11 @@ body {
   width: 16px;
   height: 16px;
   margin: 0;
+  padding: 0;
   border: 0;
-  border-radius: 4px;
-  background: var(--dsw-surface);
-  box-shadow: 0 0 0 1px var(--dsw-border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   color: var(--dsw-sidebar-fg);
   opacity: 0;
   pointer-events: none;
@@ -510,12 +511,9 @@ body {
 
 .inspector-crumb-toggle:hover,
 .inspector-crumb-toggle.is-open {
-  background: var(--dsw-hover);
+  background: transparent;
+  box-shadow: none;
   color: var(--dsw-sidebar-fg-active);
-}
-
-.inspector-crumb-toggle.is-open {
-  transform: translateY(-50%) rotate(180deg);
 }
 
 .inspector-crumb-leaf,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
检查器面包屑展开按钮改为向右箭头，去掉边框和背景。

侧栏里表格/视图只有点展开那一列才会打开子列表或记录预览；点名称只切换当前表/视图，不会把折叠项打开。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

