### PR TITLE
fix(inspector): Session 检查器可以添加数据库面板

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -116,6 +116,7 @@ export function CollectionBrowser({
   onOpenRecord,
   onCloseRecord,
   onCrumbTarget,
+  embed = false,
 }: {
   moduleId?: string
   collectionPath: string
@@ -132,6 +133,8 @@ export function CollectionBrowser({
   onOpenRecord?: (recordId: string, viewId?: string | null, collection?: string) => void
   onCloseRecord?: () => void
   onCrumbTarget?: (target: CrumbTarget) => void
+  /** 检查器内页：只有中间舞台，不写侧栏开关/视图存储。 */
+  embed?: boolean
 }) {
   ensureFsdbStyle()
   const [stat, setStat] = useState<StatResult | null>(null)
@@ -239,6 +242,7 @@ export function CollectionBrowser({
   }
 
   useEffect(() => {
+    if (embed) return
     function onToggle(event: Event) {
       const id = (event as CustomEvent<{ id?: string }>).detail?.id
       if (!id || (moduleId && id !== moduleId)) return
@@ -246,9 +250,10 @@ export function CollectionBrowser({
     }
     window.addEventListener('biu:toggle-module-sidebar', onToggle)
     return () => window.removeEventListener('biu:toggle-module-sidebar', onToggle)
-  }, [collectionPath, moduleId])
+  }, [collectionPath, embed, moduleId])
 
   useEffect(() => {
+    if (embed) return
     const sync = (open: boolean) => setInspectorOpen(open)
     const onOpen = () => sync(true)
     const onClose = () => sync(false)
@@ -261,7 +266,7 @@ export function CollectionBrowser({
       window.removeEventListener('biu:inspector-close', onClose)
       window.removeEventListener('biu:inspector-toggle', onToggle)
     }
-  }, [])
+  }, [embed])
 
   useEffect(() => {
     function onPointer(event: MouseEvent) {
@@ -433,7 +438,9 @@ export function CollectionBrowser({
       debounce = window.setTimeout(() => void reloadRef.current(), 120)
     }
     window.addEventListener('fsdb:change', onChange)
-    const timer = window.setInterval(() => {
+    const timer = embed
+      ? 0
+      : window.setInterval(() => {
           if (detailIdRef.current) return
           void reloadRef.current()
         }, 20000)
@@ -442,7 +449,7 @@ export function CollectionBrowser({
       window.clearInterval(timer)
       window.removeEventListener('fsdb:change', onChange)
     }
-  }, [collectionPath])
+  }, [collectionPath, embed])
 
   useEffect(() => {
     void reload()
@@ -619,13 +626,13 @@ export function CollectionBrowser({
   }, [collectionPath, detailId])
 
   useEffect(() => {
-    if (!detailId) return
+    if (embed || !detailId) return
     const onKey = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setDetailId(null)
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [detailId])
+  }, [detailId, embed])
 
   useEffect(() => {
     if (dlg?.kind !== 'rename') return
@@ -636,14 +643,17 @@ export function CollectionBrowser({
     viewsRef.current = next
     setViews(next)
     rememberViews(collectionPath, next)
-    localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
-    pushSavedViews(collectionPath, next)
+    if (!embed) {
+      localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
+      pushSavedViews(collectionPath, next)
+    }
     window.dispatchEvent(new Event('fsdb:change'))
     window.dispatchEvent(new Event('fsdb:crumb-labels'))
   }
 
   function rememberActiveView(id: string) {
     setActiveViewId(id)
+    if (embed) return
     try {
       localStorage.setItem(activeViewStorageKey(collectionPath), id)
     } catch {
@@ -1265,9 +1275,10 @@ export function CollectionBrowser({
 
   return (
     <div
-      className="fsdb-page tasks-root"
+      className={`fsdb-page tasks-root${embed ? ' inspector-database-page' : ''}`}
+      data-testid={embed ? 'inspector-database' : undefined}
     >
-      {viewsOpen ? (
+      {!embed && viewsOpen ? (
         <DataSidebar
           tables={tables}
           collectionPath={collectionPath}
@@ -1298,6 +1309,7 @@ export function CollectionBrowser({
         />
       ) : null}
       <div className="fsdb-right">
+        {embed ? null : (
         <header className="chat-view-header" data-biu-ignore>
           <div className="chat-view-header-left">
             <CrumbTrail
@@ -1342,6 +1354,7 @@ export function CollectionBrowser({
             </button>
           </div>
         </header>
+        )}
         <div className="fsdb-right-body">
         {!detailId ? (
         <div className="tasks-main fsdb-main">

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -263,7 +263,7 @@ const CSS = `
 .fsdb-dlg-ok.is-danger{border-color:var(--dsw-danger);background:var(--dsw-danger);color:var(--dsw-bg)}
 .fsdb-dlg-ok:disabled,.fsdb-dlg-cancel:disabled{opacity:.6;cursor:default}
 .fsdb-save{border:0;border-radius:8px;padding:8px 10px;background:var(--dsw-business);color:#fff;font:inherit;font-size:14px;cursor:pointer}
-.fsdb-empty,.fsdb-muted,.fsdb-meta,.fsdb-footnote{color:var(--dsw-label-2)}
+.fsdb-empty,.fsdb-muted,.fsdb-meta,.fsdb-footnote,.fsdb-inspector-empty{color:var(--dsw-label-2)}
 .fsdb-footnote{margin:0;font-size:14px;font-weight:400}
 .fsdb-tags{display:inline-flex;gap:4px;flex-wrap:wrap;align-items:center}
 .fsdb-tag{display:inline-flex;align-items:center;height:22px;padding:0 6px;border-radius:4px;font-size:14px;font-weight:500;line-height:22px;color:var(--dsw-label);background:rgba(255,255,255,.08);white-space:nowrap;max-width:110px;overflow:hidden;text-overflow:ellipsis}

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -8,6 +8,7 @@ import type { CollectionChrome } from '@biu/type-file-system/ui'
 import { isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
 import { pathForCenter, pathForCrumbTarget, type CrumbTarget } from './sidebar-nav.ts'
 import { CollectionBrowser } from './browser.tsx'
+import { DatabaseInspectorBrowse, DatabaseInspectorTab, bindInspectorSnapshot } from './inspector-database.tsx'
 import { DatabaseUiService, getDatabaseUi } from './database-ui.ts'
 import {
   bootLoadCollections,
@@ -283,6 +284,23 @@ export function apply(ctx: Context) {
   })
   ctx.inject(['snapshot'], (inner) => {
     const snapshot = inner.get('snapshot') as SnapshotService
+    bindInspectorSnapshot({
+      subscribe: snapshot.subscribe ?? (() => () => undefined),
+      get: () => snapshot.get?.() ?? {},
+    })
+    const databaseBrowse = slots.place('inspector-panels', DatabaseInspectorBrowse, {
+      key: 'fsdb-database-browse',
+      order: -25,
+      props: () => ({
+        tabId: 'database',
+        tabLabel: '数据库',
+        tabIcon: CircleStackIcon,
+        Tab: DatabaseInspectorTab,
+        requiresSession: true,
+        centerKinds: ['session'],
+        repeatable: true,
+      }),
+    })
     let lastKey = ''
     const fromSnap = () => {
       const rows = snapshot.get?.().collections ?? []
@@ -303,6 +321,7 @@ export function apply(ctx: Context) {
       window.clearTimeout(debounce)
       offSnap?.()
       off()
+      void databaseBrowse.dispose?.()
     }
   })
   void bootLoadCollections(loadCollections, {

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { ChevronLeftIcon, ChevronRightIcon, CircleStackIcon } from '@heroicons/react/16/solid'
+import { useLocation } from 'react-router-dom'
+import type { SlotProps } from '@biu/type-slots'
+import type { CollectionInfo } from '@biu/type-file-system'
+import type { CollectionChrome } from '@biu/type-file-system/ui'
+import { parseAppPath } from '@biu/web-session-view'
+import { buildCrumbs, pathForCrumbTarget, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
+import { CollectionBrowser } from './browser.tsx'
+import { CrumbTrail } from './crumb-trail.tsx'
+import { defaultViewId, loadRecords, loadViews, viewForPath } from './view-storage.ts'
+import { DATA_MODULE, DATA_MODULE_ID, databaseRecordPath, databaseViewPath } from './database-path.ts'
+import {
+  getInspectorDbPath,
+  isInspectorDatabasePath,
+  seedInspectorDbPath,
+  setInspectorDbPath,
+  subscribeInspectorDbPath,
+} from './inspector-db-route.ts'
+import { getDatabaseUi } from './database-ui.ts'
+
+const EMPTY_CHROME: CollectionChrome = {}
+
+type InspectorSnapshot = {
+  subscribe: (fn: () => void) => () => void
+  get: () => { collections?: CollectionInfo[] }
+}
+
+let snapshotRef: InspectorSnapshot | undefined
+
+export function bindInspectorSnapshot(source: InspectorSnapshot) {
+  snapshotRef = source
+}
+
+function subscribeInspectorSnapshot(fn: () => void) {
+  if (!snapshotRef) return () => undefined
+  return snapshotRef.subscribe(fn)
+}
+
+function readInspectorCollections() {
+  return (snapshotRef?.get().collections ?? []) as CollectionInfo[]
+}
+
+function useInspectorCollections() {
+  return useSyncExternalStore(subscribeInspectorSnapshot, readInspectorCollections, () => [] as CollectionInfo[])
+}
+
+let viewTick = 0
+
+function tableLabel(table: CollectionInfo) {
+  return table.view?.title ?? table.label ?? table.path.replace(/^\//, '')
+}
+
+function useViewTick() {
+  return useSyncExternalStore(
+    (fn) => {
+      const bump = () => {
+        viewTick += 1
+        fn()
+      }
+      window.addEventListener('fsdb:change', bump)
+      window.addEventListener('fsdb:crumb-labels', bump)
+      window.addEventListener('storage', bump)
+      return () => {
+        window.removeEventListener('fsdb:change', bump)
+        window.removeEventListener('fsdb:crumb-labels', bump)
+        window.removeEventListener('storage', bump)
+      }
+    },
+    () => viewTick,
+    () => 0,
+  )
+}
+
+function useInspectorDbPath(paneId: string) {
+  return useSyncExternalStore(
+    subscribeInspectorDbPath,
+    () => getInspectorDbPath(paneId),
+    () => '',
+  )
+}
+
+function defaultInspectorDbPath(tables: CollectionInfo[]) {
+  const first = tables[0]
+  if (!first?.path) return ''
+  return databaseViewPath(first.path, defaultViewId(first.path))
+}
+
+function useBindInspectorDbPath(paneId: string, tables: CollectionInfo[]) {
+  const location = useLocation()
+  const inspectorPath = useInspectorDbPath(paneId)
+  useEffect(() => {
+    if (inspectorPath) return
+    if (isInspectorDatabasePath(location.pathname)) {
+      seedInspectorDbPath(paneId, location.pathname)
+      return
+    }
+    const fallback = defaultInspectorDbPath(tables)
+    if (fallback) setInspectorDbPath(paneId, fallback)
+  }, [inspectorPath, location.pathname, paneId, tables])
+  if (inspectorPath) return inspectorPath
+  if (isInspectorDatabasePath(location.pathname)) return location.pathname
+  return ''
+}
+
+function crumbsForRoute(
+  pathname: string,
+  tables: CollectionInfo[],
+): { crumbs: Crumb[]; collection: string; viewId?: string; recordId?: string } {
+  const parsed = parseAppPath(pathname, [DATA_MODULE])
+  const collection = parsed.kind === 'collection-view' || parsed.kind === 'record' ? parsed.collection : ''
+  const table = tables.find((item) => item.path === collection)
+  const views = collection ? loadViews(collection) : []
+  const urlViewId = parsed.kind === 'collection-view' ? parsed.viewId : undefined
+  const recordId = parsed.kind === 'record' ? parsed.recordId : undefined
+  const resolvedView = collection ? viewForPath(collection, urlViewId) : null
+  const activeViewId = resolvedView?.id ?? urlViewId
+  const records = collection ? loadRecords(collection) : []
+  const recordHit = recordId ? records.find((row) => row.id === recordId) : undefined
+  const crumbs = buildCrumbs({
+    collection,
+    collectionLabel: table ? tableLabel(table) : collection,
+    tables: tables.map((item) => ({ path: item.path, label: tableLabel(item), icon: item.view?.icon })),
+    viewId: collection ? activeViewId : undefined,
+    viewName: resolvedView?.name,
+    views: views.map((item) => ({ id: item.id, name: item.name, mode: item.mode })),
+    recordId,
+    recordLabel: recordHit?.label ?? recordId,
+    records,
+  })
+  return { crumbs, collection, viewId: activeViewId, recordId }
+}
+
+function goInspector(paneId: string, target: CrumbTarget) {
+  setInspectorDbPath(paneId, pathForCrumbTarget(target))
+}
+
+function paneOf(props: { paneId?: unknown }) {
+  return String(props.paneId || 'database')
+}
+
+export function DatabaseInspectorTab({
+  active,
+  onActivate,
+  paneId,
+}: {
+  active?: boolean
+  onActivate?: () => void
+  paneId?: string
+}) {
+  const id = paneOf({ paneId })
+  const collections = useInspectorCollections()
+  const tables = useMemo(
+    () => collections.filter((row) => row.path && row.path !== '/'),
+    [collections],
+  )
+  const inspectorPath = useBindInspectorDbPath(id, tables)
+  const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
+  const [trailOpen, setTrailOpen] = useState(false)
+  const crumbRef = useRef<HTMLElement>(null)
+  const tabRef = useRef<HTMLDivElement>(null)
+  useViewTick()
+  useEffect(() => {
+    function onPointer(event: globalThis.MouseEvent) {
+      const target = event.target as Node
+      if (tabRef.current?.contains(target)) return
+      if (target instanceof Element && target.closest('[data-fsdb-crumb-menu]')) return
+      setCrumbOpen(null)
+      setTrailOpen(false)
+    }
+    document.addEventListener('mousedown', onPointer)
+    return () => document.removeEventListener('mousedown', onPointer)
+  }, [])
+  const { crumbs } = crumbsForRoute(inspectorPath, tables)
+  const leaf = crumbs.at(-1)
+  const leafChoice = leaf?.choices.find((item) => item.id === leaf.id)
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent('biu:inspector-caption', {
+        detail: {
+          id,
+          label: leaf?.label ?? '数据',
+          kind: leaf?.kind,
+          mode: leafChoice?.mode,
+          icon: leafChoice?.icon,
+          emoji: leafChoice?.emoji,
+        },
+      }),
+    )
+  }, [id, leaf?.id, leaf?.kind, leaf?.label, leafChoice?.emoji, leafChoice?.icon, leafChoice?.mode])
+
+  return (
+    <div
+      ref={tabRef}
+      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}${trailOpen ? ' is-crumb-open' : ''}`}
+      role="tab"
+      aria-selected={Boolean(active)}
+      data-testid="inspector-tab-database"
+      data-pane={id}
+      onClick={() => onActivate?.()}
+      title={crumbs.map((item) => item.label).join(' / ') || '数据'}
+    >
+      {crumbs.length ? (
+        <CrumbTrail
+          crumbs={crumbs}
+          openId={crumbOpen}
+          onOpenId={setCrumbOpen}
+          onActivate={onActivate}
+          allowMenu={trailOpen}
+          onPick={(target) => {
+            onActivate?.()
+            goInspector(id, target)
+          }}
+          navRef={crumbRef}
+          className="inspector-crumb-full fsdb-crumbs"
+          label="数据库位置"
+        />
+      ) : (
+        <span className="inspector-crumb-leaf">
+          <CircleStackIcon aria-hidden className="chat-view-project-icon" />
+          <span className="chat-view-project-name">数据</span>
+        </span>
+      )}
+      {crumbs.length > 1 ? (
+        <button
+          type="button"
+          className={`inspector-crumb-toggle${trailOpen ? ' is-open' : ''}`}
+          title={trailOpen ? '收起面包屑' : '展开面包屑'}
+          aria-label={trailOpen ? '收起面包屑' : '展开面包屑'}
+          aria-expanded={trailOpen}
+          data-testid="inspector-crumb-toggle"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onActivate?.()
+            setTrailOpen((open) => {
+              if (open) setCrumbOpen(null)
+              return !open
+            })
+          }}
+        >
+          {trailOpen ? (
+            <ChevronLeftIcon aria-hidden className="size-3" />
+          ) : (
+            <ChevronRightIcon aria-hidden className="size-3" />
+          )}
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
+export function DatabaseInspectorBrowse(props: SlotProps) {
+  const id = paneOf(props)
+  const ui = getDatabaseUi()
+  const collections = useInspectorCollections()
+  const tables = useMemo(
+    () => collections.filter((row) => row.path && row.path !== '/'),
+    [collections],
+  )
+  const inspectorPath = useBindInspectorDbPath(id, tables)
+  useViewTick()
+  const { collection, viewId, recordId } = crumbsForRoute(inspectorPath, tables)
+  const currentPath = collection
+  const table = tables.find((item) => item.path === currentPath)
+  const title = table ? tableLabel(table) : '数据'
+  const chrome = useSyncExternalStore(
+    (fn) => (ui ? ui.subscribe(fn) : () => undefined),
+    () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
+    () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
+  )
+
+  if (!currentPath) {
+    return <p className="fsdb-inspector-empty">没有数据表</p>
+  }
+
+  return (
+    <CollectionBrowser
+      embed
+      moduleId={DATA_MODULE_ID}
+      collectionPath={currentPath}
+      title={title}
+      blurb={table?.view?.blurb ?? ''}
+      chrome={chrome}
+      tables={tables}
+      routeRecordId={recordId ?? null}
+      routeViewId={viewId}
+      onOpenTable={(path, nextViewId) => {
+        setInspectorDbPath(id, databaseViewPath(path, nextViewId ?? defaultViewId(path)))
+      }}
+      onOpenView={(nextViewId) => setInspectorDbPath(id, databaseViewPath(currentPath, nextViewId))}
+      onOpenRecord={(recordIdNext, _viewId, nextCollection) => {
+        setInspectorDbPath(id, databaseRecordPath(nextCollection ?? currentPath, recordIdNext))
+      }}
+      onCloseRecord={() => {
+        setInspectorDbPath(id, databaseViewPath(currentPath, defaultViewId(currentPath)))
+      }}
+      onCrumbTarget={(target) => goInspector(id, target)}
+    />
+  )
+}

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  getInspectorDbPath,
+  isInspectorDatabasePath,
+  seedInspectorDbPath,
+  setInspectorDbPath,
+} from './inspector-db-route.ts'
+
+test('inspector database path does not overwrite after first seed', () => {
+  setInspectorDbPath('')
+  seedInspectorDbPath('/database/pages')
+  assert.equal(getInspectorDbPath(), '/database/pages')
+  seedInspectorDbPath('/database/tasks')
+  assert.equal(getInspectorDbPath(), '/database/pages')
+  setInspectorDbPath('/database/tasks')
+  assert.equal(getInspectorDbPath(), '/database/tasks')
+})
+
+test('chat routes are not seeded as inspector database paths', () => {
+  setInspectorDbPath('')
+  assert.equal(isInspectorDatabasePath('/s/abc'), false)
+  assert.equal(isInspectorDatabasePath('/database/pages'), true)
+  seedInspectorDbPath('/s/abc')
+  assert.equal(getInspectorDbPath(), '')
+  seedInspectorDbPath('/database/pages')
+  assert.equal(getInspectorDbPath(), '/database/pages')
+})
+
+test('each inspector database pane keeps its own path', () => {
+  setInspectorDbPath('database::a', '/database/pages')
+  setInspectorDbPath('database::b', '/database/tasks')
+  assert.equal(getInspectorDbPath('database::a'), '/database/pages')
+  assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
+  seedInspectorDbPath('database::a', '/database/events')
+  assert.equal(getInspectorDbPath('database::a'), '/database/pages')
+})

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,0 +1,51 @@
+/** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
+
+import { DATA_MODULE_PATH } from './database-path.ts'
+
+const DEFAULT_PANE = 'database'
+const listeners = new Set<() => void>()
+const paths = new Map<string, string>()
+
+export function subscribeInspectorDbPath(fn: () => void) {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+function bump() {
+  for (const fn of listeners) fn()
+}
+
+export function isInspectorDatabasePath(pathname: string) {
+  const path = String(pathname || '').split('?')[0]
+  return path === DATA_MODULE_PATH || path.startsWith(`${DATA_MODULE_PATH}/`)
+}
+
+function panePath(paneId = DEFAULT_PANE) {
+  const path = paths.get(paneId) ?? ''
+  return isInspectorDatabasePath(path) ? path : ''
+}
+
+export function getInspectorDbPath(paneId = DEFAULT_PANE) {
+  return panePath(paneId)
+}
+
+export function setInspectorDbPath(paneId: string, next?: string) {
+  const id = next === undefined ? DEFAULT_PANE : paneId
+  const path = next === undefined ? paneId : next
+  const stored = isInspectorDatabasePath(path) ? path : ''
+  if ((paths.get(id) ?? '') === stored) return
+  if (!stored) paths.delete(id)
+  else paths.set(id, stored)
+  bump()
+}
+
+export function seedInspectorDbPath(paneId: string, pathname?: string) {
+  const id = pathname === undefined ? DEFAULT_PANE : paneId
+  const path = pathname === undefined ? paneId : pathname
+  if (panePath(id)) return
+  if (!isInspectorDatabasePath(path)) return
+  paths.set(id, path)
+  bump()
+}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -56,13 +56,20 @@ test('filesystem header toggles the right inspector, not the left data sidebar',
 test('database extras sit after the record detail, not in the inspector', () => {
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.doesNotMatch(page, /biu:inspector-open/)
-  assert.doesNotMatch(page, /slots\.place\('inspector-panels'/)
+  assert.match(page, /slots\.place\('inspector-panels'/)
+  assert.match(page, /DatabaseInspectorBrowse/)
+  assert.match(page, /centerKinds: \['session'\]/)
+  assert.match(page, /repeatable: true/)
   assert.doesNotMatch(page, /RecordPanePanel/)
-  assert.doesNotMatch(page, /fsdb-database-browse/)
   assert.match(detail, /fsdb-detail-extras/)
   assert.match(detail, /data-testid=\{`fsdb-pane-\$\{pane\.id\}`\}/)
-  assert.doesNotMatch(browser, /embed \?/)
+  assert.match(browser, /embed \?/)
   assert.doesNotMatch(browser, /setRecordFocus/)
+})
+
+test('inspector embed does not poll the collection every 20s', () => {
+  assert.match(browser, /const timer = embed/)
+  assert.match(browser, /}, 20000\)/)
 })
 
 test('switching tables does not remount the whole browser', () => {

--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -8,6 +8,17 @@ test('inspector only offers session panels when a session is selected', () => {
   assert.equal(inspectorPanelMatches(extra, null), false)
 })
 
+test('session inspector can add a database pane', () => {
+  assert.equal(
+    inspectorPanelMatches({ requiresSession: true, centerKinds: ['session'], repeatable: true }, 's1'),
+    true,
+  )
+  assert.equal(
+    inspectorPanelMatches({ requiresSession: true, centerKinds: ['session'] }, null),
+    false,
+  )
+})
+
 test('page panels never appear in the session inspector', () => {
   assert.equal(inspectorPanelMatches({ centerKinds: ['collection-view', 'record'] }, 's1'), false)
   assert.equal(inspectorPanelMatches({ centerKinds: ['task'] }, 's1'), false)

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -7,7 +7,7 @@ export type InspectorPanelExtra = {
   action?: unknown
 }
 
-/** 右侧检查器只跟当前 Session：页面附加块不进这一栏。 */
+/** 右侧检查器跟当前 Session：页面附加块不进这一栏，但 Session 可以加数据库。 */
 export function inspectorPanelMatches(extra: InspectorPanelExtra, sessionId: string | null): boolean {
   if (!sessionId) return false
   const kinds = Array.isArray(extra.centerKinds)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -251,7 +251,7 @@ export const SessionInspector = memo(function SessionInspector({
   }, [onWidthChange])
 
   useEffect(() => {
-    const activeTab = tabsRef.current?.querySelector<HTMLElement>('.inspector-tab.is-active')
+    const activeTab = tabsRef.current?.querySelector<HTMLElement>('.inspector-tab.is-active, .inspector-crumb-tab.is-active')
     activeTab?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
   }, [tab])
 

--- a/web/style.css
+++ b/web/style.css
@@ -422,6 +422,98 @@ body {
   display: none;
 }
 
+.inspector-crumb-tab {
+  position: relative;
+  flex: none;
+  max-width: none;
+  min-width: max-content;
+  overflow: visible;
+  padding-right: 18px;
+}
+
+.inspector-crumb-tab .inspector-crumb-full .fsdb-crumb:not(:last-child) {
+  display: none;
+}
+
+.inspector-crumb-tab .inspector-crumb-full .fsdb-crumb:last-child .fsdb-crumb-sep {
+  display: none;
+}
+
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:not(:last-child) {
+  display: inline-flex;
+}
+
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-full .fsdb-crumb:last-child .fsdb-crumb-sep {
+  display: inline;
+}
+
+.inspector-crumb-toggle {
+  position: absolute;
+  right: 2px;
+  top: 50%;
+  z-index: 4;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--dsw-sidebar-fg);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  cursor: pointer;
+}
+
+.inspector-crumb-tab:hover .inspector-crumb-toggle,
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-toggle,
+.inspector-crumb-tab:focus-within .inspector-crumb-toggle {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.inspector-crumb-toggle:hover,
+.inspector-crumb-toggle.is-open {
+  background: transparent;
+  box-shadow: none;
+  color: var(--dsw-sidebar-fg-active);
+}
+
+.inspector-crumb-leaf,
+.inspector-crumb-full {
+  display: inline-flex;
+  min-width: max-content;
+  max-width: none;
+  align-items: center;
+  gap: 2px;
+  overflow: visible;
+}
+
+.inspector-crumb-full .fsdb-crumb-btn {
+  max-width: 140px;
+}
+
+.inspector-crumb-full .fsdb-crumb-menu {
+  z-index: 90;
+}
+
+.inspector-database-rail.fsdb-views {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+  border-right: 0;
+}
+
+.inspector-database-page {
+  width: 100%;
+  min-height: 0;
+  flex: 1;
+}
+
 .inspector-catalog {
   display: flex;
   min-height: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Session 检查器可以加数据库，不再把数据库当成「页面附加块」挡在外面。

- 加号目录提供可重复的「数据库」面板（`requiresSession` + `centerKinds: session`）
- 每个 Tab 自己记路径，不改中间主界面，也不跟聊天 URL
- 任务脚本/进度汇报等页面附加块仍然跟在记录详情后面
- 检查器内嵌浏览不拉左侧栏、不 20 秒轮询、不写视图存储

相关单测 83 项通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

