### PR TITLE
fix(fs): emoji 面板 #191919 无边框，并能选中

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -48,6 +48,90 @@ const SIDEBAR_BRAND_GRADIENT =
 
 const RECORD_EMOJI_PRESETS = ['⭐', '🔥', '✅', '📌', '💡', '🎯', '📦', '🧩', '📄', '⚡']
 
+function RecordEmojiBoard({
+  anchor,
+  draft,
+  onDraft,
+  onPick,
+  onClear,
+  onClose,
+}: {
+  anchor: HTMLElement
+  draft: string
+  onDraft: (next: string) => void
+  onPick: (emoji: string) => void
+  onClear: () => void
+  onClose: () => void
+}) {
+  const [pos, setPos] = useState({ left: 0, top: 0 })
+  useLayoutEffect(() => {
+    const place = () => {
+      const box = anchor.getBoundingClientRect()
+      const width = 168
+      setPos({
+        left: Math.min(box.left, Math.max(8, window.innerWidth - width - 8)),
+        top: box.bottom + 4,
+      })
+    }
+    place()
+    window.addEventListener('resize', place)
+    window.addEventListener('scroll', place, true)
+    return () => {
+      window.removeEventListener('resize', place)
+      window.removeEventListener('scroll', place, true)
+    }
+  }, [anchor])
+  useEffect(() => {
+    const onPointer = (event: MouseEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (anchor.contains(target)) return
+      if (target instanceof Element && target.closest('.fsdb-emoji-picker')) return
+      onClose()
+    }
+    document.addEventListener('mousedown', onPointer)
+    return () => document.removeEventListener('mousedown', onPointer)
+  }, [anchor, onClose])
+  if (typeof document === 'undefined') return null
+  return createPortal(
+    <div
+      className="fsdb-emoji-picker is-fixed"
+      data-biu-ignore
+      role="dialog"
+      aria-label="选择图标"
+      style={{ left: pos.left, top: pos.top }}
+      onMouseDown={(event) => event.stopPropagation()}
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="fsdb-emoji-picker-presets">
+        {RECORD_EMOJI_PRESETS.map((item) => (
+          <button key={item} type="button" className="fsdb-emoji-picker-item" onClick={() => onPick(item)}>
+            {item}
+          </button>
+        ))}
+      </div>
+      <input
+        className="fsdb-emoji-picker-input"
+        value={draft}
+        placeholder="输入 emoji"
+        maxLength={8}
+        onChange={(event) => onDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            onPick(draft)
+          }
+          if (event.key === 'Escape') onClose()
+        }}
+      />
+      <button type="button" className="fsdb-emoji-picker-clear" onClick={onClear}>
+        恢复默认
+      </button>
+    </div>,
+    document.body,
+  )
+}
+
 type PreviewState = { items: DbRecord[]; total: number; loading: boolean; error: string }
 
 const previewCache = new Map<string, { items: DbRecord[]; total: number }>()
@@ -76,6 +160,7 @@ function ViewRecordPreview({
     error: '',
   }))
   const [pickerId, setPickerId] = useState<string | null>(null)
+  const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null)
   const [emojiDraft, setEmojiDraft] = useState('')
 
   useEffect(() => {
@@ -103,16 +188,6 @@ function ViewRecordPreview({
       cancelled = true
     }
   }, [key, open, path, view.query, view.sortField, view.sortDir, view.filters])
-  useEffect(() => {
-    if (!pickerId) return
-    const onPointer = (event: MouseEvent) => {
-      const target = event.target
-      if (target instanceof Element && target.closest('.fsdb-emoji-picker, .fsdb-record-icon')) return
-      setPickerId(null)
-    }
-    document.addEventListener('mousedown', onPointer)
-    return () => document.removeEventListener('mousedown', onPointer)
-  }, [pickerId])
 
   async function loadMore() {
     const more = nextPreviewLimit(state.items.length, state.total)
@@ -137,6 +212,7 @@ function ViewRecordPreview({
       previewCache.set(key, { items, total: state.total })
       setState((prev) => ({ ...prev, items }))
       setPickerId(null)
+      setPickerAnchor(null)
       window.dispatchEvent(new Event('fsdb:change'))
     } catch (err) {
       setState((prev) => ({ ...prev, error: String(err) }))
@@ -166,44 +242,32 @@ function ViewRecordPreview({
                   aria-label={emoji ? `更换 ${recordPreviewLabel(row)} 的图标` : `设置 ${recordPreviewLabel(row)} 的图标`}
                   onClick={(event) => {
                     event.stopPropagation()
-                    setPickerId((prev) => (prev === row.id ? null : row.id))
+                    const btn = event.currentTarget
+                    setPickerId((prev) => {
+                      if (prev === row.id) {
+                        setPickerAnchor(null)
+                        return null
+                      }
+                      setPickerAnchor(btn)
+                      return row.id
+                    })
                     setEmojiDraft(emoji)
                   }}
                 >
-                  <TableGlyph icon={tableIcon} />
+                  {emoji ? <span className="fsdb-record-emoji">{emoji}</span> : <TableGlyph icon={tableIcon} />}
                 </button>
-                {pickerId === row.id ? (
-                  <div className="fsdb-emoji-picker" data-biu-ignore onClick={(event) => event.stopPropagation()}>
-                    <div className="fsdb-emoji-picker-presets">
-                      {RECORD_EMOJI_PRESETS.map((item) => (
-                        <button
-                          key={item}
-                          type="button"
-                          className="fsdb-emoji-picker-item"
-                          onClick={() => void saveEmoji(row, item)}
-                        >
-                          {item}
-                        </button>
-                      ))}
-                    </div>
-                    <input
-                      className="fsdb-emoji-picker-input"
-                      value={emojiDraft}
-                      placeholder="输入 emoji"
-                      maxLength={8}
-                      onChange={(event) => setEmojiDraft(event.target.value)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Enter') {
-                          event.preventDefault()
-                          void saveEmoji(row, emojiDraft)
-                        }
-                        if (event.key === 'Escape') setPickerId(null)
-                      }}
-                    />
-                    <button type="button" className="fsdb-emoji-picker-clear" onClick={() => void saveEmoji(row, '')}>
-                      恢复默认
-                    </button>
-                  </div>
+                {pickerId === row.id && pickerAnchor ? (
+                  <RecordEmojiBoard
+                    anchor={pickerAnchor}
+                    draft={emojiDraft}
+                    onDraft={setEmojiDraft}
+                    onPick={(next) => void saveEmoji(row, next)}
+                    onClear={() => void saveEmoji(row, '')}
+                    onClose={() => {
+                      setPickerId(null)
+                      setPickerAnchor(null)
+                    }}
+                  />
                 ) : null}
               </span>
               <button

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -28,6 +28,7 @@ test('table and view rows only expand from the fold column', () => {
 
 test('sidebar records paint detail immediately without reloading the view', () => {
   const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(browser, /flushSync\(\(\) => \{\s*setOpenDetailId\(recordId\)/)
   assert.match(browser, /if \(row\) setDetailRow\(row\)/)
   assert.match(browser, /onOpenRecord\?\.\(recordId, view\.id, path\)/)
@@ -36,6 +37,11 @@ test('sidebar records paint detail immediately without reloading the view', () =
   assert.match(browser, /!detailId \?/)
   assert.match(sidebar, /onOpenRecord\?\.\(row\.id, row\)/)
   assert.match(sidebar, /event.stopPropagation\(\)/)
+  assert.match(sidebar, /function RecordEmojiBoard/)
+  assert.match(sidebar, /className="fsdb-emoji-picker is-fixed"/)
+  assert.match(sidebar, /fsdb-record-emoji/)
+  assert.match(css, /\.fsdb-emoji-picker \{[^}]*border:\s*0/s)
+  assert.match(css, /\.fsdb-emoji-picker \{[^}]*background:\s*#191919/s)
 })
 
 test('table title opens record from the title-side button', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -1531,10 +1531,15 @@ body {
   z-index: 30;
   width: 168px;
   padding: 8px;
-  border: 1px solid var(--dsw-border);
+  border: 0;
   border-radius: 10px;
-  background: var(--dsw-sidebar);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, .18);
+  background: #191919;
+  box-shadow: none;
+}
+
+.fsdb-emoji-picker.is-fixed {
+  position: fixed;
+  z-index: 140;
 }
 
 .fsdb-emoji-picker-presets {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏记录图标的 emoji 面板：

- 背景 `#191919`，去掉边框和阴影
- 用 `position: fixed` portal 挂到 `document.body`，避免被侧栏 `overflow` 裁切导致点不到
- 选中后图标处显示该 emoji，不再一直是表的 clipboard 图标
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

