### PR TITLE
fix(chat): 清空上下文提示改为上下文占输入文字比例

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -24,7 +24,7 @@ function parseAgentMode(value: unknown): AgentMode {
   return value === 'minimal' || value === 'create' ? value : 'standard'
 }
 
-/** 最新一条回复的历史输入占比（0..1），驱动橡皮擦底色。 */
+/** 最新一条回复里，上下文（更早 turn）占发给模型的输入文字的比例（0..1）。 */
 function latestHistRatio(nodes: ChatNode[]): number | null {
   const last = nodes.at(-1)
   if (!last || last.kind !== 'reply') return null
@@ -332,7 +332,7 @@ export function ApprovalsRail(props: SlotProps) {
             className="project-chip project-chip-icon-only relative"
             data-dock-tip={
               histRatio != null
-                ? `清空上下文 · 历史 ${Math.round(histRatio * 100)}%`
+                ? `清空上下文 · 上下文占输入文字 ${Math.round(histRatio * 100)}%`
                 : '清空上下文'
             }
             onClick={() => void clearContext()}

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -60,6 +60,8 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).not.toMatch(/\.project-chip-hist-bar\s*\{[^}]*color-scheme:/s)
     expect(css).not.toMatch(/\.project-chip-hist-bar\s*\{[^}]*mix-blend-mode:/s)
     expect(approvals).toMatch(/project-chip-hist-bar/)
+    expect(approvals).toContain('上下文占输入文字')
+    expect(approvals).not.toMatch(/清空上下文 · 历史/)
     expect(approvals).not.toMatch(/backgroundColor/)
   })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
清空上下文按钮的悬停提示由「历史 87%」改为「上下文占输入文字 87%」，数字仍是发给模型的输入里更早上下文所占比例（`histPct`），只改文案。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

