### PR TITLE
Declare shell size on bundled store plugins

### DIFF
--- a/.plugin-dev/store-heavy-ping/manifest.json
+++ b/.plugin-dev/store-heavy-ping/manifest.json
@@ -4,5 +4,12 @@
   "blurb": "内置测试插件：用来测 heavy plugin（plugin_sandbox 多文件相对 import，再 plugin_pack）。打开后提供 GET /api/store-heavy-ping。",
   "tags": ["demo", "host"],
   "author": "Biu",
-  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web"
+  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "shell": {
+    "width": 480,
+    "height": 360,
+    "minWidth": 200,
+    "minHeight": 160,
+    "resizable": true
+  }
 }

--- a/.plugin/gomoku-nordic/manifest.json
+++ b/.plugin/gomoku-nordic/manifest.json
@@ -10,5 +10,12 @@
   ],
   "author": "cordis",
   "authorUrl": "",
-  "createdAt": 1787998752911
+  "createdAt": 1787998752911,
+  "shell": {
+    "width": 396,
+    "height": 560,
+    "minWidth": 396,
+    "minHeight": 560,
+    "resizable": false
+  }
 }

--- a/.plugin/store-gomoku/manifest.json
+++ b/.plugin/store-gomoku/manifest.json
@@ -4,5 +4,12 @@
   "blurb": "15×15 五子棋小游戏：黑白双方轮流落子，先连成五子者胜，支持悔棋与重开。",
   "tags": ["game", "web"],
   "author": "Biu",
-  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web"
+  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "shell": {
+    "width": 360,
+    "height": 520,
+    "minWidth": 360,
+    "minHeight": 520,
+    "resizable": false
+  }
 }

--- a/.plugin/store-heavy-ping/manifest.json
+++ b/.plugin/store-heavy-ping/manifest.json
@@ -4,5 +4,12 @@
   "blurb": "内置测试插件：用来测 heavy plugin（plugin_sandbox 多文件相对 import，再 plugin_pack）。打开后提供 GET /api/store-heavy-ping。",
   "tags": ["demo", "host"],
   "author": "Biu",
-  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web"
+  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "shell": {
+    "width": 480,
+    "height": 360,
+    "minWidth": 200,
+    "minHeight": 160,
+    "resizable": true
+  }
 }

--- a/.plugin/store-hello/manifest.json
+++ b/.plugin/store-hello/manifest.json
@@ -4,5 +4,12 @@
   "blurb": "内置测试插件：安装后在本页显示横幅，并提供 GET /api/store-hello。",
   "tags": ["demo", "web"],
   "author": "Biu",
-  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web"
+  "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "shell": {
+    "width": 360,
+    "height": 320,
+    "minWidth": 360,
+    "minHeight": 320,
+    "resizable": false
+  }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
给仓库里已安装的商店插件补上 `manifest.shell`，和运行窗口契约对齐。

| 插件 | 内容区 | 说明 |
| --- | --- | --- |
| `store-hello` | 360×320，不可缩放 | 匹配 Hello 卡片 |
| `store-gomoku` | 360×520，不可缩放 | 匹配棋盘卡片 |
| `gomoku-nordic` | 396×560，不可缩放 | 15×15 + 内边距 |
| `store-heavy-ping`（`.plugin` 与 `.plugin-dev`） | 默认 480×360 | 仅 host，无窗口，声明缺省值 |

解析层对旧 manifest 仍有缺省尺寸；这些内置插件现在把尺寸写进文件，打开就不会落在 480×360 里裁切。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

