### PR TITLE
用量面板去掉描边，只用底色

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -2253,8 +2253,13 @@ body {
   border-top: 1px solid var(--dsw-border);
 }
 
-/* 右侧检查器底板与中间画布同色，不跟左侧栏 */
-[data-testid='session-inspector'] .usage-panel,
+/* 右侧检查器：用量卡片用输入条同色底，不要描边 */
+[data-testid='session-inspector'] .usage-panel {
+  background: var(--dsw-sidebar);
+  border: 0;
+  box-shadow: none;
+}
+
 [data-testid='session-inspector'] .traj-root,
 [data-testid='session-inspector'] .traj-meta,
 [data-testid='session-inspector'] .traj-head,
@@ -2596,11 +2601,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  border: 1px solid var(--dsw-border);
+  border: 0;
   border-radius: 14px;
   padding: 12px;
-  background: var(--dsw-surface);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  background: var(--dsw-sidebar);
+  box-shadow: none;
 }
 
 .usage-panel-head {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Token usage 面板去掉 1px 边框和阴影。背景改成和输入条一样的 `--dsw-sidebar`，靠底色和检查器画布区分，页面不会一圈描边显得脏。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

