### PR TITLE
fix(fs): 视图详情跳转到对应表列表

### DIFF
--- a/packages/core-file-system/src/catalog-views.test.ts
+++ b/packages/core-file-system/src/catalog-views.test.ts
@@ -10,6 +10,7 @@ import {
   mergeTableViews,
   stubBuiltinAllView,
   stubBuiltinCatalogView,
+  catalogRowOpenTarget,
 } from './catalog-views.ts'
 
 test('each registered table gets a builtin catalog view', () => {
@@ -59,4 +60,13 @@ test('every registered table gets a read-only 全部xx view', () => {
   assert.equal(merged.filter((view) => view.id === builtinAllViewId('/sessions')).length, 1)
   assert.equal(merged.some((view) => view.id === 'mine'), true)
   assert.equal(stubBuiltinAllView('builtin-all:/pages')?.name, '全部pages')
+})
+
+test('catalog view rows open the source table view instead of a record pane', () => {
+  assert.deepEqual(catalogRowOpenTarget({ tablePath: '/plugins', viewId: builtinAllViewId('/plugins') }), {
+    collection: '/plugins',
+    viewId: builtinAllViewId('/plugins'),
+  })
+  assert.equal(catalogRowOpenTarget({ tablePath: '', viewId: 'x' }), null)
+  assert.equal(catalogRowOpenTarget({ tablePath: '/events' }), null)
 })

--- a/packages/core-file-system/src/catalog-views.ts
+++ b/packages/core-file-system/src/catalog-views.ts
@@ -122,3 +122,11 @@ export function stubBuiltinCatalogView(id: string): SavedView | null {
     builtin: true,
   })
 }
+
+/** /views 表里的一行：打开时应跳到该视图对应表，而不是看视图记录自己的属性。 */
+export function catalogRowOpenTarget(row: { tablePath?: unknown; viewId?: unknown }) {
+  const collection = normalizeCollectionPath(String(row.tablePath ?? ''))
+  const viewId = String(row.viewId ?? '').trim()
+  if (!collection || collection === '/' || !viewId) return null
+  return { collection, viewId }
+}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -90,7 +90,7 @@ import {
 } from './view-storage.ts'
 import { listCollection, readJson } from './db-client.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
-import { mergeCatalogViews, mergeTableViews, stubBuiltinCatalogView, builtinCatalogViewId } from '../catalog-views.ts'
+import { mergeCatalogViews, mergeTableViews, stubBuiltinCatalogView, builtinCatalogViewId, catalogRowOpenTarget } from '../catalog-views.ts'
 import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 
 type StatResult = { schema?: CollectionSchema }
@@ -191,6 +191,16 @@ export function CollectionBrowser({
     })
     if (id) onOpenRecord?.(id, activeViewId, dataPath)
     else onCloseRecord?.()
+  }
+  const openRow = (row: DbRecord) => {
+    if (dataPath === VIEWS_COLLECTION_PATH) {
+      const target = catalogRowOpenTarget(row)
+      if (target) {
+        onOpenTable?.(target.collection, target.viewId)
+        return
+      }
+    }
+    setDetailId(row.id, row)
   }
   const [hydrated, setHydrated] = useState(false)
   const [viewsOpen, setViewsOpen] = useState(() => {
@@ -1173,7 +1183,7 @@ export function CollectionBrowser({
               title="查看详情"
               onClick={(event) => {
                 event.stopPropagation()
-                setDetailId(row.id, row)
+                openRow(row)
               }}
             >
               <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
@@ -1267,7 +1277,7 @@ export function CollectionBrowser({
     return (
       <li className={`tasks-queue-item${row.id === detailId ? ' is-active' : ''}`} {...recordPick(row)}>
         <div className="tasks-queue-item-body">
-          <button type="button" className="tasks-queue-item-main" data-biu-action="open" onClick={() => setDetailId(row.id, row)}>
+          <button type="button" className="tasks-queue-item-main" data-biu-action="open" onClick={() => openRow(row)}>
             <span className="tasks-queue-item-title">
               <RecordTitle row={row} openDetail={false} />
             </span>
@@ -1283,7 +1293,7 @@ export function CollectionBrowser({
     return (
       <div className={`tasks-minicard${row.id === detailId ? ' is-active' : ''}`} {...recordPick(row)}>
         <div className="tasks-minicard-title">
-          <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => setDetailId(row.id, row)}>
+          <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => openRow(row)}>
             <span className="tasks-minicard-titletext">
               <RecordTitle row={row} openDetail={false} />
             </span>

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -60,6 +60,9 @@ test('table title opens record from the title-side button', () => {
   assert.match(browser, /tasks-tree-count/)
   assert.match(browser, /kidCount/)
   assert.match(browser, /tasks-tree-toggle is-empty/)
+  assert.match(browser, /openRow\(row\)/)
+  assert.match(browser, /catalogRowOpenTarget/)
+  assert.match(browser, /onOpenTable\?\.\(target\.collection, target\.viewId\)/)
   assert.doesNotMatch(browser, /recordPick\(row\)\} onClick=\{\(\) => setDetailId\(row\.id\)\}/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在表的视图列表（如「全部插件」）里点开详情，不再进入视图记录的属性页，而是和左侧边栏点该视图一样跳到对应表+视图路由，看到真正的记录列表。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

