### PR TITLE
中间列最窄改为原来的三分之二

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -76,6 +76,19 @@ test('narrow viewport hides the left pane outright, then shrinks inspector, then
   assert.equal(squeezeCenter.center, CENTER_MIN - 80)
 })
 
+test('center min is two thirds of the old 768 so side panes stay visible longer', () => {
+  assert.equal(CENTER_MIN, 512)
+  const keepBoth = allocateShellColumns({
+    viewportWidth: SIDEBAR_MAX + 600 + 320,
+    leftPane: true,
+    inspectorOpen: true,
+    inspectorWidth: 320,
+  })
+  assert.equal(keepBoth.left, SIDEBAR_MAX)
+  assert.equal(keepBoth.inspector, 320)
+  assert.equal(keepBoth.center, 600)
+})
+
 test('expanding chat clamps inspector so the column is at least ENTER', () => {
   const next = inspectorWidthForExpandedChat({
     viewportWidth: 1440,

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -1,7 +1,8 @@
 /** 聊天列窄于此时自动弹出覆盖对话框（px）。不自动收回。 */
 export const CHAT_OVERLAY_ENTER = 420
 export const SIDEBAR_MAX = 280
-export const CENTER_MIN = 768
+/** 中间列最窄约为对话内容最大宽 768 的 2/3，好让左右栏先完整显示。 */
+export const CENTER_MIN = 512
 export const INSPECTOR_MIN = 240
 const RAIL = 0
 const SIDEBAR = SIDEBAR_MAX

--- a/web/style.css
+++ b/web/style.css
@@ -46,7 +46,7 @@
   --dsw-chat-pad-y: 10px;
   --dsw-chat-reply-pad-x: 12px;
   --dsw-chat-max-width: 768px;
-  --dsw-center-min: 768px;
+  --dsw-center-min: 512px;
   --dsw-sidebar-max: 280px;
   --dsw-inspector-min: 240px;
   --dsw-chat-code-bg: var(--dsw-sidebar);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
中间聊天列以前保底 768px，窄了就先关掉左侧、再压检查器，两边经常显示不全。保底改成 512px（768 的 2/3），左右栏可以先占满自己的宽度，中间再收窄。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

