### PR TITLE
每种已登记表在「视图」上有一条内置目录视图

### DIFF
--- a/packages/core-file-system/src/catalog-views.test.ts
+++ b/packages/core-file-system/src/catalog-views.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { builtinCatalogViewId, builtinCatalogViews, mergeCatalogViews, stubBuiltinCatalogView } from './catalog-views.ts'
+
+test('each registered table gets a builtin catalog view', () => {
+  const tables = [
+    { id: 'views', path: '/views', kind: 'collection' as const, label: '视图', view: { moduleId: 'views-db', route: '/db-views', title: '视图' } },
+    { id: 'pages', path: '/pages', kind: 'collection' as const, label: '页面', view: { moduleId: 'page', route: '/pages', title: '页面' } },
+    { id: 'tasks', path: '/tasks', kind: 'collection' as const, label: '任务', view: { moduleId: 'tasks-2', route: '/tasks-2', title: '任务' } },
+  ]
+  const listed = builtinCatalogViews(tables)
+  assert.equal(listed.length, 3)
+  assert.equal(listed[1]?.id, builtinCatalogViewId('/pages'))
+  assert.equal(listed[1]?.name, '页面')
+  assert.deepEqual(listed[1]?.filters, { tablePath: '/pages' })
+  assert.equal(listed[1]?.builtin, true)
+  const merged = mergeCatalogViews(tables, [
+    { id: builtinCatalogViewId('/pages'), name: '旧的', mode: 'table', sortField: 'id', sortDir: 'asc', filters: {}, columns: [] },
+    { id: 'user-1', name: '周报', mode: 'table', sortField: 'id', sortDir: 'asc', filters: {}, columns: [] },
+  ])
+  assert.equal(merged.filter((view) => view.builtin).length, 3)
+  assert.equal(merged.some((view) => view.id === 'user-1'), true)
+  assert.equal(merged.filter((view) => view.id === builtinCatalogViewId('/pages')).length, 1)
+})
+
+test('stub builtin catalog view from route id', () => {
+  const stub = stubBuiltinCatalogView('builtin:/drawings')
+  assert.equal(stub?.builtin, true)
+  assert.deepEqual(stub?.filters, { tablePath: '/drawings' })
+  assert.equal(stubBuiltinCatalogView('user-1'), null)
+})

--- a/packages/core-file-system/src/catalog-views.ts
+++ b/packages/core-file-system/src/catalog-views.ts
@@ -1,0 +1,61 @@
+import type { CollectionInfo } from '@biu/type-file-system'
+import { normalizeCollectionPath } from './paths.ts'
+import { normalizeSavedView, type SavedView } from './web/saved-view.ts'
+
+export function builtinCatalogViewId(collectionPath: string) {
+  return `builtin:${normalizeCollectionPath(collectionPath)}`
+}
+
+export function isBuiltinCatalogViewId(id: string) {
+  return id.startsWith('builtin:')
+}
+
+export function builtinCatalogViews(tables: CollectionInfo[]): SavedView[] {
+  return tables
+    .filter((table) => table.path && table.path !== '/')
+    .map((table) => {
+      const path = normalizeCollectionPath(table.path)
+      return normalizeSavedView({
+        id: builtinCatalogViewId(path),
+        name: table.view?.title ?? table.label ?? path.replace(/^\//, ''),
+        mode: 'table',
+        sortField: 'title',
+        sortDir: 'asc',
+        filters: { tablePath: path },
+        columns: [],
+        groupBy: '',
+        tree: true,
+        wrap: false,
+        truncate: true,
+        query: '',
+        builtin: true,
+      })
+    })
+}
+
+export function mergeCatalogViews(tables: CollectionInfo[], user: SavedView[]): SavedView[] {
+  const builtins = builtinCatalogViews(tables)
+  const extra = user.filter((view) => !view.builtin && !isBuiltinCatalogViewId(view.id))
+  return [...builtins, ...extra]
+}
+
+/** 路由里已经是 builtin: 时，即使本地还没合并登记表，也能先还原筛选。 */
+export function stubBuiltinCatalogView(id: string): SavedView | null {
+  if (!isBuiltinCatalogViewId(id)) return null
+  const path = normalizeCollectionPath(id.slice('builtin:'.length))
+  return normalizeSavedView({
+    id: builtinCatalogViewId(path),
+    name: path.replace(/^\//, '') || 'views',
+    mode: 'table',
+    sortField: 'title',
+    sortDir: 'asc',
+    filters: { tablePath: path },
+    columns: [],
+    groupBy: '',
+    tree: true,
+    wrap: false,
+    truncate: true,
+    query: '',
+    builtin: true,
+  })
+}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -89,6 +89,8 @@ import {
 } from './view-storage.ts'
 import { listCollection, readJson } from './db-client.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
+import { mergeCatalogViews } from '../catalog-views.ts'
+import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 
 type StatResult = { schema?: CollectionSchema }
 
@@ -157,16 +159,22 @@ export function CollectionBrowser({
   const [sortField, setSortField] = useState(initialView?.sortField ?? 'id')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(initialView?.sortDir ?? 'asc')
   const [filters, setFilters] = useState<Record<string, string>>(initialView?.filters ?? {})
-  const queryFilters = useMemo(() => ({ ...filters, ...lockedFilters }), [filters, lockedFilters])
-  const lockedFilterKeys = Object.keys(lockedFilters)
-  const lockedSource = lockedFilters.tablePath ?? ''
+  const [columnKeys, setColumnKeys] = useState<string[]>(initialView?.columns ?? [])
+  const tablePathsKey = tables.map((table) => `${table.path}\t${table.view?.title ?? table.label ?? ''}`).join('\n')
+  const [views, setViews] = useState<SavedView[]>(() => loadViews(collectionPath))
+  const [activeViewId, setActiveViewId] = useState<string | null>(initialView?.id ?? null)
+  const catalogLocks = useMemo(() => {
+    const current = views.find((view) => view.id === activeViewId)
+    if (!current?.builtin) return lockedFilters
+    return { ...current.filters, ...lockedFilters }
+  }, [activeViewId, lockedFilters, views])
+  const queryFilters = useMemo(() => ({ ...filters, ...catalogLocks }), [catalogLocks, filters])
+  const lockedFilterKeys = Object.keys(catalogLocks)
+  const lockedSource = catalogLocks.tablePath ?? ''
   useEffect(() => {
     if (!lockedSource) return
     setMode('table')
   }, [lockedSource])
-  const [columnKeys, setColumnKeys] = useState<string[]>(initialView?.columns ?? [])
-  const [views, setViews] = useState<SavedView[]>(() => loadViews(collectionPath))
-  const [activeViewId, setActiveViewId] = useState<string | null>(initialView?.id ?? null)
   const detailId = openDetailId
   const setDetailId = (id: string | null, row?: DbRecord | null) => {
     flushSync(() => {
@@ -418,26 +426,32 @@ export function CollectionBrowser({
     setError('')
     setPage(0)
     const stored = viewForPath(collectionPath, routeViewId)
-    if (stored) {
-      setViews(loadViews(collectionPath))
-      setActiveViewId(stored.id)
-      setMode(stored.mode)
-      setSortField(stored.sortField)
-      setSortDir(stored.sortDir)
-      setFilters(stored.filters)
-      setColumnKeys(stored.columns)
-      setGroupBy(stored.groupBy ?? '')
-      setShowTree(stored.tree !== false)
-      setWrapCells(!!stored.wrap)
-      setTruncateCells(stored.truncate !== false)
-      setQuery(stored.query ?? '')
+    const user = loadViews(collectionPath)
+    const listed = collectionPath === VIEWS_COLLECTION_PATH ? mergeCatalogViews(tables, user) : user
+    rememberViews(collectionPath, listed)
+    if (stored || listed[0]) {
+      const next = (routeViewId && listed.find((item) => item.id === routeViewId)) || stored || listed[0]
+      setViews(listed)
+      if (next) {
+        setActiveViewId(next.id)
+        setMode(next.mode)
+        setSortField(next.sortField)
+        setSortDir(next.sortDir)
+        setFilters(next.filters)
+        setColumnKeys(next.columns)
+        setGroupBy(next.groupBy ?? '')
+        setShowTree(next.tree !== false)
+        setWrapCells(!!next.wrap)
+        setTruncateCells(next.truncate !== false)
+        setQuery(next.query ?? '')
+      }
     } else {
       setViews([])
       setActiveViewId(null)
       setQuery('')
       setFilters({})
     }
-  }, [collectionPath])
+  }, [collectionPath, tablePathsKey])
 
   useEffect(() => {
     let debounce = 0
@@ -655,12 +669,14 @@ export function CollectionBrowser({
   }, [dlg])
 
   function persistViews(next: SavedView[]) {
-    viewsRef.current = next
-    setViews(next)
-    rememberViews(collectionPath, next)
+    const listed = collectionPath === VIEWS_COLLECTION_PATH ? mergeCatalogViews(tables, next) : next
+    const stored = listed.filter((view) => !view.builtin)
+    viewsRef.current = listed
+    setViews(listed)
+    rememberViews(collectionPath, listed)
     if (!embed) {
-      localStorage.setItem(viewsKey(collectionPath), JSON.stringify(next))
-      pushSavedViews(collectionPath, next)
+      localStorage.setItem(viewsKey(collectionPath), JSON.stringify(stored))
+      pushSavedViews(collectionPath, stored)
     }
     window.dispatchEvent(new Event('fsdb:change'))
     window.dispatchEvent(new Event('fsdb:crumb-labels'))
@@ -762,14 +778,14 @@ export function CollectionBrowser({
   function copyView(source?: SavedView) {
     commitView(
       source
-        ? { ...source, id: `${Date.now()}`, name: uniqueViewName(`${source.name} 副本`) }
+        ? { ...source, id: `${Date.now()}`, name: uniqueViewName(`${source.name} 副本`), builtin: false }
         : {
             id: `${Date.now()}`,
             name: uniqueViewName(`${activeView?.name ?? title} 副本`),
             mode,
             sortField,
             sortDir,
-            filters,
+            filters: { ...queryFilters },
             columns: columnKeys,
             groupBy,
             tree: showTree,
@@ -782,6 +798,8 @@ export function CollectionBrowser({
 
   function patchActiveView(patch: Partial<SavedView>) {
     if (!activeViewId) return
+    const current = views.find((view) => view.id === activeViewId)
+    if (current?.builtin) return
     persistViews(views.map((view) => (view.id === activeViewId ? { ...view, ...patch } : view)))
   }
 
@@ -797,6 +815,10 @@ export function CollectionBrowser({
 
   function applyRename(name?: string) {
     if (!dlg || dlg.kind !== 'rename') return
+    if (dlg.view.builtin) {
+      setDlg(null)
+      return
+    }
     const next = (name ?? '').trim()
     if (!next) {
       setDlgError('请填写名称')
@@ -812,6 +834,10 @@ export function CollectionBrowser({
 
   function applyDeleteView() {
     if (!dlg || dlg.kind !== 'delete') return
+    if (dlg.view.builtin) {
+      setDlg(null)
+      return
+    }
     const removedId = dlg.view.id
     const remaining = views.filter((item) => item.id !== removedId)
     setDlg(null)
@@ -843,6 +869,7 @@ export function CollectionBrowser({
     if (!pinned.length) return
     setColumnKeys(pinned)
     if (!activeViewId) return
+    if (views.find((view) => view.id === activeViewId)?.builtin) return
     persistViews(views.map((view) => (view.id === activeViewId ? { ...view, columns: pinned } : view)))
   }
 
@@ -1218,7 +1245,8 @@ export function CollectionBrowser({
     if (hydratePath.current === collectionPath) return
     hydratePath.current = collectionPath
     let next = loadViews(collectionPath)
-    if (!next.length) {
+    if (collectionPath === VIEWS_COLLECTION_PATH) next = mergeCatalogViews(tables, next)
+    if (!next.length && collectionPath !== VIEWS_COLLECTION_PATH) {
       next = [
         normalizeSavedView({
           id: `${Date.now()}`,
@@ -1237,11 +1265,12 @@ export function CollectionBrowser({
       ]
     }
     persistViews(next)
+    const listed = viewsRef.current
     const view =
-      next.find((item) => item.id === routeViewId) ??
-      next.find((item) => item.id === loadActiveViewId(collectionPath, next)) ??
-      next[0]
-    applyView(view)
+      listed.find((item) => item.id === routeViewId) ??
+      listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ??
+      listed[0]
+    if (view) applyView(view)
     setHydrated(true)
   }, [allColumnKeys, collectionPath, schema, schemaDefaultKeys])
 
@@ -1250,7 +1279,7 @@ export function CollectionBrowser({
     const id = window.setTimeout(() => {
       if (hydratePath.current !== collectionPath) return
       const current = viewsRef.current.find((view) => view.id === activeViewId)
-      if (!current) return
+      if (!current || current.builtin) return
       const next = normalizeSavedView({
         ...current,
         mode,
@@ -1396,6 +1425,7 @@ export function CollectionBrowser({
                         <span className="tasks-viewdd-item-name">{view.name}</span>
                         {view.id === activeViewId ? <CheckCircleIcon aria-hidden className="size-[14px] tasks-viewdd-check" /> : null}
                       </button>
+                      {view.builtin ? null : (
                       <span className="tasks-viewdd-item-actions">
                         <button type="button" className="tasks-viewdd-act" title="重命名" onClick={() => renameView(view)}>
                           <PencilSquareIcon aria-hidden className="size-[14px]" />
@@ -1404,6 +1434,7 @@ export function CollectionBrowser({
                           <TrashIcon aria-hidden className="size-[14px]" />
                         </button>
                       </span>
+                      )}
                     </div>
                   ))}
                   <div className="tasks-viewdd-foot">
@@ -1598,6 +1629,7 @@ export function CollectionBrowser({
                 </div>
               ) : null}
             </div>
+            {activeView?.builtin ? null : (
             <div className="tasks-filter-btn-wrap" ref={filterRef}>
               <button
                 type="button"
@@ -1650,6 +1682,7 @@ export function CollectionBrowser({
                 </div>
               ) : null}
             </div>
+            )}
             {mode === 'table' ? (
             <div className="tasks-filter-btn-wrap" ref={configRef}>
               <button

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -10,6 +10,8 @@ import {
   TrashIcon,
 } from '@heroicons/react/16/solid'
 import type { CollectionInfo, DbRecord } from '@biu/type-file-system'
+import { mergeCatalogViews } from '../catalog-views.ts'
+import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 import type { SavedView } from './saved-view.ts'
 import {
   fetchViewPreview,
@@ -270,7 +272,7 @@ export const DataSidebar = memo(function DataSidebar({
   title: string
   views: SavedView[]
   activeViewId: string | null
-  onOpenTable?: (path: string, viewId?: string) => void
+  onOpenTable?: (path: string, viewId?: string, opts?: { catalog?: boolean }) => void
   onApplyView: (view: SavedView) => void
   onRenameView: (view: SavedView) => void
   onDeleteView: (view: SavedView) => void
@@ -302,7 +304,9 @@ export const DataSidebar = memo(function DataSidebar({
   usePreviewTotalsVersion()
 
   function viewsFor(path: string) {
-    return path === collectionPath ? views : loadViews(path)
+    const listed = path === collectionPath ? views : loadViews(path)
+    if (path === VIEWS_COLLECTION_PATH) return mergeCatalogViews(tables, listed)
+    return listed
   }
 
   const starredRows = starredViews.flatMap((item) => {
@@ -325,7 +329,7 @@ export const DataSidebar = memo(function DataSidebar({
       }
     }
     return jobs
-  }, [dataOpen, favOpen, listedTables, openTables, starredRows, views, collectionPath])
+  }, [dataOpen, favOpen, listedTables, openTables, starredRows, tables, views, collectionPath])
 
   const countJobKey = countJobs.map((job) => viewTotalKey(job.path, job.view)).join('|')
   useEffect(() => {
@@ -608,7 +612,7 @@ export const DataSidebar = memo(function DataSidebar({
                                   </button>
                                 </div>
                                 <ChatCount count={getPreviewTotal(viewTotalKey(table.path, view))} />
-                                {table.path === collectionPath ? (
+                                {table.path === collectionPath && !view.builtin ? (
                                   <>
                                     <button
                                       type="button"

--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -13,7 +13,10 @@ test('view and record helpers match the database URL scheme', () => {
 })
 
 test('collection header opens the views catalog filtered by that table', () => {
-  assert.equal(viewsCatalogHref('/events'), '/database/views?source=%2Fevents')
+  assert.equal(
+    viewsCatalogHref('/events'),
+    `/database/views/view/${encodeURIComponent('builtin:/events')}?source=%2Fevents`,
+  )
   assert.equal(viewsCatalogSource('?source=%2Fevents'), '/events')
-  assert.equal(viewsCatalogHref('/views'), '/database/views')
+  assert.equal(viewsCatalogHref('/views'), `/database/views/view/${encodeURIComponent('builtin:/views')}`)
 })

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -1,4 +1,5 @@
 import { buildAppPath, type AppRoute } from '@biu/web-session-view'
+import { builtinCatalogViewId } from '../catalog-views.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
 export const DATA_MODULE_ID = 'database'
@@ -27,9 +28,10 @@ export function databaseRecordPath(collection: string, recordId: string): string
 
 export const VIEWS_COLLECTION_PATH = '/views'
 
-export function viewsCatalogHref(sourcePath: string, viewId?: string): string {
-  const base = databaseViewPath(VIEWS_COLLECTION_PATH, viewId)
+export function viewsCatalogHref(sourcePath: string): string {
   const source = normalizeCollectionPath(sourcePath)
+  const viewId = builtinCatalogViewId(source || VIEWS_COLLECTION_PATH)
+  const base = databaseViewPath(VIEWS_COLLECTION_PATH, viewId)
   if (!source || source === VIEWS_COLLECTION_PATH) return base
   return `${base}?source=${encodeURIComponent(source)}`
 }

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -124,10 +124,8 @@ function CollectionPage(props: SlotProps) {
   }, [collectionFromRoute, tables])
 
   const sourceFilter = useMemo(() => viewsCatalogSource(location.search), [location.search])
-  const lockedFilters = useMemo(
-    () => (currentPath === VIEWS_COLLECTION_PATH && sourceFilter ? { tablePath: sourceFilter } : {}),
-    [currentPath, sourceFilter],
-  )
+  const lockedFilters: Record<string, string> =
+    currentPath === VIEWS_COLLECTION_PATH && sourceFilter ? { tablePath: sourceFilter } : {}
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')
   return (
@@ -144,8 +142,8 @@ function CollectionPage(props: SlotProps) {
       expandedViewKey={expandedViewKey}
       onExpandedViewKeyChange={setExpandedViewKey}
       onOpenTable={(path, viewId, opts) => {
-        if (opts?.catalog && path !== VIEWS_COLLECTION_PATH) {
-          navigate(viewsCatalogHref(path, defaultViewId(VIEWS_COLLECTION_PATH)))
+        if (opts?.catalog) {
+          navigate(viewsCatalogHref(path))
           return
         }
         go({ collection: path, viewId: viewId ?? defaultViewId(path) })
@@ -155,7 +153,7 @@ function CollectionPage(props: SlotProps) {
         go({ collection: collection ?? currentPath, recordId })
       }
       onCloseRecord={() =>
-        go({ collection: currentPath, viewId: defaultViewId(currentPath) }, { replace: true })
+        go({ collection: currentPath, viewId: defaultViewId(currentPath, viewFromRoute) }, { replace: true })
       }
       onCrumbTarget={(target: CrumbTarget) => navigate(pathForCrumbTarget(target))}
     />

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -282,7 +282,7 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
   const { collection, viewId, recordId } = crumbsForRoute(pathname, tables)
   const currentPath = collection
   const sourceFilter = viewsCatalogSource(search)
-  const lockedFilters =
+  const lockedFilters: Record<string, string> =
     currentPath === VIEWS_COLLECTION_PATH && sourceFilter ? { tablePath: sourceFilter } : {}
   const table = tables.find((item) => item.path === currentPath)
   const title = table ? tableLabel(table) : '数据'
@@ -309,8 +309,8 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
       routeRecordId={recordId ?? null}
       routeViewId={viewId}
       onOpenTable={(path, nextViewId, opts) => {
-        if (opts?.catalog && path !== VIEWS_COLLECTION_PATH) {
-          setInspectorDbPath(id, viewsCatalogHref(path, defaultViewId(VIEWS_COLLECTION_PATH)))
+        if (opts?.catalog) {
+          setInspectorDbPath(id, viewsCatalogHref(path))
           return
         }
         setInspectorDbPath(id, databaseViewPath(path, nextViewId ?? defaultViewId(path)))
@@ -320,7 +320,7 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
         setInspectorDbPath(id, databaseRecordPath(nextCollection ?? currentPath, recordIdNext))
       }}
       onCloseRecord={() => {
-        setInspectorDbPath(id, databaseViewPath(currentPath, defaultViewId(currentPath)))
+        setInspectorDbPath(id, databaseViewPath(currentPath, defaultViewId(currentPath, viewId)))
       }}
       onCrumbTarget={(target) => goInspector(id, target)}
     />

--- a/packages/core-file-system/src/web/saved-view.ts
+++ b/packages/core-file-system/src/web/saved-view.ts
@@ -14,6 +14,8 @@ export type SavedView = {
   truncate?: boolean
   query?: string
   pageSize?: number
+  /** 系统按表登记生成的目录视图，不能改筛选、不能删改名。 */
+  builtin?: boolean
 }
 
 const MODES: ViewMode[] = ['queue', 'table', 'cards', 'board']
@@ -32,6 +34,7 @@ export function normalizeSavedView(view: SavedView): SavedView {
     truncate: view.truncate !== false,
     query: view.query ?? '',
     pageSize: normalizePageSize(view.pageSize),
+    builtin: Boolean(view.builtin),
   }
 }
 

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -1,32 +1,10 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { isViewStarred, loadStarredViews, loadViews, persistStarredViews, rememberViews, toggleStarredView, viewForPath, viewsKey } from './view-storage.ts'
-import { normalizeSavedView } from './saved-view.ts'
+import { builtinCatalogViewId } from '../catalog-views.ts'
+import { defaultViewId, viewForPath } from './view-storage.ts'
+import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 
-test('toggleStarredView stars a view, not a whole table', () => {
-  const next = toggleStarredView([], '/pages', 'v1')
-  assert.deepEqual(next, [{ path: '/pages', viewId: 'v1' }])
-  assert.equal(isViewStarred(next, '/pages', 'v1'), true)
-  assert.equal(isViewStarred(next, '/pages', 'v2'), false)
-  assert.deepEqual(toggleStarredView(next, '/pages', 'v1'), [])
-  persistStarredViews([{ path: '/tasks', viewId: 'a' }])
-  assert.deepEqual(loadStarredViews(), [{ path: '/tasks', viewId: 'a' }])
-})
-
-test('loadViews prefers in-memory names over stale localStorage', () => {
-  const path = '/pages'
-  const stale = normalizeSavedView({
-    id: 'v1',
-    name: '默认视图',
-    mode: 'table',
-    sortField: 'id',
-    sortDir: 'asc',
-    filters: {},
-    columns: [],
-  })
-  localStorage.setItem(viewsKey(path), JSON.stringify([stale]))
-  rememberViews(path, [{ ...stale, name: '周报' }])
-  assert.equal(loadViews(path)[0]?.name, '周报')
-  assert.equal(viewForPath(path)?.id, 'v1')
-  assert.equal(viewForPath(path, 'missing')?.id, 'v1')
+test('views collection defaults to the builtin catalog for itself', () => {
+  assert.equal(defaultViewId(VIEWS_COLLECTION_PATH), builtinCatalogViewId(VIEWS_COLLECTION_PATH))
+  assert.equal(viewForPath(VIEWS_COLLECTION_PATH, 'builtin:/events')?.filters.tablePath, '/events')
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -1,3 +1,5 @@
+import { builtinCatalogViewId, stubBuiltinCatalogView } from '../catalog-views.ts'
+import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 import { normalizeSavedView, type SavedView } from './saved-view.ts'
 
 export function viewsKey(collectionPath: string) {
@@ -52,13 +54,15 @@ export function loadActiveViewId(collectionPath: string, listed: SavedView[]) {
 export function viewForPath(collectionPath: string, routeViewId?: string): SavedView | null {
   const listed = loadViews(collectionPath)
   const preferred =
-    (routeViewId ? listed.find((item) => item.id === routeViewId) : undefined) ??
+    (routeViewId ? listed.find((item) => item.id === routeViewId) ?? stubBuiltinCatalogView(routeViewId) : undefined) ??
     listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ??
+    (collectionPath === VIEWS_COLLECTION_PATH ? stubBuiltinCatalogView(builtinCatalogViewId(VIEWS_COLLECTION_PATH)) : undefined) ??
     listed[0]
   return preferred ? normalizeSavedView(preferred) : null
 }
 
 export function defaultViewId(collectionPath: string, routeViewId?: string) {
+  if (!routeViewId && collectionPath === VIEWS_COLLECTION_PATH) return builtinCatalogViewId(VIEWS_COLLECTION_PATH)
   return viewForPath(collectionPath, routeViewId)?.id
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点侧栏表名（绘画、任务、页面等）应打开「视图」集合上对应的系统内置目录视图（`builtin:/drawings` 这类 id），而不是「视图」表 localStorage 里的第一条用户视图。

内置视图按已登记表动态生成（不写死六种），不能改筛选、不能改名删除，仍可搜索。拷贝后得到可编辑副本。内置定义只在客户端合成，不写入 `/views` 的 store 行。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

