### PR TITLE
feat(dock): 底栏分成页面 / 浮层工具 / 系统托盘

### DIFF
--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import type { Context } from 'cordis'
-import { SignalIcon, QueueListIcon, ChatBubbleLeftIcon } from '@heroicons/react/16/solid'
+import { SignalIcon, QueueListIcon, ChatBubbleBottomCenterTextIcon } from '@heroicons/react/16/solid'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import type { SlotProps } from '@biu/web-slots'
 import { ApprovalsRail } from './approvals.tsx'
@@ -86,8 +86,9 @@ export function apply(ctx: Context) {
     id: 'composer',
     title: '对话',
     kind: 'composer',
+    group: 'tools',
     order: 30,
-    Icon: () => createElement(ChatBubbleLeftIcon, { className: 'size-5' }),
+    Icon: () => createElement(ChatBubbleBottomCenterTextIcon, { className: 'size-5' }),
     onOpen: () => {
       if (getChatOverlay()) {
         setChatOverlay(false)

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -34,7 +34,8 @@ export function apply(ctx: Context) {
     id: 'pick',
     title: '选取',
     kind: 'tool',
-    order: 20,
+    group: 'tools',
+    order: 31,
     Icon: PickDockIcon,
     onOpen: () => pick.toggle(),
   })

--- a/packages/core-dock/src/web/os-dock.test.ts
+++ b/packages/core-dock/src/web/os-dock.test.ts
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict'
 test('os dock auto-hides behind a peek bar and opens on hover', () => {
   const src = readFileSync(resolve(import.meta.dirname, './os-dock.tsx'), 'utf8')
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  assert.match(src, /places.*tools.*tray/s)
   assert.match(src, /os-dock-peek/)
   assert.match(src, /os-dock-edge/)
   assert.match(src, /is-open/)

--- a/packages/core-dock/src/web/os-dock.tsx
+++ b/packages/core-dock/src/web/os-dock.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
+import { Fragment, useCallback, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
 import type { SlotProps } from '@biu/type-slots'
-import type { DockApp, DockService } from './service.ts'
+import type { DockApp, DockGroup, DockService } from './service.ts'
+
+const DOCK_GROUPS: DockGroup[] = ['places', 'tools', 'tray']
 
 const HIDE_MS = 280
 
@@ -54,8 +56,10 @@ export function OsDock(props: SlotProps) {
     () => dock.list(),
     () => dock.list(),
   )
-  const pinned = apps.filter((app) => app.group === 'pinned')
-  const running = apps.filter((app) => app.group === 'running')
+  const sections = DOCK_GROUPS.map((group) => ({
+    group,
+    apps: apps.filter((app) => app.group === group),
+  })).filter((section) => section.apps.length)
   const [open, setOpen] = useState(false)
   const hideTimer = useRef(0)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -104,12 +108,13 @@ export function OsDock(props: SlotProps) {
       <div className="os-dock-edge" aria-hidden />
       <div className="os-dock-peek" aria-hidden />
       <div className="os-dock-shelf">
-        {pinned.map((app) => (
-          <DockTile key={app.id} app={app} dock={dock} />
-        ))}
-        {running.length ? <span className="os-dock-sep" aria-hidden /> : null}
-        {running.map((app) => (
-          <DockTile key={app.id} app={app} dock={dock} />
+        {sections.map((section, index) => (
+          <Fragment key={section.group}>
+            {index > 0 ? <span className="os-dock-sep" aria-hidden /> : null}
+            {section.apps.map((app) => (
+              <DockTile key={app.id} app={app} dock={dock} />
+            ))}
+          </Fragment>
         ))}
       </div>
     </div>

--- a/packages/core-dock/src/web/service.test.ts
+++ b/packages/core-dock/src/web/service.test.ts
@@ -7,13 +7,15 @@ function dock() {
 }
 
 describe('DockService', () => {
-  it('keeps pinned apps on the left and running plugins after the separator', () => {
+  it('orders dock as places, tools, then tray', () => {
     const svc = dock()
-    svc.register({ id: 'composer', title: 'Composer', order: 30, kind: 'composer' })
-    svc.register({ id: 'session', title: 'Session', order: 10, kind: 'session' })
-    svc.register({ id: 'pick', title: '选取', order: 20, kind: 'tool' })
-    svc.register({ id: 'plugin:notes', title: 'Notes', group: 'running', kind: 'plugin', pinned: false })
-    expect(svc.list().map((app) => app.id)).toEqual(['session', 'pick', 'composer', 'plugin:notes'])
+    svc.register({ id: 'composer', title: 'Composer', kind: 'composer' })
+    svc.register({ id: 'session', title: 'Session', kind: 'session' })
+    svc.register({ id: 'pick', title: '选取', kind: 'tool' })
+    svc.register({ id: 'settings', title: 'Settings', kind: 'tool', group: 'tray' })
+    svc.register({ id: 'plugin:notes', title: 'Notes', group: 'tray', kind: 'plugin', pinned: false })
+    expect(svc.list().map((app) => app.id)).toEqual(['session', 'composer', 'pick', 'settings', 'plugin:notes'])
+    expect(svc.list().map((app) => app.group)).toEqual(['places', 'tools', 'tools', 'tray', 'tray'])
   })
 
   it('open focuses an app and close keeps pinned tiles', () => {
@@ -43,7 +45,7 @@ describe('DockService', () => {
 
   it('close removes unpinned plugin tiles', () => {
     const svc = dock()
-    svc.register({ id: 'plugin:x', title: 'X', pinned: false, group: 'running', kind: 'plugin' })
+    svc.register({ id: 'plugin:x', title: 'X', pinned: false, group: 'tray', kind: 'plugin' })
     svc.close('plugin:x')
     expect(svc.list()).toEqual([])
   })

--- a/packages/core-dock/src/web/service.ts
+++ b/packages/core-dock/src/web/service.ts
@@ -1,8 +1,21 @@
 import { Service, type Context } from 'cordis'
 
-export type DockGroup = 'pinned' | 'running'
+export type DockGroup = 'places' | 'tools' | 'tray'
 
 export type DockKind = 'session' | 'tool' | 'composer' | 'plugin' | 'module'
+
+const GROUP_RANK: Record<DockGroup, number> = {
+  places: 0,
+  tools: 1,
+  tray: 2,
+}
+
+function defaultGroup(kind: DockKind, pinned: boolean): DockGroup {
+  if (!pinned || kind === 'plugin') return 'tray'
+  if (kind === 'session' || kind === 'module') return 'places'
+  if (kind === 'composer') return 'tools'
+  return 'tools'
+}
 
 export type DockApp = {
   id: string
@@ -41,8 +54,10 @@ type Listener = () => void
 
 const DEFAULT_ORDER: Record<string, number> = {
   session: 10,
-  pick: 20,
   composer: 30,
+  pick: 31,
+  settings: 200,
+  update: 201,
 }
 
 export class DockService extends Service {
@@ -61,10 +76,10 @@ export class DockService extends Service {
     const next: DockApp = {
       id: input.id,
       title: input.title,
-      order: input.order ?? existing?.order ?? DEFAULT_ORDER[input.id] ?? 100,
-      group: input.group ?? existing?.group ?? (input.pinned === false ? 'running' : 'pinned'),
+      order: input.order ?? existing?.order ?? DEFAULT_ORDER[input.id] ?? (input.kind === 'plugin' || existing?.kind === 'plugin' ? 300 : 100),
       kind: input.kind ?? existing?.kind ?? 'tool',
       pinned: input.pinned ?? existing?.pinned ?? true,
+      group: input.group ?? existing?.group ?? defaultGroup(input.kind ?? existing?.kind ?? 'tool', input.pinned ?? existing?.pinned ?? true),
       running: existing?.running ?? false,
       focused: existing?.focused ?? false,
       minimized: existing?.minimized ?? false,
@@ -151,7 +166,7 @@ export class DockService extends Service {
 
   private rebuild(): DockApp[] {
     return [...this.apps.values()].sort((a, b) => {
-      if (a.group !== b.group) return a.group === 'pinned' ? -1 : 1
+      if (a.group !== b.group) return GROUP_RANK[a.group] - GROUP_RANK[b.group]
       return a.order - b.order || a.id.localeCompare(b.id)
     })
   }

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -350,10 +350,10 @@ function PluginExtrasLayer(props: SlotProps) {
       dock.register({
         id: dockId,
         title,
-        group: 'running',
+        group: 'tray',
         kind: 'plugin',
         pinned: false,
-        order: 100 + entry.order,
+        order: 300 + entry.order,
         Icon,
         onOpen: () => {
           setMinimized((cur) => {

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -79,6 +79,7 @@ function ShellDockPins({
       id: 'session',
       title: 'Session',
       kind: 'session',
+      group: 'places',
       order: 10,
       Tile,
     })

--- a/packages/web-app-shell/src/web/shell-dock-nav.tsx
+++ b/packages/web-app-shell/src/web/shell-dock-nav.tsx
@@ -75,6 +75,7 @@ function ShellDockUpdate({ dock }: { dock: DockService }) {
       id: 'update',
       title: label,
       kind: 'tool',
+      group: 'tray',
       order: 201,
       Icon,
       onOpen: () => {
@@ -114,6 +115,7 @@ export function ShellDockNav({
         id: `module:${mod.id}`,
         title: mod.label,
         kind: 'module',
+        group: 'places',
         order: 11 + (mod.order ?? 0),
         Icon,
         onOpen: () => {
@@ -141,6 +143,7 @@ export function ShellDockNav({
       id: 'settings',
       title: 'Settings',
       kind: 'tool',
+      group: 'tray',
       order: 200,
       Icon,
       onOpen: onSettings,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
底栏按用途切成三组，组间用分隔线：

- **places（左）**：小人、Agent/频道/数据库等模块，决定主区页面
- **tools（中）**：悬浮对话、Pick
- **tray（右）**：设置、下载、运行中的插件窗口

悬浮对话改用 `ChatBubbleBottomCenterTextIcon`，避免和左侧 Agent 气泡撞图。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

