### PR TITLE
Plugin window title bar #202020; lock zoom when fixed size

### DIFF
--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -64,3 +64,12 @@ test('plugin window sizes from manifest.shell instead of measuring DOM', async (
   const create = await readFile(resolve(import.meta.dirname, '../host/plugin-create.ts'), 'utf8')
   assert.match(create, /manifest\.shell/)
 })
+
+test('plugin window chrome uses #202020 and disables zoom when not resizable', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const src = await readFile(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.match(src, /bg-\[#202020\]/)
+  assert.match(src, /disabled=\{!shell\.resizable\}/)
+  assert.match(src, /cursor-not-allowed/)
+})

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -193,7 +193,7 @@ function PluginAppWindow({
       onPointerDown={bringFront}
     >
       <header
-        className={`flex h-8 shrink-0 items-center gap-3 bg-transparent px-3 opacity-0 transition-opacity duration-150 group-hover/win:opacity-100 ${fullscreen ? '' : 'cursor-grab active:cursor-grabbing'}`}
+        className={`flex h-8 shrink-0 items-center gap-3 bg-[#202020] px-3 ${fullscreen ? '' : 'cursor-grab active:cursor-grabbing'}`}
         onPointerDown={startDrag}
       >
         <div className="group/traffic flex items-center gap-1.75">
@@ -221,14 +221,23 @@ function PluginAppWindow({
           </button>
           <button
             type="button"
-            className="relative size-3 cursor-pointer rounded-full border-0 bg-[#28c840] p-0 shadow-[inset_0_0_0_.5px_rgba(0,0,0,.28)]"
-            title={fullscreen ? '还原' : '全屏'}
-            aria-label={fullscreen ? `还原 ${title}` : `全屏 ${title}`}
-            onClick={onToggleFullscreen}
+            className={`relative size-3 rounded-full border-0 p-0 shadow-[inset_0_0_0_.5px_rgba(0,0,0,.28)] ${
+              shell.resizable
+                ? 'cursor-pointer bg-[#28c840]'
+                : 'cursor-not-allowed bg-[#3a3a3c]'
+            }`}
+            title={shell.resizable ? (fullscreen ? '还原' : '全屏') : '固定尺寸，不能放大'}
+            aria-label={
+              shell.resizable ? (fullscreen ? `还原 ${title}` : `全屏 ${title}`) : `${title} 固定尺寸，不能放大`
+            }
+            disabled={!shell.resizable}
+            onClick={shell.resizable ? onToggleFullscreen : undefined}
           >
-            <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-[7px] leading-none font-bold text-[#0b5f18] group-hover/traffic:flex">
-              {fullscreen ? '↘' : '↗'}
-            </span>
+            {shell.resizable ? (
+              <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-[7px] leading-none font-bold text-[#0b5f18] group-hover/traffic:flex">
+                {fullscreen ? '↘' : '↗'}
+              </span>
+            ) : null}
           </button>
         </div>
         <div className="min-w-0 flex-1 truncate text-center text-[12px] font-medium tracking-tight text-white/70">
@@ -310,7 +319,7 @@ function PluginExtrasLayer(props: SlotProps) {
             title={title}
             pluginId={pluginId}
             shell={shell}
-            fullscreen={fullscreenId === entry.id}
+            fullscreen={Boolean(shell.resizable) && fullscreenId === entry.id}
             onClose={() => {
               setMinimized((cur) => {
                 const next = { ...cur }
@@ -324,7 +333,10 @@ function PluginExtrasLayer(props: SlotProps) {
               if (fullscreenId === entry.id) setFullscreenId(null)
               setMinimized((cur) => ({ ...cur, [entry.id]: true }))
             }}
-            onToggleFullscreen={() => setFullscreenId((cur) => (cur === entry.id ? null : entry.id))}
+            onToggleFullscreen={() => {
+              if (!shell.resizable) return
+              setFullscreenId((cur) => (cur === entry.id ? null : entry.id))
+            }}
           >
             <Component renderSlot={() => null} />
           </PluginAppWindow>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
商店插件运行窗口标题栏改为始终可见的 `#202020`，避免和插件背景糊在一起。

`manifest.shell.resizable === false` 时绿色放大按钮禁用（灰色、不可点），也不能进入全屏。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

