### PR TITLE
fix(ui): 改用更简单的实心垃圾桶图标

### DIFF
--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -7,7 +7,8 @@
  * 3. 一处保存，不再拆成三块互相抢焦点
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIcon, TrashIcon, SignalSlashIcon, XMarkIcon } from '@heroicons/react/16/solid'
+import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIcon, SignalSlashIcon, XMarkIcon } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -570,7 +571,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
               void onRemoveConnection(ep.id)
             }}
           >
-            <TrashIcon className="size-3" />
+            <TrashGlyph className="size-3" />
           </button>
         ) : null}
       </div>
@@ -1068,7 +1069,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                                     }
                                   }}
                                 >
-                                  <TrashIcon className="size-3" />
+                                  <TrashGlyph className="size-3" />
                                 </span>
                               ) : selected ? (
                                 <CheckIcon className="size-3.5 shrink-0" />
@@ -1112,7 +1113,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                     className="inline-flex self-start items-center gap-1 text-[11px] text-(--dsw-danger,#b42318) hover:underline"
                     onClick={() => void onRemoveConnection(active.id)}
                   >
-                    <TrashIcon className="size-3" />
+                    <TrashGlyph className="size-3" />
                     删除此连接
                   </button>
                 ) : null}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -28,11 +28,11 @@ import {
   Squares2X2Icon,
   StarIcon,
   TableCellsIcon,
-  TrashIcon,
   ViewColumnsIcon,
 } from '@heroicons/react/16/solid'
 import type { CollectionActionInfo, CollectionInfo, CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import {
   contentFieldKey,
   defaultColumnKeys,
@@ -1562,7 +1562,7 @@ export function CollectionBrowser({
                           <PencilSquareIcon aria-hidden className="size-[14px]" />
                         </button>
                         <button type="button" className="tasks-viewdd-act is-danger" title="删除" onClick={() => deleteView(view)}>
-                          <TrashIcon aria-hidden className="size-[14px]" />
+                          <TrashGlyph aria-hidden className="size-[14px]" />
                         </button>
                       </span>
                       )}

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -8,8 +8,8 @@ import {
   PlusIcon,
   Square2StackIcon,
   StarIcon,
-  TrashIcon,
 } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import type { CollectionInfo, DbRecord } from '@biu/type-file-system'
 import { mergeCatalogViews, mergeTableViews } from '../catalog-views.ts'
 import { VIEWS_COLLECTION_PATH } from './database-path.ts'
@@ -689,7 +689,7 @@ export const DataSidebar = memo(function DataSidebar({
                                       aria-label={`删除 ${view.name}`}
                                       onClick={() => onDeleteView(view)}
                                     >
-                                      <TrashIcon className="size-4 shrink-0" />
+                                      <TrashGlyph className="size-4 shrink-0" />
                                     </button>
                                   </>
                                 ) : null}

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -18,10 +18,10 @@ import {
   RectangleStackIcon,
   StopIcon,
   TableCellsIcon,
-  TrashIcon,
   Squares2X2Icon,
   ViewColumnsIcon,
 } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import type { CollectionSchema, DbRecord, FieldSpec, FieldType } from '@biu/type-file-system'
 import { asAttachment, asHttpHref, asImageSrc } from '@biu/type-file-system'
 import {
@@ -38,7 +38,7 @@ export function actionIcon(id: string) {
   const cls = 'size-[14px]'
   if (id === 'start' || id === 'play' || id === 'run' || id === 'open') return <PlayIcon aria-hidden className={cls} />
   if (id === 'stop' || id === 'close' || id === 'pause') return <StopIcon aria-hidden className={cls} />
-  if (id === 'uninstall' || id === 'delete' || id === 'remove') return <TrashIcon aria-hidden className={cls} />
+  if (id === 'uninstall' || id === 'delete' || id === 'remove') return <TrashGlyph aria-hidden className={cls} />
   if (id === 'edit' || id === 'rename') return <PencilSquareIcon aria-hidden className={cls} />
   if (id === 'refresh') return <ArrowPathIcon aria-hidden className={cls} />
   return null

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode, Dispatch, SetStateAction } from 'react'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import type { CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
-import { HashtagIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { HashtagIcon } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { contentFieldKey, formatField, resolveFieldType, uniqueValues } from './fields.ts'
 import { LocalText } from './controls.tsx'
 import { FieldEditor, FieldGlyph, FilePreview } from './fsdb-cells.tsx'
@@ -60,7 +61,7 @@ export function RecordDetail({
                 )}
                 {onDelete ? (
                   <button type="button" className="tasks-icon-btn is-danger" title="删除" aria-label="删除记录" onClick={onDelete}>
-                    <TrashIcon aria-hidden className="size-[14px]" />
+                    <TrashGlyph aria-hidden className="size-[14px]" />
                   </button>
                 ) : null}
                 </div>

--- a/packages/core-plugin-system/package.json
+++ b/packages/core-plugin-system/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@biu/type-file-system": "0.1.0",
     "@biu/type-slots": "0.1.0",
-    "@biu/web-slots": "0.1.0"
+    "@biu/web-slots": "0.1.0",
+    "@biu/web-session-view": "0.1.0"
   }
 }

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -1,4 +1,5 @@
-import { PlayIcon, StopIcon, TrashIcon } from '@heroicons/react/16/solid'
+import { PlayIcon, StopIcon } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { asHttpHref } from '@biu/type-file-system'
 import type { CollectionChrome, FsActionProps, FsCellProps } from '@biu/type-file-system/ui'
 import type { DbRecord } from '@biu/type-file-system'
@@ -56,7 +57,7 @@ function PluginAction({ action, busy, run }: FsActionProps) {
     ) : action.id === 'stop' ? (
       <StopIcon aria-hidden className="size-[14px]" />
     ) : action.id === 'uninstall' ? (
-      <TrashIcon aria-hidden className="size-[14px]" />
+      <TrashGlyph aria-hidden className="size-[14px]" />
     ) : null
   return (
     <button

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -27,12 +27,12 @@ import {
   PlusIcon,
   SignalIcon,
   StarIcon,
-  TrashIcon,
   FolderIcon,
   TagIcon,
   FolderMinusIcon,
   BookmarkSlashIcon,
 } from '@heroicons/react/16/solid'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 
 /** 项目/标签分组视图的持久化 key。 */
 const GROUP_BY_KEY = 'cordis.sidebar.groupBy'
@@ -138,7 +138,7 @@ const SessionRow = memo(function SessionRow({
           onDelete(item)
         }}
       >
-        <TrashIcon {...chromeIcon} />
+        <TrashGlyph {...chromeIcon} />
       </button>
       <button
         type="button"

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -6,7 +6,6 @@ import {
   PlusIcon,
   Squares2X2Icon,
   TableCellsIcon,
-  TrashIcon,
   ViewColumnsIcon,
   ClipboardDocumentListIcon,
   ChatBubbleLeftRightIcon,
@@ -16,6 +15,7 @@ import {
   EyeIcon,
 } from '@heroicons/react/16/solid'
 import { chromeIcon } from './chrome-icon.ts'
+import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import {
   bindSessionView,
   type SessionViewService,
@@ -392,7 +392,7 @@ export const SessionInspector = memo(function SessionInspector({
                         closeOpenedTab(item.id)
                       }}
                     >
-                      <TrashIcon {...chromeIcon} />
+                      <TrashGlyph {...chromeIcon} />
                     </button>
                   </div>
                   )

--- a/packages/web-session-view/package.json
+++ b/packages/web-session-view/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/web/index.ts",
     "./dialog": "./src/web/session-config-dialog.tsx",
-    "./folder-glyph": "./src/web/folder-glyph.tsx"
+    "./folder-glyph": "./src/web/folder-glyph.tsx",
+    "./trash-glyph": "./src/web/trash-glyph.tsx"
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",

--- a/packages/web-session-view/src/web/trash-glyph.test.ts
+++ b/packages/web-session-view/src/web/trash-glyph.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+test('trash glyph is a solid can without inner slits', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './trash-glyph.tsx'), 'utf8')
+  assert.match(src, /fill="currentColor"/)
+  assert.match(src, /<path d=/)
+  assert.doesNotMatch(src, /clipRule/)
+  assert.doesNotMatch(src, /6\.05 6a\.75/)
+})

--- a/packages/web-session-view/src/web/trash-glyph.tsx
+++ b/packages/web-session-view/src/web/trash-glyph.tsx
@@ -1,0 +1,17 @@
+import type { SVGProps } from 'react'
+
+/** 实心垃圾桶：盖 + 桶身，没有 Heroicons 那两条内槽。 */
+export function TrashGlyph({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden
+      data-slot="icon"
+      className={className ?? 'size-4 shrink-0'}
+      {...props}
+    >
+      <path d="M6.35 1.5h3.3c.33 0 .62.2.73.5l.32 1h2.55a.75.75 0 0 1 0 1.5H2.75a.75.75 0 0 1 0-1.5h2.55l.32-1c.11-.3.4-.5.73-.5ZM4.15 5.5h7.7l-.48 8.08A1.6 1.6 0 0 1 9.78 15H6.22a1.6 1.6 0 0 1-1.59-1.42L4.15 5.5Z" />
+    </svg>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Heroicons 的垃圾桶带盖子内槽，小尺寸显得碎。换成实心盖+桶身剪影，侧栏删除、记录删除、插件卸载等处统一使用。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

