### PR TITLE
feat(dock): 图标悬停放大

### DIFF
--- a/packages/core-dock/src/web/os-dock.test.ts
+++ b/packages/core-dock/src/web/os-dock.test.ts
@@ -18,4 +18,6 @@ test('os dock auto-hides behind a peek bar and opens on hover', () => {
   assert.match(css, /\.os-dock-shelf\s*\{[^}]*translateY\(calc\(100% \+ 20px\)\)/s)
   assert.match(css, /\.os-dock\.is-open \.os-dock-shelf\s*\{[^}]*translateY\(0\)/s)
   assert.match(css, /\.os-dock\.is-open \.os-dock-peek\s*\{[^}]*opacity:\s*0/s)
+  assert.match(css, /\.os-dock-item:hover/)
+  assert.match(css, /scale\(1\.24\)/)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -344,6 +344,30 @@ body {
   padding: 0;
   color: inherit;
   cursor: pointer;
+  transform-origin: 50% 100%;
+  transition: transform .18s cubic-bezier(.22, 1.2, .36, 1);
+}
+
+.os-dock-item:hover,
+.os-dock-item:focus-visible {
+  z-index: 2;
+  transform: translateY(-4px) scale(1.24);
+}
+
+.os-dock-item:active {
+  transform: translateY(-2px) scale(1.1);
+  transition-duration: .08s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .os-dock-item {
+    transition: none;
+  }
+  .os-dock-item:hover,
+  .os-dock-item:focus-visible,
+  .os-dock-item:active {
+    transform: none;
+  }
 }
 
 .os-dock-tile {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dock 图标悬停/聚焦时上浮并放大到约 1.24 倍，按下略收回，让底栏有一点互动感。关闭系统动画偏好时不做位移。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

