### PR TITLE
fix(fs): 列表/卡片/看板不展示空属性

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -46,6 +46,7 @@ import {
   parentFieldKey,
   resolveFieldType,
   uniqueValues,
+  fieldHasValue,
   type ViewMode,
 } from './fields.ts'
 import { AppDialog, CellSelect, CheckRow, LocalText } from './controls.tsx'
@@ -1199,7 +1200,9 @@ export function CollectionBrowser({
 
   function RecordProperties({ row, omit }: { row: DbRecord; omit?: string }) {
     const hide = omit ?? activeGroup?.key
-    const cols = hide ? propColumns.filter((item) => item.key !== hide) : propColumns
+    const cols = (hide ? propColumns.filter((item) => item.key !== hide) : propColumns).filter((item) =>
+      fieldHasValue(item.field, row[item.key]),
+    )
     if (!cols.length) return null
     return (
       <div className="fsdb-proplist">

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
-import { defaultColumnKeys, pinLabelColumn, contentFieldKey, flattenTree, formatField, groupField, groupRecords, matchActionWhen, matchesFilters, parentFieldKey, resolveFieldType, sortRows } from './fields'
+import { defaultColumnKeys, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, matchActionWhen, matchesFilters, parentFieldKey, resolveFieldType, sortRows } from './fields'
 
 const schema: CollectionSchema = {
   labelField: 'title',
@@ -22,6 +22,23 @@ test('resolveFieldType maps legacy aliases', () => {
   assert.equal(resolveFieldType({ type: 'string', format: 'url' }), 'url')
   assert.equal(resolveFieldType({ type: 'image' }), 'image')
   assert.equal(resolveFieldType({ type: 'attachment' }), 'attachment')
+})
+
+test('fieldHasValue hides missing list/card/board chips', () => {
+  assert.equal(fieldHasValue({ type: 'string' }, ''), false)
+  assert.equal(fieldHasValue({ type: 'string' }, '   '), false)
+  assert.equal(fieldHasValue({ type: 'string' }, null), false)
+  assert.equal(fieldHasValue({ type: 'string' }, 'hello'), true)
+  assert.equal(fieldHasValue({ type: 'select', enum: ['todo'] }, ''), false)
+  assert.equal(fieldHasValue({ type: 'select', enum: ['todo'] }, 'todo'), true)
+  assert.equal(fieldHasValue({ type: 'multi-select' }, []), false)
+  assert.equal(fieldHasValue({ type: 'multi-select' }, ['a']), true)
+  assert.equal(fieldHasValue({ type: 'boolean' }, false), false)
+  assert.equal(fieldHasValue({ type: 'boolean' }, true), true)
+  assert.equal(fieldHasValue({ type: 'number' }, 0), true)
+  assert.equal(fieldHasValue({ type: 'datetime' }, 0), false)
+  assert.equal(fieldHasValue({ type: 'url' }, 'javascript:alert(1)'), false)
+  assert.equal(fieldHasValue({ type: 'url' }, 'https://example.com'), true)
 })
 
 test('formatField renders datetime bytes tags and media', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -176,6 +176,17 @@ export function formatField(field: FieldSpec | undefined, value: unknown): strin
   return String(value)
 }
 
+/** 列表 / 卡片 / 看板：没有实际内容的属性不渲染（表格单元格仍可显示空位）。 */
+export function fieldHasValue(field: FieldSpec | undefined, value: unknown): boolean {
+  if (value == null) return false
+  if (typeof value === 'string' && !value.trim()) return false
+  if (Array.isArray(value) && asStringList(value).length === 0) return false
+  if (!field) return true
+  const kind = resolveFieldType(field)
+  if (kind === 'boolean') return value === true || value === 'true'
+  return formatField(field, value) !== '—'
+}
+
 export function contentFieldKey(schema: CollectionSchema | undefined) {
   if (!schema) return null
   const preferred = schema.contentField ?? 'content'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
列表、卡片、看板里 `RecordProperties` 不再展示没有实际内容的属性（空字符串、空多选、false 布尔、无效日期/URL 等）。表格视图单元格仍保留空位，方便编辑。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

