### PR TITLE
fix(pick): 关闭聊天窗后退出选取模式

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -42,6 +42,7 @@ describe('composer dock stacking above sticky user', () => {
     expect(shell).not.toMatch(/hit\.closest\('\.dock-agent-stack'\)/)
     expect(shell).toContain('OverlayChatWindow')
     expect(overlayWin).toContain('chat-overlay-drag')
+    expect(overlayWin).toContain('data-biu-ignore')
     expect(overlayWin).toContain("key: 'se'")
     expect(overlayWin).toContain('chat-overlay-resize-')
     expect(css).toMatch(/\.chat-overlay-panel \{/)

--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -5,13 +5,31 @@ import assert from 'node:assert/strict'
 
 const overlay = readFileSync(resolve(import.meta.dirname, './overlay.tsx'), 'utf8')
 
-test('pick capture does not eat sidebar, dock, or inspector chrome clicks', () => {
+test('pick capture does not eat sidebar, dock, inspector, or chat overlay clicks', () => {
   assert.match(overlay, /function ignorePickCapture/)
   assert.match(overlay, /\.app-side-bar/)
   assert.match(overlay, /data-os-dock/)
   assert.match(overlay, /data-biu-ignore/)
+  assert.match(overlay, /chat-overlay-panel/)
   assert.doesNotMatch(overlay, /\.app-rail/)
   assert.doesNotMatch(overlay, /\.session-inspector/)
+})
+
+test('close button inside the chat overlay is not captured while picking', async () => {
+  const { ignorePickCapture } = await import('./overlay.tsx')
+  const panel = document.createElement('div')
+  panel.setAttribute('data-testid', 'chat-overlay-panel')
+  const close = document.createElement('button')
+  close.setAttribute('data-testid', 'chat-overlay-close')
+  panel.append(close)
+  document.body.append(panel)
+  assert.equal(ignorePickCapture(close), true)
+  panel.remove()
+})
+
+test('closing the chat overlay exits pick mode', () => {
+  assert.match(overlay, /biu:overlay-closed/)
+  assert.match(overlay, /pick.exit\(\)/)
 })
 
 test('Command/Ctrl+Q toggles pick mode', () => {

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -5,10 +5,10 @@ import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect } from './resolve
 
 const DRAG_PX = 6
 
-const PICK_NAV_GUARD =
-  '[data-biu-ignore], .app-side-bar, .brand-corner-cluster, [data-os-dock], [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"]'
+export const PICK_NAV_GUARD =
+  '[data-biu-ignore], .app-side-bar, .brand-corner-cluster, [data-os-dock], [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"], [data-testid="chat-overlay-panel"]'
 
-function ignorePickCapture(target: Element) {
+export function ignorePickCapture(target: Element) {
   return Boolean(target.closest(PICK_NAV_GUARD))
 }
 
@@ -115,6 +115,13 @@ export function PickOverlay(_props: SlotProps) {
     }
     window.addEventListener('keydown', onHotkey)
     return () => window.removeEventListener('keydown', onHotkey)
+  }, [pick])
+
+  useEffect(() => {
+    if (!pick) return
+    const onClosed = () => pick.exit()
+    window.addEventListener('biu:overlay-closed', onClosed)
+    return () => window.removeEventListener('biu:overlay-closed', onClosed)
   }, [pick])
 
   if (!picking) return null

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -162,6 +162,18 @@ test('pick opens a compose-only overlay; send reveals the thread', () => {
   assert.equal(getOverlayThread(), false)
 })
 
+test('closing the overlay notifies pick to exit', () => {
+  setChatOverlay(true)
+  let closed = 0
+  const onClosed = () => {
+    closed += 1
+  }
+  window.addEventListener('biu:overlay-closed', onClosed)
+  setChatOverlay(false)
+  window.removeEventListener('biu:overlay-closed', onClosed)
+  assert.equal(closed, 1)
+})
+
 test('autohide resets when overlay closes', () => {
   setChatOverlay(true)
   setOverlayAutohide(true)

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -118,6 +118,7 @@ export function setChatOverlay(next: boolean) {
   if (!next) {
     setOverlayAutohide(false)
     setOverlayThread(false)
+    if (typeof window !== 'undefined') window.dispatchEvent(new Event('biu:overlay-closed'))
   }
   emit()
 }

--- a/packages/web-app-shell/src/web/overlay-window.tsx
+++ b/packages/web-app-shell/src/web/overlay-window.tsx
@@ -127,6 +127,7 @@ export function OverlayChatWindow({
       ref={boxRef}
       className="chat-overlay-panel"
       data-testid="chat-overlay-panel"
+      data-biu-ignore
       style={{ top: geom.y, left: geom.x, width: geom.w, height: geom.h, zIndex: z }}
       onPointerDown={bringFront}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取对象后仍弹出聊天窗。关掉窗口（关闭按钮、Dock 对话开关等）会发出 `biu:overlay-closed`，选取模式自动退出，已选芯片留在输入框。

聊天浮窗整层不参与选取捕获，关闭按钮在选取进行中也能点到。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

