### PR TITLE
fix(pick): 关掉聊天窗后抬手不再把窗口打开

### DIFF
--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -36,6 +36,10 @@ test('Escape blurs the focused control so the UA focus ring does not linger', ()
   assert.match(overlay, /active.blur\(\)/)
 })
 
+test('pointerup does not attach picks after pick mode has exited', () => {
+  assert.match(overlay, /if \(!pick.picking\) return/)
+})
+
 test('Command/Ctrl+Q toggles pick mode', () => {
   assert.match(overlay, /event.metaKey \|\| event.ctrlKey/)
   assert.match(overlay, /key === 'q'/)

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -65,6 +65,7 @@ export function PickOverlay(_props: SlotProps) {
       if (!drag) return
       const started = drag
       drag = null
+      if (!pick.picking) return
       if (started.boxed) {
         const box = boxFromPoints(started.x, started.y, event.clientX, event.clientY)
         pick.addMany(resolvePicksInRect(box, route()).map((hit) => hit.ref))

--- a/packages/cap-pick/src/web/service.test.ts
+++ b/packages/cap-pick/src/web/service.test.ts
@@ -51,6 +51,7 @@ test('adding a pick notifies the overlay to open', () => {
     attached += 1
   }
   window.addEventListener('biu:pick-attached', onAttached)
+  pick.enter()
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
   window.removeEventListener('biu:pick-attached', onAttached)
@@ -65,10 +66,30 @@ test('a new pick notifies once; the same pick does not notify again', () => {
     attached += 1
   }
   window.addEventListener('biu:pick-attached', onAttached)
+  pick.enter()
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
   pick.add({ kind: 'page', id: 'p2', label: '另一页', route: '/pages' })
   window.removeEventListener('biu:pick-attached', onAttached)
   assert.equal(attached, 2)
+})
+
+test('after overlay closes, more picks do not open the chat again', () => {
+  const ctx = new Context()
+  const pick = new PickService(ctx)
+  let attached = 0
+  const onAttached = () => {
+    attached += 1
+  }
+  window.addEventListener('biu:pick-attached', onAttached)
+  pick.enter()
+  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
+  assert.equal(attached, 1)
+  window.dispatchEvent(new Event('biu:overlay-closed'))
+  assert.equal(pick.picking, false)
+  pick.add({ kind: 'page', id: 'p2', label: '另一页', route: '/pages' })
+  window.removeEventListener('biu:pick-attached', onAttached)
+  assert.equal(attached, 1)
+  assert.equal(pick.refs.length, 2)
 })
 
 test('overlay-closed on window exits pick mode and keeps chips', () => {

--- a/packages/cap-pick/src/web/service.ts
+++ b/packages/cap-pick/src/web/service.ts
@@ -78,7 +78,7 @@ export class PickService extends Service {
     this.marquee = null
     this.marqueeHits = []
     this.bump()
-    if (this.refs.length > before && typeof window !== 'undefined') {
+    if (this.picking && this.refs.length > before && typeof window !== 'undefined') {
       window.dispatchEvent(new Event('biu:pick-attached'))
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
关窗时选取已经 exit，但同一轮鼠标抬手还在 `add`，又发出 `pick-attached`，聊天窗被马上打开。

现在只有「选取模式仍开着」才会发打开事件。关掉窗口 = 退出选取，之后这次点击不会再把窗口钉开。芯片还在。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5dea49f-22c1-4757-863a-2969d928394f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5dea49f-22c1-4757-863a-2969d928394f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

