### PR TITLE
fix(shell): 左侧栏拉到顶才出标签

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -52,11 +52,9 @@ test('sidebar below min width is gone', () => {
 test('sidebar labels appear only after LABEL_AT', () => {
   assert.equal(SIDEBAR_DEFAULT, 72)
   assert.equal(SIDEBAR_MIN, Math.round(SIDEBAR_DEFAULT * (2 / 3)))
-  assert.equal(SIDEBAR_LABEL_AT, 160)
-  assert.equal(SIDEBAR_TAG_AT, 300)
+  assert.equal(SIDEBAR_LABEL_AT, SIDEBAR_MAX)
+  assert.equal(SIDEBAR_TAG_AT, SIDEBAR_MAX)
   assert.ok(SIDEBAR_DEFAULT < SIDEBAR_LABEL_AT)
-  assert.ok(SIDEBAR_LABEL_AT < SIDEBAR_TAG_AT)
-  assert.ok(SIDEBAR_TAG_AT < SIDEBAR_MAX)
   assert.ok(SIDEBAR_MIN < SIDEBAR_DEFAULT)
   const icon = allocateShellColumns({
     viewportWidth: 1600,

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -1,14 +1,14 @@
 /** 聊天列窄于此时自动弹出覆盖对话框（px）。不自动收回。 */
 export const CHAT_OVERLAY_ENTER = 420
 export const SIDEBAR_MAX = 360
-/** 聊天左侧默认宽度：图标轨，不显示会话名。往外拉过这个宽度才出标签。 */
+/** 聊天左侧默认宽度：图标轨，不显示会话名。拉到最大宽度才出标签。 */
 export const SIDEBAR_DEFAULT = 72
 /** 最小宽度约为默认的 2/3；再窄整栏关掉，不留细条。 */
 export const SIDEBAR_MIN = Math.round(SIDEBAR_DEFAULT * (2 / 3))
-/** 往右拉到这个宽度才显示文字标签（会话名、「添加聊天」等）。默认 72 仍是图标轨。 */
-export const SIDEBAR_LABEL_AT = 160
-/** 再往右拉到这个宽度才显示会话 tag（日报、总结、+N 等）。 */
-export const SIDEBAR_TAG_AT = 300
+/** 拉到侧栏最大宽度才显示文字标签（会话名、「添加聊天」等）。 */
+export const SIDEBAR_LABEL_AT = SIDEBAR_MAX
+/** 拉到侧栏最大宽度才显示会话 tag（日报、总结、+N 等）。 */
+export const SIDEBAR_TAG_AT = SIDEBAR_MAX
 /** 中间列最窄约为对话内容最大宽 768 的 2/3，好让左右栏先完整显示。 */
 export const CENTER_MIN = 512
 export const INSPECTOR_MIN = 240

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -37,5 +37,8 @@ describe('sidebar text colors', () => {
     expect(shell).toMatch(/SIDEBAR_LABEL_AT/)
     expect(shell).toMatch(/SIDEBAR_TAG_AT/)
     expect(shell).toMatch(/data-testid="header-sidebar-expand"/)
+    const overlay = readFileSync(resolve(import.meta.dirname, './chat-overlay.ts'), 'utf8')
+    expect(overlay).toMatch(/SIDEBAR_LABEL_AT = SIDEBAR_MAX/)
+    expect(overlay).toMatch(/SIDEBAR_TAG_AT = SIDEBAR_MAX/)
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
左侧聊天侧栏在未拉满时只保留图标轨：会话名、「添加聊天」等文字，以及日报/总结/+N 这类会话 tag，都只在宽度达到 `SIDEBAR_MAX`（360px）时出现。

此前文字标签在 160px、tag 在 300px 就会显示。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

