### PR TITLE
feat(chat): 左侧边栏可展开收起，够宽才显示标签

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -8,6 +8,8 @@ import {
   CENTER_MIN,
   INSPECTOR_MIN,
   SIDEBAR_MAX,
+  SIDEBAR_MIN,
+  SIDEBAR_LABEL_AT,
   getChatOverlay,
   setChatOverlay,
   getOverlayThread,
@@ -27,11 +29,24 @@ import {
   requestInspectorAction,
 } from './chat-overlay.ts'
 
-test('chat column subtracts rail, sidebar and inspector', () => {
+test('collapsed chat sidebar still occupies the icon rail', () => {
   assert.equal(
-    chatColumnWidth({ viewportWidth: 1600, inspectorOpen: true, inspectorWidth: 320, sidebarCollapsed: false }),
-    1600 - SIDEBAR_MAX - 320,
+    chatColumnWidth({ viewportWidth: 1600, inspectorOpen: true, inspectorWidth: 320, sidebarCollapsed: true }),
+    1600 - SIDEBAR_MIN - 320,
   )
+})
+
+test('sidebar labels appear only after LABEL_AT', () => {
+  assert.equal(SIDEBAR_LABEL_AT, 160)
+  assert.ok(SIDEBAR_MIN < SIDEBAR_LABEL_AT)
+  const icon = allocateShellColumns({
+    viewportWidth: 1600,
+    leftPane: true,
+    leftWidth: SIDEBAR_MIN,
+    inspectorOpen: false,
+    inspectorWidth: 320,
+  })
+  assert.equal(icon.left, SIDEBAR_MIN)
 })
 
 test('narrow viewport hides the left pane outright, then shrinks inspector, then center', () => {

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -1,6 +1,10 @@
 /** 聊天列窄于此时自动弹出覆盖对话框（px）。不自动收回。 */
 export const CHAT_OVERLAY_ENTER = 420
 export const SIDEBAR_MAX = 280
+/** 收成图标轨的宽度；再窄就整栏关掉。 */
+export const SIDEBAR_MIN = 52
+/** 侧栏至少这么宽才显示文字标签（会话名、「添加聊天」等）。 */
+export const SIDEBAR_LABEL_AT = 160
 /** 中间列最窄约为对话内容最大宽 768 的 2/3，好让左右栏先完整显示。 */
 export const CENTER_MIN = 512
 export const INSPECTOR_MIN = 240
@@ -12,12 +16,13 @@ export function allocateShellColumns(opts: {
   viewportWidth: number
   railWidth?: number
   leftPane: boolean
+  leftWidth?: number
   inspectorOpen: boolean
   inspectorWidth: number
 }) {
   const rail = opts.railWidth ?? RAIL
   const available = Math.max(0, opts.viewportWidth - rail)
-  let left = opts.leftPane ? SIDEBAR_MAX : 0
+  let left = opts.leftPane ? Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, opts.leftWidth ?? SIDEBAR_MAX)) : 0
   let inspector = opts.inspectorOpen ? Math.max(INSPECTOR_MIN, opts.inspectorWidth) : 0
   let center = available - left - inspector
   if (center < CENTER_MIN && left > 0) {
@@ -41,7 +46,8 @@ export function chatColumnWidth(opts: {
 }) {
   return allocateShellColumns({
     viewportWidth: opts.viewportWidth,
-    leftPane: !opts.sidebarCollapsed,
+    leftPane: true,
+    leftWidth: opts.sidebarCollapsed ? SIDEBAR_MIN : SIDEBAR_MAX,
     inspectorOpen: opts.inspectorOpen,
     inspectorWidth: opts.inspectorWidth,
   }).center
@@ -53,7 +59,7 @@ export function inspectorWidthForExpandedChat(opts: {
   inspectorWidth: number
   sidebarCollapsed: boolean
 }) {
-  const side = opts.sidebarCollapsed ? 0 : SIDEBAR
+  const side = opts.sidebarCollapsed ? SIDEBAR_MIN : SIDEBAR
   const maxInspector = opts.viewportWidth - RAIL - side - CHAT_OVERLAY_ENTER
   return Math.min(opts.inspectorWidth, Math.max(INSPECTOR_MIN, Math.round(maxInspector)))
 }
@@ -254,7 +260,9 @@ export function toggleChatOverlay() {
     } catch {
       /* ignore */
     }
-    const sidebarCollapsed = Boolean(document.querySelector('.app-shell-agent.is-sidebar-collapsed'))
+    const shell = document.querySelector('[data-testid="app-shell"]')
+    const col = shell ? Number.parseFloat(getComputedStyle(shell).getPropertyValue('--sidebar-col')) : NaN
+    const sidebarCollapsed = !Number.isFinite(col) || col < SIDEBAR_MIN
     requestInspectorWidth(
       inspectorWidthForExpandedChat({
         viewportWidth: window.innerWidth,

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { createPortal } from 'react-dom'
 import { Link, useNavigate } from 'react-router-dom'
 import { isMascotDancing, subscribeMascotDance } from '@biu/web-mascot'
@@ -22,6 +22,7 @@ import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 import { chromeIcon, chromeIconClass } from './chrome-icon.ts'
 import {
   ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   PlusIcon,
@@ -120,7 +121,7 @@ const SessionRow = memo(function SessionRow({
           dancing={dancing}
           title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
         />
-        <span className="min-w-0 flex-1 truncate font-medium">
+        <span className="sidebar-label min-w-0 flex-1 truncate font-medium">
           {(item.type ?? 'chat') === 'live' ? (
             <span className="mr-1 text-[9px] font-semibold tracking-wide uppercase">
               live
@@ -163,10 +164,13 @@ const SessionRow = memo(function SessionRow({
 
 export type ChatSidebarProps = {
   visible: boolean
+  narrow?: boolean
   routeSessionId: string | null
   useSessionView: ReturnType<typeof bindSessionView>
   sessionView: SessionViewService
   onCollapse?: () => void
+  onExpand?: () => void
+  onWidthChange?: (width: number) => void
 }
 
 /**
@@ -174,10 +178,13 @@ export type ChatSidebarProps = {
  */
 export const ChatSidebar = memo(function ChatSidebar({
   visible,
+  narrow = false,
   routeSessionId,
   useSessionView,
   sessionView,
   onCollapse,
+  onExpand,
+  onWidthChange,
 }: ChatSidebarProps) {
   const navigate = useNavigate()
   const sessions = useSessionView((state) => state.sessions)
@@ -270,12 +277,48 @@ export const ChatSidebar = memo(function ChatSidebar({
     [sessionView],
   )
 
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  useEffect(() => {
+    const onMove = (event: PointerEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      onWidthChange?.(drag.startWidth + (event.clientX - drag.startX))
+    }
+    const onUp = () => {
+      dragRef.current = null
+      document.body.style.removeProperty('cursor')
+      document.body.style.removeProperty('user-select')
+    }
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onUp)
+    return () => {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onUp)
+    }
+  }, [onWidthChange])
+
   return (
     <aside
-      className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar) ${visible ? 'flex' : 'hidden'
+      className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)${narrow ? ' is-narrow' : ''} ${visible ? 'flex' : 'hidden'
         }`}
       aria-hidden={!visible}
+      data-testid="chat-sidebar"
     >
+      {onWidthChange ? (
+        <div
+          className="sidebar-resize"
+          data-biu-ignore
+          data-testid="sidebar-resize"
+          title="拖动调整宽度"
+          onPointerDown={(event) => {
+            event.preventDefault()
+            const visual = event.currentTarget.parentElement?.getBoundingClientRect().width ?? 0
+            dragRef.current = { startX: event.clientX, startWidth: visual }
+            document.body.style.cursor = 'col-resize'
+            document.body.style.userSelect = 'none'
+          }}
+        />
+      ) : null}
       <div className="app-side-bar-head app-side-bar-head-brand">
         <span
           className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
@@ -283,16 +326,29 @@ export const ChatSidebar = memo(function ChatSidebar({
         >
           Biu Agent OS
         </span>
-        <button
-          type="button"
-          className="chat-view-header-expand"
-          title="收起左侧边栏"
-          aria-label="收起左侧边栏"
-          data-testid="sidebar-collapse"
-          onClick={onCollapse}
-        >
-          <ChevronDoubleLeftIcon {...chromeIcon} />
-        </button>
+        {narrow ? (
+          <button
+            type="button"
+            className="chat-view-header-expand"
+            title="展开左侧边栏"
+            aria-label="展开左侧边栏"
+            data-testid="sidebar-expand"
+            onClick={onExpand}
+          >
+            <ChevronDoubleRightIcon {...chromeIcon} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="chat-view-header-expand"
+            title="收起左侧边栏"
+            aria-label="收起左侧边栏"
+            data-testid="sidebar-collapse"
+            onClick={onCollapse}
+          >
+            <ChevronDoubleLeftIcon {...chromeIcon} />
+          </button>
+        )}
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="app-side-actions" role="navigation" aria-label="Chat actions">
@@ -339,7 +395,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                         aria-expanded={!sectionCollapsed}
                         onClick={() => toggleSection(section.kind)}
                       >
-                        <span className="min-w-0 flex-1 truncate tracking-normal">{section.label}</span>
+                        <span className="sidebar-label min-w-0 flex-1 truncate tracking-normal">{section.label}</span>
                       </button>
                       {section.kind !== 'pinned' ? (
                         <div
@@ -434,7 +490,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                                       )}
                                     </span>
                                   </span>
-                                  <span className="min-w-0 flex-1 truncate">{group.label}</span>
+                                  <span className="sidebar-label min-w-0 flex-1 truncate">{group.label}</span>
                                   {canAddHere ? (
                                     <button
                                       type="button"

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -19,6 +19,9 @@ import {
   toggleOverlayPinned,
   requestInspectorClose,
   allocateShellColumns,
+  SIDEBAR_LABEL_AT,
+  SIDEBAR_MAX,
+  SIDEBAR_MIN,
 } from './chat-overlay.ts'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import type { Context } from 'cordis'
@@ -439,7 +442,54 @@ function Shell(props: SlotProps) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string>('plugins')
   const [configOpen, setConfigOpen] = useState(false)
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem('cordis.sidebar.collapsed') === '1'
+    } catch {
+      return false
+    }
+  })
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    try {
+      const n = Number(localStorage.getItem('cordis.sidebar.width'))
+      if (Number.isFinite(n) && n >= SIDEBAR_MIN && n <= SIDEBAR_MAX) return n
+    } catch {
+      /* ignore */
+    }
+    return SIDEBAR_MAX
+  })
+  const lastWideSidebar = useRef(sidebarWidth >= SIDEBAR_LABEL_AT ? sidebarWidth : SIDEBAR_MAX)
+  const persistSidebar = useCallback((width: number, collapsed: boolean) => {
+    const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, Math.round(width)))
+    setSidebarWidth(next)
+    setSidebarCollapsed(collapsed)
+    if (next >= SIDEBAR_LABEL_AT) lastWideSidebar.current = next
+    try {
+      localStorage.setItem('cordis.sidebar.width', String(next))
+      localStorage.setItem('cordis.sidebar.collapsed', collapsed ? '1' : '0')
+    } catch {
+      /* ignore */
+    }
+  }, [])
+  const collapseSidebar = useCallback(() => {
+    setSidebarCollapsed(true)
+    try {
+      localStorage.setItem('cordis.sidebar.collapsed', '1')
+    } catch {
+      /* ignore */
+    }
+  }, [])
+  const expandSidebar = useCallback(
+    () => persistSidebar(Math.max(SIDEBAR_LABEL_AT, lastWideSidebar.current, sidebarWidth), false),
+    [persistSidebar, sidebarWidth],
+  )
+  const onSidebarWidthChange = useCallback(
+    (width: number) => {
+      const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, Math.round(width)))
+      persistSidebar(next, next <= SIDEBAR_MIN)
+    },
+    [persistSidebar],
+  )
   const [railOpen, setRailOpen] = useState(false)
   const [railPinned, setRailPinned] = useState(() => {
     try {
@@ -553,7 +603,9 @@ function Shell(props: SlotProps) {
   // 侧栏高亮跟 URL，不跟 store：点一下立刻亮，不等 load 完成
   const routeSessionId = appRoute.kind === 'session' ? appRoute.sessionId : null
   const agentHref = sessionId ? `/s/${sessionId}` : '/'
-  const showChatSidebar = activeModule === 'agent' && !sidebarCollapsed
+  const showChatSidebar = activeModule === 'agent'
+  const sidebarCol = sidebarCollapsed ? SIDEBAR_MIN : sidebarWidth
+  const sidebarNarrow = sidebarCol < SIDEBAR_LABEL_AT
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window === 'undefined' ? 1440 : window.innerWidth,
   )
@@ -571,14 +623,17 @@ function Shell(props: SlotProps) {
   const shellColumns = allocateShellColumns({
     viewportWidth,
     leftPane,
+    leftWidth: showChatSidebar ? sidebarCol : undefined,
     inspectorOpen: inspectorVisible,
     inspectorWidth,
   })
   const leftHidden = shellColumns.left <= 0
   const onAgentRailClick = useCallback((alreadyActive: boolean) => {
-    if (alreadyActive) setSidebarCollapsed((prev) => !prev)
-    else setSidebarCollapsed(false)
-  }, [])
+    if (alreadyActive) {
+      if (sidebarCollapsed || sidebarWidth < SIDEBAR_LABEL_AT) expandSidebar()
+      else collapseSidebar()
+    } else expandSidebar()
+  }, [collapseSidebar, expandSidebar, sidebarCollapsed, sidebarWidth])
 
   // 工具检查 /debuginspect：打开右侧轨迹 Tab（主区不再切 Debug 页）
   useEffect(() => {
@@ -631,6 +686,18 @@ function Shell(props: SlotProps) {
   const chatHeader = (
     <header className="chat-view-header" data-biu-ignore>
       <div className="chat-view-header-left">
+        {sidebarNarrow ? (
+          <button
+            type="button"
+            className="chat-view-header-expand"
+            title="展开左侧边栏"
+            aria-label="展开左侧边栏"
+            data-testid="header-sidebar-expand"
+            onClick={expandSidebar}
+          >
+            <ChevronDoubleRightIcon {...chromeIcon} />
+          </button>
+        ) : null}
         {project ? (
           <div className="chat-view-project" title={project.path ?? project.name}>
             <FolderGlyph className="chat-view-project-icon" />
@@ -699,7 +766,7 @@ function Shell(props: SlotProps) {
   return (
     <div
       className={`app-shell${activeModule === 'agent'
-          ? ` app-shell-agent${sidebarCollapsed || leftHidden ? ' is-sidebar-collapsed' : ''}${inspectorVisible ? ' is-inspector-open' : ''}${overlayAutohide ? ' is-chat-overlay-autohide' : ''
+          ? ` app-shell-agent${leftHidden ? ' is-sidebar-collapsed' : ''}${sidebarNarrow && !leftHidden ? ' is-sidebar-narrow' : ''}${inspectorVisible ? ' is-inspector-open' : ''}${overlayAutohide ? ' is-chat-overlay-autohide' : ''
           }`
           : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}`
         }${railOpen || railPinned ? ' is-rail-open' : ''}${leftHidden ? ' is-left-hidden' : ''}`}
@@ -741,10 +808,13 @@ function Shell(props: SlotProps) {
 
       <ChatSidebar
         visible={showChatSidebar && !leftHidden}
+        narrow={sidebarNarrow}
         routeSessionId={routeSessionId}
         useSessionView={useSessionView}
         sessionView={sessionView}
-        onCollapse={() => setSidebarCollapsed(true)}
+        onCollapse={collapseSidebar}
+        onExpand={expandSidebar}
+        onWidthChange={onSidebarWidthChange}
       />
 
       <DanceStage sessions={danceSessions} on={dancing} shape={danceShape} />

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -16,12 +16,24 @@ describe('sidebar text colors', () => {
   it('left-aligns the sidebar brand with the list below', () => {
     expect(css).toMatch(/\.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*flex-start/s)
     expect(css).toMatch(/\.app-side-bar-head-brand\s*\{[^}]*padding-left:\s*16px/s)
-    expect(css).not.toMatch(/\.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*center/s)
+    expect(css).toMatch(/\.app-side-bar\.is-narrow \.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*center/s)
   })
 
   it('session rows do not start a native drag ghost', () => {
     const sidebar = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'utf8')
     expect(sidebar).toMatch(/draggable=\{false\}/)
     expect(sidebar).toMatch(/onDragStart=\{\(event\) => event.preventDefault\(\)\}/)
+  })
+
+  it('hides labels until the chat sidebar is wide enough', () => {
+    expect(css).toMatch(/\.sidebar-label\s*\{[^}]*font-size:\s*14px/s)
+    expect(css).toMatch(/\.app-side-bar\.is-narrow \.sidebar-label/)
+    expect(css).toMatch(/\.app-side-bar\.is-narrow \.app-side-actions-label/)
+    const sidebar = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'utf8')
+    expect(sidebar).toMatch(/data-testid="sidebar-expand"/)
+    expect(sidebar).toMatch(/data-testid="sidebar-resize"/)
+    const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+    expect(shell).toMatch(/SIDEBAR_LABEL_AT/)
+    expect(shell).toMatch(/data-testid="header-sidebar-expand"/)
   })
 })

--- a/web/style.css
+++ b/web/style.css
@@ -1125,9 +1125,69 @@ body {
   transform: translateZ(0);
   backface-visibility: hidden;
   color: var(--dsw-sidebar-fg);
+  position: relative;
   min-width: 0;
   width: 100%;
   max-width: var(--dsw-sidebar-max);
+}
+
+.sidebar-resize {
+  position: absolute;
+  inset-block: 0;
+  right: -1px;
+  z-index: 10;
+  width: 0;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.sidebar-resize::after {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  right: -3px;
+  width: 7px;
+}
+
+.sidebar-label {
+  font-size: 14px;
+}
+
+.app-side-bar.is-narrow .sidebar-label,
+.app-side-bar.is-narrow .app-side-actions-label,
+.app-side-bar.is-narrow .sidebar-section-head,
+.app-side-bar.is-narrow .sidebar-group-head,
+.app-side-bar.is-narrow .sidebar-chat-count,
+.app-side-bar.is-narrow .chat-session-row-delete,
+.app-side-bar.is-narrow .chat-session-row-star,
+.app-side-bar.is-narrow .app-side-bar-head-brand > span:first-child {
+  display: none;
+}
+
+.app-side-bar.is-narrow .app-side-bar-head-brand {
+  justify-content: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.app-side-bar.is-narrow .app-side-bar-head-brand .chat-view-header-expand {
+  position: static;
+}
+
+.app-side-bar.is-narrow .app-side-actions-item {
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.app-side-bar.is-narrow .chat-session-row {
+  justify-content: center;
+  padding-inline: 0;
+}
+
+.app-side-bar.is-narrow .chat-session-row > a,
+.app-side-bar.is-narrow .chat-session-row > .chat-session-row-main {
+  justify-content: center;
+  padding-left: 0;
 }
 
 .app-side-actions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天左侧边栏可以展开、收起，也可以拖右边沿改宽度。

- 收起：留下约 52px 图标轨（头像、加号），不显示文字
- 宽度 **≥ 160px** 才显示标签（会话名、「添加聊天」等），字号 **14px**
- 侧栏标题按钮：展开用双箭头右，收起用双箭头左；不够宽时中间顶栏也有展开
- 宽度和收起状态会记在本地

以前点收起是整栏消失且没有展开入口，这次改掉了。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

