### PR TITLE
侧栏标签要拉到 160px 才显示，不是一拉就出

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -52,11 +52,11 @@ test('sidebar below min width is gone', () => {
 test('sidebar labels appear only after LABEL_AT', () => {
   assert.equal(SIDEBAR_DEFAULT, 72)
   assert.equal(SIDEBAR_MIN, Math.round(SIDEBAR_DEFAULT * (2 / 3)))
-  assert.equal(SIDEBAR_LABEL_AT, SIDEBAR_DEFAULT + 1)
+  assert.equal(SIDEBAR_LABEL_AT, 160)
   assert.equal(SIDEBAR_TAG_AT, 300)
+  assert.ok(SIDEBAR_DEFAULT < SIDEBAR_LABEL_AT)
   assert.ok(SIDEBAR_LABEL_AT < SIDEBAR_TAG_AT)
   assert.ok(SIDEBAR_TAG_AT < SIDEBAR_MAX)
-  assert.ok(SIDEBAR_DEFAULT < SIDEBAR_LABEL_AT)
   assert.ok(SIDEBAR_MIN < SIDEBAR_DEFAULT)
   const icon = allocateShellColumns({
     viewportWidth: 1600,

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -5,8 +5,8 @@ export const SIDEBAR_MAX = 360
 export const SIDEBAR_DEFAULT = 72
 /** 最小宽度约为默认的 2/3；再窄整栏关掉，不留细条。 */
 export const SIDEBAR_MIN = Math.round(SIDEBAR_DEFAULT * (2 / 3))
-/** 比默认宽度更宽才显示文字标签（会话名、「添加聊天」等）。 */
-export const SIDEBAR_LABEL_AT = SIDEBAR_DEFAULT + 1
+/** 往右拉到这个宽度才显示文字标签（会话名、「添加聊天」等）。默认 72 仍是图标轨。 */
+export const SIDEBAR_LABEL_AT = 160
 /** 再往右拉到这个宽度才显示会话 tag（日报、总结、+N 等）。 */
 export const SIDEBAR_TAG_AT = 300
 /** 中间列最窄约为对话内容最大宽 768 的 2/3，好让左右栏先完整显示。 */

--- a/web/style.css
+++ b/web/style.css
@@ -47,7 +47,7 @@
   --dsw-chat-reply-pad-x: 12px;
   --dsw-chat-max-width: 768px;
   --dsw-center-min: 512px;
-  --dsw-sidebar-max: 280px;
+  --dsw-sidebar-max: 360px;
   --dsw-inspector-min: 240px;
   --dsw-chat-code-bg: var(--dsw-sidebar);
   --dsw-chat-hist-fill: #ff3e51;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
默认 72px 仍是图标轨。往右拉一点不会出标签；拉到约 160px 才显示会话名等文字。CSS 最大宽度改为 360px，才能继续往右拉到显示 tag 的 300px。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

