### PR TITLE
feat(plugins): 商店 listing 与开发沙箱登记进文件系统

### DIFF
--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -38,6 +38,7 @@ test('views and events are system collections; user tables sort first', () => {
   const { user, system } = sortDataCollections([
     { path: '/events' },
     { path: '/plugins' },
+    { path: '/plugin-sandboxes' },
     { path: '/views' },
     { path: '/sessions' },
     { path: '/pages' },
@@ -45,7 +46,7 @@ test('views and events are system collections; user tables sort first', () => {
   ])
   assert.deepEqual(
     user.map((item) => item.path),
-    ['/sessions', '/tasks', '/pages', '/plugins'],
+    ['/sessions', '/tasks', '/pages', '/plugins', '/plugin-sandboxes'],
   )
   assert.deepEqual(
     system.map((item) => item.path),

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -29,7 +29,7 @@ export function databaseRecordPath(collection: string, recordId: string): string
 export const VIEWS_COLLECTION_PATH = '/views'
 export const EVENTS_COLLECTION_PATH = '/events'
 
-const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/plugins'] as const
+const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/plugins', '/plugin-sandboxes'] as const
 
 /** 视图、事件由系统自己记下，侧栏归在系统数据。 */
 export function isSystemCollection(path: string) {

--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -1,14 +1,34 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { DbRecord } from '@biu/type-file-system'
-import { pluginsCollection } from './collection.ts'
+import { pluginSandboxesCollection, pluginsCollection } from './collection.ts'
 import type { PluginStoreService } from './store.ts'
+import { defaultStoreShell } from '../shell.ts'
 
-test('pluginsCollection registers /plugins and start/stop/uninstall', async () => {
+test('pluginsCollection registers /plugins with store listing fields', async () => {
   const items: DbRecord[] = [{ id: 'demo', name: 'Demo', enabled: false }]
   const calls: string[] = []
   const spec = pluginsCollection({
-    list: () => Promise.resolve(items),
+    list: () =>
+      Promise.resolve([
+        {
+          id: 'demo',
+          name: 'Demo',
+          blurb: 'hi',
+          tags: ['lab'],
+          author: 'ann',
+          authorUrl: '',
+          enabled: false,
+          running: false,
+          bytes: 12,
+          createdAt: 1,
+          updatedAt: 2,
+          lastRunAt: null,
+          hasHost: true,
+          hasWeb: true,
+          shell: defaultStoreShell(),
+        },
+      ]),
     openPlugin(id: string) {
       calls.push(`open:${id}`)
       items[0]!.enabled = true
@@ -23,6 +43,9 @@ test('pluginsCollection registers /plugins and start/stop/uninstall', async () =
   } as PluginStoreService)
   assert.equal(spec.path, '/plugins')
   assert.equal(spec.view?.moduleId, 'plugins')
+  const listed = await spec.list()
+  assert.equal(listed[0]?.shellWidth, defaultStoreShell().width)
+  assert.equal(listed[0]?.hasWeb, true)
   assert.deepEqual(
     spec.actions?.map((item) => item.id),
     ['start', 'stop', 'uninstall'],
@@ -31,8 +54,39 @@ test('pluginsCollection registers /plugins and start/stop/uninstall', async () =
   assert.deepEqual(calls, ['open:demo'])
   assert.equal(spec.update, undefined)
   assert.deepEqual(spec.records, { update: false, create: false, delete: false })
-  assert.deepEqual(spec.schema.columns, ['name', 'blurb', 'running', 'tags'])
+  assert.ok(spec.schema.columns?.includes('shellWidth'))
+  assert.ok(spec.schema.columns?.includes('enabled'))
   assert.equal(spec.schema.fields.authorUrl?.type, 'url')
   assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { running: false })
   assert.deepEqual(spec.actions?.find((item) => item.id === 'stop')?.when, { running: true })
+})
+
+test('pluginSandboxesCollection registers .plugin-dev drafts', async () => {
+  const packed: string[] = []
+  const spec = pluginSandboxesCollection({
+    listSandboxes: () =>
+      Promise.resolve([
+        {
+          id: 'draft-hello',
+          name: 'Hello',
+          blurb: '',
+          tags: [],
+          author: '',
+          authorUrl: '',
+          hasHost: true,
+          hasWeb: false,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ]),
+    pack(id: string) {
+      packed.push(id)
+    },
+  } as PluginStoreService)
+  assert.equal(spec.path, '/plugin-sandboxes')
+  assert.equal(spec.view?.title, '插件沙箱')
+  const listed = await spec.list()
+  assert.equal(listed[0]?.id, 'draft-hello')
+  await spec.actions!.find((item) => item.id === 'pack')!.run('draft-hello', listed[0]!)
+  assert.deepEqual(packed, ['draft-hello'])
 })

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -1,68 +1,172 @@
-import type { CollectionSpec } from "@biu/type-file-system";
-import type { PluginStoreService } from "./store.ts";
+import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import type { PluginStoreService, StoreListing } from './store.ts'
+
+function asPluginRecord(row: StoreListing): DbRecord {
+  const shell = row.shell
+  return {
+    id: row.id,
+    name: row.name,
+    title: row.name,
+    blurb: row.blurb,
+    tags: row.tags,
+    author: row.author,
+    authorUrl: row.authorUrl,
+    enabled: row.enabled,
+    running: row.running,
+    bytes: row.bytes,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    lastRunAt: row.lastRunAt,
+    hasHost: row.hasHost,
+    hasWeb: row.hasWeb,
+    shellWidth: shell.width,
+    shellHeight: shell.height,
+    shellMinWidth: shell.minWidth,
+    shellMinHeight: shell.minHeight,
+    shellResizable: shell.resizable,
+  }
+}
 
 export function pluginsCollection(store: PluginStoreService): CollectionSpec {
-  const find = async (id: string) =>
-    (await store.list()).find((row) => row.id === id) ?? null;
+  const list = async () => (await store.list()).map(asPluginRecord)
+  const find = async (id: string) => (await list()).find((row) => row.id === id) ?? null
   return {
-    id: "plugins",
-    path: "/plugins",
-    label: "插件",
+    id: 'plugins',
+    path: '/plugins',
+    label: '插件',
     view: {
-      moduleId: "plugins",
-      route: "/plugins",
-      title: "插件",
+      moduleId: 'plugins',
+      route: '/plugins',
+      title: '插件',
       inspector: true,
-      blurb: "",
+      blurb: '已安装到 .plugin 的商店插件：运行状态、体积、外壳尺寸和作者。',
       order: 30,
-      icon: "puzzle-piece",
+      icon: 'puzzle-piece',
     },
     records: { update: false, create: false, delete: false },
     schema: {
-      labelField: "name",
-      columns: ["name", "blurb", "running", "tags"],
+      labelField: 'name',
+      columns: [
+        'name',
+        'blurb',
+        'running',
+        'enabled',
+        'tags',
+        'author',
+        'bytes',
+        'shellWidth',
+        'shellHeight',
+        'hasHost',
+        'hasWeb',
+      ],
       fields: {
-        name: { type: "string", label: "名称" },
-        blurb: { type: "string", label: "简介" },
-        enabled: { type: "boolean", label: "已打开" },
-        running: { type: "boolean", label: "运行中" },
-        tags: { type: "multi-select", label: "标签" },
-        bytes: { type: "bytes", label: "大小" },
-        lastRunAt: { type: "datetime", label: "上次运行" },
-        hasHost: { type: "boolean", label: "Host" },
-        hasWeb: { type: "boolean", label: "Web" },
-        author: { type: "string", label: "作者" },
-        authorUrl: { type: "url", label: "作者链接" },
+        name: { type: 'string', label: '名称' },
+        blurb: { type: 'string', label: '简介' },
+        enabled: { type: 'boolean', label: '已打开' },
+        running: { type: 'boolean', label: '运行中' },
+        tags: { type: 'multi-select', label: '标签' },
+        bytes: { type: 'bytes', label: '大小' },
+        createdAt: { type: 'datetime', label: '创建时间' },
+        updatedAt: { type: 'datetime', label: '更新时间' },
+        lastRunAt: { type: 'datetime', label: '上次运行' },
+        hasHost: { type: 'boolean', label: 'Host' },
+        hasWeb: { type: 'boolean', label: 'Web' },
+        author: { type: 'string', label: '作者' },
+        authorUrl: { type: 'url', label: '作者链接' },
+        shellWidth: { type: 'number', label: '窗口宽' },
+        shellHeight: { type: 'number', label: '窗口高' },
+        shellMinWidth: { type: 'number', label: '最小宽' },
+        shellMinHeight: { type: 'number', label: '最小高' },
+        shellResizable: { type: 'boolean', label: '可缩放' },
       },
     },
-    list: () => store.list(),
+    list,
     get: find,
     actions: [
       {
-        id: "start",
-        label: "运行",
+        id: 'start',
+        label: '运行',
         when: { running: false },
         run: async (id) => {
-          await store.openPlugin(id);
+          await store.openPlugin(id)
         },
       },
       {
-        id: "stop",
-        label: "停止",
+        id: 'stop',
+        label: '停止',
         when: { running: true },
         run: async (id) => {
-          await store.close(id);
+          await store.close(id)
         },
       },
       {
-        id: "uninstall",
-        label: "卸载",
-        tone: "danger",
-        confirm: "确定卸载这个插件？代码会被删掉。",
+        id: 'uninstall',
+        label: '卸载',
+        tone: 'danger',
+        confirm: '确定卸载这个插件？代码会被删掉。',
         run: async (id) => {
-          await store.uninstall(id);
+          await store.uninstall(id)
         },
       },
     ],
-  };
+  }
+}
+
+export function pluginSandboxesCollection(store: PluginStoreService): CollectionSpec {
+  const list = async () =>
+    (await store.listSandboxes()).map((row) => ({
+      id: row.id,
+      name: row.name,
+      title: row.name,
+      blurb: row.blurb,
+      tags: row.tags,
+      author: row.author,
+      authorUrl: row.authorUrl,
+      hasHost: row.hasHost,
+      hasWeb: row.hasWeb,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    }))
+  const find = async (id: string) => (await list()).find((row) => row.id === id) ?? null
+  return {
+    id: 'plugin-sandboxes',
+    path: '/plugin-sandboxes',
+    label: '插件沙箱',
+    view: {
+      moduleId: 'plugin-sandboxes',
+      route: '/plugin-sandboxes',
+      title: '插件沙箱',
+      inspector: true,
+      blurb: '.plugin-dev 里的开发沙箱：源码还没打包进已安装插件。',
+      order: 31,
+      icon: 'puzzle-piece',
+    },
+    records: { update: false, create: false, delete: false },
+    schema: {
+      labelField: 'name',
+      columns: ['name', 'blurb', 'tags', 'author', 'hasHost', 'hasWeb', 'updatedAt'],
+      fields: {
+        name: { type: 'string', label: '名称' },
+        blurb: { type: 'string', label: '简介' },
+        tags: { type: 'multi-select', label: '标签' },
+        author: { type: 'string', label: '作者' },
+        authorUrl: { type: 'url', label: '作者链接' },
+        hasHost: { type: 'boolean', label: 'Host' },
+        hasWeb: { type: 'boolean', label: 'Web' },
+        createdAt: { type: 'datetime', label: '创建时间' },
+        updatedAt: { type: 'datetime', label: '更新时间' },
+      },
+    },
+    list,
+    get: find,
+    actions: [
+      {
+        id: 'pack',
+        label: '打包安装',
+        run: async (id) => {
+          await store.pack(id)
+        },
+      },
+    ],
+  }
 }

--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -142,6 +142,8 @@ test('web-only plugin opens without host.js', async () => {
     })
     await assert.rejects(() => store.pack('store-empty'), /sandbox not found/)
     await store.pack('store-banner')
+    const sandboxes = await store.listSandboxes()
+    assert.equal(sandboxes.find((row) => row.id === 'store-banner')?.hasWeb, true)
     await store.openPlugin('store-banner')
     assert.equal(forks.get('store-banner')?.web, '/api/plugin-store/files/store-banner/web.js')
     await assert.rejects(() => store.readInstalledFile('store-banner', 'host.js'))

--- a/packages/core-plugin-system/src/host/index.ts
+++ b/packages/core-plugin-system/src/host/index.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'cordis'
-import { pluginsCollection } from './collection.ts'
+import { pluginsCollection, pluginSandboxesCollection } from './collection.ts'
 import { openStore } from './store.ts'
 
 export const name = 'core-plugin-system'
@@ -10,11 +10,12 @@ export {
   defaultPluginDir,
   defaultStatePath,
 } from './store.ts'
-export { pluginsCollection } from './collection.ts'
+export { pluginsCollection, pluginSandboxesCollection } from './collection.ts'
 
 export async function apply(ctx: Context) {
   const store = await openStore(ctx)
   ctx.inject(['database'], (inner) => {
     inner.database.register(pluginsCollection(store))
+    inner.database.register(pluginSandboxesCollection(store))
   })
 }

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -273,6 +273,42 @@ export class PluginStoreService extends Service {
     return { id: manifest.id, sandboxPath: sandbox, pluginPath: dest }
   }
 
+  async listSandboxes() {
+    const names = existsSync(this.sandboxDir) ? await readdir(this.sandboxDir) : []
+    const items: Array<{
+      id: string
+      name: string
+      blurb: string
+      tags: string[]
+      author: string
+      authorUrl: string
+      hasHost: boolean
+      hasWeb: boolean
+      createdAt: number
+      updatedAt: number
+    }> = []
+    for (const name of names.sort()) {
+      const dir = join(this.sandboxDir, name)
+      if (!(await stat(dir)).isDirectory()) continue
+      if (!existsSync(join(dir, 'manifest.json'))) continue
+      const manifest = await readManifest(dir)
+      const stats = await pluginDirStats(dir)
+      items.push({
+        id: manifest.id,
+        name: manifest.name,
+        blurb: manifest.blurb,
+        tags: manifest.tags,
+        author: manifest.author,
+        authorUrl: manifest.authorUrl,
+        hasHost: Boolean(findEntry(dir, HOST_ENTRIES)),
+        hasWeb: Boolean(findEntry(dir, WEB_ENTRIES)),
+        createdAt: manifest.createdAt || stats.createdAt,
+        updatedAt: stats.updatedAt,
+      })
+    }
+    return items
+  }
+
   async list(): Promise<StoreListing[]> {
     if (this.listCache) return this.listCache
     const names = existsSync(this.pluginDir) ? await readdir(this.pluginDir) : []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把插件系统里已有的数据接到 Core File System：

- `/plugins`：展开 `StoreListing`（运行/开关、标签、作者、体积、外壳宽高、host/web）
- `/plugin-sandboxes`：扫描 `.plugin-dev`，只读，动作「打包安装」
- 用户数据侧栏排序加上沙箱表

不改插件商店 API，只补 collection 注册。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

