### PR TITLE
fix(pick): 选中对象只触发一次打开聊天窗

### DIFF
--- a/packages/cap-pick/src/web/service.test.ts
+++ b/packages/cap-pick/src/web/service.test.ts
@@ -52,8 +52,23 @@ test('adding a pick notifies the overlay to open', () => {
   }
   window.addEventListener('biu:pick-attached', onAttached)
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
+  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
   window.removeEventListener('biu:pick-attached', onAttached)
   assert.equal(attached, 1)
+})
+
+test('a new pick notifies once; the same pick does not notify again', () => {
+  const ctx = new Context()
+  const pick = new PickService(ctx)
+  let attached = 0
+  const onAttached = () => {
+    attached += 1
+  }
+  window.addEventListener('biu:pick-attached', onAttached)
+  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
+  pick.add({ kind: 'page', id: 'p2', label: '另一页', route: '/pages' })
+  window.removeEventListener('biu:pick-attached', onAttached)
+  assert.equal(attached, 2)
 })
 
 test('overlay-closed on window exits pick mode and keeps chips', () => {

--- a/packages/cap-pick/src/web/service.ts
+++ b/packages/cap-pick/src/web/service.ts
@@ -72,12 +72,15 @@ export class PickService extends Service {
       this.bump()
       return
     }
+    const before = this.refs.length
     this.refs = dedupePicks([...this.refs, ...refs])
     this.hover = null
     this.marquee = null
     this.marqueeHits = []
     this.bump()
-    if (typeof window !== 'undefined') window.dispatchEvent(new Event('biu:pick-attached'))
+    if (this.refs.length > before && typeof window !== 'undefined') {
+      window.dispatchEvent(new Event('biu:pick-attached'))
+    }
   }
 
   removeLast() {

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -151,6 +151,14 @@ test('overlay starts closed', () => {
   setChatOverlay(false)
 })
 
+test('pick-attached only opens; closing stays closed even if chips remain', () => {
+  setChatOverlay(false)
+  window.dispatchEvent(new Event('biu:pick-attached'))
+  assert.equal(getChatOverlay(), true)
+  closeChatOverlay()
+  assert.equal(getChatOverlay(), false)
+})
+
 test('pick opens a compose-only overlay; send reveals the thread', () => {
   setChatOverlay(false)
   openOverlayComposer({ revealThread: false })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取打开聊天窗是一次性动作：只有名单里**新出现**对象时才发 `pick-attached` 并打开。

窗口开着与否只由 overlay 开关决定，不跟「现在有没有选中对象」绑在一起。关掉后芯片还在，也不会因为同一个对象再被点一次而钉开。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

