### PR TITLE
Esc 退出选取后不再出现白色外边框

### DIFF
--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -13,6 +13,11 @@ test('pick capture does not eat sidebar, rail, or inspector chrome clicks', () =
   assert.doesNotMatch(overlay, /\.session-inspector/)
 })
 
+test('Escape exits pick and blurs so no focus ring remains', () => {
+  assert.match(overlay, /event.key === 'Escape'/)
+  assert.match(overlay, /active\.blur\(\)/)
+})
+
 test('Command/Ctrl+Q toggles pick mode', () => {
   assert.match(overlay, /event.metaKey \|\| event.ctrlKey/)
   assert.match(overlay, /key === 'q'/)

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -84,6 +84,8 @@ export function PickOverlay(_props: SlotProps) {
       if (event.key === 'Escape') {
         event.preventDefault()
         pick.exit()
+        const active = document.activeElement
+        if (active instanceof HTMLElement) active.blur()
       }
     }
 

--- a/web/style.css
+++ b/web/style.css
@@ -371,6 +371,15 @@ body {
   border-radius: 999px;
   background: #262626;
   color: var(--dsw-sidebar-fg);
+  outline: none;
+  box-shadow: none;
+}
+
+.brand-corner-leading .project-chip:focus,
+.brand-corner-leading .project-chip:focus-visible {
+  outline: none;
+  box-shadow: none;
+  border-color: var(--dsw-border);
 }
 
 .brand-agent-menu {
@@ -2007,8 +2016,9 @@ body {
   border-style: dashed;
 }
 
-.project-chip:hover:not(:disabled) {
-  color: var(--dsw-sidebar-fg-active);
+.project-chip:focus,
+.project-chip:focus-visible {
+  outline: none;
 }
 
 .project-chip:disabled,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取后按 Esc，焦点还留在右下角选取按钮上，浏览器会画出一圈白的 :focus-visible。退出时 blur，并去掉这颗按钮的焦点描边。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

