### PR TITLE
fix(inspector): 没有已打开面板时只留一条分隔线

### DIFF
--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -41,7 +41,8 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /PaneLeafIcon/)
   assert.match(inspector, /createPortal/)
   assert.match(inspector, /inspector-add-menu is-fixed/)
-  assert.match(css, /\.inspector-add-owner\s*\{[^}]*border-bottom:\s*1px solid var\(--dsw-border\)/s)
+  assert.match(css, /\.inspector-add-owner\.has-open\s*\{[^}]*border-bottom:\s*1px solid var\(--dsw-border\)/s)
+  assert.match(inspector, /inspector-add-owner\$\{headerTabs\.length \? ' has-open' : ''\}/)
   assert.doesNotMatch(inspector, /添加\$\{item\.label\}/)
 })
 

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -369,7 +369,7 @@ export const SessionInspector = memo(function SessionInspector({
               style={{ right: plusPos.right, top: plusPos.top }}
             >
               {sessionId && sessionIdentity ? (
-                <div className="inspector-add-owner" data-testid="inspector-add-owner">
+                <div className={`inspector-add-owner${headerTabs.length ? ' has-open' : ''}`} data-testid="inspector-add-owner">
                   <SidebarMascot
                     size={22}
                     sessionId={sessionId}

--- a/web/style.css
+++ b/web/style.css
@@ -849,13 +849,17 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 2px 8px 8px;
-  margin-bottom: 2px;
-  border-bottom: 1px solid var(--dsw-border);
+  padding: 2px 8px 6px;
   color: var(--dsw-sidebar-fg-active);
   font-size: 14px;
   font-weight: 600;
   line-height: 1.3;
+}
+
+.inspector-add-owner.has-open {
+  margin-bottom: 2px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--dsw-border);
 }
 
 .inspector-add-owner .sidebar-mascot {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
加号菜单里，没打开任何面板时小人底边和目录顶边会叠成两条线。现在没选中面板只留目录上面那一条；有已打开面板时才再加小人下面那条。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

