### PR TITLE
聊天左侧默认不显示标签，最小宽度约为默认的 2/3

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -9,6 +9,7 @@ import {
   INSPECTOR_MIN,
   SIDEBAR_MAX,
   SIDEBAR_MIN,
+  SIDEBAR_DEFAULT,
   SIDEBAR_LABEL_AT,
   getChatOverlay,
   setChatOverlay,
@@ -37,8 +38,11 @@ test('collapsed chat sidebar still occupies the icon rail', () => {
 })
 
 test('sidebar labels appear only after LABEL_AT', () => {
-  assert.equal(SIDEBAR_LABEL_AT, 160)
-  assert.ok(SIDEBAR_MIN < SIDEBAR_LABEL_AT)
+  assert.equal(SIDEBAR_DEFAULT, 72)
+  assert.equal(SIDEBAR_MIN, Math.round(SIDEBAR_DEFAULT * (2 / 3)))
+  assert.equal(SIDEBAR_LABEL_AT, SIDEBAR_DEFAULT + 1)
+  assert.ok(SIDEBAR_DEFAULT < SIDEBAR_LABEL_AT)
+  assert.ok(SIDEBAR_MIN < SIDEBAR_DEFAULT)
   const icon = allocateShellColumns({
     viewportWidth: 1600,
     leftPane: true,

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -1,10 +1,12 @@
 /** 聊天列窄于此时自动弹出覆盖对话框（px）。不自动收回。 */
 export const CHAT_OVERLAY_ENTER = 420
 export const SIDEBAR_MAX = 280
-/** 收成图标轨的宽度；再窄就整栏关掉。 */
-export const SIDEBAR_MIN = 52
-/** 侧栏至少这么宽才显示文字标签（会话名、「添加聊天」等）。 */
-export const SIDEBAR_LABEL_AT = 160
+/** 聊天左侧默认宽度：图标轨，不显示会话名。往外拉过这个宽度才出标签。 */
+export const SIDEBAR_DEFAULT = 72
+/** 最小宽度约为默认的 2/3，再窄图标会挤。 */
+export const SIDEBAR_MIN = Math.round(SIDEBAR_DEFAULT * (2 / 3))
+/** 比默认宽度更宽才显示文字标签（会话名、「添加聊天」等）。 */
+export const SIDEBAR_LABEL_AT = SIDEBAR_DEFAULT + 1
 /** 中间列最窄约为对话内容最大宽 768 的 2/3，好让左右栏先完整显示。 */
 export const CENTER_MIN = 512
 export const INSPECTOR_MIN = 240

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -19,6 +19,7 @@ import {
   toggleOverlayPinned,
   requestInspectorClose,
   allocateShellColumns,
+  SIDEBAR_DEFAULT,
   SIDEBAR_LABEL_AT,
   SIDEBAR_MAX,
   SIDEBAR_MIN,
@@ -456,7 +457,7 @@ function Shell(props: SlotProps) {
     } catch {
       /* ignore */
     }
-    return SIDEBAR_MAX
+    return SIDEBAR_DEFAULT
   })
   const lastWideSidebar = useRef(sidebarWidth >= SIDEBAR_LABEL_AT ? sidebarWidth : SIDEBAR_MAX)
   const persistSidebar = useCallback((width: number, collapsed: boolean) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天左侧默认 72px 图标轨，不显示会话名；往外拉过默认宽度才出标签。最小宽度 48px（约为默认的 2/3），可以再收一点，但不会收成一条缝。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

