### PR TITLE
feat(fs): 树形表格显示子项数量，悬浮不挤位

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -586,7 +586,7 @@ export function CollectionBrowser({
   const parentKey = useMemo(() => parentFieldKey(schema, items), [items, schema])
   const flattenRows = useCallback(
     (rows: DbRecord[]) => {
-      if (!parentKey || !showTree) return rows.map((row) => ({ row, depth: 0, hasKids: false }))
+      if (!parentKey || !showTree) return rows.map((row) => ({ row, depth: 0, hasKids: false, kidCount: 0 }))
       return flattenTree(rows, parentKey, collapsed)
     },
     [collapsed, parentKey, showTree],
@@ -1061,11 +1061,13 @@ export function CollectionBrowser({
     openDetail = true,
     depth = 0,
     hasKids = false,
+    kidCount = 0,
   }: {
     row: DbRecord
     openDetail?: boolean
     depth?: number
     hasKids?: boolean
+    kidCount?: number
   }) {
     const key = schema?.labelField
     const field = key && schema ? schema.fields[key] : undefined
@@ -1103,20 +1105,27 @@ export function CollectionBrowser({
         ) : null}
         <span className="fsdb-title-text">{body}</span>
         {openDetail ? (
-          <button
-            type="button"
-            className="tasks-title-open"
-            data-testid="record-title-open"
-            data-biu-action="open"
-            aria-label="查看详情"
-            title="查看详情"
-            onClick={(event) => {
-              event.stopPropagation()
-              setDetailId(row.id, row)
-            }}
-          >
-            <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
-          </button>
+          <span className="tasks-title-aside">
+            {tree && kidCount > 0 ? (
+              <span className="sidebar-chat-count tasks-tree-count" title={`${kidCount} 项`}>
+                <span className="sidebar-chat-count-num">{kidCount}</span>
+              </span>
+            ) : null}
+            <button
+              type="button"
+              className="tasks-title-open"
+              data-testid="record-title-open"
+              data-biu-action="open"
+              aria-label="查看详情"
+              title="查看详情"
+              onClick={(event) => {
+                event.stopPropagation()
+                setDetailId(row.id, row)
+              }}
+            >
+              <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
+            </button>
+          </span>
         ) : null}
       </div>
     )
@@ -1247,12 +1256,12 @@ export function CollectionBrowser({
     }
     return (
       <>
-        {listed.map(({ row, depth, hasKids }) => (
+        {listed.map(({ row, depth, hasKids, kidCount }) => (
           <tr key={`${keyPrefix}${row.id}`} className={row.id === detailId ? 'is-active' : undefined} {...recordPick(row)}>
             {columns.map((col) => (
               <td key={col.key}>
                 {col.key === schema?.labelField ? (
-                  <RecordTitle row={row} depth={depth} hasKids={hasKids} />
+                  <RecordTitle row={row} depth={depth} hasKids={hasKids} kidCount={kidCount} />
                 ) : (
                   <span className="fsdb-cell">{renderCell(row, col.key, col.field)}</span>
                 )}

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -152,12 +152,12 @@ test('flattenTree keeps sibling order, indents children, and hides collapsed sub
     { id: 'g', title: 'grand', parentId: 'c1' },
   ]
   assert.deepEqual(
-    flattenTree(rows, 'parentId').map((item) => [item.row.id, item.depth, item.hasKids]),
+    flattenTree(rows, 'parentId').map((item) => [item.row.id, item.depth, item.hasKids, item.kidCount]),
     [
-      ['p', 0, true],
-      ['c2', 1, false],
-      ['c1', 1, true],
-      ['g', 2, false],
+      ['p', 0, true, 3],
+      ['c2', 1, false, 0],
+      ['c1', 1, true, 1],
+      ['g', 2, false, 0],
     ],
   )
   assert.deepEqual(

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -42,7 +42,7 @@ export function parentFieldKey(schema: CollectionSchema | undefined, rows: DbRec
   return null
 }
 
-export type TreeRow = { row: DbRecord; depth: number; hasKids: boolean }
+export type TreeRow = { row: DbRecord; depth: number; hasKids: boolean; kidCount: number }
 
 export function flattenTree(rows: DbRecord[], parentKey: string, collapsed: Record<string, boolean> = {}): TreeRow[] {
   const ids = new Set(rows.map((row) => row.id))
@@ -55,6 +55,15 @@ export function flattenTree(rows: DbRecord[], parentKey: string, collapsed: Reco
     const bucket = children.get(parent)
     if (bucket) bucket.push(row)
     else children.set(parent, [row])
+  }
+  const memo = new Map<string, number>()
+  const kidCountOf = (id: string): number => {
+    const hit = memo.get(id)
+    if (hit != null) return hit
+    const kids = children.get(id) ?? []
+    const total = kids.reduce((sum, child) => sum + 1 + kidCountOf(child.id), 0)
+    memo.set(id, total)
+    return total
   }
   const out: TreeRow[] = []
   const seen = new Set<string>()
@@ -69,7 +78,7 @@ export function flattenTree(rows: DbRecord[], parentKey: string, collapsed: Reco
     for (const row of children.get(parent) ?? []) {
       if (seen.has(row.id)) continue
       seen.add(row.id)
-      out.push({ row, depth, hasKids: hasKids.has(row.id) })
+      out.push({ row, depth, hasKids: hasKids.has(row.id), kidCount: kidCountOf(row.id) })
       if (collapsed[row.id]) skip(row.id)
       else visit(row.id, depth + 1)
     }
@@ -78,7 +87,7 @@ export function flattenTree(rows: DbRecord[], parentKey: string, collapsed: Reco
   for (const row of rows) {
     if (seen.has(row.id)) continue
     seen.add(row.id)
-    out.push({ row, depth: 0, hasKids: hasKids.has(row.id) })
+    out.push({ row, depth: 0, hasKids: hasKids.has(row.id), kidCount: kidCountOf(row.id) })
     if (!collapsed[row.id]) visit(row.id, 1)
   }
   return out

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -109,9 +109,13 @@ const CSS = `
 .fsdb-page .tasks-tree-toggle.is-empty:hover{background:transparent}
 .fsdb-page .fsdb-title-text{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
 .fsdb-page .tasks-table.is-wrap .fsdb-title-text{white-space:normal}
-.fsdb-page .tasks-title-open{flex:none;width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:4px;cursor:pointer;padding:0;opacity:0}
+.fsdb-page .tasks-title-aside{position:relative;flex:none;display:grid;place-items:center;width:24px;height:24px}
+.fsdb-page .tasks-title-aside .tasks-tree-count,.fsdb-page .tasks-title-aside .tasks-title-open{grid-area:1/1}
+.fsdb-page .tasks-title-open{flex:none;width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:6px;cursor:pointer;padding:0;opacity:0;z-index:1}
 .fsdb-page .tasks-title-cell:hover .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible{opacity:1}
+.fsdb-page .tasks-title-cell:hover .tasks-tree-count,.fsdb-page .tasks-title-aside:has(.tasks-title-open:focus-visible) .tasks-tree-count{opacity:0}
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
+.fsdb-page .tasks-tree-count{pointer-events:none}
 .fsdb-page .tasks-table.is-truncate:not(.is-wrap) .fsdb-cell{max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-propchip-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-propchip-v:has(.tasks-cellselect){overflow:visible}
 .fsdb-page .tasks-table.is-wrap .fsdb-cell{white-space:normal;overflow-wrap:anywhere;word-break:break-word}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -39,6 +39,9 @@ test('sidebar records paint detail immediately without reloading the view', () =
 test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /className="tasks-title-open"/)
+  assert.match(browser, /tasks-title-aside/)
+  assert.match(browser, /tasks-tree-count/)
+  assert.match(browser, /kidCount/)
   assert.match(browser, /tasks-tree-toggle is-empty/)
   assert.doesNotMatch(browser, /recordPick\(row\)\} onClick=\{\(\) => setDetailId\(row\.id\)\}/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
树形表格里，有子记录的行会在标题右侧显示底下有多少项（含子级的子级）。

数字占的是原来「放大看详情」那一格，样式和左侧边栏计数一样。悬浮时放大按钮叠在同一格上，不会把数字挤到左边。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

