### PR TITLE
fix(chat): 关掉聊天窗不再被立刻强制打开

### DIFF
--- a/packages/web-app-shell/src/web/chat-decouple.test.ts
+++ b/packages/web-app-shell/src/web/chat-decouple.test.ts
@@ -12,6 +12,7 @@ test('overlay chat is a resident floating window off the agent page', () => {
   assert.match(shell, /chat-overlay-close/)
   assert.match(shell, /closeChatOverlay\(\)/)
   assert.match(shell, /onPointerDown/)
+  assert.doesNotMatch(shell, /if \(overlay\) setChatOverlay\(true\)/)
   assert.doesNotMatch(shell, /overlayCollapsed/)
   assert.doesNotMatch(shell, /is-compose-only/)
   assert.doesNotMatch(shell, /is-autohide/)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -108,9 +108,6 @@ const AgentMainPanels = memo(function AgentMainPanels({
   useEffect(() => {
     setOverlayMounted(true)
   }, [])
-  useEffect(() => {
-    if (overlay) setChatOverlay(true)
-  }, [overlay])
   const stageRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (!overlay) return

--- a/packages/web-app-shell/src/web/overlay-window.test.ts
+++ b/packages/web-app-shell/src/web/overlay-window.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment jsdom */
+import { test, afterEach } from 'vitest'
+import assert from 'node:assert/strict'
+import { createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { act } from 'react'
+import { OverlayChatWindow } from './overlay-window.tsx'
+import { closeChatOverlay, getChatOverlay, setChatOverlay } from './chat-overlay.ts'
+
+let root: Root | null = null
+let host: HTMLDivElement | null = null
+
+afterEach(() => {
+  act(() => {
+    root?.unmount()
+  })
+  host?.remove()
+  root = null
+  host = null
+  setChatOverlay(false)
+})
+
+test('clicking the overlay close button actually closes the overlay', () => {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  setChatOverlay(true)
+  const header = createElement(
+    'button',
+    { type: 'button', 'data-testid': 'chat-overlay-close' },
+    'close',
+  )
+  act(() => {
+    root!.render(
+      createElement(OverlayChatWindow, {
+        header,
+        thread: createElement('div'),
+        dock: createElement('div'),
+      }),
+    )
+  })
+  assert.equal(getChatOverlay(), true)
+  const close = document.querySelector('[data-testid="chat-overlay-close"]')
+  assert.ok(close)
+  act(() => {
+    close!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true }))
+  })
+  assert.equal(getChatOverlay(), false)
+  closeChatOverlay()
+})

--- a/packages/web-app-shell/src/web/overlay-window.tsx
+++ b/packages/web-app-shell/src/web/overlay-window.tsx
@@ -3,6 +3,7 @@ import {
   clampOverlayWinGeom,
   readOverlayWinGeom,
   writeOverlayWinGeom,
+  closeChatOverlay,
   type OverlayWinGeom,
 } from './chat-overlay.ts'
 
@@ -37,6 +38,20 @@ export function OverlayChatWindow({
     window.addEventListener('biu:overlay-focus', onFocus)
     return () => window.removeEventListener('biu:overlay-focus', onFocus)
   }, [bringFront])
+
+  useEffect(() => {
+    const el = boxRef.current
+    if (!el) return
+    const onClose = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Element) || !target.closest('[data-testid="chat-overlay-close"]')) return
+      event.preventDefault()
+      event.stopPropagation()
+      closeChatOverlay()
+    }
+    el.addEventListener('pointerdown', onClose, true)
+    return () => el.removeEventListener('pointerdown', onClose, true)
+  }, [])
 
   useEffect(() => {
     const onMove = (event: PointerEvent) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天窗关不掉，是因为离开对话页时有一段 `if (overlay) setChatOverlay(true)`，会把窗口重新钉开。

这段去掉了。关闭按钮改在浮窗捕获阶段处理，点 X 会关窗并退出选取。选取对象、Dock 对话按钮仍会打开窗口。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

