### PR TITLE
撤回 Tiptap 段落 flex，恢复输入光标

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -75,7 +75,9 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*vertical-align:\s*middle/s)
     expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*line-height:\s*1/s)
     expect(css).toMatch(/\.pick-kind-icon\s*\{[^}]*display:\s*block/s)
-    expect(css).toMatch(/\.composer-pill\.has-chips \.composer-tiptap p[\s\S]*?align-items:\s*center/)
+    expect(css).toMatch(
+      /\.composer-pill\.is-expanded \.composer-tiptap p,\s*\n\.composer-pill\.has-chips \.composer-tiptap p,\s*\n\.composer-tiptap\.is-readonly p \{\s*line-height:\s*2/,
+    )
   })
 
   it('uses Tiptap for inline pick chips in the composer', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -4012,16 +4012,10 @@ body {
   padding: 2px 0;
 }
 
-.composer-pill.is-expanded .composer-tiptap p {
-  line-height: 2;
-}
-
+.composer-pill.is-expanded .composer-tiptap p,
 .composer-pill.has-chips .composer-tiptap p,
 .composer-tiptap.is-readonly p {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  line-height: 1.45;
+  line-height: 2;
 }
 
 .composer-tiptap.is-readonly {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
最近为了让 pick 芯片和文字垂直对齐，给 `.composer-tiptap p` 加了 `display: flex`。ProseMirror 的光标依赖普通文档流，flex 段落后 caret 会消失、也点不进文字。

这次只撤回段落 flex，芯片继续用 `inline-flex` + `vertical-align: middle` 对齐，不再动 Tiptap 节点结构。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

