### PR TITLE
fix(shell): 侧栏会话 tag 缩小，避免撑高行

### DIFF
--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -60,13 +60,13 @@ function SessionTagBadges({ tags }: { tags?: string[] }) {
       {shown.map((tag) => (
         <span
           key={tag}
-          className="sidebar-tag max-w-18 truncate rounded-sm bg-(--dsw-hover-weak,var(--dsw-hover)) px-1 py-px text-[14px] leading-5 font-medium"
+          className="sidebar-tag max-w-18 truncate rounded-sm bg-(--dsw-hover-weak,var(--dsw-hover)) px-1"
         >
           {tag}
         </span>
       ))}
       {extra > 0 ? (
-        <span className="sidebar-tag shrink-0 rounded-sm px-0.5 py-px text-[14px] leading-5 font-medium opacity-80">
+        <span className="sidebar-tag shrink-0 rounded-sm px-0.5 opacity-80">
           +{extra}
         </span>
       ) : null}

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -26,7 +26,9 @@ describe('sidebar text colors', () => {
   })
 
   it('hides labels until the chat sidebar is wide enough', () => {
-    expect(css).toMatch(/\.sidebar-label,\s*\.app-side-actions-label,\s*\.sidebar-tag\s*\{[^}]*font-size:\s*14px/s)
+    expect(css).toMatch(/\.sidebar-label,\s*\.app-side-actions-label\s*\{[^}]*font-size:\s*14px/s)
+    expect(css).toMatch(/\.sidebar-tag\s*\{[^}]*font-size:\s*11px/s)
+    expect(css).toMatch(/\.sidebar-tag\s*\{[^}]*line-height:\s*16px/s)
     expect(css).toMatch(/\.sidebar-chat-count-num\s*\{[^}]*font-size:\s*14px/s)
     expect(css).toMatch(/\.app-side-bar:not\(\.is-wide\) \.sidebar-tag/)
     const sidebar = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'utf8')

--- a/web/style.css
+++ b/web/style.css
@@ -1150,9 +1150,14 @@ body {
 }
 
 .sidebar-label,
-.app-side-actions-label,
-.sidebar-tag {
+.app-side-actions-label {
   font-size: 14px;
+}
+
+.sidebar-tag {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
 }
 
 .app-side-bar:not(.is-wide) .sidebar-tag {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话行上的日报 / 总结 / +N 从 14px（行高 20px）改成 **11px / 行高 16px**，去掉竖向 padding，避免把原先那一行撑高。会话名和「添加聊天」仍是 14px。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

