### PR TITLE
有芯片时不要把段落行高拉成两倍

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -73,10 +73,11 @@ describe('composer dock stacking above sticky user', () => {
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*align-items:\s*center/s)
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*vertical-align:\s*middle/s)
+    expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*line-height:\s*1/s)
     expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*line-height:\s*1/s)
     expect(css).toMatch(/\.pick-kind-icon\s*\{[^}]*display:\s*block/s)
     expect(css).toMatch(
-      /\.composer-pill\.is-expanded \.composer-tiptap p,\s*\n\.composer-pill\.has-chips \.composer-tiptap p,\s*\n\.composer-tiptap\.is-readonly p \{\s*line-height:\s*2/,
+      /\.composer-pill\.has-chips \.composer-tiptap p,\s*\n\.composer-tiptap\.is-readonly p \{\s*line-height:\s*1\.45/,
     )
   })
 

--- a/web/style.css
+++ b/web/style.css
@@ -4011,6 +4011,7 @@ body {
   display: inline-flex;
   align-items: center;
   vertical-align: middle;
+  line-height: 1;
   margin: 0px 0px 0px 2px;
   padding-right: 2px;
   max-width: min(240px, 70%);
@@ -4025,10 +4026,13 @@ body {
   padding: 2px 0;
 }
 
-.composer-pill.is-expanded .composer-tiptap p,
+.composer-pill.is-expanded .composer-tiptap p {
+  line-height: 2;
+}
+
 .composer-pill.has-chips .composer-tiptap p,
 .composer-tiptap.is-readonly p {
-  line-height: 2;
+  line-height: 1.45;
 }
 
 .composer-tiptap.is-readonly {
@@ -4478,7 +4482,7 @@ body {
   border: 0;
   border-radius: 6px;
   background: var(--dsw-pick-fill);
-  padding: 2px 4px;
+  padding: 3px 6px;
   color: #b8c0de;
   font-family: var(--font-sans);
   font-size: var(--dsw-chat-chip-font-size);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
撤回 Tiptap 段落 flex 时，把有芯片段落的 `line-height: 2` 加回去了，光标热区跟着整行被撑得很高。有选取时段落改回 1.45，芯片略加高一点，不再撑行。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

