### PR TITLE
fix(table): 只有标题打开按钮才进入记录详情

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1323,6 +1323,8 @@ export function CollectionBrowser({
           <button
             type="button"
             className="tasks-title-open"
+            data-testid="record-title-open"
+            data-biu-action="open"
             aria-label="查看详情"
             title="查看详情"
             onClick={(event) => {
@@ -1465,7 +1467,7 @@ export function CollectionBrowser({
     return (
       <>
         {listed.map(({ row, depth, hasKids }) => (
-          <tr key={`${keyPrefix}${row.id}`} className={row.id === detailId ? 'is-active' : undefined} {...recordPick(row)} onClick={() => setDetailId(row.id)}>
+          <tr key={`${keyPrefix}${row.id}`} className={row.id === detailId ? 'is-active' : undefined} {...recordPick(row)}>
             {columns.map((col) => (
               <td key={col.key}>
                 {col.key === schema?.labelField ? (

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -23,6 +23,12 @@ test('table and view rows only expand from the fold column', () => {
   assert.doesNotMatch(css, /\.chat-session-row:hover \.sidebar-group-fold-chevron/)
 })
 
+test('table view opens a record only from the title-side button', () => {
+  assert.match(browser, /data-testid="record-title-open"/)
+  assert.match(browser, /className="tasks-title-open"/)
+  assert.doesNotMatch(browser, /recordPick\(row\)\} onClick=\{\(\) => setDetailId\(row\.id\)\}/)
+})
+
 test('filesystem header toggles the right inspector, not the left data sidebar', () => {
   assert.match(browser, /data-testid="fsdb-inspector-toggle"/)
   assert.match(browser, /biu:inspector-toggle/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格视图里点一行任意位置（单元格、标题文字）不再打开记录详情。只有标题右侧悬停出现的打开按钮会 `setDetailId`。

队列/卡片视图仍保持整块点击打开，本次未改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

