### PR TITLE
Plugin windows: Notion-style hover controls, no chrome

### DIFF
--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -139,7 +139,7 @@ export async function readSandboxManifest(dir: string) {
 const CONTRACT = [
   '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。不要改 packages/ 或 cordis.plugins.json。',
   'host 与 web 按需，至少一侧。Web：ctx.slots.place("plugin-store-extras", Comp, { key })。运行窗口会给 extras 套 macOS 窗口框（关/缩/全屏），key 尽量用插件 id。',
-  '有 web 时必须显式写 shell.width 与 shell.height（内容区像素，不含标题栏）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
+  '有 web 时必须显式写 shell.width 与 shell.height（内容区像素）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
 ].join(' ')
 
 const PLUGIN_CREATE_DESCRIPTION = [
@@ -190,7 +190,7 @@ const ID_NAME_BLURB = {
   authorUrl: { type: 'string', description: '作者主页 / 仓库链接' },
   shell: {
     type: 'object',
-    description: '有 web 时必填。运行窗口内容区像素（不含标题栏）。必须给 width 和 height。',
+    description: '有 web 时必填。运行窗口内容区像素。必须给 width 和 height。',
     properties: {
       width: { type: 'number', description: '内容区宽，必填' },
       height: { type: 'number', description: '内容区高，必填' },

--- a/packages/core-plugin-system/src/shell.test.ts
+++ b/packages/core-plugin-system/src/shell.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { WIN_CHROME_H, centeredGeom, declaredStoreShell, parseStoreShell, windowOuterSize } from './shell.ts'
+import { centeredGeom, declaredStoreShell, parseStoreShell, windowOuterSize } from './shell.ts'
 
 test('parseStoreShell defaults and clamps declared content size', () => {
   const d = parseStoreShell(undefined)
@@ -16,11 +16,11 @@ test('parseStoreShell defaults and clamps declared content size', () => {
   assert.equal(tiny.minWidth, 80)
 })
 
-test('windowOuterSize uses content size plus title chrome', () => {
+test('windowOuterSize matches declared content size', () => {
   const shell = parseStoreShell({ width: 640, height: 480 })
   const size = windowOuterSize(shell, { w: 1600, h: 900 })
   assert.equal(size.w, 640)
-  assert.equal(size.h, 480 + WIN_CHROME_H)
+  assert.equal(size.h, 480)
   const fitted = windowOuterSize(shell, { w: 400, h: 300 })
   assert.equal(fitted.w, 400)
   assert.equal(fitted.h, 300)
@@ -29,7 +29,7 @@ test('windowOuterSize uses content size plus title chrome', () => {
 test('centeredGeom keeps the window on screen', () => {
   const geom = centeredGeom(parseStoreShell({ width: 640, height: 400 }), { w: 1200, h: 800 }, '')
   assert.equal(geom.w, 640)
-  assert.equal(geom.h, 400 + WIN_CHROME_H)
+  assert.equal(geom.h, 400)
   assert.ok(geom.x >= 16)
   assert.ok(geom.y >= 16)
 })

--- a/packages/core-plugin-system/src/shell.ts
+++ b/packages/core-plugin-system/src/shell.ts
@@ -1,4 +1,4 @@
-export const WIN_CHROME_H = 32
+export const WIN_CHROME_H = 0
 export const WIN_DEFAULT_W = 480
 export const WIN_DEFAULT_H = 360
 export const WIN_ABS_MIN = 80
@@ -42,11 +42,11 @@ export function declaredStoreShell(value: unknown): boolean {
 export function requireDeclaredShell(value: unknown, hasWeb: boolean, where: string) {
   if (!hasWeb) return
   if (!declaredStoreShell(value)) {
-    throw new Error(`${where}: web plugins must set shell.width and shell.height (content pixels, excluding the title bar)`)
+    throw new Error(`${where}: web plugins must set shell.width and shell.height (content pixels)`)
   }
 }
 
-/** manifest.shell：width/height 是内容区像素，不含标题栏。缺省 480×360。 */
+/** manifest.shell：width/height 是内容区像素。缺省 480×360。 */
 export function parseStoreShell(value: unknown): StoreShell {
   const d = defaultStoreShell()
   if (!value || typeof value !== 'object' || Array.isArray(value)) return d

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -65,11 +65,15 @@ test('plugin window sizes from manifest.shell instead of measuring DOM', async (
   assert.match(create, /manifest\.shell/)
 })
 
-test('plugin window chrome uses #202020 and disables zoom when not resizable', async () => {
+test('plugin window hover controls sit on the right without a title bar', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './index.tsx'), 'utf8')
-  assert.match(src, /bg-\[#202020\]/)
+  assert.match(src, /group-hover\/win:opacity-100/)
+  assert.match(src, /absolute top-2 left-full/)
+  assert.match(src, /flex-col/)
+  assert.match(src, /bg-white\/55/)
   assert.match(src, /disabled=\{!shell\.resizable\}/)
-  assert.match(src, /cursor-not-allowed/)
+  assert.doesNotMatch(src, /bg-\[#202020\]/)
+  assert.doesNotMatch(src, /bg-\[#ff5f57\]/)
 })

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -3,6 +3,7 @@ import type { Context } from 'cordis'
 import { useSlotEntries, type SlotsService } from '@biu/web-slots'
 import type { SlotProps } from '@biu/type-slots'
 
+import { XMarkIcon, MinusIcon, ArrowsPointingOutIcon, ArrowsPointingInIcon } from '@heroicons/react/16/solid'
 import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { pluginsChrome } from './chrome.tsx'
 import {
@@ -182,7 +183,7 @@ function PluginAppWindow({
   return (
     <section
       ref={boxRef}
-      className="group/win pointer-events-auto fixed flex min-h-0 min-w-0 flex-col overflow-hidden bg-transparent text-(--dsw-label)"
+      className="group/win pointer-events-auto fixed flex min-h-0 min-w-0 flex-col overflow-visible bg-transparent text-(--dsw-label)"
       style={style}
       data-testid={`plugin-app-window-${extraId}`}
       data-plugin-id={pluginId}
@@ -192,62 +193,49 @@ function PluginAppWindow({
       data-fullscreen={fullscreen || undefined}
       onPointerDown={bringFront}
     >
-      <header
-        className={`flex h-8 shrink-0 items-center gap-3 bg-[#202020] px-3 ${fullscreen ? '' : 'cursor-grab active:cursor-grabbing'}`}
-        onPointerDown={startDrag}
-      >
-        <div className="group/traffic flex items-center gap-1.75">
-          <button
-            type="button"
-            className="relative size-3 cursor-pointer rounded-full border-0 bg-[#ff5f57] p-0 shadow-[inset_0_0_0_.5px_rgba(0,0,0,.28)]"
-            title="关闭"
-            aria-label={`关闭 ${title}`}
-            onClick={onClose}
-          >
-            <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-[8px] leading-none font-bold text-[#4d0000] group-hover/traffic:flex">
-              ×
-            </span>
-          </button>
-          <button
-            type="button"
-            className="relative size-3 cursor-pointer rounded-full border-0 bg-[#febc2e] p-0 shadow-[inset_0_0_0_.5px_rgba(0,0,0,.28)]"
-            title="最小化"
-            aria-label={`最小化 ${title}`}
-            onClick={onMinimize}
-          >
-            <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-[9px] leading-none font-bold text-[#985700] group-hover/traffic:flex">
-              −
-            </span>
-          </button>
-          <button
-            type="button"
-            className={`relative size-3 rounded-full border-0 p-0 shadow-[inset_0_0_0_.5px_rgba(0,0,0,.28)] ${
-              shell.resizable
-                ? 'cursor-pointer bg-[#28c840]'
-                : 'cursor-not-allowed bg-[#3a3a3c]'
-            }`}
-            title={shell.resizable ? (fullscreen ? '还原' : '全屏') : '固定尺寸，不能放大'}
-            aria-label={
-              shell.resizable ? (fullscreen ? `还原 ${title}` : `全屏 ${title}`) : `${title} 固定尺寸，不能放大`
-            }
-            disabled={!shell.resizable}
-            onClick={shell.resizable ? onToggleFullscreen : undefined}
-          >
-            {shell.resizable ? (
-              <span className="pointer-events-none absolute inset-0 hidden items-center justify-center text-[7px] leading-none font-bold text-[#0b5f18] group-hover/traffic:flex">
-                {fullscreen ? '↘' : '↗'}
-              </span>
-            ) : null}
-          </button>
-        </div>
-        <div className="min-w-0 flex-1 truncate text-center text-[12px] font-medium tracking-tight text-white/70">
-          {title}
-        </div>
-        <span className="w-13 shrink-0" aria-hidden />
-      </header>
-      <div className="plugin-store-window-body flex min-h-0 min-w-0 flex-1 overflow-hidden bg-transparent">
+      <div className="plugin-store-window-body relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-transparent">
         {children}
       </div>
+      <nav
+        className="pointer-events-none absolute top-2 left-full z-20 ml-1.5 flex cursor-grab flex-col gap-0.5 rounded-lg bg-white/55 p-0.5 opacity-0 shadow-[0_1px_2px_rgba(15,15,15,.06)] backdrop-blur-md transition-opacity duration-150 group-hover/win:pointer-events-auto group-hover/win:opacity-100 active:cursor-grabbing"
+        aria-label={`${title} 窗口`}
+        onPointerDown={startDrag}
+      >
+        <button
+          type="button"
+          className="flex size-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-neutral-500 transition-colors hover:bg-black/5 hover:text-neutral-800"
+          title="关闭"
+          aria-label={`关闭 ${title}`}
+          onClick={onClose}
+        >
+          <XMarkIcon className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          className="flex size-6 cursor-pointer items-center justify-center rounded-md border-0 bg-transparent p-0 text-neutral-500 transition-colors hover:bg-black/5 hover:text-neutral-800"
+          title="最小化"
+          aria-label={`最小化 ${title}`}
+          onClick={onMinimize}
+        >
+          <MinusIcon className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          className={`flex size-6 items-center justify-center rounded-md border-0 bg-transparent p-0 transition-colors ${
+            shell.resizable
+              ? 'cursor-pointer text-neutral-500 hover:bg-black/5 hover:text-neutral-800'
+              : 'cursor-not-allowed text-neutral-400/50'
+          }`}
+          title={shell.resizable ? (fullscreen ? '还原' : '全屏') : '固定尺寸，不能放大'}
+          aria-label={
+            shell.resizable ? (fullscreen ? `还原 ${title}` : `全屏 ${title}`) : `${title} 固定尺寸，不能放大`
+          }
+          disabled={!shell.resizable}
+          onClick={shell.resizable ? onToggleFullscreen : undefined}
+        >
+          {fullscreen ? <ArrowsPointingInIcon className="size-3.5" /> : <ArrowsPointingOutIcon className="size-3.5" />}
+        </button>
+      </nav>
       {fullscreen || !shell.resizable
         ? null
         : handles.map((item) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉商店插件窗口的标题栏和交通灯。鼠标悬停时，关闭 / 最小化 / 放大三个浅色半透明图标竖排浮在插件右侧（Notion 块手柄那种），不抢内容。固定尺寸插件放大按钮仍然禁用。窗口高度等于 `shell.height`，不再预留标题栏。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

