### PR TITLE
fix(fs): 新建按钮颜色 #4F7FDE，圆角更小

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -43,8 +43,8 @@ const CSS = `
 .fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:none;min-width:0}
 .fsdb-locked-filter{display:inline-flex;align-items:center;height:26px;padding:0 8px;border-radius:8px;background:color-mix(in srgb,var(--dsw-business) 12%,transparent);color:var(--dsw-business);font-size:13px;font-weight:650;cursor:default}
 .fsdb-page .tasks-toolbar-right{display:flex;align-items:center;gap:2px;flex:none;margin-left:auto}
-.fsdb-page .fsdb-create-btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;margin-left:8px;padding:0 10px;border:0;border-radius:8px;background:#4B90F6;color:#fff;cursor:pointer;font:inherit;font-size:14px;font-weight:600;white-space:nowrap}
-.fsdb-page .fsdb-create-btn:hover{background:color-mix(in srgb,#4B90F6 88%,#000)}
+.fsdb-page .fsdb-create-btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;margin-left:8px;padding:0 10px;border:0;border-radius:4px;background:#4F7FDE;color:#fff;cursor:pointer;font:inherit;font-size:14px;font-weight:600;white-space:nowrap}
+.fsdb-page .fsdb-create-btn:hover{background:color-mix(in srgb,#4F7FDE 88%,#000)}
 .fsdb-page .tasks-search-wrap{display:inline-flex;align-items:center;gap:0;flex:none;min-width:0;padding:0;border:0;border-radius:8px;background:transparent;color:var(--dsw-label-2)}
 .fsdb-page .tasks-search-wrap.is-open{flex:0 1 168px;gap:2px}
 .fsdb-page .tasks-search{flex:1;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;outline:none;min-width:0;padding:4px 4px 4px 0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -70,7 +70,8 @@ test('create record sits at the right of the toolbar with a blue label', () => {
     /className="tasks-toolbar-left"[\s\S]*?aria-label="新建记录"[\s\S]*?className="tasks-toolbar-right"/,
   )
   const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
-  assert.match(css, /\.fsdb-create-btn\{[^}]*background:#4B90F6/)
+  assert.match(css, /\.fsdb-create-btn\{[^}]*border-radius:4px/)
+  assert.match(css, /\.fsdb-create-btn\{[^}]*background:#4F7FDE/)
 })
 
 test('filesystem header expands the shared left sidebar and toggles the right inspector', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
视图工具栏「新建」按钮背景改为 `#4F7FDE`，圆角从 8px 收到 4px。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

