### PR TITLE
Store plugin windows follow manifest.shell size

### DIFF
--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -42,6 +42,13 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
     const listed = await store.list()
     assert.equal(listed[0]?.createdAt, manifest.createdAt)
     assert.equal(listed[0]?.lastRunAt, null)
+    assert.deepEqual(listed[0]?.shell, {
+      width: 480,
+      height: 360,
+      minWidth: 200,
+      minHeight: 160,
+      resizable: true,
+    })
     const hostJs = await readFile(join(pluginDir, 'store-echo', 'host.js'), 'utf8')
     assert.match(hostJs, /\bapply\b/)
     assert.doesNotMatch(hostJs, /ctx: \{/)
@@ -49,6 +56,33 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
       () => store.create({ id: 'store-empty', name: 'Empty' }),
       /hostJs and\/or webJs/,
     )
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('create writes manifest.shell from input', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-shell-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const pluginDir = join(dir, '.plugin')
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    await store.create({
+      id: 'store-game',
+      name: 'Game',
+      shell: { width: 640, height: 480, resizable: false },
+      webJs: `export const name = 'store-game'\nexport function apply() {}`,
+    })
+    const manifest = JSON.parse(await readFile(join(pluginDir, 'store-game', 'manifest.json'), 'utf8')) as {
+      shell: { width: number; height: number; resizable: boolean }
+    }
+    assert.equal(manifest.shell.width, 640)
+    assert.equal(manifest.shell.height, 480)
+    assert.equal(manifest.shell.resizable, false)
+    const listed = await store.list()
+    assert.equal(listed[0]?.shell.width, 640)
+    assert.equal(listed[0]?.shell.resizable, false)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { Context } from 'cordis'
 import type { PluginStoreService } from './store.ts'
+import { parseStoreShell, type StoreShell } from '../shell.ts'
 
 export type PluginCreateInput = {
   id: string
@@ -11,6 +12,7 @@ export type PluginCreateInput = {
   tags?: string[]
   author?: string
   authorUrl?: string
+  shell?: StoreShell | Record<string, unknown>
   hostJs?: string
   webJs?: string
 }
@@ -23,6 +25,7 @@ export type StoreManifestFields = {
   author: string
   authorUrl: string
   createdAt: number
+  shell: StoreShell
 }
 
 export function parseTags(value: unknown): string[] {
@@ -35,7 +38,7 @@ export function parseTags(value: unknown): string[] {
 }
 
 export function buildStoreManifest(
-  input: Pick<PluginCreateInput, 'id' | 'name' | 'blurb' | 'tags' | 'author' | 'authorUrl'>,
+  input: Pick<PluginCreateInput, 'id' | 'name' | 'blurb' | 'tags' | 'author' | 'authorUrl' | 'shell'>,
   existing?: Partial<StoreManifestFields>,
   now = Date.now(),
 ): StoreManifestFields {
@@ -48,6 +51,7 @@ export function buildStoreManifest(
     author: String(input.author ?? existing?.author ?? '').trim(),
     authorUrl: String(input.authorUrl ?? existing?.authorUrl ?? '').trim(),
     createdAt: Number.isFinite(createdAt) && createdAt > 0 ? createdAt : now,
+    shell: parseStoreShell(input.shell ?? existing?.shell),
   }
 }
 
@@ -65,6 +69,7 @@ export function parseStoreManifest(raw: unknown): StoreManifestFields {
       tags: parseTags(data.tags),
       author: data.author != null ? String(data.author) : undefined,
       authorUrl: data.authorUrl != null ? String(data.authorUrl) : data.author_url != null ? String(data.author_url) : undefined,
+      shell: data.shell,
     },
     { createdAt },
     Number.isFinite(createdAt) && createdAt > 0 ? createdAt : 0,
@@ -132,6 +137,7 @@ export async function readSandboxManifest(dir: string) {
 const CONTRACT = [
   '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。不要改 packages/ 或 cordis.plugins.json。',
   'host 与 web 按需，至少一侧。Web：ctx.slots.place("plugin-store-extras", Comp, { key })。运行窗口会给 extras 套 macOS 窗口框（关/缩/全屏），key 尽量用插件 id。',
+  '有 UI 时在 manifest.shell 声明内容区像素：{ width, height, minWidth?, minHeight?, resizable? }。窗口按这个尺寸打开，插件根节点铺满窗口，不要用 100vw 或测量 DOM 撑开外壳。缺省 480×360。',
 ].join(' ')
 
 const PLUGIN_CREATE_DESCRIPTION = [
@@ -160,6 +166,7 @@ function createArgs(args: Record<string, unknown>): PluginCreateInput {
     tags: parseTags(args.tags),
     author: args.author != null ? String(args.author) : undefined,
     authorUrl: args.authorUrl != null ? String(args.authorUrl) : undefined,
+    shell: args.shell && typeof args.shell === 'object' ? (args.shell as Record<string, unknown>) : undefined,
     hostJs: args.hostJs != null ? String(args.hostJs) : undefined,
     webJs: args.webJs != null ? String(args.webJs) : undefined,
   }
@@ -179,6 +186,17 @@ const ID_NAME_BLURB = {
   },
   author: { type: 'string', description: '作者名' },
   authorUrl: { type: 'string', description: '作者主页 / 仓库链接' },
+  shell: {
+    type: 'object',
+    description: '运行窗口内容区尺寸（像素，不含标题栏）。缺省 480×360。',
+    properties: {
+      width: { type: 'number', description: '内容区宽' },
+      height: { type: 'number', description: '内容区高' },
+      minWidth: { type: 'number' },
+      minHeight: { type: 'number' },
+      resizable: { type: 'boolean', description: 'false 则锁死尺寸，适合固定画布' },
+    },
+  },
 }
 
 export function registerPluginCreate(ctx: Context, store: PluginStoreService) {

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -15,7 +15,9 @@ import {
   registerPluginCreate,
   WEB_ENTRIES,
   type PluginCreateInput,
+  type StoreManifestFields,
 } from './plugin-create.ts'
+import type { StoreShell } from '../shell.ts'
 
 export type StoreListing = {
   id: string
@@ -32,17 +34,10 @@ export type StoreListing = {
   lastRunAt: number | null
   hasHost: boolean
   hasWeb: boolean
+  shell: StoreShell
 }
 
-export type StoreManifest = {
-  id: string
-  name: string
-  blurb: string
-  tags: string[]
-  author: string
-  authorUrl: string
-  createdAt: number
-}
+export type StoreManifest = StoreManifestFields
 
 type StoreHub = {
   adopt(entry: CatalogEntry): Promise<unknown>

--- a/packages/core-plugin-system/src/shell.test.ts
+++ b/packages/core-plugin-system/src/shell.test.ts
@@ -1,0 +1,35 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { WIN_CHROME_H, centeredGeom, parseStoreShell, windowOuterSize } from './shell.ts'
+
+test('parseStoreShell defaults and clamps declared content size', () => {
+  const d = parseStoreShell(undefined)
+  assert.equal(d.width, 480)
+  assert.equal(d.height, 360)
+  assert.equal(d.resizable, true)
+  const game = parseStoreShell({ width: 640, height: 480, resizable: false })
+  assert.equal(game.width, 640)
+  assert.equal(game.height, 480)
+  assert.equal(game.resizable, false)
+  const tiny = parseStoreShell({ width: 12, height: 12, minWidth: 12, minHeight: 12 })
+  assert.equal(tiny.width, 80)
+  assert.equal(tiny.minWidth, 80)
+})
+
+test('windowOuterSize uses content size plus title chrome', () => {
+  const shell = parseStoreShell({ width: 640, height: 480 })
+  const size = windowOuterSize(shell, { w: 1600, h: 900 })
+  assert.equal(size.w, 640)
+  assert.equal(size.h, 480 + WIN_CHROME_H)
+  const fitted = windowOuterSize(shell, { w: 400, h: 300 })
+  assert.equal(fitted.w, 400)
+  assert.equal(fitted.h, 300)
+})
+
+test('centeredGeom keeps the window on screen', () => {
+  const geom = centeredGeom(parseStoreShell({ width: 640, height: 400 }), { w: 1200, h: 800 }, '')
+  assert.equal(geom.w, 640)
+  assert.equal(geom.h, 400 + WIN_CHROME_H)
+  assert.ok(geom.x >= 16)
+  assert.ok(geom.y >= 16)
+})

--- a/packages/core-plugin-system/src/shell.ts
+++ b/packages/core-plugin-system/src/shell.ts
@@ -1,0 +1,90 @@
+export const WIN_CHROME_H = 32
+export const WIN_DEFAULT_W = 480
+export const WIN_DEFAULT_H = 360
+export const WIN_ABS_MIN = 80
+export const WIN_ABS_MAX = 8192
+
+export type StoreShell = {
+  width: number
+  height: number
+  minWidth: number
+  minHeight: number
+  resizable: boolean
+}
+
+export type WinGeom = { x: number; y: number; w: number; h: number }
+
+export function defaultStoreShell(): StoreShell {
+  return {
+    width: WIN_DEFAULT_W,
+    height: WIN_DEFAULT_H,
+    minWidth: 200,
+    minHeight: 160,
+    resizable: true,
+  }
+}
+
+function dim(value: unknown, fallback: number, min: number, max: number) {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return fallback
+  return Math.min(max, Math.max(min, Math.round(n)))
+}
+
+/** manifest.shell：width/height 是内容区像素，不含标题栏。缺省 480×360。 */
+export function parseStoreShell(value: unknown): StoreShell {
+  const d = defaultStoreShell()
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return d
+  const rec = value as Record<string, unknown>
+  const width = dim(rec.width ?? rec.w, d.width, WIN_ABS_MIN, WIN_ABS_MAX)
+  const height = dim(rec.height ?? rec.h, d.height, WIN_ABS_MIN, WIN_ABS_MAX)
+  const minWidth = dim(rec.minWidth ?? rec.min_width, Math.min(d.minWidth, width), WIN_ABS_MIN, width)
+  const minHeight = dim(rec.minHeight ?? rec.min_height, Math.min(d.minHeight, height), WIN_ABS_MIN, height)
+  return {
+    width,
+    height,
+    minWidth,
+    minHeight,
+    resizable: rec.resizable == null ? true : rec.resizable !== false,
+  }
+}
+
+export function windowOuterSize(shell: StoreShell, viewport: { w: number; h: number }): { w: number; h: number } {
+  const minW = Math.min(viewport.w, Math.max(WIN_ABS_MIN, shell.minWidth))
+  const minH = Math.min(viewport.h, Math.max(WIN_ABS_MIN, shell.minHeight + WIN_CHROME_H))
+  return {
+    w: Math.min(viewport.w, Math.max(minW, shell.width)),
+    h: Math.min(viewport.h, Math.max(minH, shell.height + WIN_CHROME_H)),
+  }
+}
+
+export function centeredGeom(shell: StoreShell, viewport: { w: number; h: number }, seed = ''): WinGeom {
+  const size = windowOuterSize(shell, viewport)
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) >>> 0
+  const jitterX = seed ? (hash % 5) * 28 - 56 : 0
+  const jitterY = seed ? (hash % 4) * 24 - 48 : 0
+  return clampGeom(
+    {
+      x: Math.max(16, Math.round((viewport.w - size.w) / 2) + jitterX),
+      y: Math.max(16, Math.round((viewport.h - size.h) / 2) + jitterY),
+      ...size,
+    },
+    shell,
+    viewport,
+  )
+}
+
+export function clampGeom(next: WinGeom, shell: StoreShell, viewport: { w: number; h: number }): WinGeom {
+  const minW = Math.max(WIN_ABS_MIN, shell.minWidth)
+  const minH = Math.max(WIN_ABS_MIN, shell.minHeight + WIN_CHROME_H)
+  const w = Math.min(viewport.w, Math.max(minW, next.w))
+  const h = Math.min(viewport.h, Math.max(minH, next.h))
+  const maxX = Math.max(0, viewport.w - 64)
+  const maxY = Math.max(0, viewport.h - 36)
+  return {
+    x: Math.min(maxX, Math.max(0, next.x)),
+    y: Math.min(maxY, Math.max(0, next.y)),
+    w,
+    h,
+  }
+}

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -52,3 +52,15 @@ test('plugin system web passes name/tags/action chrome into databaseUi', async (
   assert.equal(typeof ui.last?.chrome.cells?.tags, 'function')
   assert.equal(typeof ui.last?.chrome.Action, 'function')
 })
+
+test('plugin window sizes from manifest.shell instead of measuring DOM', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const src = await readFile(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.match(src, /data-shell-width=\{shell\.width\}/)
+  assert.match(src, /parseStoreShell/)
+  assert.doesNotMatch(src, /measurePluginBox/)
+  assert.doesNotMatch(src, /ResizeObserver/)
+  const create = await readFile(resolve(import.meta.dirname, '../host/plugin-create.ts'), 'utf8')
+  assert.match(create, /manifest\.shell/)
+})

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -5,11 +5,20 @@ import type { SlotProps } from '@biu/type-slots'
 
 import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { pluginsChrome } from './chrome.tsx'
+import {
+  WIN_CHROME_H,
+  centeredGeom,
+  clampGeom,
+  defaultStoreShell,
+  parseStoreShell,
+  type StoreShell,
+  type WinGeom,
+} from '../shell.ts'
 
 export const name = 'core-plugin-system-ui'
 export const inject = ['slots', 'databaseUi']
 
-type StoreListing = { id: string; name: string }
+type StoreListing = { id: string; name: string; shell?: StoreShell }
 
 async function readJson<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, init)
@@ -28,60 +37,20 @@ function resolveListing(extraId: string, items: StoreListing[]) {
   )
 }
 
-const WIN_MIN_W = 200
-const WIN_MIN_H = 160
-const WIN_CHROME_H = 32
-const WIN_DEFAULT_W = 480
-const WIN_DEFAULT_H = 360
+function viewport() {
+  return { w: window.innerWidth, h: window.innerHeight }
+}
+
 let pluginWindowZ = 21
 
-type WinGeom = { x: number; y: number; w: number; h: number }
 type ResizeEdge = { north?: boolean; south?: boolean; east?: boolean; west?: boolean }
 type ResizeSession = WinGeom & ResizeEdge & { px: number; py: number }
-
-function defaultPos(seed: string): { x: number; y: number } {
-  let hash = 0
-  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) >>> 0
-  return {
-    x: Math.max(16, Math.round(window.innerWidth / 2 - 160) + (hash % 5) * 28 - 56),
-    y: Math.max(16, Math.round(window.innerHeight / 2 - 120) + (hash % 4) * 24 - 48),
-  }
-}
-
-function clampGeom(next: WinGeom, lockSize: boolean): WinGeom {
-  const maxX = Math.max(0, window.innerWidth - 64)
-  const maxY = Math.max(0, window.innerHeight - 36)
-  return {
-    x: Math.min(maxX, Math.max(0, next.x)),
-    y: Math.min(maxY, Math.max(0, next.y)),
-    w: lockSize ? Math.min(window.innerWidth, Math.max(WIN_MIN_W, next.w)) : next.w,
-    h: lockSize ? Math.min(window.innerHeight, Math.max(WIN_MIN_H, next.h)) : next.h,
-  }
-}
-
-function innerHasExplicitSize(el: HTMLElement | null): { w: boolean; h: boolean } {
-  if (!el) return { w: false, h: false }
-  return {
-    w: Boolean(el.style.width) || el.hasAttribute('width'),
-    h: Boolean(el.style.height) || el.hasAttribute('height'),
-  }
-}
-
-function measurePluginBox(body: HTMLElement): { w: number; h: number } {
-  const inner = body.firstElementChild as HTMLElement | null
-  const explicit = innerHasExplicitSize(inner)
-  const w = explicit.w && inner ? inner.offsetWidth : WIN_DEFAULT_W
-  const contentH = explicit.h && inner ? inner.offsetHeight : WIN_DEFAULT_H
-  return {
-    w: Math.max(WIN_MIN_W, w),
-    h: Math.max(WIN_MIN_H, contentH + WIN_CHROME_H),
-  }
-}
 
 function PluginAppWindow({
   extraId,
   title,
   pluginId,
+  shell,
   fullscreen,
   onClose,
   onMinimize,
@@ -91,52 +60,24 @@ function PluginAppWindow({
   extraId: string
   title: string
   pluginId: string
+  shell: StoreShell
   fullscreen: boolean
   onClose: () => void
   onMinimize: () => void
   onToggleFullscreen: () => void
   children: ReactNode
 }) {
-  const [geom, setGeom] = useState<WinGeom>(() => ({
-    ...defaultPos(extraId),
-    w: WIN_DEFAULT_W,
-    h: WIN_DEFAULT_H + WIN_CHROME_H,
-  }))
+  const [geom, setGeom] = useState<WinGeom>(() => centeredGeom(shell, viewport(), extraId))
   const [userSized, setUserSized] = useState(false)
   const [z, setZ] = useState(() => ++pluginWindowZ)
   const boxRef = useRef<HTMLElement>(null)
-  const bodyRef = useRef<HTMLDivElement>(null)
-  const centeredRef = useRef(false)
   const dragRef = useRef<{ px: number; py: number; x: number; y: number } | null>(null)
   const resizeRef = useRef<ResizeSession | null>(null)
 
   useEffect(() => {
     if (userSized || fullscreen) return
-    const body = bodyRef.current
-    const box = boxRef.current
-    if (!body || !box) return
-    const applyMeasure = () => {
-      const size = measurePluginBox(body)
-      setGeom((cur) => {
-        const next = { ...cur, ...size }
-        if (!centeredRef.current) {
-          centeredRef.current = true
-          next.x = Math.max(16, Math.round((window.innerWidth - size.w) / 2))
-          next.y = Math.max(16, Math.round((window.innerHeight - size.h) / 2))
-        }
-        return clampGeom(next, true)
-      })
-    }
-    applyMeasure()
-    const id = window.requestAnimationFrame(applyMeasure)
-    const inner = body.firstElementChild
-    const ro = inner ? new ResizeObserver(applyMeasure) : null
-    if (inner) ro?.observe(inner)
-    return () => {
-      window.cancelAnimationFrame(id)
-      ro?.disconnect()
-    }
-  }, [userSized, fullscreen])
+    setGeom(centeredGeom(shell, viewport(), extraId))
+  }, [extraId, fullscreen, shell.height, shell.minHeight, shell.minWidth, shell.width, userSized])
 
   useEffect(() => {
     const onMove = (event: PointerEvent) => {
@@ -149,11 +90,13 @@ function PluginAppWindow({
               x: drag.x + event.clientX - drag.px,
               y: drag.y + event.clientY - drag.py,
             },
-            userSized,
+            shell,
+            viewport(),
           ),
         )
         return
       }
+      if (!shell.resizable) return
       const resize = resizeRef.current
       if (!resize) return
       const dx = event.clientX - resize.px
@@ -161,24 +104,26 @@ function PluginAppWindow({
       let { x, y, w, h } = resize
       if (resize.east) w = resize.w + dx
       if (resize.south) h = resize.h + dy
+      const minW = shell.minWidth
+      const minH = shell.minHeight + WIN_CHROME_H
       if (resize.west) {
         w = resize.w - dx
         x = resize.x + dx
-        if (w < WIN_MIN_W) {
-          x = resize.x + resize.w - WIN_MIN_W
-          w = WIN_MIN_W
+        if (w < minW) {
+          x = resize.x + resize.w - minW
+          w = minW
         }
       }
       if (resize.north) {
         h = resize.h - dy
         y = resize.y + dy
-        if (h < WIN_MIN_H) {
-          y = resize.y + resize.h - WIN_MIN_H
-          h = WIN_MIN_H
+        if (h < minH) {
+          y = resize.y + resize.h - minH
+          h = minH
         }
       }
       setUserSized(true)
-      setGeom(clampGeom({ x, y, w, h }, true))
+      setGeom(clampGeom({ x, y, w, h }, shell, viewport()))
     }
     const onUp = () => {
       dragRef.current = null
@@ -192,7 +137,7 @@ function PluginAppWindow({
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onUp)
     }
-  }, [userSized])
+  }, [shell.minHeight, shell.minWidth, shell.resizable])
 
   const bringFront = () => setZ(++pluginWindowZ)
 
@@ -205,7 +150,7 @@ function PluginAppWindow({
   }
 
   const startResize = (edge: ResizeEdge) => (event: ReactPointerEvent) => {
-    if (fullscreen) return
+    if (fullscreen || !shell.resizable) return
     event.preventDefault()
     event.stopPropagation()
     bringFront()
@@ -241,6 +186,9 @@ function PluginAppWindow({
       style={style}
       data-testid={`plugin-app-window-${extraId}`}
       data-plugin-id={pluginId}
+      data-shell-width={shell.width}
+      data-shell-height={shell.height}
+      data-shell-resizable={shell.resizable ? '1' : '0'}
       data-fullscreen={fullscreen || undefined}
       onPointerDown={bringFront}
     >
@@ -288,10 +236,10 @@ function PluginAppWindow({
         </div>
         <span className="w-13 shrink-0" aria-hidden />
       </header>
-      <div ref={bodyRef} className="min-h-0 min-w-0 flex-1 overflow-auto bg-transparent">
+      <div className="plugin-store-window-body flex min-h-0 min-w-0 flex-1 overflow-hidden bg-transparent">
         {children}
       </div>
-      {fullscreen
+      {fullscreen || !shell.resizable
         ? null
         : handles.map((item) => (
             <div
@@ -353,6 +301,7 @@ function PluginExtrasLayer(props: SlotProps) {
         const listing = resolveListing(entry.id, listings)
         const pluginId = listing?.id ?? entry.id
         const title = listing?.name ?? entry.id
+        const shell = parseStoreShell(listing?.shell ?? defaultStoreShell())
         const Component = entry.Component
         return (
           <PluginAppWindow
@@ -360,6 +309,7 @@ function PluginExtrasLayer(props: SlotProps) {
             extraId={entry.id}
             title={title}
             pluginId={pluginId}
+            shell={shell}
             fullscreen={fullscreenId === entry.id}
             onClose={() => {
               setMinimized((cur) => {
@@ -422,4 +372,14 @@ export function apply(ctx: Context) {
       'plugin-store-extras': { kind: 'list' },
     },
   })
+}
+
+if (typeof document !== 'undefined') {
+  const id = 'biu-plugin-store-window-style'
+  const style = document.getElementById(id) ?? document.createElement('style')
+  style.id = id
+  style.textContent = `
+.plugin-store-window-body > * { box-sizing:border-box; width:100%; height:100%; min-width:0; min-height:0; }
+`
+  document.documentElement.appendChild(style)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
商店插件运行窗口不再靠量 DOM。

`manifest.json` 增加 `shell`：

```json
{
  "shell": {
    "width": 640,
    "height": 480,
    "minWidth": 320,
    "minHeight": 240,
    "resizable": true
  }
}
```

- `width` / `height` 是内容区像素，标题栏由壳加上
- 未声明时仍用 480×360
- `resizable: false` 锁死尺寸（适合固定画布）
- 插件根节点铺满窗口（`overflow: hidden`），不再 `overflow: auto` 套滚动条
- `plugin_create` / `plugin_sandbox` 可传 `shell`，契约里写了要声明尺寸

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

