### PR TITLE
fix(fs): 侧栏点记录立刻切详情

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import { createPortal } from 'react-dom'
+import { createPortal, flushSync } from 'react-dom'
 import {
   ArrowDownIcon,
   ArrowPathIcon,
@@ -480,7 +480,8 @@ export function CollectionBrowser({
   const [stat, setStat] = useState<StatResult | null>(null)
   const [items, setItems] = useState<Array<DbRecord & { path?: string }>>([])
   const [error, setError] = useState('')
-  const detailId = routeRecordId
+  const [openDetailId, setOpenDetailId] = useState<string | null>(routeRecordId)
+  const [detailRow, setDetailRow] = useState<DbRecord | null>(null)
   const [detailBody, setDetailBody] = useState<unknown>(null)
   const [draft, setDraft] = useState<Record<string, string>>({})
   const [busyKey, setBusyKey] = useState<string | null>(null)
@@ -497,7 +498,13 @@ export function CollectionBrowser({
   const [columnKeys, setColumnKeys] = useState<string[]>(initialView?.columns ?? [])
   const [views, setViews] = useState<SavedView[]>(() => loadViews(collectionPath))
   const [activeViewId, setActiveViewId] = useState<string | null>(initialView?.id ?? null)
-  const setDetailId = (id: string | null) => {
+  const detailId = openDetailId
+  const setDetailId = (id: string | null, row?: DbRecord | null) => {
+    flushSync(() => {
+      setOpenDetailId(id)
+      if (id && row) setDetailRow(row)
+      if (!id) setDetailRow(null)
+    })
     if (id) onOpenRecord?.(id, activeViewId)
     else onCloseRecord?.()
   }
@@ -777,6 +784,35 @@ export function CollectionBrowser({
     void reload()
   }, [reload])
 
+  useLayoutEffect(() => {
+    setOpenDetailId(routeRecordId)
+    if (!routeRecordId) setDetailRow(null)
+  }, [routeRecordId])
+
+  useEffect(() => {
+    if (!detailId) {
+      setDetailRow(null)
+      return
+    }
+    const hit = items.find((row) => row.id === detailId)
+    if (hit) {
+      setDetailRow(hit)
+      return
+    }
+    if (detailRow?.id === detailId) return
+    let cancelled = false
+    void readJson<{ value?: DbRecord }>(`/api/db/read?path=${encodeURIComponent(`${collectionPath}/${detailId}`)}`)
+      .then((data) => {
+        const row = data.value
+        if (cancelled || !row?.id) return
+        setDetailRow(row)
+      })
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [collectionPath, detailId, detailRow?.id, items])
+
   useEffect(() => () => window.clearTimeout(noticeTimer.current), [])
 
   const schema = stat?.schema
@@ -853,7 +889,10 @@ export function CollectionBrowser({
     [collapsed, parentKey, showTree],
   )
 
-  const selected = visible.find((item) => item.id === detailId) ?? items.find((item) => item.id === detailId) ?? null
+  const selected =
+    (detailId &&
+      (items.find((item) => item.id === detailId) ?? (detailRow?.id === detailId ? detailRow : null))) ||
+    null
   useEffect(() => {
     const rows = items.map((row) => ({
       id: row.id,
@@ -1599,7 +1638,13 @@ export function CollectionBrowser({
           onDeleteView={deleteView}
           onAddView={addEmptyView}
           onCopyView={copyView}
-          onOpenRecord={(path, view, recordId) => {
+          onOpenRecord={(path, view, recordId, row) => {
+            if (path === collectionPath) {
+              flushSync(() => {
+                setOpenDetailId(recordId)
+                if (row) setDetailRow(row)
+              })
+            }
             onOpenRecord?.(recordId, view.id, path)
           }}
           expandedViewKey={expandedViewKey}
@@ -1655,7 +1700,7 @@ export function CollectionBrowser({
         </header>
         )}
         <div className="fsdb-right-body">
-        {!selected ? (
+        {!detailId ? (
         <div className="tasks-main fsdb-main">
         <div className="tasks-toolbar" data-biu-ignore>
           <div className="tasks-toolbar-left">

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1370,7 +1370,7 @@ export function CollectionBrowser({
             title="查看详情"
             onClick={(event) => {
               event.stopPropagation()
-              setDetailId(row.id)
+              setDetailId(row.id, row)
             }}
           >
             <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
@@ -1463,7 +1463,7 @@ export function CollectionBrowser({
     return (
       <li className={`tasks-queue-item${row.id === detailId ? ' is-active' : ''}`} {...recordPick(row)}>
         <div className="tasks-queue-item-body">
-          <button type="button" className="tasks-queue-item-main" data-biu-action="open" onClick={() => setDetailId(row.id)}>
+          <button type="button" className="tasks-queue-item-main" data-biu-action="open" onClick={() => setDetailId(row.id, row)}>
             <span className="tasks-queue-item-title">
               <RecordTitle row={row} openDetail={false} />
             </span>
@@ -1479,7 +1479,7 @@ export function CollectionBrowser({
     return (
       <div className={`tasks-minicard${row.id === detailId ? ' is-active' : ''}`} {...recordPick(row)}>
         <div className="tasks-minicard-title">
-          <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => setDetailId(row.id)}>
+          <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => setDetailId(row.id, row)}>
             <span className="tasks-minicard-titletext">
               <RecordTitle row={row} openDetail={false} />
             </span>

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -62,7 +62,7 @@ function ViewRecordPreview({
   open: boolean
   recordKind: string
   tableIcon?: string
-  onOpenRecord?: (recordId: string) => void
+  onOpenRecord?: (recordId: string, row?: DbRecord) => void
 }) {
   const key = previewCacheKey(path, view)
   const cached = previewCache.get(key)
@@ -207,7 +207,10 @@ function ViewRecordPreview({
                 type="button"
                 className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
                 title={recordPreviewLabel(row)}
-                onClick={() => onOpenRecord?.(row.id)}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenRecord?.(row.id, row)
+                }}
               >
                 {recordPreviewLabel(row)}
               </button>
@@ -273,7 +276,7 @@ export const DataSidebar = memo(function DataSidebar({
   onDeleteView: (view: SavedView) => void
   onAddView: () => void
   onCopyView: () => void
-  onOpenRecord?: (path: string, view: SavedView, recordId: string) => void
+  onOpenRecord?: (path: string, view: SavedView, recordId: string, row?: DbRecord) => void
   expandedViewKey?: string | null
   onExpandedViewKeyChange?: (key: string | null) => void
   onCollapse?: () => void
@@ -364,8 +367,8 @@ export const DataSidebar = memo(function DataSidebar({
     else setExpandedViewKeyLocal(next)
   }
 
-  function openRecord(path: string, view: SavedView, recordId: string) {
-    onOpenRecord?.(path, view, recordId)
+  function openRecord(path: string, view: SavedView, recordId: string, row?: DbRecord) {
+    onOpenRecord?.(path, view, recordId, row)
   }
 
   return (
@@ -494,7 +497,7 @@ export const DataSidebar = memo(function DataSidebar({
                           open={expanded}
                           recordKind={recordPickKind(table.view?.moduleId)}
                           tableIcon={table.view?.icon}
-                          onOpenRecord={(id) => openRecord(table.path, view, id)}
+                          onOpenRecord={(id, row) => openRecord(table.path, view, id, row)}
                         />
                       </div>
                     )
@@ -646,7 +649,7 @@ export const DataSidebar = memo(function DataSidebar({
                                 open={expanded}
                                 recordKind={recordPickKind(table.view?.moduleId)}
                                 tableIcon={table.view?.icon}
-                                onOpenRecord={(id) => openRecord(table.path, view, id)}
+                                onOpenRecord={(id, row) => openRecord(table.path, view, id, row)}
                               />
                             </div>
                           )

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -23,7 +23,19 @@ test('table and view rows only expand from the fold column', () => {
   assert.doesNotMatch(css, /\.chat-session-row:hover \.sidebar-group-fold-chevron/)
 })
 
-test('table view opens a record only from the title-side button', () => {
+test('sidebar records paint detail immediately without reloading the view', () => {
+  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  assert.match(browser, /flushSync\(\(\) => \{\s*setOpenDetailId\(recordId\)/)
+  assert.match(browser, /if \(row\) setDetailRow\(row\)/)
+  assert.match(browser, /onOpenRecord\?\.\(recordId, view\.id, path\)/)
+  assert.doesNotMatch(browser, /if \(path === collectionPath\) applyView\(view\)/)
+  assert.doesNotMatch(browser, /onOpenRecord=\{\(path, view, recordId\) => \{\s*selectView/)
+  assert.match(browser, /!detailId \?/)
+  assert.match(sidebar, /onOpenRecord\?\.\(row\.id, row\)/)
+  assert.match(sidebar, /event.stopPropagation\(\)/)
+})
+
+test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /className="tasks-title-open"/)
   assert.doesNotMatch(browser, /recordPick\(row\)\} onClick=\{\(\) => setDetailId\(row\.id\)\}/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏点记录时路由其实已经对了，卡顿来自主区一直等 React Router 把 `recordId` 写回来，中间还可能整表 `applyView`。

现在点击当下就用预览里已有的那一行 `flushSync` 切到详情，导航随后跟上，不再为开记录重载视图。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

