### PR TITLE
新建会话名去掉「小」字

### DIFF
--- a/packages/host-sessions/src/host/session-mascot.test.ts
+++ b/packages/host-sessions/src/host/session-mascot.test.ts
@@ -23,7 +23,7 @@ test('create persists mascot on the session record', async () => {
   const item = listed.find((row) => row.id === record.id)
   assert.deepEqual(item?.mascot, record.mascot)
   assert.equal(item?.title, nameFromSessionMascot(record.mascot!))
-  assert.match(item?.title ?? '', /^小/)
+  assert.match(item?.title ?? '', /^[墨栗赤橙金翠青蓝紫玫灰]/)
   assert.notEqual(item?.title, record.id.slice(0, 8))
 })
 

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -61,7 +61,7 @@ test('sqlite session store round-trips and listSummaries skips full reload', asy
   await ctx.sessions.append('sql1', { type: 'turn/end', turn: 1, reason: 'complete' })
   const summaries = await ctx.sessions.listSummaries()
   assert.equal(summaries[0]?.id, 'sql1')
-  assert.match(summaries[0]?.title ?? '', /^小/)
+  assert.match(summaries[0]?.title ?? '', /^[墨栗赤橙金翠青蓝紫玫灰]/)
   assert.notEqual(summaries[0]?.title, 'sql1')
   assert.equal(summaries[0]?.eventCount, 4)
 

--- a/packages/type-session/src/session-mascot-name.test.ts
+++ b/packages/type-session/src/session-mascot-name.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict'
 import { nameFromSessionMascot, sessionDisplayTitle } from './index.ts'
 
 test('mascot names encode color, shape and eye', () => {
-  assert.equal(nameFromSessionMascot({ shape: 'blob', color: 'blue', eye: 0 }), '小蓝团爱')
-  assert.equal(nameFromSessionMascot({ shape: 'cloud', color: 'cyan', eye: 2 }), '小青云新')
-  assert.match(nameFromSessionMascot({ shape: 'leaf', color: 'red', eye: 1 }), /^小赤叶/)
+  assert.equal(nameFromSessionMascot({ shape: 'blob', color: 'blue', eye: 0 }), '蓝团爱')
+  assert.equal(nameFromSessionMascot({ shape: 'cloud', color: 'cyan', eye: 2 }), '青云新')
+  assert.match(nameFromSessionMascot({ shape: 'leaf', color: 'red', eye: 1 }), /^赤叶/)
 })
 
 test('untitled empty session uses the mascot name, not the id prefix', () => {
@@ -16,6 +16,6 @@ test('untitled empty session uses the mascot name, not the id prefix', () => {
       events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
       mascot: { shape: 'pebble', color: 'orange', eye: 1 },
     }),
-    '小橙石美',
+    '橙石美',
   )
 })

--- a/packages/type-session/src/session-mascot-name.ts
+++ b/packages/type-session/src/session-mascot-name.ts
@@ -72,5 +72,5 @@ export function nameFromSessionMascot(mascot: { shape: string; color: string; ey
       ? Math.abs(Math.trunc(mascot.eye)) % MASCOT_EYE_NAME.length
       : 0
   const eye = MASCOT_EYE_NAME[eyeIndex] ?? '爱'
-  return `小${color}${shape}${eye}`
+  return `${color}${shape}${eye}`
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
新建会话标题去掉「小」前缀，只保留颜色、外形、眼睛，例如蓝团爱。已有带「小」的会话名不会自动改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

