### PR TITLE
fix(ui): 全站上下滚动条改成聊天页细条

### DIFF
--- a/packages/cap-chat/src/web/scrollbar.test.tsx
+++ b/packages/cap-chat/src/web/scrollbar.test.tsx
@@ -1,11 +1,6 @@
 /**
- * 回归保护：chat 主滚动容器（.chat-stage）此前用浏览器原生默认滚动条，
- * thumb 宽度取决于系统/浏览器默认（macOS overlay scrollbar 偏粗），用户不喜欢这种过宽样式。
- *
- * 修复（web/style.css）：给 .chat-stage 加"更细"的自定义滚动条
- * （WebKit ::-webkit-scrollbar 固定窄宽 + 标准 scrollbar-width:thin 兼顾 Firefox），
- * 颜色与暗色 UI 统一，hover/滚动时显现，不改变原有布局与交互。
- * 下面用源码断言保证该细滚动条样式不被后续改动误删。
+ * 回归保护：全站上下滚动条与聊天页同一套细条（web/style.css 全局 *）。
+ * WebKit 固定 10px 轨宽 + Firefox scrollbar-width:thin；.chat-stage 另保 gutter。
  */
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
@@ -15,22 +10,20 @@ const root = resolve(import.meta.dirname, '../../../..')
 
 const styleCss = () => readFileSync(resolve(root, 'web/style.css'), 'utf8')
 
-describe('chat scrollbar: slim custom thumb on .chat-stage', () => {
-  it('defines a custom ::-webkit-scrollbar with a fixed narrow width (slim, not the default fat bar)', () => {
+describe('slim custom scrollbars (chat-style, app-wide)', () => {
+  it('defines a custom ::-webkit-scrollbar with a fixed narrow width on all elements', () => {
     const css = styleCss()
-    // 固定窄轨道宽度，让 thumb 变细；宽度固定，不随内容/系统默认变化
-    expect(css).toMatch(/\.chat-stage::-webkit-scrollbar\s*\{[^}]*width:\s*10px/s)
-    expect(css).toMatch(/\.chat-stage::-webkit-scrollbar-thumb\s*\{/s)
+    expect(css).toMatch(/\*::-webkit-scrollbar\s*\{[^}]*width:\s*10px/s)
+    expect(css).toMatch(/\*::-webkit-scrollbar-thumb\s*\{/s)
   })
 
   it('keeps standard (non-WebKit) scrollbars thin & theme-aligned for consistency', () => {
     const css = styleCss()
-    // Firefox 等标准引擎：narrow 宽度 + 主题色
-    expect(css).toMatch(/\.chat-stage\s*\{[^}]*scrollbar-width:\s*thin/s)
-    expect(css).toMatch(/\.chat-stage\s*\{[^}]*scrollbar-color:/s)
+    expect(css).toMatch(/\*\s*\{[^}]*scrollbar-width:\s*thin/s)
+    expect(css).toMatch(/\*\s*\{[^}]*scrollbar-color:/s)
   })
 
-  it('keeps scrollbar-gutter stable so layout does not shift when the bar appears', () => {
+  it('keeps scrollbar-gutter stable on .chat-stage so layout does not shift when the bar appears', () => {
     const css = styleCss()
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*scrollbar-gutter:\s*stable/s)
   })

--- a/web/style.css
+++ b/web/style.css
@@ -79,6 +79,38 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/*
+ * 全局细滚动条：与聊天页 .chat-stage 同一套（固定窄轨 + 内边距让 thumb 更细）。
+ * 上下（纵向）width:10px；横向一并变细，避免侧栏/弹层仍用系统粗条。
+ */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--dsw-label-3) 55%, transparent) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 999px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--dsw-label-3) 55%, transparent);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  min-height: 32px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--dsw-label-2) 70%, transparent);
+  background-clip: padding-box;
+}
+
 .toggle {
   position: relative;
   flex: 0 0 auto;
@@ -3519,44 +3551,9 @@ body {
   max-width: var(--dsw-chat-max-width);
 }
 
-/*
- * 自定义更细的滚动条（用户诉求：thumb 过宽的原生默认滚动条不好看，希望更细/精致）：
- * chat 主滚动容器此前用的是浏览器原生默认滚动条，宽度取决于系统/浏览器默认
- * （macOS overlay scrollbar 滚动时显示偏粗）。这里改为固定窄宽的自定义滚动条，
- * 横向很细、颜色与暗色 UI 统一，hover/滚动时显现，不改变布局与交互。
- */
+/* 对话主列：预留 gutter，避免细滚动条出现时挤布局（样式走全局 * 规则） */
 .chat-stage {
   scrollbar-gutter: stable;
-  /* 非 WebKit（如 Firefox）细滚动条：细而窄、颜色与暗色 UI 对齐，避免默认粗条 */
-  scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--dsw-label-3) 55%, transparent) transparent;
-}
-
-.chat-stage::-webkit-scrollbar {
-  width: 10px;
-}
-
-.chat-stage::-webkit-scrollbar-track {
-  background: transparent;
-  border-radius: 999px;
-}
-
-.chat-stage::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--dsw-label-3) 55%, transparent);
-  border-radius: 999px;
-  /* 内边距产生“窄条间隙”，视觉更细，不随 scrollHeight 变粗 */
-  border: 2px solid transparent;
-  background-clip: padding-box;
-}
-
-.chat-stage::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--dsw-label-2) 70%, transparent);
-  background-clip: padding-box;
-}
-
-/* 滚动时可滚动才显现；内容不满一屏时完全隐藏，避免空轨道 */
-.chat-stage::-webkit-scrollbar-thumb {
-  min-height: 32px;
 }
 
 /* 底部输入栏 + dock 悬浮控件：叠在对话内容之上 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把聊天页 `.chat-stage` 那套细滚动条（10px 轨宽、透明轨道、thumb 内边距更细）提到全局 `*`，侧栏、弹层、检查器等上下滑动条与对话页一致。聊天主列仍保留 `scrollbar-gutter: stable`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

