### PR TITLE
fix(chat): 悬停 dock 小人即弹出 Agent 菜单

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -15,7 +15,6 @@ import { bindSessionView, type ChatNode, type DispatchedTaskRow, type SessionVie
 import { BrandAgentMenu, SidebarMascot, resolveSessionMascot } from '@biu/web-mascot'
 import { SessionProjectPanel } from './project-panel.tsx'
 import { ChatLiveMetrics } from './live-hud.tsx'
-import { setOverlayAutohide } from '@biu/web-app-shell/chat-overlay'
 import { shouldNavigateToSession } from './composer-nav.ts'
 
 type AgentMode = 'minimal' | 'standard' | 'create'
@@ -349,7 +348,15 @@ export function ApprovalsRail(props: SlotProps) {
               ref={sessionPickerRef}
               className="dock-agent-stack"
               data-testid="dock-agent-stack"
-              onMouseEnter={() => setOverlayAutohide(false)}
+              onMouseEnter={() => {
+                setSessionPickerOpen(true)
+                setAgentMenuOpen(false)
+                setApprovalMenuOpen(false)
+              }}
+              onMouseLeave={(event) => {
+                if (sessionPickerRef.current?.contains(event.relatedTarget as Node)) return
+                setSessionPickerOpen(false)
+              }}
             >
               <button
                 type="button"

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -30,9 +30,14 @@ describe('composer dock stacking above sticky user', () => {
     expect(composer).toContain('biu:composer-focus')
   })
 
-  it('keeps the dock session mascot clickable while the overlay is autohidden', () => {
+  it('opens the dock agent menu on hover without waking the overlay', () => {
+    const approvals = readFileSync(resolve(root, 'packages/cap-chat/src/web/approvals.tsx'), 'utf8')
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     const shell = readFileSync(resolve(root, 'packages/web-app-shell/src/web/index.tsx'), 'utf8')
+    expect(approvals).toMatch(/onMouseEnter=\{\(\) => \{\s*setSessionPickerOpen\(true\)/)
+    expect(approvals).toMatch(/onMouseLeave=\{\(event\) => \{/)
+    expect(approvals).not.toMatch(/onMouseEnter=\{\(\) => setOverlayAutohide\(false\)\}/)
+    expect(css).toMatch(/\.chat-overlay-panel\.is-autohide \{\s*[^}]*overflow:\s*visible/)
     expect(shell).toMatch(/overlayCollapsed = !overlayOpen \|\| hidden/)
     expect(css).toMatch(
       /\.chat-overlay-panel\.is-autohide \.dock-agent-stack,\s*\n\.chat-overlay-panel\.is-autohide \.dock-agent-stack \* \{\s*pointer-events:\s*auto/,

--- a/web/style.css
+++ b/web/style.css
@@ -959,6 +959,7 @@ body {
   padding: 0;
   background: transparent;
   box-shadow: none;
+  overflow: visible;
   pointer-events: none !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
收起态的输入栏小人悬停即弹出 Agent 列表，不必先点一下唤醒浮层。移开鼠标菜单收起。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

