### PR TITLE
fix(inspector): 右侧栏只跟 Session，页面附加块跟详情

### DIFF
--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -3673,14 +3673,6 @@ function TasksModulePage(props: SlotProps) {
   )
 }
 
-function TasksInspectorPanel(props: SlotProps) {
-  return (
-    <div className="tasks-inspector-panel">
-      <TasksWorkspace compact tasksView={props.tasksView as TasksViewService | undefined} />
-    </div>
-  )
-}
-
 function formatClock(iso?: string) {
   if (!iso) return 'waiting…'
   const date = new Date(iso)
@@ -3705,7 +3697,6 @@ export const name = 'tasks-ui'
 export const inject = ['slots', 'appModules', 'snapshot']
 
 const tasksModuleProps = { moduleId: 'tasks' }
-const tasksInspectorProps = { tabId: 'tasks', tabLabel: '任务', tabIcon: ClipboardDocumentListIcon, centerKinds: ['task'] }
 
 type AppModulesService = {
   register: (mod: {
@@ -3742,11 +3733,6 @@ export function apply(ctx: Context) {
     key: 'tasks-module',
     order: 20,
     props: () => ({ ...tasksModuleProps, tasksView }),
-  })
-  slots.place('inspector-panels', TasksInspectorPanel, {
-    key: 'tasks-inspector',
-    order: 10,
-    props: () => ({ ...tasksInspectorProps, tasksView }),
   })
   slots.place('demos', ClockBadge, {
     key: 'clock',

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2334,6 +2334,23 @@ export function CollectionBrowser({
                     </div>
                   )
                 })() : null}
+                {chrome?.panes?.length ? (
+                  <div className="fsdb-detail-extras">
+                    {chrome.panes.map((pane) => {
+                      const Pane = pane.Pane
+                      const count = pane.badge?.(selected)
+                      return (
+                        <section key={pane.id} className="fsdb-detail-extra" data-testid={`fsdb-pane-${pane.id}`}>
+                          <h3 className="fsdb-detail-extra-title">
+                            {pane.label}
+                            {count ? <span className="fsdb-detail-extra-count">{count}</span> : null}
+                          </h3>
+                          <Pane record={selected} />
+                        </section>
+                      )
+                    })}
+                  </div>
+                ) : null}
               </div>
             </div>
           </div>
@@ -2595,6 +2612,9 @@ if (typeof document !== 'undefined') {
 .fsdb-detail-title-input{width:100%;margin:0;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:700;line-height:1.35;outline:none;padding:0;resize:none}
 .fsdb-detail-id{font-size:14px;font-weight:400;color:var(--dsw-label-2);font-family:var(--font-mono);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-detail-doc{width:100%;min-height:180px;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;line-height:1.65;outline:none;resize:none;padding:8px 0 0;margin:0}
+.fsdb-detail-extras{display:flex;flex-direction:column;gap:20px;margin-top:8px;padding-top:16px;border-top:1px solid var(--dsw-border)}
+.fsdb-detail-extra-title{display:flex;align-items:center;gap:8px;margin:0 0 8px;font-size:14px;font-weight:700;color:var(--dsw-label)}
+.fsdb-detail-extra-count{font-size:11px;font-weight:700;color:var(--dsw-label-3)}
 .fsdb-fields{display:flex;flex-direction:column;gap:8px}
 .fsdb-field{display:flex;flex-direction:column;gap:4px;color:var(--dsw-label-3);font-size:14px}
 .fsdb-field em{font-style:normal;color:var(--dsw-label);font-size:14px}

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -14,7 +14,6 @@ import {
   collectionNavKey,
 } from './nav-boot.ts'
 import { loadActiveViewId, loadViews, pushAllSavedViews } from './view-storage.ts'
-import { DatabaseInspectorBrowse, DatabaseInspectorTab, bindInspectorSnapshot } from './inspector-database.tsx'
 
 type SlotsService = {
   place: (slot: string, view: unknown, opts: { key: string; order?: number; props?: () => Record<string, unknown> }) => { dispose?: () => unknown }
@@ -71,11 +70,8 @@ function defaultViewId(collectionPath: string) {
   return loadActiveViewId(collectionPath, loadViews(collectionPath)) ?? undefined
 }
 
-let fileSystemSlots: SlotsService | undefined
-
 function CollectionPage(props: SlotProps) {
   const tables = (props.tables as CollectionInfo[] | undefined) ?? []
-  const slots = fileSystemSlots
   const ui = getDatabaseUi()
   const location = useLocation()
   const navigate = useNavigate()
@@ -139,36 +135,6 @@ function CollectionPage(props: SlotProps) {
     go({ collection: first.path, viewId: defaultViewId(first.path) }, { replace: true })
   }, [collectionFromRoute, tables])
 
-  const paneIds = (chrome.panes ?? []).map((pane) => pane.id).filter(Boolean)
-  const paneKey = [...new Set(paneIds)].join('\0')
-
-  useEffect(() => {
-    if (!slots || !ui || !currentPath) return
-    if (parsed.kind !== 'collection-view' && parsed.kind !== 'record') return
-    const seen = new Set<string>()
-    const placed = []
-    for (const pane of ui.chrome(currentPath).panes ?? []) {
-      if (!pane.id || seen.has(pane.id)) continue
-      seen.add(pane.id)
-      placed.push(
-        slots.place('inspector-panels', RecordPanePanel, {
-          key: `fsdb-pane-${pane.id}`,
-          order: 20,
-          props: () => ({
-            tabId: pane.id,
-            tabLabel: pane.label,
-            tabIcon: CircleStackIcon,
-            centerKinds: ['collection-view', 'record'],
-            paneId: pane.id,
-          }),
-        }),
-      )
-    }
-    return () => {
-      for (const item of placed) void item.dispose?.()
-    }
-  }, [currentPath, paneKey, parsed.kind, slots, ui])
-
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')
   return (
@@ -193,27 +159,6 @@ function CollectionPage(props: SlotProps) {
       }
       onCrumbTarget={(target: CrumbTarget) => navigate(pathForCrumbTarget(target))}
     />
-  )
-}
-
-function RecordPanePanel(props: SlotProps) {
-  const ui = getDatabaseUi()
-  const paneId = String(props.paneId ?? '')
-  const focus = useSyncExternalStore(
-    (fn) => (ui ? ui.subscribe(fn) : () => undefined),
-    () => ui?.getRecordFocus() ?? null,
-    () => null,
-  )
-  const pane = focus ? ui?.chrome(focus.path).panes?.find((item) => item.id === paneId) : undefined
-  const record = focus?.record
-  if (!pane || !record) {
-    return <p className="fsdb-inspector-empty">打开一条记录</p>
-  }
-  const Pane = pane.Pane
-  return (
-    <div className="fsdb-inspector-panel" data-testid={`fsdb-pane-${paneId}`}>
-      <Pane record={record} />
-    </div>
   )
 }
 
@@ -260,7 +205,6 @@ export const inject = ['slots', 'appModules']
 export function apply(ctx: Context) {
   new DatabaseUiService(ctx)
   const slots = ctx.get('slots') as SlotsService
-  fileSystemSlots = slots
   const appModules = ctx.get('appModules') as AppModulesService
   const mounted = new Map<string, () => void>()
   let liveTables: CollectionInfo[] = []
@@ -352,22 +296,6 @@ export function apply(ctx: Context) {
   })
   ctx.inject(['snapshot'], (inner) => {
     const snapshot = inner.get('snapshot') as SnapshotService
-    bindInspectorSnapshot({
-      subscribe: snapshot.subscribe ?? (() => () => undefined),
-      get: () => snapshot.get?.() ?? {},
-    })
-    const databaseBrowse = slots.place('inspector-panels', DatabaseInspectorBrowse, {
-      key: 'fsdb-database-browse',
-      order: -25,
-      props: () => ({
-        tabId: 'database',
-        tabLabel: '数据库',
-        tabIcon: CircleStackIcon,
-        Tab: DatabaseInspectorTab,
-        common: true,
-        repeatable: true,
-      }),
-    })
     let lastKey = ''
     const fromSnap = () => {
       const rows = snapshot.get?.().collections ?? []
@@ -388,7 +316,6 @@ export function apply(ctx: Context) {
       window.clearTimeout(debounce)
       offSnap?.()
       off()
-      void databaseBrowse.dispose?.()
     }
   })
   void bootLoadCollections(loadCollections, {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -52,37 +52,19 @@ test('filesystem header toggles the right inspector, not the left data sidebar',
   assert.doesNotMatch(browser, /展开左侧边栏/)
 })
 
-test('database does not auto-open inspector content; panes follow the current table', () => {
+test('database extras sit after the record detail, not in the inspector', () => {
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.doesNotMatch(page, /biu:inspector-open/)
-  assert.match(page, /centerKinds: \['collection-view', 'record'\]/)
-  assert.match(page, /if \(!pane.id \|\| seen.has\(pane.id\)\) continue/)
-})
-
-test('database can be added to the inspector and browsed by crumbs', () => {
-  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
-  assert.match(page, /fsdb-database-browse/)
-  assert.match(page, /tabLabel: '数据库'/)
-  assert.match(page, /Tab: DatabaseInspectorTab/)
-  assert.match(page, /repeatable: true/)
-  const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
-  assert.match(browse, /bindInspectorSnapshot/)
-  assert.doesNotMatch(browse, /useSnapshot\?:/)
-  assert.match(browse, /inspector-crumb-leaf/)
-  assert.match(browse, /CrumbTrail/)
-  assert.doesNotMatch(browse, /onMouseEnter/)
-  assert.doesNotMatch(browse, /go\(event, \{ kind: 'root' \}\)/)
-  assert.match(browse, /embed/)
-  assert.match(browse, /biu:inspector-caption/)
-  assert.doesNotMatch(browse, /DataSidebar/)
-  assert.match(browser, /embed = false/)
+  assert.doesNotMatch(page, /slots\.place\('inspector-panels'/)
+  assert.doesNotMatch(page, /RecordPanePanel/)
+  assert.doesNotMatch(page, /fsdb-database-browse/)
+  assert.match(browser, /fsdb-detail-extras/)
+  assert.match(browser, /data-testid=\{`fsdb-pane-\$\{pane\.id\}`\}/)
 })
 
 test('switching tables does not remount the whole browser', () => {
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.doesNotMatch(page, /key=\{currentPath\}/)
-  const browse = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
-  assert.doesNotMatch(browse, /key=\{currentPath\}/)
 })
 
 test('inspector embed does not poll the collection every 20s', () => {

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -26,7 +26,7 @@ import type { SlotProps } from '@biu/web-slots'
 import { bindSnapshot, type SnapshotService } from '@biu/web-snapshot'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
-import { centerKindFromRoute, parseAppPath } from '@biu/web-session-view'
+import { parseAppPath } from '@biu/web-session-view'
 import {
   isMascotDancing,
   mascotDanceShape,
@@ -549,7 +549,6 @@ function Shell(props: SlotProps) {
     }
   }, [])
   const appRoute = parseAppPath(location.pathname, pluginModules)
-  const centerKind = centerKindFromRoute(appRoute)
   const inspectorVisible = inspectorOpen
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
@@ -788,7 +787,6 @@ function Shell(props: SlotProps) {
         sessionView={sessionView}
         slots={slots}
         renderSlot={props.renderSlot}
-        centerKind={centerKind}
       />
 
       <SessionConfigDialog

--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -2,36 +2,17 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { inspectorPanelMatches, inspectorViewProps, resolveInspectorTab } from './inspector-panels.ts'
 
-test('session-only panels stay on chat and hide on database/task', () => {
+test('inspector only offers session panels when a session is selected', () => {
   const extra = { centerKinds: ['session'], requiresSession: true }
-  assert.equal(inspectorPanelMatches(extra, 'session', 's1'), true)
-  assert.equal(inspectorPanelMatches(extra, 'session', null), false)
-  assert.equal(inspectorPanelMatches(extra, 'record', 's1'), false)
-  assert.equal(inspectorPanelMatches(extra, 'collection-view', 's1'), false)
-  assert.equal(inspectorPanelMatches(extra, 'task', 's1'), false)
+  assert.equal(inspectorPanelMatches(extra, 's1'), true)
+  assert.equal(inspectorPanelMatches(extra, null), false)
 })
 
-test('record panes are offered on the table and the record, not on chat', () => {
-  const extra = { centerKinds: ['collection-view', 'record'] }
-  assert.equal(inspectorPanelMatches(extra, 'record', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'collection-view', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'session', 's1'), false)
-})
-
-test('task inspector only appears on the tasks module', () => {
-  const extra = { centerKinds: ['task'] }
-  assert.equal(inspectorPanelMatches(extra, 'task', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'session', 's1'), false)
-  assert.equal(inspectorPanelMatches(extra, 'record', null), false)
-})
-
-test('common tools stay available on every center', () => {
-  const extra = { common: true, action: 'add-view' }
-  assert.equal(inspectorPanelMatches(extra, 'collection-view', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'record', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'session', 's1'), true)
-  assert.equal(inspectorPanelMatches(extra, 'session', null), true)
-  assert.equal(inspectorPanelMatches(extra, 'module', null), true)
+test('page panels never appear in the session inspector', () => {
+  assert.equal(inspectorPanelMatches({ centerKinds: ['collection-view', 'record'] }, 's1'), false)
+  assert.equal(inspectorPanelMatches({ centerKinds: ['task'] }, 's1'), false)
+  assert.equal(inspectorPanelMatches({ common: true, action: 'add-view' }, 's1'), false)
+  assert.equal(inspectorPanelMatches({ common: true }, 's1'), false)
 })
 
 test('inspector does not auto-open the first available tab', () => {
@@ -47,11 +28,10 @@ test('inspector selects a hanging tab instead of showing an empty pane', () => {
   assert.equal(resolveInspectorTab('database::a1', ['database'], ['database::a1']), 'database::a1')
 })
 
-test('legacy untagged panels stay off session and database centers', () => {
-  assert.equal(inspectorPanelMatches({}, 'session', 's1'), false)
-  assert.equal(inspectorPanelMatches({}, 'record', null), false)
-  assert.equal(inspectorPanelMatches({ requiresSession: true }, 'session', 's1'), true)
-  assert.equal(inspectorPanelMatches({ requiresSession: true }, 'task', 's1'), false)
+test('legacy untagged panels stay out of the inspector', () => {
+  assert.equal(inspectorPanelMatches({}, 's1'), false)
+  assert.equal(inspectorPanelMatches({ requiresSession: true }, null), false)
+  assert.equal(inspectorPanelMatches({ requiresSession: true }, 's1'), true)
 })
 
 test('inspector view props drop tab chrome and databaseUi', () => {

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -7,27 +7,15 @@ export type InspectorPanelExtra = {
   action?: unknown
 }
 
-export function inspectorPanelMatches(
-  extra: InspectorPanelExtra,
-  centerKind: InspectorCenterKind,
-  sessionId: string | null,
-): boolean {
-  if (extra.common) {
-    if (extra.requiresSession && !sessionId) return false
-    return true
-  }
+/** 右侧检查器只跟当前 Session：页面附加块不进这一栏。 */
+export function inspectorPanelMatches(extra: InspectorPanelExtra, sessionId: string | null): boolean {
+  if (!sessionId) return false
   const kinds = Array.isArray(extra.centerKinds)
     ? extra.centerKinds.filter((item): item is InspectorCenterKind => typeof item === 'string')
     : []
-  if (kinds.length) {
-    if (!kinds.includes(centerKind)) return false
-  } else if (extra.requiresSession) {
-    if (centerKind !== 'session') return false
-  } else if (centerKind === 'session' || centerKind === 'collection-view' || centerKind === 'record') {
-    return false
-  }
-  if (extra.requiresSession && !sessionId) return false
-  return true
+  if (kinds.length) return kinds.includes('session')
+  if (extra.common) return false
+  return Boolean(extra.requiresSession)
 }
 
 /** 检查器槽位上的元数据不要摊到 React 组件 props 上（Cordis 服务一碰 $$typeof 就会炸）。 */

--- a/packages/web-app-shell/src/web/inspector-session-tabs.test.ts
+++ b/packages/web-app-shell/src/web/inspector-session-tabs.test.ts
@@ -3,6 +3,6 @@ import assert from 'node:assert/strict'
 import { inspectorPanelMatches } from './inspector-panels.ts'
 
 test('requiresSession tabs hide when no session is selected', () => {
-  assert.equal(inspectorPanelMatches({ requiresSession: true }, 'session', null), false)
-  assert.equal(inspectorPanelMatches({ requiresSession: true, centerKinds: ['session'] }, 'session', 'abc'), true)
+  assert.equal(inspectorPanelMatches({ requiresSession: true }, null), false)
+  assert.equal(inspectorPanelMatches({ requiresSession: true, centerKinds: ['session'] }, 'abc'), true)
 })

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -18,7 +18,6 @@ import {
 import { chromeIcon } from './chrome-icon.ts'
 import {
   bindSessionView,
-  type InspectorCenterKind,
   type SessionViewService,
 } from '@biu/web-session-view'
 import { useSlotEntries } from '@biu/web-slots'
@@ -72,7 +71,6 @@ export type SessionInspectorProps = {
   sessionView: SessionViewService
   slots: SlotsService
   renderSlot: (name: string) => ReactNode
-  centerKind: InspectorCenterKind
 }
 
 function inspectorTabStorageKey(sid: string | null | undefined) {
@@ -102,7 +100,6 @@ export const SessionInspector = memo(function SessionInspector({
   sessionView,
   slots,
   renderSlot,
-  centerKind,
 }: SessionInspectorProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const focusCallId = useSessionView((state) => state.focusCallId)
@@ -113,7 +110,7 @@ export const SessionInspector = memo(function SessionInspector({
       .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
       .flatMap((entry) => {
         const extra = entry.props?.() ?? {}
-        if (!inspectorPanelMatches(extra, centerKind, sessionId)) return []
+        if (!inspectorPanelMatches(extra, sessionId)) return []
         return [{
           entry,
           id: String(extra.tabId ?? entry.id),
@@ -127,7 +124,7 @@ export const SessionInspector = memo(function SessionInspector({
           action: typeof extra.action === 'string' ? extra.action : '',
         }]
       })
-  }, [centerKind, extras, sessionId])
+  }, [extras, sessionId])
   const allowedTabs = useMemo(() => extraTabs.map((item) => item.id), [extraTabs])
   const displayTabs = extraTabs.filter((item) => !item.action)
   const toolTabs = extraTabs.filter((item) => item.action)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器只认当前 Session：有 session 时才提供轨迹/用量等会话面板，不再随数据库/任务页切换过滤。

任务表上的「脚本」「进度汇报」等 chrome 附加块改到记录详情下方，跟中间路由走，不再出现在右侧栏。检查器里可重复打开的「数据库」浏览也拿掉了。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

