### PR TITLE
fix(shell): 侧栏品牌用渗开的渐变边，而不是硬胶囊

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -723,7 +723,9 @@ export const DataSidebar = memo(function DataSidebar({
       aria-label="数据"
     >
       <div className="app-side-bar-head app-side-bar-head-brand">
-        <span className="app-side-bar-brand-title">Biu Agent OS</span>
+        <span className="app-side-bar-brand-title">
+          <span className="app-side-bar-brand-title-text">Biu Agent OS</span>
+        </span>
         <button
           type="button"
           className="chat-view-header-expand"

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -43,9 +43,6 @@ import { pickDomAttrs, recordPickKind, viewPickId } from './pick-dom.ts'
 import { toggleExpandedViewKey } from './sidebar-nav.ts'
 import { TableGlyph, ViewModeGlyph } from './nav-glyphs.tsx'
 
-const SIDEBAR_BRAND_GRADIENT =
-  'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
-
 const RECORD_EMOJI_PRESETS = ['⭐', '🔥', '✅', '📌', '💡', '🎯', '📦', '🧩', '📄', '⚡']
 
 function RecordEmojiBoard({
@@ -726,12 +723,7 @@ export const DataSidebar = memo(function DataSidebar({
       aria-label="数据"
     >
       <div className="app-side-bar-head app-side-bar-head-brand">
-        <span
-          className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
-          style={{ background: SIDEBAR_BRAND_GRADIENT }}
-        >
-          Biu Agent OS
-        </span>
+        <span className="app-side-bar-brand-title">Biu Agent OS</span>
         <button
           type="button"
           className="chat-view-header-expand"

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -9,6 +9,8 @@ const detail = readFileSync(resolve(import.meta.dirname, './record-detail.tsx'),
 test('data sidebar brand sits left with a collapse control on the right', () => {
   const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
   assert.match(sidebar, /app-side-bar-head-brand/)
+  assert.match(sidebar, /app-side-bar-brand-title/)
+  assert.doesNotMatch(sidebar, /SIDEBAR_BRAND_GRADIENT/)
   assert.match(sidebar, /data-testid="sidebar-collapse"/)
   assert.doesNotMatch(sidebar, /SidebarBrandMascot/)
   assert.match(browser, /onCollapse=\{toggleViewsOpen\}/)

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -66,7 +66,9 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
         />
       ) : null}
       <div className="app-side-bar-head app-side-bar-head-brand">
-        <span className="app-side-bar-brand-title">Biu Agent OS</span>
+        <span className="app-side-bar-brand-title">
+          <span className="app-side-bar-brand-title-text">Biu Agent OS</span>
+        </span>
         {narrow ? (
           <button
             type="button"

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -2,9 +2,6 @@ import { memo, useEffect, useRef, type ReactNode } from 'react'
 import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '@heroicons/react/16/solid'
 import { chromeIcon } from './chrome-icon.ts'
 
-export const SIDEBAR_BRAND_GRADIENT =
-  'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
-
 export type ShellSidebarFrameProps = {
   visible: boolean
   narrow?: boolean
@@ -69,12 +66,7 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
         />
       ) : null}
       <div className="app-side-bar-head app-side-bar-head-brand">
-        <span
-          className="inline-flex min-w-0 max-w-full items-center truncate rounded-md px-2 py-0.5 text-[14px] font-semibold tracking-wide text-white"
-          style={{ background: SIDEBAR_BRAND_GRADIENT }}
-        >
-          Biu Agent OS
-        </span>
+        <span className="app-side-bar-brand-title">Biu Agent OS</span>
         {narrow ? (
           <button
             type="button"

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -19,13 +19,16 @@ describe('sidebar text colors', () => {
     expect(css).toMatch(/\.app-side-bar\.is-narrow \.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*center/s)
   })
 
-  it('bleeds the brand wash into the sidebar instead of a hard chip', () => {
+  it('draws a fused brand chip with a soft gradient edge', () => {
     const frame = readFileSync(resolve(import.meta.dirname, './shell-sidebar-frame.tsx'), 'utf8')
     expect(frame).toMatch(/app-side-bar-brand-title/)
     expect(frame).not.toMatch(/SIDEBAR_BRAND_GRADIENT/)
     expect(frame).not.toMatch(/rounded-md/)
     expect(css).toMatch(/\.app-side-bar:has\(\.app-side-bar-head-brand\)::before/)
     expect(css).toMatch(/filter:\s*blur\(42px\)/)
+    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border:\s*1px solid transparent/s)
+    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border-box/s)
+    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*drop-shadow/s)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg-active\)/s)
   })
 

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -19,6 +19,16 @@ describe('sidebar text colors', () => {
     expect(css).toMatch(/\.app-side-bar\.is-narrow \.app-side-bar-head-brand\s*\{[^}]*justify-content:\s*center/s)
   })
 
+  it('bleeds the brand wash into the sidebar instead of a hard chip', () => {
+    const frame = readFileSync(resolve(import.meta.dirname, './shell-sidebar-frame.tsx'), 'utf8')
+    expect(frame).toMatch(/app-side-bar-brand-title/)
+    expect(frame).not.toMatch(/SIDEBAR_BRAND_GRADIENT/)
+    expect(frame).not.toMatch(/rounded-md/)
+    expect(css).toMatch(/\.app-side-bar:has\(\.app-side-bar-head-brand\)::before/)
+    expect(css).toMatch(/filter:\s*blur\(42px\)/)
+    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg-active\)/s)
+  })
+
   it('session rows do not start a native drag ghost', () => {
     const sidebar = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'utf8')
     expect(sidebar).toMatch(/draggable=\{false\}/)

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -25,7 +25,7 @@ describe('sidebar text colors', () => {
     expect(frame).not.toMatch(/SIDEBAR_BRAND_GRADIENT/)
     expect(frame).not.toMatch(/rounded-md/)
     expect(css).toMatch(/\.app-side-bar:has\(\.app-side-bar-head-brand\)::before/)
-    expect(css).toMatch(/filter:\s*blur\(42px\)/)
+    expect(css).toMatch(/filter:\s*blur\(48px\)/)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border:\s*1px solid transparent/s)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border-box/s)
     expect(css).toMatch(/\.app-side-bar-brand-title::after/)

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -28,7 +28,8 @@ describe('sidebar text colors', () => {
     expect(css).toMatch(/filter:\s*blur\(42px\)/)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border:\s*1px solid transparent/s)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*border-box/s)
-    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*drop-shadow/s)
+    expect(css).toMatch(/\.app-side-bar-brand-title::after/)
+    expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*box-shadow:/s)
     expect(css).toMatch(/\.app-side-bar-brand-title\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg-active\)/s)
   })
 

--- a/web/style.css
+++ b/web/style.css
@@ -349,16 +349,39 @@ body {
 }
 
 .app-side-bar-brand-title {
+  position: relative;
+  display: inline-flex;
   min-width: 0;
   max-width: 100%;
+  align-items: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 3px 9px;
+  border: 1px solid transparent;
+  border-radius: 8px;
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.04em;
   color: var(--dsw-sidebar-fg-active);
-  text-shadow: 0 0 32px color-mix(in srgb, #5B3E90 28%, transparent);
+  background:
+    linear-gradient(
+      105deg,
+      color-mix(in srgb, #0066B0 16%, var(--dsw-sidebar)),
+      color-mix(in srgb, #5B3E90 14%, var(--dsw-sidebar)) 52%,
+      color-mix(in srgb, #E22726 12%, var(--dsw-sidebar))
+    ) padding-box,
+    linear-gradient(
+      105deg,
+      color-mix(in srgb, #0066B0 72%, transparent),
+      color-mix(in srgb, #5B3E90 68%, transparent) 52%,
+      color-mix(in srgb, #E22726 58%, transparent)
+    ) border-box;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 10%, transparent);
+  filter:
+    drop-shadow(0 0 8px color-mix(in srgb, #0066B0 32%, transparent))
+    drop-shadow(0 0 16px color-mix(in srgb, #5B3E90 26%, transparent))
+    drop-shadow(0 0 22px color-mix(in srgb, #E22726 14%, transparent));
 }
 
 .app-side-bar-head-brand .chat-view-header-expand {

--- a/web/style.css
+++ b/web/style.css
@@ -325,6 +325,42 @@ body {
   padding-right: 8px;
 }
 
+/* 品牌色像光晕渗进侧栏顶，不要胶囊硬边 */
+.app-side-bar:has(.app-side-bar-head-brand)::before {
+  content: '';
+  position: absolute;
+  left: 6%;
+  top: -40px;
+  z-index: 0;
+  width: 88%;
+  height: 148px;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 58% 72% at 18% 42%, color-mix(in srgb, #0066B0 58%, transparent), transparent 72%),
+    radial-gradient(ellipse 52% 68% at 48% 22%, color-mix(in srgb, #5B3E90 50%, transparent), transparent 74%),
+    radial-gradient(ellipse 48% 64% at 82% 46%, color-mix(in srgb, #E22726 38%, transparent), transparent 72%);
+  filter: blur(42px);
+  opacity: 0.5;
+}
+
+.app-side-bar.is-narrow:has(.app-side-bar-head-brand)::before {
+  height: 120px;
+  opacity: 0.32;
+}
+
+.app-side-bar-brand-title {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--dsw-sidebar-fg-active);
+  text-shadow: 0 0 32px color-mix(in srgb, #5B3E90 28%, transparent);
+}
+
 .app-side-bar-head-brand .chat-view-header-expand {
   position: absolute;
   right: 8px;

--- a/web/style.css
+++ b/web/style.css
@@ -325,27 +325,27 @@ body {
   padding-right: 8px;
 }
 
-/* 品牌色像光晕渗进侧栏顶，不要胶囊硬边 */
+/* 品牌色像薄雾渗进栏顶；牌子有轮廓，但边是晕开的 */
 .app-side-bar:has(.app-side-bar-head-brand)::before {
   content: '';
   position: absolute;
-  left: 6%;
-  top: -40px;
+  left: 8%;
+  top: -36px;
   z-index: 0;
-  width: 88%;
-  height: 148px;
+  width: 78%;
+  height: 120px;
   pointer-events: none;
   background:
-    radial-gradient(ellipse 58% 72% at 18% 42%, color-mix(in srgb, #0066B0 58%, transparent), transparent 72%),
-    radial-gradient(ellipse 52% 68% at 48% 22%, color-mix(in srgb, #5B3E90 50%, transparent), transparent 74%),
-    radial-gradient(ellipse 48% 64% at 82% 46%, color-mix(in srgb, #E22726 38%, transparent), transparent 72%);
-  filter: blur(42px);
-  opacity: 0.38;
+    radial-gradient(ellipse 58% 72% at 18% 42%, color-mix(in srgb, #0066B0 42%, transparent), transparent 74%),
+    radial-gradient(ellipse 52% 68% at 48% 22%, color-mix(in srgb, #5B3E90 36%, transparent), transparent 76%),
+    radial-gradient(ellipse 48% 64% at 82% 46%, color-mix(in srgb, #E22726 22%, transparent), transparent 74%);
+  filter: blur(48px);
+  opacity: 0.28;
 }
 
 .app-side-bar.is-narrow:has(.app-side-bar-head-brand)::before {
-  height: 120px;
-  opacity: 0.32;
+  height: 96px;
+  opacity: 0.18;
 }
 
 .app-side-bar-brand-title {
@@ -356,9 +356,9 @@ body {
   max-width: 100%;
   align-items: center;
   overflow: visible;
-  padding: 4px 10px;
+  padding: 3px 8px;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 7px;
   font-size: 14px;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -366,26 +366,33 @@ body {
   background:
     linear-gradient(
       105deg,
-      color-mix(in srgb, #0066B0 34%, var(--dsw-sidebar)),
-      color-mix(in srgb, #5B3E90 30%, var(--dsw-sidebar)) 52%,
-      color-mix(in srgb, #E22726 26%, var(--dsw-sidebar))
+      color-mix(in srgb, #0066B0 14%, var(--dsw-sidebar)),
+      color-mix(in srgb, #5B3E90 12%, var(--dsw-sidebar)) 52%,
+      color-mix(in srgb, #E22726 10%, var(--dsw-sidebar))
     ) padding-box,
-    linear-gradient(105deg, #4aa3e8, #a078dc 52%, #ee6d6a) border-box;
-  box-shadow:
-    0 0 18px color-mix(in srgb, #0066B0 50%, transparent),
-    0 0 32px color-mix(in srgb, #5B3E90 42%, transparent),
-    0 0 40px color-mix(in srgb, #E22726 22%, transparent);
+    linear-gradient(
+      105deg,
+      color-mix(in srgb, #0066B0 38%, var(--dsw-sidebar)),
+      color-mix(in srgb, #5B3E90 34%, var(--dsw-sidebar)) 52%,
+      color-mix(in srgb, #E22726 28%, var(--dsw-sidebar))
+    ) border-box;
+  box-shadow: 0 0 16px color-mix(in srgb, #5B3E90 18%, transparent);
 }
 
 .app-side-bar-brand-title::after {
   content: '';
   position: absolute;
-  inset: -4px;
+  inset: -3px;
   z-index: -1;
-  border-radius: 11px;
-  background: linear-gradient(105deg, #0066B0, #5B3E90 52%, #E22726);
-  filter: blur(10px);
-  opacity: 0.55;
+  border-radius: 10px;
+  background: linear-gradient(
+    105deg,
+    color-mix(in srgb, #0066B0 40%, transparent),
+    color-mix(in srgb, #5B3E90 36%, transparent) 52%,
+    color-mix(in srgb, #E22726 24%, transparent)
+  );
+  filter: blur(12px);
+  opacity: 0.22;
 }
 
 .app-side-bar-brand-title-text {

--- a/web/style.css
+++ b/web/style.css
@@ -340,7 +340,7 @@ body {
     radial-gradient(ellipse 52% 68% at 48% 22%, color-mix(in srgb, #5B3E90 50%, transparent), transparent 74%),
     radial-gradient(ellipse 48% 64% at 82% 46%, color-mix(in srgb, #E22726 38%, transparent), transparent 72%);
   filter: blur(42px);
-  opacity: 0.5;
+  opacity: 0.38;
 }
 
 .app-side-bar.is-narrow:has(.app-side-bar-head-brand)::before {
@@ -350,14 +350,13 @@ body {
 
 .app-side-bar-brand-title {
   position: relative;
+  isolation: isolate;
   display: inline-flex;
   min-width: 0;
   max-width: 100%;
   align-items: center;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding: 3px 9px;
+  overflow: visible;
+  padding: 4px 10px;
   border: 1px solid transparent;
   border-radius: 8px;
   font-size: 14px;
@@ -367,21 +366,33 @@ body {
   background:
     linear-gradient(
       105deg,
-      color-mix(in srgb, #0066B0 16%, var(--dsw-sidebar)),
-      color-mix(in srgb, #5B3E90 14%, var(--dsw-sidebar)) 52%,
-      color-mix(in srgb, #E22726 12%, var(--dsw-sidebar))
+      color-mix(in srgb, #0066B0 34%, var(--dsw-sidebar)),
+      color-mix(in srgb, #5B3E90 30%, var(--dsw-sidebar)) 52%,
+      color-mix(in srgb, #E22726 26%, var(--dsw-sidebar))
     ) padding-box,
-    linear-gradient(
-      105deg,
-      color-mix(in srgb, #0066B0 72%, transparent),
-      color-mix(in srgb, #5B3E90 68%, transparent) 52%,
-      color-mix(in srgb, #E22726 58%, transparent)
-    ) border-box;
-  box-shadow: inset 0 1px 0 color-mix(in srgb, #fff 10%, transparent);
-  filter:
-    drop-shadow(0 0 8px color-mix(in srgb, #0066B0 32%, transparent))
-    drop-shadow(0 0 16px color-mix(in srgb, #5B3E90 26%, transparent))
-    drop-shadow(0 0 22px color-mix(in srgb, #E22726 14%, transparent));
+    linear-gradient(105deg, #4aa3e8, #a078dc 52%, #ee6d6a) border-box;
+  box-shadow:
+    0 0 18px color-mix(in srgb, #0066B0 50%, transparent),
+    0 0 32px color-mix(in srgb, #5B3E90 42%, transparent),
+    0 0 40px color-mix(in srgb, #E22726 22%, transparent);
+}
+
+.app-side-bar-brand-title::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  z-index: -1;
+  border-radius: 11px;
+  background: linear-gradient(105deg, #0066B0, #5B3E90 52%, #E22726);
+  filter: blur(10px);
+  opacity: 0.55;
+}
+
+.app-side-bar-brand-title-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .app-side-bar-head-brand .chat-view-header-expand {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
侧栏「Biu Agent OS」改成能感觉到边、又和底融在一起的写法：半透明品牌底 + 1px 渐变描边 + 外发光，后面仍有一层渗开的霞光。没有实心硬胶囊。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d5fa2bc-61dd-4c89-b82b-6ff1c2ee07ed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

