### PR TITLE
fix(chat): 中间小人悬停展开输入框，不再弹出聊天列表

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -11,7 +11,7 @@ import {
 } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type ChatNode, type DispatchedTaskRow, type SessionViewService } from '@biu/web-session-view'
-import { BrandAgentMenu, SidebarMascot, resolveSessionMascot } from '@biu/web-mascot'
+import { SidebarMascot, resolveSessionMascot } from '@biu/web-mascot'
 import { SessionProjectPanel } from './project-panel.tsx'
 import { ChatLiveMetrics } from './live-hud.tsx'
 
@@ -165,21 +165,8 @@ export function ApprovalsRail(props: SlotProps) {
   const [clearBusy, setClearBusy] = useState(false)
   const [agentMenuOpen, setAgentMenuOpen] = useState(false)
   const [approvalMenuOpen, setApprovalMenuOpen] = useState(false)
-  const [sessionPickerOpen, setSessionPickerOpen] = useState(false)
   const agentMenuRef = useRef<HTMLDivElement>(null)
   const approvalMenuRef = useRef<HTMLDivElement>(null)
-  const sessionPickerRef = useRef<HTMLSpanElement>(null)
-  const cornerAgents = useMemo(
-    () =>
-      sessions.map((item) => ({
-        id: item.id,
-        title: item.title,
-        updatedAt: item.updatedAt,
-        type: item.type,
-        mascot: item.mascot,
-      })),
-    [sessions],
-  )
 
   const refreshAgentMode = useCallback(async () => {
     try {
@@ -197,25 +184,19 @@ export function ApprovalsRail(props: SlotProps) {
   }, [refreshAgentMode])
 
   useEffect(() => {
-    if (!agentMenuOpen && !approvalMenuOpen && !sessionPickerOpen) return
+    if (!agentMenuOpen && !approvalMenuOpen) return
     const onDown = (event: MouseEvent) => {
       const node = event.target as Node
-      if (
-        agentMenuRef.current?.contains(node) ||
-        approvalMenuRef.current?.contains(node) ||
-        sessionPickerRef.current?.contains(node)
-      ) {
+      if (agentMenuRef.current?.contains(node) || approvalMenuRef.current?.contains(node)) {
         return
       }
       setAgentMenuOpen(false)
       setApprovalMenuOpen(false)
-      setSessionPickerOpen(false)
     }
     const onKey = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return
       setAgentMenuOpen(false)
       setApprovalMenuOpen(false)
-      setSessionPickerOpen(false)
     }
     window.addEventListener('mousedown', onDown)
     window.addEventListener('keydown', onKey)
@@ -223,7 +204,7 @@ export function ApprovalsRail(props: SlotProps) {
       window.removeEventListener('mousedown', onDown)
       window.removeEventListener('keydown', onKey)
     }
-  }, [agentMenuOpen, approvalMenuOpen, sessionPickerOpen])
+  }, [agentMenuOpen, approvalMenuOpen])
 
   // 快捷键：command+e / ctrl+e 触发清空上下文（在输入框中同样生效）
   const clearContextRef = useRef<() => void>(() => {})
@@ -340,34 +321,13 @@ export function ApprovalsRail(props: SlotProps) {
             <PaintBrushIcon className="size-4 relative z-1" aria-hidden />
           </button>
           {sessionId && sessionIdentity ? (
-            <span
-              ref={sessionPickerRef}
-              className="dock-agent-stack"
-              data-testid="dock-agent-stack"
-              onMouseEnter={() => {
-                setSessionPickerOpen(true)
-                setAgentMenuOpen(false)
-                setApprovalMenuOpen(false)
-              }}
-              onMouseLeave={(event) => {
-                if (sessionPickerRef.current?.contains(event.relatedTarget as Node)) return
-                setSessionPickerOpen(false)
-              }}
-            >
-              <button
-                type="button"
+            <span className="dock-agent-stack" data-testid="dock-agent-stack">
+              <span
                 className="dock-session-mascot"
                 data-testid="dock-session-mascot"
                 data-dock-tip={mainAgentName}
                 title={mainAgentName}
-                aria-label={mainAgentName ? `切换 Agent，当前：${mainAgentName}` : '切换 Agent'}
-                aria-haspopup="menu"
-                aria-expanded={sessionPickerOpen}
-                onClick={() => {
-                  setSessionPickerOpen((prev) => !prev)
-                  setAgentMenuOpen(false)
-                  setApprovalMenuOpen(false)
-                }}
+                aria-label={mainAgentName || undefined}
               >
                 <SidebarMascot
                   size={28}
@@ -377,17 +337,7 @@ export function ApprovalsRail(props: SlotProps) {
                   animate={false}
                   title=""
                 />
-              </button>
-              {sessionPickerOpen ? (
-                <BrandAgentMenu
-                  agents={cornerAgents}
-                  activeId={sessionId}
-                  onSelect={(id) => {
-                    setSessionPickerOpen(false)
-                    void sessionView.load(id, { view: 'chat' })
-                  }}
-                />
-              ) : null}
+              </span>
               {visibleWorkers.map((worker, index) => {
                 const identity = resolveSessionMascot(worker.sessionId, worker.mascot)
                 const listed = sessions.find((item) => item.id === worker.sessionId)

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -30,17 +30,16 @@ describe('composer dock stacking above sticky user', () => {
     expect(composer).toContain('biu:composer-focus')
   })
 
-  it('opens the dock agent menu on hover without waking the overlay', () => {
+  it('wakes the overlay composer on dock mascot hover, without an agent list', () => {
     const approvals = readFileSync(resolve(root, 'packages/cap-chat/src/web/approvals.tsx'), 'utf8')
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     const shell = readFileSync(resolve(root, 'packages/web-app-shell/src/web/index.tsx'), 'utf8')
-    expect(approvals).toMatch(/onMouseEnter=\{\(\) => \{\s*setSessionPickerOpen\(true\)/)
-    expect(approvals).toMatch(/onMouseLeave=\{\(event\) => \{/)
-    expect(approvals).toContain("void sessionView.load(id, { view: 'chat' })")
-    expect(approvals).not.toContain('shouldNavigateToSession')
-    expect(shell).toMatch(/hit\.closest\('\.dock-agent-stack'\)/)
-    expect(css).toMatch(/\.chat-overlay-panel\.is-autohide \{\s*[^}]*overflow:\s*visible/)
+    expect(approvals).toContain('dock-session-mascot')
+    expect(approvals).not.toContain('BrandAgentMenu')
+    expect(approvals).not.toContain('setSessionPickerOpen')
+    expect(shell).not.toMatch(/hit\.closest\('\.dock-agent-stack'\)/)
     expect(shell).toMatch(/overlayCollapsed = !overlayOpen \|\| hidden/)
+    expect(css).toMatch(/\.chat-overlay-panel\.is-autohide \{\s*[^}]*overflow:\s*visible/)
     expect(css).toMatch(
       /\.chat-overlay-panel\.is-autohide \.dock-agent-stack,\s*\n\.chat-overlay-panel\.is-autohide \.dock-agent-stack \* \{\s*pointer-events:\s*auto/,
     )

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -254,9 +254,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
     }
   })
   heightRef.current = overlayChatHeight
-  const keepVisible = useCallback((event?: { target?: EventTarget | null }) => {
-    const hit = event?.target
-    if (hit instanceof Element && hit.closest('.dock-agent-stack')) return
+  const keepVisible = useCallback(() => {
     setOverlayAutohide(false)
   }, [])
   const hideIfIdle = useCallback(
@@ -352,7 +350,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
             ['--overlay-chat-height' as string]: `${overlayChatHeight}px`,
             ['--rail-w' as string]: railOpen ? '48px' : '0px',
           } as CSSProperties}
-          onMouseEnter={(event) => keepVisible(event)}
+          onMouseEnter={keepVisible}
           onMouseLeave={hideIfIdle}
         >
           <div

--- a/web/style.css
+++ b/web/style.css
@@ -1990,12 +1990,6 @@ body {
   gap: 4px;
 }
 
-.dock-agent-stack .brand-agent-menu {
-  left: 0;
-  right: auto;
-  bottom: calc(100% + 8px);
-}
-
 .dock-session-mascot,
 .dock-worker-mascot {
   display: inline-flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
中间 dock 小人悬停时展开 overlay 输入栏，不再弹出 `BrandAgentMenu` 会话列表。会话切换仍在右下角吉祥物菜单。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

