### PR TITLE
feat(fs): 点「会话」看全部视图，路由仍停在表路径

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1443,6 +1443,12 @@ export function CollectionBrowser({
               openId={crumbOpen}
               onOpenId={setCrumbOpen}
               onPick={(target) => {
+                if (target.kind === 'view' && target.collection === collectionPath) {
+                  const view = views.find((item) => item.id === target.viewId)
+                  if (view) selectView(view)
+                  setCrumbOpen(null)
+                  return
+                }
                 onCrumbTarget?.(target)
                 setCrumbOpen(null)
               }}

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -10,7 +10,11 @@ describe('顶栏三级标题', () => {
   it('中间顶栏点标题出菜单', () => {
     expect(trail).toContain("aria-haspopup={canPick ? 'menu' : undefined}")
     expect(trail).toContain('allowMenu')
-    expect(trail).toContain('<CrumbItemGlyph kind={crumb.kind}')
+    expect(trail).toContain("crumb.kind === 'collection' ? crumb.choices.length > 0")
+    expect(browser).toContain("target.kind === 'view' && target.collection === collectionPath")
+    expect(browser).toContain('<CrumbTrail')
+    const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+    expect(page).toMatch(/onOpenView=\{\(\) => \{[\s\S]*go\(\{ collection: currentPath \}, \{ replace: true \}\)/)
     expect(trail).toContain('createPortal')
     expect(trail).toContain('data-fsdb-crumb-menu')
     expect(trail).not.toContain('data-testid="crumb-expand"')

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -44,7 +44,8 @@ export function CrumbTrail({
   return (
     <nav className={className ?? 'fsdb-crumbs'} aria-label={label ?? '位置'} ref={navRef}>
       {crumbs.map((crumb, index) => {
-        const canPick = allowMenu && crumb.choices.length > 1
+        const canPick =
+          allowMenu && (crumb.kind === 'collection' ? crumb.choices.length > 0 : crumb.choices.length > 1)
         const open = openId === crumb.id
         const current = crumb.choices.find((item) => item.id === crumb.id)
         return (
@@ -86,7 +87,11 @@ export function CrumbTrail({
           </span>
         )
       })}
-      {allowMenu && openCrumb && openCrumb.choices.length > 1 && menuPos && typeof document !== 'undefined'
+      {allowMenu &&
+      openCrumb &&
+      (openCrumb.kind === 'collection' ? openCrumb.choices.length > 0 : openCrumb.choices.length > 1) &&
+      menuPos &&
+      typeof document !== 'undefined'
         ? createPortal(
             <div
               className="fsdb-crumb-menu is-fixed"
@@ -94,23 +99,31 @@ export function CrumbTrail({
               data-fsdb-crumb-menu=""
               style={{ left: menuPos.left, top: menuPos.top }}
             >
-              {openCrumb.choices.map((choice) => (
-                <button
-                  key={choice.id}
-                  type="button"
-                  className={`fsdb-crumb-option${choice.id === openCrumb.id ? ' is-active' : ''}`}
-                  role="menuitem"
-                  onClick={(event) => {
-                    event.preventDefault()
-                    event.stopPropagation()
-                    onPick(choice.target)
-                    onOpenId(null)
-                  }}
-                >
-                  <CrumbItemGlyph kind={openCrumb.kind} icon={choice.icon} mode={choice.mode} emoji={choice.emoji} />
-                  <span className="chat-view-project-name">{choice.label}</span>
-                </button>
-              ))}
+              {openCrumb.choices.map((choice) => {
+                const viewId = crumbs.find((item) => item.kind === 'view')?.id
+                const active =
+                  choice.target.kind === 'view'
+                    ? choice.target.viewId === viewId
+                    : choice.id === openCrumb.id
+                const glyphKind = choice.target.kind === 'view' ? 'view' : openCrumb.kind
+                return (
+                  <button
+                    key={choice.id}
+                    type="button"
+                    className={`fsdb-crumb-option${active ? ' is-active' : ''}`}
+                    role="menuitem"
+                    onClick={(event) => {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      onPick(choice.target)
+                      onOpenId(null)
+                    }}
+                  >
+                    <CrumbItemGlyph kind={glyphKind} icon={choice.icon} mode={choice.mode} emoji={choice.emoji} />
+                    <span className="chat-view-project-name">{choice.label}</span>
+                  </button>
+                )
+              })}
             </div>,
             document.body,
           )

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -148,7 +148,9 @@ function CollectionPage(props: SlotProps) {
         }
         go({ collection: path, viewId: viewId ?? defaultViewId(path) })
       }}
-      onOpenView={(viewId) => go({ collection: currentPath, viewId })}
+      onOpenView={() => {
+        if (viewFromRoute || recordFromRoute) go({ collection: currentPath }, { replace: true })
+      }}
       onOpenRecord={(recordId, _viewId, collection) =>
         go({ collection: collection ?? currentPath, recordId })
       }

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -156,10 +156,13 @@ test('面包屑点上级会清掉后面几级', () => {
   assert.equal(crumbs[0]!.label, 'Task')
   assert.equal(pathForCrumbTarget(crumbs[0]!.target), '/database/tasks')
   assert.equal(pathForCrumbTarget(crumbs[1]!.target), '/database/tasks/view/1787983501816')
-  const pages = crumbs[0]!.choices.find((item) => item.id === '/pages')
-  assert.equal(pathForCrumbTarget(pages!.target), '/database/pages')
-  assert.equal(pages!.icon, 'puzzle-piece')
+  assert.equal(crumbButtonAction(crumbs[0]!), 'menu')
+  const board = crumbs[0]!.choices.find((item) => item.id === 'board')
+  assert.equal(board?.label, '看板')
+  assert.equal(board?.mode, 'board')
+  assert.equal(pathForCrumbTarget(board!.target), '/database/tasks/view/board')
   assert.equal(crumbs[1]!.choices.find((item) => item.id === 'board')?.mode, 'board')
+  assert.ok(!crumbs[0]!.choices.some((item) => item.id === '/pages'))
 })
 
 test('记录页面包屑是表 / 视图 / 记录，点表只回到表', () => {
@@ -199,6 +202,7 @@ test('一项时点面包屑回到上一级，多项出菜单', () => {
   assert.equal(crumbs[2]!.choices[0]!.icon, 'clipboard')
   assert.equal(crumbButtonAction(crumbs[2]!, crumbs[1]!), crumbs[1]!.target)
   assert.equal(crumbButtonAction(crumbs[1]!, crumbs[0]!), crumbs[0]!.target)
+  assert.equal(crumbButtonAction(crumbs[0]!), 'menu')
   const many = buildCrumbs({
     collection: '/tasks',
     collectionLabel: 'Task',

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -99,11 +99,11 @@ export function buildCrumbs(input: {
     id: input.collection,
     label: input.collectionLabel,
     target: { kind: 'collection', collection: input.collection },
-    choices: input.tables.map((table) => ({
-      id: table.path,
-      label: table.label,
-      icon: table.icon,
-      target: { kind: 'collection', collection: table.path },
+    choices: (input.views ?? []).map((view) => ({
+      id: view.id,
+      label: view.name,
+      mode: view.mode,
+      target: { kind: 'view', collection: input.collection, viewId: view.id },
     })),
   })
   if (input.viewId) {
@@ -144,8 +144,9 @@ export function crumbLabelAction(crumb: Crumb, parent?: Crumb): CrumbTarget {
   return { kind: 'root' }
 }
 
-/** 多项则出菜单；只有一项时点这一级回到上一级。 */
+/** 表级列出该表全部视图（一项也出菜单）。其它级多项出菜单，一项回到上一级。 */
 export function crumbButtonAction(crumb: Crumb, parent?: Crumb): 'menu' | CrumbTarget {
+  if (crumb.kind === 'collection' && crumb.choices.length > 0) return 'menu'
   if (crumb.choices.length > 1) return 'menu'
   return crumbLabelAction(crumb, parent)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点顶栏面包屑「会话」（当前表）会列出这张表的全部视图，一项也会出菜单。

选中某个视图只切换当前页内容；地址栏保持表级路由（例如 `http://127.0.0.1:5173/database/sessions`），不再写成 `/database/sessions/view/:id`。若当时 URL 里已有 `/view/` 或记录段，会 replace 回表路径。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

