### PR TITLE
fix(fs): 详情标题用 h1，距导航栏 80px

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -217,6 +217,7 @@ const CSS = `
 .fsdb-detail-head-actions{display:inline-flex;align-items:center;gap:2px;justify-self:end}
 .fsdb-detail-split{display:flex;flex-direction:column;flex:1;min-height:0;overflow:auto}
 .fsdb-detail-main{display:flex;flex-direction:column;gap:8px;padding:20px 22px 24px;min-width:0}
+.fsdb-page:not(.inspector-database-page) .fsdb-detail-main{padding-top:80px}
 .fsdb-detail-aside{display:flex;flex-direction:column;gap:2px;padding:8px 0 12px}
 .fsdb-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;font-size:14px;color:var(--dsw-label-3)}
 .fsdb-prop>span:first-child{font-size:14px;font-weight:600;color:var(--dsw-label-3);display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -227,8 +228,9 @@ const CSS = `
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
 .fsdb-prop-val .fsdb-tags{display:flex;flex-wrap:nowrap}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:8px;min-width:0}
-.fsdb-detail-title-input{width:100%;margin:0;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:700;line-height:1.35;outline:none;padding:0;resize:none}
-.fsdb-detail-title-row .fsdb-detail-title-input{flex:1;min-width:0}
+.fsdb-detail-title{flex:1;min-width:0;margin:0;color:var(--dsw-label);font-size:32px;font-weight:700;line-height:1.2}
+.fsdb-detail-title-input{display:block;width:100%;margin:0;border:0;background:transparent;color:inherit;font:inherit;font-size:inherit;font-weight:inherit;line-height:inherit;outline:none;padding:0;resize:none}
+.fsdb-detail-title-row .fsdb-detail-title-input{flex:none}
 .fsdb-page .tasks-icon-btn.is-danger:hover{background:color-mix(in srgb,var(--dsw-danger) 16%,transparent);color:var(--dsw-danger)}
 .fsdb-detail-id{font-size:14px;font-weight:400;color:var(--dsw-label-2);font-family:var(--font-mono);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-detail-doc{width:100%;min-height:180px;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;line-height:1.65;outline:none;resize:none;padding:8px 0 0;margin:0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -75,6 +75,7 @@ test('filesystem header expands the shared left sidebar and toggles the right in
 
 test('database extras sit after the record detail, not in the inspector', () => {
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  const style = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
   assert.doesNotMatch(page, /biu:inspector-open/)
   assert.match(page, /slots\.place\('inspector-panels'/)
   assert.match(page, /view\?\.inspector/)
@@ -83,6 +84,10 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.doesNotMatch(page, /tabLabel: '数据库'/)
   assert.doesNotMatch(page, /RecordPanePanel/)
   assert.match(detail, /fsdb-detail-extras/)
+  assert.match(detail, /<h1 className="fsdb-detail-title">/)
+  assert.doesNotMatch(detail, /<h2 className="fsdb-detail-title-input">/)
+  assert.match(style, /\.fsdb-page:not\(\.inspector-database-page\) \.fsdb-detail-main\{[^}]*padding-top:80px/)
+  assert.match(style, /\.fsdb-detail-title\{[^}]*font-size:32px/)
   assert.match(detail, /data-testid=\{`fsdb-pane-\$\{pane\.id\}`\}/)
   assert.match(browser, /embed \?/)
   assert.doesNotMatch(browser, /setRecordFocus/)

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -40,21 +40,23 @@ export function RecordDetail({
               <div className="fsdb-detail-main">
                 <div className="fsdb-detail-title-row">
                 {schema.labelField && schema.fields[schema.labelField]?.writable ? (
-                  <LocalText
-                    as="textarea"
-                    className="fsdb-detail-title-input"
-                    value={draft[schema.labelField] ?? ''}
-                    rows={(draft[schema.labelField] ?? '').length > 48 ? 2 : 1}
-                    onCommit={(raw) => {
-                      const next = raw.trim()
-                      setDraft((prev) => ({ ...prev, [schema.labelField!]: next }))
-                      if (next && next !== String(selected[schema.labelField!] ?? '')) {
-                        void writeOne(selected, schema.labelField!, schema.fields[schema.labelField!]!, next)
-                      }
-                    }}
-                  />
+                  <h1 className="fsdb-detail-title">
+                    <LocalText
+                      as="textarea"
+                      className="fsdb-detail-title-input"
+                      value={draft[schema.labelField] ?? ''}
+                      rows={(draft[schema.labelField] ?? '').length > 48 ? 2 : 1}
+                      onCommit={(raw) => {
+                        const next = raw.trim()
+                        setDraft((prev) => ({ ...prev, [schema.labelField!]: next }))
+                        if (next && next !== String(selected[schema.labelField!] ?? '')) {
+                          void writeOne(selected, schema.labelField!, schema.fields[schema.labelField!]!, next)
+                        }
+                      }}
+                    />
+                  </h1>
                 ) : (
-                  <h2 className="fsdb-detail-title-input">{labelOf(selected)}</h2>
+                  <h1 className="fsdb-detail-title">{labelOf(selected)}</h1>
                 )}
                 {onDelete ? (
                   <button type="button" className="tasks-icon-btn is-danger" title="删除" aria-label="删除记录" onClick={onDelete}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
记录详情标题改为语义 `h1`（可编辑时 textarea 包在 h1 里），字号 32px / 字重 700。

中间页详情区 `padding-top: 80px`，标题与顶栏面包屑导航相距 80px。检查器内嵌详情仍用原来的 20px 上内边距。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

