### PR TITLE
Require shell size when creating web store plugins

### DIFF
--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -137,6 +137,7 @@ test('web-only plugin opens without host.js', async () => {
     await store.initSandbox({
       id: 'store-banner',
       name: 'Banner',
+      shell: { width: 360, height: 240 },
       webJs: `export const name = 'store-banner-web'\nexport const inject = ['slots']\nexport function apply() {}\n`,
     })
     await assert.rejects(() => store.pack('store-empty'), /sandbox not found/)

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -88,6 +88,54 @@ test('create writes manifest.shell from input', async () => {
   }
 })
 
+test('create with web rejects missing shell size', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-shell-required-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'store.json'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await assert.rejects(
+      () =>
+        store.create({
+          id: 'store-game',
+          name: 'Game',
+          webJs: `export const name = 'store-game'\nexport function apply() {}`,
+        }),
+      /shell\.width and shell\.height/,
+    )
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('pack with web rejects sandbox manifest without shell size', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-pack-shell-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'store.json'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await store.initSandbox({ id: 'store-ui', name: 'UI' })
+    const sandbox = join(dir, '.plugin-dev', 'store-ui')
+    await writeFile(
+      join(sandbox, 'web.tsx'),
+      `export const name = 'store-ui'\nexport function apply() {}\n`,
+    )
+    await assert.rejects(() => store.pack('store-ui'), /shell\.width and shell\.height/)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-create-'))
   try {

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import type { Context } from 'cordis'
 import type { PluginStoreService } from './store.ts'
-import { parseStoreShell, type StoreShell } from '../shell.ts'
+import { declaredStoreShell, parseStoreShell, requireDeclaredShell, type StoreShell } from '../shell.ts'
 
 export type PluginCreateInput = {
   id: string
@@ -25,7 +25,7 @@ export type StoreManifestFields = {
   author: string
   authorUrl: string
   createdAt: number
-  shell: StoreShell
+  shell?: StoreShell
 }
 
 export function parseTags(value: unknown): string[] {
@@ -51,7 +51,9 @@ export function buildStoreManifest(
     author: String(input.author ?? existing?.author ?? '').trim(),
     authorUrl: String(input.authorUrl ?? existing?.authorUrl ?? '').trim(),
     createdAt: Number.isFinite(createdAt) && createdAt > 0 ? createdAt : now,
-    shell: parseStoreShell(input.shell ?? existing?.shell),
+    ...(declaredStoreShell(input.shell ?? existing?.shell)
+      ? { shell: parseStoreShell(input.shell ?? existing?.shell) }
+      : {}),
   }
 }
 
@@ -137,7 +139,7 @@ export async function readSandboxManifest(dir: string) {
 const CONTRACT = [
   '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。不要改 packages/ 或 cordis.plugins.json。',
   'host 与 web 按需，至少一侧。Web：ctx.slots.place("plugin-store-extras", Comp, { key })。运行窗口会给 extras 套 macOS 窗口框（关/缩/全屏），key 尽量用插件 id。',
-  '有 UI 时在 manifest.shell 声明内容区像素：{ width, height, minWidth?, minHeight?, resizable? }。窗口按这个尺寸打开，插件根节点铺满窗口，不要用 100vw 或测量 DOM 撑开外壳。缺省 480×360。',
+  '有 web 时必须显式写 shell.width 与 shell.height（内容区像素，不含标题栏）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
 ].join(' ')
 
 const PLUGIN_CREATE_DESCRIPTION = [
@@ -155,7 +157,7 @@ const PLUGIN_SANDBOX_DESCRIPTION = [
 
 const PLUGIN_PACK_DESCRIPTION = [
   '把 .plugin-dev/<id>/ 沙箱打包进 .plugin/<id>/（manifest.json + bundle 后的 host.js / web.js）。',
-  '入口：host.ts|tsx|js 与 web.tsx|ts|js，至少要有一个。已打开的插件会重新挂上。',
+  '入口：host.ts|tsx|js 与 web.tsx|ts|js，至少要有一个。有 web 时 manifest.shell 必须已写 width/height，否则拒绝打包。已打开的插件会重新挂上。',
 ].join(' ')
 
 function createArgs(args: Record<string, unknown>): PluginCreateInput {
@@ -188,14 +190,15 @@ const ID_NAME_BLURB = {
   authorUrl: { type: 'string', description: '作者主页 / 仓库链接' },
   shell: {
     type: 'object',
-    description: '运行窗口内容区尺寸（像素，不含标题栏）。缺省 480×360。',
+    description: '有 web 时必填。运行窗口内容区像素（不含标题栏）。必须给 width 和 height。',
     properties: {
-      width: { type: 'number', description: '内容区宽' },
-      height: { type: 'number', description: '内容区高' },
+      width: { type: 'number', description: '内容区宽，必填' },
+      height: { type: 'number', description: '内容区高，必填' },
       minWidth: { type: 'number' },
       minHeight: { type: 'number' },
       resizable: { type: 'boolean', description: 'false 则锁死尺寸，适合固定画布' },
     },
+    required: ['width', 'height'],
   },
 }
 
@@ -254,4 +257,4 @@ export function registerPluginCreate(ctx: Context, store: PluginStoreService) {
   })
 }
 
-export { HOST_ENTRIES, WEB_ENTRIES }
+export { HOST_ENTRIES, WEB_ENTRIES, requireDeclaredShell, declaredStoreShell }

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -11,13 +11,12 @@ import {
   findEntry,
   HOST_ENTRIES,
   parseStoreManifest,
-  readSandboxManifest,
   registerPluginCreate,
   WEB_ENTRIES,
   type PluginCreateInput,
   type StoreManifestFields,
 } from './plugin-create.ts'
-import type { StoreShell } from '../shell.ts'
+import { parseStoreShell, requireDeclaredShell, type StoreShell } from '../shell.ts'
 
 export type StoreListing = {
   id: string
@@ -212,6 +211,7 @@ export class PluginStoreService extends Service {
     const hostJs = String(input.hostJs ?? '').trim()
     const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     if (!hostJs && !webSrc) throw new Error('plugin_create needs hostJs and/or webJs')
+    requireDeclaredShell(input.shell, Boolean(webSrc), 'plugin_create')
     this.invalidateList()
     const dest = this.pluginPath(id)
     mkdirSync(dest, { recursive: true })
@@ -234,11 +234,13 @@ export class PluginStoreService extends Service {
     if (!name) throw new Error('plugin name required')
     const dest = this.sandboxPath(id)
     mkdirSync(dest, { recursive: true })
+    const hostJs = String(input.hostJs ?? '').trim()
+    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
+    const hasWeb = Boolean(webSrc) || Boolean(findEntry(dest, WEB_ENTRIES))
+    requireDeclaredShell(input.shell, hasWeb, 'plugin_sandbox')
     const existing = existsSync(join(dest, 'manifest.json')) ? await readManifest(dest).catch(() => undefined) : undefined
     const manifest = buildStoreManifest(input, existing)
     await writeFile(join(dest, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-    const hostJs = String(input.hostJs ?? '').trim()
-    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     if (hostJs) await writeFile(join(dest, 'host.ts'), hostJs.endsWith('\n') ? hostJs : `${hostJs}\n`)
     if (webSrc) await writeFile(join(dest, 'web.tsx'), webSrc.endsWith('\n') ? webSrc : `${webSrc}\n`)
     return { id, sandboxPath: dest }
@@ -249,10 +251,16 @@ export class PluginStoreService extends Service {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     const sandbox = this.sandboxPath(id)
     if (!existsSync(join(sandbox, 'manifest.json'))) throw new Error(`sandbox not found: ${sandbox}`)
-    const manifest = await readSandboxManifest(sandbox)
+    const raw = JSON.parse(await readFile(join(sandbox, 'manifest.json'), 'utf8')) as unknown
+    const manifest = parseStoreManifest(raw)
     const hostEntry = findEntry(sandbox, HOST_ENTRIES)
     const webEntry = findEntry(sandbox, WEB_ENTRIES)
     if (!hostEntry && !webEntry) throw new Error('sandbox needs host.ts/js or web.tsx/ts/js')
+    requireDeclaredShell(
+      raw && typeof raw === 'object' ? (raw as { shell?: unknown }).shell : undefined,
+      Boolean(webEntry),
+      'plugin_pack',
+    )
     this.invalidateList()
     const dest = this.pluginPath(manifest.id)
     mkdirSync(dest, { recursive: true })
@@ -292,6 +300,7 @@ export class PluginStoreService extends Service {
         lastRunAt: this.state.lastRunAt[manifest.id] ?? null,
         hasHost: stats.hasHost,
         hasWeb: stats.hasWeb,
+        shell: parseStoreShell(manifest.shell),
       })
     }
     this.listCache = items

--- a/packages/core-plugin-system/src/shell.test.ts
+++ b/packages/core-plugin-system/src/shell.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { WIN_CHROME_H, centeredGeom, parseStoreShell, windowOuterSize } from './shell.ts'
+import { WIN_CHROME_H, centeredGeom, declaredStoreShell, parseStoreShell, windowOuterSize } from './shell.ts'
 
 test('parseStoreShell defaults and clamps declared content size', () => {
   const d = parseStoreShell(undefined)
@@ -32,4 +32,11 @@ test('centeredGeom keeps the window on screen', () => {
   assert.equal(geom.h, 400 + WIN_CHROME_H)
   assert.ok(geom.x >= 16)
   assert.ok(geom.y >= 16)
+})
+
+test('declaredStoreShell is true only when width and height are set', () => {
+  assert.equal(declaredStoreShell(undefined), false)
+  assert.equal(declaredStoreShell({}), false)
+  assert.equal(declaredStoreShell({ width: 640 }), false)
+  assert.equal(declaredStoreShell({ width: 640, height: 480 }), true)
 })

--- a/packages/core-plugin-system/src/shell.ts
+++ b/packages/core-plugin-system/src/shell.ts
@@ -30,6 +30,22 @@ function dim(value: unknown, fallback: number, min: number, max: number) {
   return Math.min(max, Math.max(min, Math.round(n)))
 }
 
+/** 是否在 manifest 里显式写了内容区宽高（缺省不算声明）。 */
+export function declaredStoreShell(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const rec = value as Record<string, unknown>
+  const width = Number(rec.width ?? rec.w)
+  const height = Number(rec.height ?? rec.h)
+  return Number.isFinite(width) && Number.isFinite(height)
+}
+
+export function requireDeclaredShell(value: unknown, hasWeb: boolean, where: string) {
+  if (!hasWeb) return
+  if (!declaredStoreShell(value)) {
+    throw new Error(`${where}: web plugins must set shell.width and shell.height (content pixels, excluding the title bar)`)
+  }
+}
+
 /** manifest.shell：width/height 是内容区像素，不含标题栏。缺省 480×360。 */
 export function parseStoreShell(value: unknown): StoreShell {
   const d = defaultStoreShell()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
有 web 的商店插件创建时必须声明 `shell.width` / `shell.height`，不能再靠默认 480×360。

- `plugin_create`：带 `webJs` 却没写宽高 → 直接报错
- `plugin_sandbox`：写入 web 或沙箱里已有 web 入口时同样必填
- `plugin_pack`：打包 web 时检查 sandbox 的 `manifest.json` 是否显式写了宽高（读文件原文，不把缺省当成已声明）
- 只有 host、没有窗口的插件可以不写 `shell`
- 工具契约和 `shell` 参数 schema 标明 width/height 必填

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

