### PR TITLE
fix(page): Page 用页面图标，不再用表格图标

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -36,6 +36,7 @@ test('page plugin registers every field type on /pages without a web module', as
   assert.equal(registered[0]?.path, '/pages')
   assert.equal(registered[0]?.view?.route, '/pages')
   assert.equal(registered[0]?.view?.moduleId, 'page')
+  assert.equal(registered[0]?.view?.icon, 'document')
   const types = new Set(Object.values(registered[0]!.schema.fields).map((field) => field.type))
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
   const listed = await registered[0]!.list()

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -76,7 +76,7 @@ function pagesCollection(now = Date.now()): CollectionSpec {
       title: 'Page',
       blurb: '每种字段类型各登记一列，假数据用来压测 Database 默认界面。',
       order: 25,
-      icon: 'table-cells',
+      icon: 'document',
     },
     schema: {
       labelField: 'title',

--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -15,6 +15,7 @@ test('chip icons exist on @heroicons/react/16/solid', () => {
     'PuzzlePieceIcon',
     'TagIcon',
     'WrenchScrewdriverIcon',
+    'DocumentIcon',
   ] as const
   for (const name of needed) {
     assert.ok(name in lu, `${name} missing`)

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -4,8 +4,8 @@ import {
   StopCircleIcon,
   HashtagIcon,
   Square3Stack3DIcon,
-  TableCellsIcon,
   RectangleStackIcon,
+  DocumentIcon,
   ClipboardDocumentCheckIcon,
   ChatBubbleLeftIcon,
   PuzzlePieceIcon,
@@ -21,7 +21,7 @@ type Glyph = ComponentType<{ className?: string }>
 const KIND_ICONS: Record<string, Glyph> = {
   session: CpuChipIcon,
   task: ClipboardDocumentCheckIcon,
-  page: TableCellsIcon,
+  page: DocumentIcon,
   collection: RectangleStackIcon,
   view: Square3Stack3DIcon,
   plugin: PuzzlePieceIcon,

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { resolvePickFromNode, resolvePicksInRect } from './resolve.ts'
 import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks } from './types.ts'
 import { pickKindIcon } from './chip.tsx'
-import { CpuChipIcon, ClipboardDocumentCheckIcon, ChatBubbleLeftIcon, PuzzlePieceIcon, TagIcon, TableCellsIcon } from '@heroicons/react/16/solid'
+import { CpuChipIcon, ClipboardDocumentCheckIcon, ChatBubbleLeftIcon, PuzzlePieceIcon, TagIcon, DocumentIcon } from '@heroicons/react/16/solid'
 
 test('splitPickStream keeps text and chips in order', () => {
   const parts = splitPickStream('看 <pick kind="task" id="t1" label="写需求" /> 和 <pick kind="plugin" id="p1" label="Hello" /> 吧')
@@ -70,7 +70,7 @@ test('kind maps to distinct icons', () => {
   assert.equal(pickKindIcon('message'), ChatBubbleLeftIcon)
   assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
   assert.equal(pickKindIcon('task'), ClipboardDocumentCheckIcon)
-  assert.equal(pickKindIcon('page'), TableCellsIcon)
+  assert.equal(pickKindIcon('page'), DocumentIcon)
   assert.notEqual(pickKindIcon('collection'), pickKindIcon('usage'))
   assert.equal(pickKindIcon('plugin'), PuzzlePieceIcon)
   assert.equal(pickKindIcon('unknown'), TagIcon)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -78,6 +78,12 @@ test('inspector embed does not poll the collection every 20s', () => {
   assert.match(browser, /}, 20000\)/)
 })
 
+test('page collection uses a document glyph, not the table/database icon', () => {
+  const glyphs = readFileSync(resolve(import.meta.dirname, './nav-glyphs.tsx'), 'utf8')
+  assert.match(glyphs, /name === 'document' \|\| name === 'document-text' \|\| name === 'page'/)
+  assert.match(glyphs, /<DocumentIcon/)
+})
+
 test('inspector no longer listens for add/copy view actions', () => {
   assert.doesNotMatch(browser, /biu:inspector-action/)
   assert.doesNotMatch(browser, /detail === 'add-view'/)

--- a/packages/core-file-system/src/web/nav-glyphs.tsx
+++ b/packages/core-file-system/src/web/nav-glyphs.tsx
@@ -3,6 +3,7 @@ import {
   ClipboardDocumentListIcon,
   ChatBubbleLeftRightIcon,
   BoltIcon,
+  DocumentIcon,
   EyeIcon,
   ListBulletIcon,
   PuzzlePieceIcon,
@@ -18,6 +19,7 @@ export function TableGlyph({ icon, className = 'size-4' }: { icon?: string; clas
   if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={className} />
   if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={className} />
   if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return <ChatBubbleLeftRightIcon aria-hidden className={className} />
+  if (name === 'document' || name === 'document-text' || name === 'page') return <DocumentIcon aria-hidden className={className} />
   if (name === 'bolt') return <BoltIcon aria-hidden className={className} />
   if (name === 'eye') return <EyeIcon aria-hidden className={className} />
   return <TableCellsIcon aria-hidden className={className} />

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -146,7 +146,7 @@ export type CollectionView = {
   title?: string
   blurb?: string
   order?: number
-  /** 导航图标名（实现侧映射），例如 clipboard-document-list、puzzle-piece。 */
+  /** 导航图标名（实现侧映射），例如 clipboard-document-list、puzzle-piece、document。 */
   icon?: string
 }
 

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -10,6 +10,7 @@ import {
   ViewColumnsIcon,
   ClipboardDocumentListIcon,
   ChatBubbleLeftRightIcon,
+  DocumentIcon,
   PuzzlePieceIcon,
   BoltIcon,
   EyeIcon,
@@ -31,6 +32,7 @@ function captionTableIcon(icon?: string) {
   if (name === 'puzzle-piece' || name === 'puzzle') return PuzzlePieceIcon
   if (name === 'clipboard-document-list' || name === 'clipboard') return ClipboardDocumentListIcon
   if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return ChatBubbleLeftRightIcon
+  if (name === 'document' || name === 'document-text' || name === 'page') return DocumentIcon
   if (name === 'bolt') return BoltIcon
   if (name === 'eye') return EyeIcon
   return TableCellsIcon


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Page 表不再用 `table-cells`（表格/数据库）图标。登记为 `document`，侧栏、面包屑、检查器叶子标题、选取芯片都画成页面图标。记录行仍跟所属表同一套图标。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

