### PR TITLE
fix(fs): 点「会话」进 /database/sessions，内容仍是当前表视图

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -549,7 +549,7 @@ export const DataSidebar = memo(function DataSidebar({
                           <button
                             type="button"
                             className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit outline-none hover:text-(--dsw-sidebar-fg-active) focus-visible:ring-1 focus-visible:ring-(--dsw-border)"
-                            onClick={() => onOpenTable?.(table.path, undefined, { catalog: true })}
+                            onClick={() => onOpenTable?.(table.path)}
                           >
                             {name}
                           </button>

--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -7,12 +7,14 @@ const plugins = [DATA_MODULE]
 
 test('view and record helpers match the database URL scheme', () => {
   assert.equal(databaseViewPath('/pages', 'default'), '/database/pages/view/default')
+  assert.equal(databaseViewPath('/sessions'), '/database/sessions')
   assert.equal(databaseRecordPath('/pages', 'rec-1'), '/database/pages/record/rec-1')
   assert.equal(parseAppPath(databaseViewPath('/pages', 'default'), plugins).kind, 'collection-view')
+  assert.equal(parseAppPath(databaseViewPath('/sessions'), plugins).kind, 'collection-view')
   assert.equal(parseAppPath(databaseRecordPath('/pages', 'rec-1'), plugins).kind, 'record')
 })
 
-test('collection header opens the views catalog filtered by that table', () => {
+test('views catalog href is filtered by table source', () => {
   assert.equal(
     viewsCatalogHref('/events'),
     `/database/views/view/${encodeURIComponent('builtin:/events')}?source=%2Fevents`,

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -146,7 +146,7 @@ function CollectionPage(props: SlotProps) {
           navigate(viewsCatalogHref(path))
           return
         }
-        go({ collection: path, viewId: viewId ?? defaultViewId(path) })
+        go({ collection: path, viewId })
       }}
       onOpenView={(viewId) => go({ collection: currentPath, viewId })}
       onOpenRecord={(recordId, _viewId, collection) =>

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -313,7 +313,7 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
           setInspectorDbPath(id, viewsCatalogHref(path))
           return
         }
-        setInspectorDbPath(id, databaseViewPath(path, nextViewId ?? defaultViewId(path)))
+        setInspectorDbPath(id, databaseViewPath(path, nextViewId))
       }}
       onOpenView={(nextViewId) => setInspectorDbPath(id, databaseViewPath(currentPath, nextViewId))}
       onOpenRecord={(recordIdNext, _viewId, nextCollection) => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -19,7 +19,11 @@ test('data sidebar brand sits left with a collapse control on the right', () => 
 test('table and view rows only expand from the fold column', () => {
   const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
-  assert.match(sidebar, /onOpenTable\?\.\(table\.path, undefined, \{ catalog: true \}\)/)
+  assert.match(sidebar, /onOpenTable\?\.\(table\.path\)/)
+  assert.doesNotMatch(sidebar, /\{ catalog: true \}/)
+  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.match(page, /go\(\{ collection: path, viewId \}\)/)
+  assert.doesNotMatch(page, /go\(\{ collection: path, viewId: viewId \?\? defaultViewId\(path\) \}\)/)
   assert.doesNotMatch(sidebar, /\[table\.path\]: true/)
   assert.doesNotMatch(sidebar, /setOpenTables\(\(prev\) => \(\{ \.\.\.prev, \[path\]: true \}\)\)/)
   assert.match(css, /\.sidebar-group-fold:hover \.sidebar-group-fold-chevron/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏点表名（如「会话」）以前会进视图目录（`/database/views/view/...?source=/sessions`）。

现在路由是表本身：`/database/sessions`。主区仍按该表当前/上次使用的视图渲染记录，不强制换成目录页，也不写 `/view/:id`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

