### PR TITLE
Page 插件改为 .page 下的 Markdown 存储

### DIFF
--- a/cordis.plugins.json
+++ b/cordis.plugins.json
@@ -118,7 +118,7 @@
       "id": "page",
       "name": "Page",
       "layer": "capability",
-      "blurb": "@biu/cap-page。每种字段类型各一列，假数据压测 Database 默认 UI。",
+      "blurb": "@biu/cap-page。页面存成工作区 .page 下的 Markdown，YAML 写属性，图片和附件在 .page/assets。",
       "package": "@biu/cap-page/host",
       "togglable": true,
       "enabled": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -5314,6 +5314,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
@@ -5429,7 +5444,8 @@
       "name": "@biu/cap-page",
       "version": "0.1.0",
       "dependencies": {
-        "@biu/type-file-system": "0.1.0"
+        "@biu/type-file-system": "0.1.0",
+        "yaml": "^2.9.0"
       },
       "peerDependencies": {
         "cordis": "4.0.0-rc.8"

--- a/packages/cap-page/package.json
+++ b/packages/cap-page/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Page：把每种字段类型登记进 File System，用假数据压测 Database 默认 UI",
+  "description": "Page：工作区 .page 下的 Markdown 页面（YAML 属性，assets 里放图片和附件）",
   "exports": {
     "./host": "./src/host/index.ts"
   },
@@ -11,6 +11,7 @@
     "cordis": "4.0.0-rc.8"
   },
   "dependencies": {
-    "@biu/type-file-system": "0.1.0"
+    "@biu/type-file-system": "0.1.0",
+    "yaml": "^2.9.0"
   }
 }

--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -1,8 +1,15 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { Context, Service } from 'cordis'
 import { asImageSrc, type CollectionSpec, type FieldType } from '@biu/type-file-system'
+import * as tools from '@biu/host-tools'
+import * as fsPlugin from '@biu/host-fs'
 import * as page from './index.ts'
+import { dumpMarkdown, splitMarkdown } from './markdown.ts'
+import { PAGE_ASSETS, PAGE_ROOT, PagesStore } from './store.ts'
 
 const FIELD_TYPES: FieldType[] = [
   'string',
@@ -19,7 +26,17 @@ const FIELD_TYPES: FieldType[] = [
   'string[]',
 ]
 
-test('page plugin registers every field type on /pages without a web module', async () => {
+test('markdown frontmatter roundtrips YAML properties and body', () => {
+  const raw = dumpMarkdown({ title: '首页', tags: ['red', 'prod'], enabled: true }, '正文第一段\n')
+  assert.match(raw, /^---\n/)
+  const { matter, body } = splitMarkdown(raw)
+  assert.equal(matter.title, '首页')
+  assert.deepEqual(matter.tags, ['red', 'prod'])
+  assert.equal(matter.enabled, true)
+  assert.equal(body, '正文第一段\n')
+})
+
+test('page plugin stores markdown under .page and assets for images', async () => {
   const ctx = new Context()
   const registered: CollectionSpec[] = []
   class FakeDb extends Service {
@@ -31,7 +48,11 @@ test('page plugin registers every field type on /pages without a web module', as
     }
   }
   new FakeDb(ctx)
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-md-'))
+  await ctx.plugin(fsPlugin, { root })
   await ctx.plugin(page)
+
   assert.equal(page.name, 'page')
   assert.equal(registered[0]?.path, '/pages')
   assert.equal(registered[0]?.view?.route, '/pages')
@@ -39,17 +60,55 @@ test('page plugin registers every field type on /pages without a web module', as
   assert.equal(registered[0]?.view?.icon, 'document')
   const types = new Set(Object.values(registered[0]!.schema.fields).map((field) => field.type))
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
-  const listed = await registered[0]!.list()
-  assert.equal(listed.length, page.ROW_COUNT)
-  assert.equal(listed[0]?.cover, '/page-covers/red.png')
-  assert.equal(asImageSrc(listed[0]?.cover), '/page-covers/red.png')
-  const written = await registered[0]!.update!('p000', { enabled: false })
-  assert.equal(written.enabled, false)
-  assert.equal(written.score, listed[0]?.score)
   assert.deepEqual(registered[0]?.records, { update: true, create: true, delete: true })
-  const created = await registered[0]!.create!({ title: '新页面' })
+
+  const spec = registered[0]!
+  assert.equal((await spec.list()).length, 0)
+
+  await mkdir(join(root, PAGE_ASSETS), { recursive: true })
+  await writeFile(join(root, PAGE_ASSETS, 'hero.png'), 'fake-png', 'utf8')
+
+  const created = await spec.create!({
+    title: '新页面',
+    notes: '# 标题\n内容',
+    cover: 'assets/hero.png',
+    tags: ['blue'],
+  })
   assert.equal(created.title, '新页面')
-  await registered[0]!.remove!(created.id)
-  const after = await registered[0]!.list()
-  assert.equal(after.length, page.ROW_COUNT)
+  assert.equal(created.notes, '# 标题\n内容')
+  assert.equal(created.cover, '/api/page/file/hero.png')
+  assert.equal(asImageSrc(created.cover), '/api/page/file/hero.png')
+
+  const disk = await readFile(join(root, PAGE_ROOT, `${created.id}.md`), 'utf8')
+  assert.match(disk, /^---\n/)
+  assert.match(disk, /title: 新页面/)
+  assert.match(disk, /cover: assets\/hero.png/)
+  assert.match(disk, /# 标题\n内容/)
+
+  const written = await spec.update!(created.id, { enabled: false })
+  assert.equal(written.enabled, false)
+  const again = await readFile(join(root, PAGE_ROOT, `${created.id}.md`), 'utf8')
+  assert.match(again, /enabled: false/)
+
+  await spec.remove!(created.id)
+  assert.equal((await spec.list()).length, 0)
+})
+
+test('PagesStore reads existing markdown files from .page', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-store-'))
+  await ctx.plugin(fsPlugin, { root })
+  await mkdir(join(root, PAGE_ROOT), { recursive: true })
+  await writeFile(
+    join(root, PAGE_ROOT, 'home.md'),
+    dumpMarkdown({ title: 'Home', status: 'live', parentId: null }, 'hello\n'),
+    'utf8',
+  )
+  const store = new PagesStore(ctx.fs)
+  const listed = await store.list()
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0]?.id, 'home')
+  assert.equal(listed[0]?.title, 'Home')
+  assert.equal(listed[0]?.notes, 'hello\n')
 })

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -1,71 +1,12 @@
 import type { Context } from 'cordis'
-import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import type { CollectionSpec } from '@biu/type-file-system'
+import { PagesStore, STATUS, type WorkspaceFs } from './store.ts'
 
-export const ROW_COUNT = 240
+export { PAGE_ROOT, PAGE_ASSETS, PagesStore } from './store.ts'
 
-const STATUS = ['draft', 'live', 'archived'] as const
 const COLORS = ['red', 'orange', 'yellow', 'green', 'blue'] as const
 
-function seedCover(color: (typeof COLORS)[number]) {
-  return `/page-covers/${color}.png`
-}
-
-type PageRow = DbRecord & {
-  title: string
-  blurb: string
-  count: number
-  enabled: boolean
-  status: (typeof STATUS)[number]
-  tags: string[]
-  aliases: string[]
-  publishedAt: number
-  size: number
-  homepage: string
-  cover: string
-  pack: { name: string; href: string; bytes: number }
-  notes: { kind: string; body: string }
-  score: number
-  parentId: string | null
-}
-
-function seed(index: number, now: number): PageRow {
-  const id = `p${String(index).padStart(3, '0')}`
-  const status = STATUS[index % STATUS.length]!
-  const color = COLORS[index % COLORS.length]!
-  const parentId = index > 0 && index % 10 === 3 ? `p${String(index - 3).padStart(3, '0')}` : null
-  return {
-    id,
-    title: `页面 ${index + 1}`,
-    blurb: `用于压测 Database 默认表的第 ${index + 1} 条假数据。`,
-    count: (index * 7) % 1000,
-    enabled: index % 3 !== 0,
-    status,
-    tags: [color, status === 'live' ? 'prod' : 'lab'],
-    aliases: [`page-${index + 1}`, `p${index}`],
-    publishedAt: now - index * 3600_000,
-    size: 2048 + index * 128,
-    homepage: `https://example.com/pages/${id}`,
-    cover: seedCover(color),
-    pack: {
-      name: `${id}.zip`,
-      href: `https://example.com/files/${id}.zip`,
-      bytes: 48_000 + index * 256,
-    },
-    notes: { kind: 'doc', body: `这是 ${id} 的正文文件内容。` },
-    score: (index % 17) * 3,
-    parentId,
-    createdAt: now - index * 7200_000,
-    updatedAt: now - index * 1800_000,
-  }
-}
-
-function pagesCollection(now = Date.now()): CollectionSpec {
-  const rows = new Map<string, PageRow>()
-  for (let i = 0; i < ROW_COUNT; i++) {
-    const row = seed(i, now)
-    rows.set(row.id, row)
-  }
-
+export function pagesCollection(store: PagesStore): CollectionSpec {
   return {
     id: 'pages',
     path: '/pages',
@@ -75,7 +16,7 @@ function pagesCollection(now = Date.now()): CollectionSpec {
       route: '/pages',
       title: '页面',
       inspector: true,
-      blurb: '每种字段类型各登记一列，假数据用来压测 Database 默认界面。',
+      blurb: '页面存成工作区 .page 下的 Markdown；属性写在 YAML frontmatter，图片和附件在 .page/assets。',
       order: 25,
       icon: 'document',
     },
@@ -116,52 +57,34 @@ function pagesCollection(now = Date.now()): CollectionSpec {
       },
     },
     records: { update: true, create: true, delete: true },
-    list: () => [...rows.values()],
-    get: (id) => rows.get(id) ?? null,
-    update: (id, patch) => {
-      const current = rows.get(id)
-      if (!current) throw new Error(`unknown page: ${id}`)
-      const next: PageRow = {
-        ...current,
-        ...patch,
-        id,
-        score: current.score,
-        updatedAt: Date.now(),
-      }
-      rows.set(id, next)
-      return next
-    },
-    create: (fields = {}) => {
-      let n = rows.size
-      let id = `p${String(n).padStart(3, '0')}`
-      while (rows.has(id)) {
-        n += 1
-        id = `p${String(n).padStart(3, '0')}`
-      }
-      const ts = Date.now()
-      const row: PageRow = {
-        ...seed(n, ts),
-        ...fields,
-        id,
-        title: typeof fields.title === 'string' && fields.title.trim() ? fields.title.trim() : '未命名页面',
-        score: 0,
-        createdAt: ts,
-        updatedAt: ts,
-      }
-      rows.set(id, row)
-      return row
-    },
-    remove: (id) => {
-      if (!rows.delete(id)) throw new Error(`unknown page: ${id}`)
-    },
+    list: () => store.list(),
+    get: (id) => store.get(id),
+    update: (id, patch) => store.update(id, patch),
+    create: (fields = {}) => store.create(fields),
+    remove: (id) => store.remove(id),
   }
 }
 
-export const name = 'page'
-export const inject = ['database']
-
-export function apply(ctx: Context) {
-  ctx.database.register(pagesCollection())
+function servePageFile(ctx: Context, store: PagesStore) {
+  ctx.inject(['http'], (inner) => {
+    inner.http.route('GET', '/api/page/file/:name', async (route) => {
+      try {
+        const { bytes, type } = await store.readAsset(route.params.name ?? '')
+        route.res.writeHead(200, { 'content-type': type, 'cache-control': 'private, max-age=60' })
+        route.res.end(bytes)
+      } catch {
+        route.send(404, { error: 'not found' })
+      }
+    })
+  })
 }
 
-export { pagesCollection }
+export const name = 'page'
+export const inject = ['database', 'fs']
+
+export function apply(ctx: Context) {
+  const store = new PagesStore(ctx.fs as WorkspaceFs)
+  ctx.database.register(pagesCollection(store))
+  servePageFile(ctx, store)
+}
+

--- a/packages/cap-page/src/host/markdown.ts
+++ b/packages/cap-page/src/host/markdown.ts
@@ -1,0 +1,22 @@
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+
+export function splitMarkdown(raw: string): { matter: Record<string, unknown>; body: string } {
+  const text = String(raw ?? '').replace(/^\uFEFF/, '')
+  if (!text.startsWith('---')) return { matter: {}, body: text }
+  const afterOpen = text.slice(3)
+  const openNl = afterOpen.startsWith('\r\n') ? 2 : afterOpen.startsWith('\n') ? 1 : 0
+  if (!openNl) return { matter: {}, body: text }
+  const rest = afterOpen.slice(openNl)
+  const match = rest.match(/\r?\n---(?:\r?\n|$)/)
+  if (!match || match.index == null) return { matter: {}, body: text }
+  const yamlText = rest.slice(0, match.index)
+  const body = rest.slice(match.index + match[0].length)
+  const parsed = parseYaml(yamlText)
+  const matter = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {}
+  return { matter, body }
+}
+
+export function dumpMarkdown(matter: Record<string, unknown>, body: string): string {
+  const yaml = stringifyYaml(matter, { lineWidth: 0 }).trimEnd()
+  return `---\n${yaml}\n---\n${body.replace(/^\n/, '')}`
+}

--- a/packages/cap-page/src/host/store.ts
+++ b/packages/cap-page/src/host/store.ts
@@ -1,0 +1,353 @@
+import { mkdir, readFile, unlink } from 'node:fs/promises'
+import { basename, dirname } from 'node:path'
+import type { DbRecord } from '@biu/type-file-system'
+import { dumpMarkdown, splitMarkdown } from './markdown.ts'
+
+export const PAGE_ROOT = '.page'
+export const PAGE_ASSETS = '.page/assets'
+
+const STATUS = ['draft', 'live', 'archived'] as const
+
+export type PageRow = DbRecord & {
+  title: string
+  blurb: string
+  count: number
+  enabled: boolean
+  status: (typeof STATUS)[number]
+  tags: string[]
+  aliases: string[]
+  publishedAt: number
+  size: number
+  homepage: string
+  cover: string
+  pack: { name: string; href: string; bytes: number }
+  notes: string
+  score: number
+  parentId: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+export type WorkspaceFs = {
+  resolve: (rel: string) => string
+  read: (rel: string) => Promise<string>
+  write: (rel: string, content: string) => Promise<unknown>
+  list: (rel?: string) => Promise<string[]>
+}
+
+const ID_RE = /^[A-Za-z0-9._-]+$/
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.map((item) => String(item)).filter(Boolean)
+}
+
+function asTime(value: unknown, fallback: number): number {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.getTime()
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim()) {
+    const asNum = Number(value)
+    if (Number.isFinite(asNum) && /^\d+(\.\d+)?$/.test(value.trim())) return asNum
+    const parsed = Date.parse(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+function asNotes(value: unknown): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'string') return value
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const rec = value as Record<string, unknown>
+    if (typeof rec.body === 'string') return rec.body
+    if (typeof rec.body === 'object') return JSON.stringify(rec.body, null, 2)
+  }
+  return String(value)
+}
+
+function asPack(value: unknown): { name: string; href: string; bytes: number } | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const rec = value as Record<string, unknown>
+  return {
+    name: String(rec.name ?? ''),
+    href: String(rec.href ?? rec.url ?? ''),
+    bytes: Number(rec.bytes) || 0,
+  }
+}
+
+function assetName(ref: string) {
+  const trimmed = ref.trim()
+  if (!trimmed) return ''
+  const cleaned = trimmed.replace(/^\/+/, '')
+  if (cleaned.startsWith(`${PAGE_ASSETS}/`)) return basename(cleaned)
+  if (cleaned.startsWith('assets/')) return basename(cleaned)
+  if (!cleaned.includes('/') && !cleaned.includes('\\')) return cleaned
+  return ''
+}
+
+export function fileUrl(name: string) {
+  return `/api/page/file/${encodeURIComponent(name)}`
+}
+
+function publicCover(stored: string) {
+  const name = assetName(stored)
+  if (name) return fileUrl(name)
+  return stored
+}
+
+function publicPack(pack: { name: string; href: string; bytes: number }) {
+  const name = assetName(pack.href) || (pack.name && assetName(pack.name) ? pack.name : '')
+  if (!name) return pack
+  return { ...pack, href: fileUrl(basename(name)) }
+}
+
+function storedCover(value: unknown, fallback: string) {
+  if (value == null) return fallback
+  const text = String(value)
+  const name = assetName(text)
+  if (name) return `assets/${name}`
+  if (text.startsWith('/api/page/file/')) {
+    const file = decodeURIComponent(text.slice('/api/page/file/'.length).split(/[?#]/)[0] ?? '')
+    return file ? `assets/${basename(file)}` : fallback
+  }
+  return text
+}
+
+function storedPackHref(href: string) {
+  const name = assetName(href)
+  if (name) return `assets/${name}`
+  if (href.startsWith('/api/page/file/')) {
+    const file = decodeURIComponent(href.slice('/api/page/file/'.length).split(/[?#]/)[0] ?? '')
+    return file ? `assets/${basename(file)}` : href
+  }
+  return href
+}
+
+function pageRel(id: string) {
+  if (!ID_RE.test(id)) throw new Error(`invalid page id: ${id}`)
+  return `${PAGE_ROOT}/${id}.md`
+}
+
+function matterOf(row: PageRow): Record<string, unknown> {
+  return {
+    title: row.title,
+    blurb: row.blurb,
+    count: row.count,
+    enabled: row.enabled,
+    status: row.status,
+    tags: row.tags,
+    aliases: row.aliases,
+    publishedAt: new Date(row.publishedAt).toISOString(),
+    size: row.size,
+    homepage: row.homepage,
+    cover: storedCover(row.cover, ''),
+    pack: {
+      name: row.pack.name,
+      href: storedPackHref(row.pack.href),
+      bytes: row.pack.bytes,
+    },
+    score: row.score,
+    parentId: row.parentId,
+    createdAt: new Date(row.createdAt).toISOString(),
+    updatedAt: new Date(row.updatedAt).toISOString(),
+  }
+}
+
+function rowFromFile(id: string, raw: string): PageRow {
+  const { matter, body } = splitMarkdown(raw)
+  const now = Date.now()
+  const pack = asPack(matter.pack) ?? { name: '', href: '', bytes: 0 }
+  const status = STATUS.includes(matter.status as (typeof STATUS)[number])
+    ? (matter.status as (typeof STATUS)[number])
+    : 'draft'
+  const createdAt = asTime(matter.createdAt, now)
+  const updatedAt = asTime(matter.updatedAt, createdAt)
+  const cover = String(matter.cover ?? '')
+  return {
+    id,
+    title: String(matter.title ?? id),
+    blurb: String(matter.blurb ?? ''),
+    count: Number(matter.count) || 0,
+    enabled: matter.enabled !== false,
+    status,
+    tags: asStringList(matter.tags),
+    aliases: asStringList(matter.aliases),
+    publishedAt: asTime(matter.publishedAt, createdAt),
+    size: Number(matter.size) || 0,
+    homepage: String(matter.homepage ?? ''),
+    cover: publicCover(cover),
+    pack: publicPack(pack),
+    notes: body,
+    score: Number(matter.score) || 0,
+    parentId: matter.parentId == null || matter.parentId === '' ? null : String(matter.parentId),
+    createdAt,
+    updatedAt,
+  }
+}
+
+function emptyRow(id: string, ts: number): PageRow {
+  return {
+    id,
+    title: '未命名页面',
+    blurb: '',
+    count: 0,
+    enabled: true,
+    status: 'draft',
+    tags: [],
+    aliases: [],
+    publishedAt: ts,
+    size: 0,
+    homepage: '',
+    cover: '',
+    pack: { name: '', href: '', bytes: 0 },
+    notes: '',
+    score: 0,
+    parentId: null,
+    createdAt: ts,
+    updatedAt: ts,
+  }
+}
+
+function applyPatch(current: PageRow, patch: Record<string, unknown>): PageRow {
+  const notes = asNotes(patch.notes)
+  const pack = patch.pack !== undefined ? asPack(patch.pack) ?? current.pack : current.pack
+  const next: PageRow = {
+    ...current,
+    ...patch,
+    id: current.id,
+    title:
+      typeof patch.title === 'string' && patch.title.trim()
+        ? patch.title.trim()
+        : current.title,
+    notes: notes ?? current.notes,
+    pack: {
+      name: pack.name,
+      href: storedPackHref(pack.href),
+      bytes: pack.bytes,
+    },
+    cover: storedCover(patch.cover !== undefined ? patch.cover : current.cover, ''),
+    parentId: 'parentId' in patch
+      ? patch.parentId == null || patch.parentId === '' ? null : String(patch.parentId)
+      : current.parentId,
+    score: current.score,
+    createdAt: current.createdAt,
+    updatedAt: Date.now(),
+  }
+  return next
+}
+
+export class PagesStore {
+  constructor(private fs: WorkspaceFs) {}
+
+  private async ensureDirs() {
+    await mkdir(dirname(this.fs.resolve(`${PAGE_ROOT}/x.md`)), { recursive: true })
+    await mkdir(this.fs.resolve(PAGE_ASSETS), { recursive: true })
+  }
+
+  async list(): Promise<PageRow[]> {
+    await this.ensureDirs()
+    let names: string[] = []
+    try {
+      names = await this.fs.list(PAGE_ROOT)
+    } catch {
+      return []
+    }
+    const rows: PageRow[] = []
+    for (const name of names) {
+      if (!name.endsWith('.md')) continue
+      const id = name.slice(0, -3)
+      if (!ID_RE.test(id)) continue
+      const row = await this.get(id)
+      if (row) rows.push(row)
+    }
+    return rows.sort((a, b) => a.id.localeCompare(b.id))
+  }
+
+  async get(id: string): Promise<PageRow | null> {
+    if (!ID_RE.test(id)) return null
+    try {
+      const raw = await this.fs.read(pageRel(id))
+      return rowFromFile(id, raw)
+    } catch {
+      return null
+    }
+  }
+
+  async update(id: string, patch: Record<string, unknown>): Promise<PageRow> {
+    const current = await this.get(id)
+    if (!current) throw new Error(`unknown page: ${id}`)
+    const next = applyPatch(current, patch)
+    await this.write(next)
+    return (await this.get(id))!
+  }
+
+  async create(fields: Record<string, unknown> = {}): Promise<PageRow> {
+    await this.ensureDirs()
+    const existing = new Set((await this.list()).map((row) => row.id))
+    let n = existing.size
+    let id = `p${String(n).padStart(3, '0')}`
+    while (existing.has(id) || !ID_RE.test(id)) {
+      n += 1
+      id = `p${String(n).padStart(3, '0')}`
+    }
+    if (typeof fields.id === 'string' && ID_RE.test(fields.id) && !existing.has(fields.id)) id = fields.id
+    const ts = Date.now()
+    const row = applyPatch(emptyRow(id, ts), { ...fields, score: 0 })
+    row.id = id
+    row.createdAt = ts
+    row.updatedAt = ts
+    if (typeof fields.title === 'string' && fields.title.trim()) row.title = fields.title.trim()
+    await this.write(row)
+    return (await this.get(id))!
+  }
+
+  async remove(id: string) {
+    if (!ID_RE.test(id)) throw new Error(`unknown page: ${id}`)
+    const full = this.fs.resolve(pageRel(id))
+    try {
+      await unlink(full)
+    } catch {
+      throw new Error(`unknown page: ${id}`)
+    }
+    try {
+      const assets = await this.fs.list(PAGE_ASSETS)
+      for (const name of assets) {
+        if (name === '.gitkeep') continue
+        if (name.startsWith(`${id}-`) || name.startsWith(`${id}.`)) {
+          await unlink(this.fs.resolve(`${PAGE_ASSETS}/${name}`)).catch(() => undefined)
+        }
+      }
+    } catch {
+      // assets dir may be empty
+    }
+  }
+
+  async readAsset(name: string): Promise<{ bytes: Buffer; type: string }> {
+    const file = basename(name)
+    if (!file || file !== name.replace(/\\/g, '/')) throw new Error('invalid asset')
+    const bytes = await readFile(this.fs.resolve(`${PAGE_ASSETS}/${file}`))
+    return { bytes, type: mimeOf(file) }
+  }
+
+  private async write(row: PageRow) {
+    await this.ensureDirs()
+    const body = row.notes ?? ''
+    await this.fs.write(pageRel(row.id), dumpMarkdown(matterOf(row), body))
+  }
+}
+
+function mimeOf(name: string) {
+  const ext = name.toLowerCase().slice(name.lastIndexOf('.'))
+  if (ext === '.png') return 'image/png'
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg'
+  if (ext === '.gif') return 'image/gif'
+  if (ext === '.webp') return 'image/webp'
+  if (ext === '.svg') return 'image/svg+xml'
+  if (ext === '.avif') return 'image/avif'
+  if (ext === '.bmp') return 'image/bmp'
+  if (ext === '.zip') return 'application/zip'
+  if (ext === '.pdf') return 'application/pdf'
+  return 'application/octet-stream'
+}
+
+export { STATUS }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把 Page 从内存假数据改成工作区文件：

- 每条页面是 `.page/{id}.md`，属性用 YAML frontmatter，正文是 Markdown
- 封面图、附件等二进制放在 `.page/assets/`
- 后端 `list/get/update/create/remove` 直接读写这些文件
- 资源通过 `GET /api/page/file/:name` 提供给界面

不再启动时灌 240 条内存假数据。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

