### PR TITLE
修复粘贴一次出现两张图片

### DIFF
--- a/packages/cap-chat/src/web/clipboard-images.test.ts
+++ b/packages/cap-chat/src/web/clipboard-images.test.ts
@@ -33,4 +33,26 @@ describe('collectClipboardImages', () => {
     expect(images).toHaveLength(1)
     expect(images[0]?.name).toBe('paste.png')
   })
+
+  it('dedups files vs items clones that differ in name and mtime', () => {
+    const fromFiles = png('image.png', 80)
+    const fromItems = new File([new Uint8Array(80)], 'unknown.png', {
+      type: 'image/png',
+      lastModified: 99,
+    })
+    const clipboard = {
+      files: [fromFiles] as unknown as FileList,
+      items: [{ kind: 'file' as const, getAsFile: () => fromItems }],
+    } as unknown as DataTransfer
+    expect(collectClipboardImages(clipboard)).toHaveLength(1)
+  })
+
+  it('falls back to items when files is empty', () => {
+    const shot = png('from-item.png', 32)
+    const clipboard = {
+      files: [] as unknown as FileList,
+      items: [{ kind: 'file' as const, getAsFile: () => shot }],
+    } as unknown as DataTransfer
+    expect(collectClipboardImages(clipboard)).toHaveLength(1)
+  })
 })

--- a/packages/cap-chat/src/web/clipboard-images.ts
+++ b/packages/cap-chat/src/web/clipboard-images.ts
@@ -3,7 +3,7 @@ const IMAGE_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp
 export { IMAGE_MIMES }
 
 function fileFingerprint(file: File): string {
-  return `${file.name}\0${file.size}\0${file.lastModified}\0${file.type}`
+  return `${file.type}\0${file.size}`
 }
 
 /** Drop / file-input: keep image files only. */
@@ -14,8 +14,9 @@ export function collectImageFiles(list: FileList | File[] | null | undefined): F
 
 /**
  * Paste often exposes the same screenshot via both `clipboardData.files`
- * and `clipboardData.items`. Dedup by name/size/mtime/type so one paste
- * becomes one pending image.
+ * and `clipboardData.items`, as two File objects with different names/mtime.
+ * Prefer `files` when it already has images; otherwise read `items`.
+ * Dedup leftover twins by type+size.
  */
 export function uniqueImageFiles(files: Array<File | null | undefined>): File[] {
   const seen = new Set<string>()
@@ -32,8 +33,9 @@ export function uniqueImageFiles(files: Array<File | null | undefined>): File[] 
 
 export function collectClipboardImages(clipboard: DataTransfer | null | undefined): File[] {
   if (!clipboard) return []
-  const fromFiles = Array.from(clipboard.files ?? [])
-  const fromItems = Array.from(clipboard.items)
-    .map((item) => (item.kind === 'file' ? item.getAsFile() : null))
-  return uniqueImageFiles([...fromFiles, ...fromItems])
+  const fromFiles = uniqueImageFiles(Array.from(clipboard.files ?? []))
+  if (fromFiles.length) return fromFiles
+  return uniqueImageFiles(
+    Array.from(clipboard.items).map((item) => (item.kind === 'file' ? item.getAsFile() : null)),
+  )
 }

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -454,8 +454,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       handlePaste(_view, event) {
         const images = collectClipboardImages(event.clipboardData)
         if (!images.length) return false
+        event.preventDefault()
         addImageFiles(images)
-        return !event.clipboardData?.getData('text/plain')
+        return true
       },
       handleKeyDown(_view, event) {
         const menu = live.current.slash


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
粘贴截图时，剪贴板常常同时在 `files` 和 `items` 里给同一张图，而且文件名/时间戳不一样，去重会失败。现在优先用 `files`，按类型+大小去重，并且吃掉 paste 事件，避免编辑器再插一份。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

