### PR TITLE
树形表格每行预留折叠槽，父节点左对齐

### DIFF
--- a/packages/cap-tasks/src/web/index.tsx
+++ b/packages/cap-tasks/src/web/index.tsx
@@ -2852,7 +2852,9 @@ function TasksTable({
                     >
                       {collapsed[task.id] ? <ChevronRightIcon aria-hidden className="size-[14px]" /> : <ChevronDownIcon aria-hidden className="size-[14px]" />}
                     </button>
-                  ) : null}
+                  ) : (
+                    <span className="tasks-tree-toggle is-empty" aria-hidden />
+                  )}
                   <input
                     className="tasks-cell-input"
                     defaultValue={task.title}
@@ -3919,7 +3921,8 @@ if (typeof document !== 'undefined') {
 .tasks-title-open:hover { opacity:1; color:var(--dsw-label); background:var(--dsw-hover); }
 .tasks-tree-toggle { width:20px; height:20px; flex:none; display:inline-flex; align-items:center; justify-content:center; border:0; background:transparent; color:var(--dsw-label-3); border-radius:4px; cursor:pointer; padding:0; }
 .tasks-tree-toggle:hover { background:var(--dsw-hover); }
-.tasks-tree-toggle.is-empty { cursor:default; }
+.tasks-tree-toggle.is-empty { cursor:default; pointer-events:none; }
+.tasks-tree-toggle.is-empty:hover { background:transparent; }
 .tasks-col-tags { width:130px; }
 .tasks-col-project { width:150px; min-width:150px; }
 .tasks-col-project .tasks-proj-tag { max-width:100%; overflow:hidden; text-overflow:ellipsis; display:inline-block; }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1041,22 +1041,26 @@ export function CollectionBrowser({
     if (!openDetail && !tree) return body
     return (
       <div className="tasks-title-cell" style={tree ? { paddingLeft: depth * 16 } : undefined}>
-        {tree && hasKids ? (
-          <button
-            type="button"
-            className="tasks-tree-toggle"
-            aria-label={collapsed[row.id] ? '展开子记录' : '收起子记录'}
-            onClick={(event) => {
-              event.stopPropagation()
-              setCollapsed((prev) => ({ ...prev, [row.id]: !prev[row.id] }))
-            }}
-          >
-            {collapsed[row.id] ? (
-              <ChevronRightIcon aria-hidden className="size-[14px]" />
-            ) : (
-              <ChevronDownIcon aria-hidden className="size-[14px]" />
-            )}
-          </button>
+        {tree ? (
+          hasKids ? (
+            <button
+              type="button"
+              className="tasks-tree-toggle"
+              aria-label={collapsed[row.id] ? '展开子记录' : '收起子记录'}
+              onClick={(event) => {
+                event.stopPropagation()
+                setCollapsed((prev) => ({ ...prev, [row.id]: !prev[row.id] }))
+              }}
+            >
+              {collapsed[row.id] ? (
+                <ChevronRightIcon aria-hidden className="size-[14px]" />
+              ) : (
+                <ChevronDownIcon aria-hidden className="size-[14px]" />
+              )}
+            </button>
+          ) : (
+            <span className="tasks-tree-toggle is-empty" aria-hidden />
+          )
         ) : null}
         <span className="fsdb-title-text">{body}</span>
         {openDetail ? (

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -105,7 +105,8 @@ const CSS = `
 .fsdb-page .tasks-title-cell{display:flex;align-items:center;gap:2px;min-width:0}
 .fsdb-page .tasks-tree-toggle{width:20px;height:20px;flex:none;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:4px;cursor:pointer;padding:0}
 .fsdb-page .tasks-tree-toggle:hover{background:var(--dsw-hover)}
-.fsdb-page .tasks-tree-toggle.is-empty{cursor:default}
+.fsdb-page .tasks-tree-toggle.is-empty{cursor:default;pointer-events:none}
+.fsdb-page .tasks-tree-toggle.is-empty:hover{background:transparent}
 .fsdb-page .fsdb-title-text{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
 .fsdb-page .tasks-table.is-wrap .fsdb-title-text{white-space:normal}
 .fsdb-page .tasks-title-open{flex:none;width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:4px;cursor:pointer;padding:0;opacity:0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -39,6 +39,7 @@ test('sidebar records paint detail immediately without reloading the view', () =
 test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /className="tasks-title-open"/)
+  assert.match(browser, /tasks-tree-toggle is-empty/)
   assert.doesNotMatch(browser, /recordPick\(row\)\} onClick=\{\(\) => setDetailId\(row\.id\)\}/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格开树形后，只有父节点有折叠箭头，叶子标题更靠左，看起来像所有标题被挤歪。每行都预留同一宽的折叠槽，父节点左侧对齐；子级再按层级往右缩，标题和右侧打开按钮齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

