### PR TITLE
fix(inspector): 视图改名后右侧面包屑立刻跟着变

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -948,10 +948,12 @@ export function CollectionBrowser({
     viewsRef.current = next
     setViews(next)
     rememberViews(collectionPath, next)
+    if (!embed) {
+      localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
+      pushSavedViews(collectionPath, next)
+    }
     window.dispatchEvent(new Event('fsdb:change'))
-    if (embed) return
-    localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
-    pushSavedViews(collectionPath, next)
+    window.dispatchEvent(new Event('fsdb:crumb-labels'))
   }
 
   function rememberActiveView(id: string) {

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -42,6 +42,13 @@ describe('顶栏三级标题', () => {
     expect(trail).toContain('<TableGlyph icon={tableIcon} />')
   })
 
+  it('改视图名会先写入缓存再通知检查器面包屑', () => {
+    expect(browser).toMatch(/rememberViews\(collectionPath, next\)[\s\S]*localStorage\.setItem\(viewsKey\(collectionPath\)[\s\S]*fsdb:change/)
+    expect(browser).toContain("window.dispatchEvent(new Event('fsdb:crumb-labels'))")
+    expect(inspector).toContain("window.addEventListener('fsdb:crumb-labels'")
+    expect(inspector).toContain('loadViews(collection)')
+  })
+
   it('右侧检查器面包屑用记录标题而不是 id', () => {
     expect(inspector).toContain('loadRecords')
     expect(inspector).toContain('recordHit?.label')

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { isViewStarred, loadStarredViews, persistStarredViews, toggleStarredView } from './view-storage.ts'
+import { isViewStarred, loadStarredViews, loadViews, persistStarredViews, rememberViews, toggleStarredView, viewsKey } from './view-storage.ts'
+import { normalizeSavedView } from './saved-view.ts'
 
 test('toggleStarredView stars a view, not a whole table', () => {
   const next = toggleStarredView([], '/pages', 'v1')
@@ -10,4 +11,20 @@ test('toggleStarredView stars a view, not a whole table', () => {
   assert.deepEqual(toggleStarredView(next, '/pages', 'v1'), [])
   persistStarredViews([{ path: '/tasks', viewId: 'a' }])
   assert.deepEqual(loadStarredViews(), [{ path: '/tasks', viewId: 'a' }])
+})
+
+test('loadViews prefers in-memory names over stale localStorage', () => {
+  const path = '/pages'
+  const stale = normalizeSavedView({
+    id: 'v1',
+    name: '默认视图',
+    mode: 'table',
+    sortField: 'id',
+    sortDir: 'asc',
+    filters: {},
+    columns: [],
+  })
+  localStorage.setItem(viewsKey(path), JSON.stringify([stale]))
+  rememberViews(path, [{ ...stale, name: '周报' }])
+  assert.equal(loadViews(path)[0]?.name, '周报')
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -15,6 +15,8 @@ export function rememberViews(collectionPath: string, views: SavedView[]) {
 }
 
 export function loadViews(collectionPath: string): SavedView[] {
+  const remembered = memoryViews.get(collectionPath)
+  if (remembered?.length) return remembered
   try {
     const raw = localStorage.getItem(viewsKey(collectionPath))
     const parsed = raw ? (JSON.parse(raw) as SavedView[]) : []
@@ -22,7 +24,7 @@ export function loadViews(collectionPath: string): SavedView[] {
   } catch {
     /* ignore */
   }
-  return memoryViews.get(collectionPath) ?? []
+  return []
 }
 
 export type CrumbRecord = { id: string; label: string; emoji?: string }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器面包屑从 localStorage 读视图名，但改名通知发得比写入早，所以一直停在旧名。现在先写入内存/存储再通知；检查器优先用内存里的名称。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

