### PR TITLE
fix(pick): 简化选取打开聊天窗的规则

### DIFF
--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -557,16 +557,18 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   useEffect(() => {
     if (!editor || !sessionId) return
     const draft = readDraftMap()[sessionId]
-    pick?.clear()
+    const keep = pick?.refs.slice() ?? []
+    if (!pick?.picking) pick?.clear()
     pickKeysRef.current = new Set()
     if (typeof draft === 'string' && draft) {
       editor.commands.setContent(jsonFromDraft(draft))
       const { refs } = serializeComposer(editor)
       if (refs.length) pick?.addMany(refs)
-      pickKeysRef.current = collectPickKeys(editor)
     } else {
       editor.commands.clearContent()
     }
+    if (keep.length && !pick?.picking) pick?.addMany(keep)
+    pickKeysRef.current = collectPickKeys(editor)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, editor])
 

--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -3,13 +3,14 @@ import assert from 'node:assert/strict'
 import * as lu from '@heroicons/react/16/solid'
 import { pickKindIcon } from './chip.tsx'
 
-test('chip icons exist on @heroicons/react/16/solid', () => {
+test('kind maps to distinct heroicons', () => {
   const needed = [
     'CpuChipIcon',
     'CircleStackIcon',
     'StopCircleIcon',
     'HashtagIcon',
     'Square3Stack3DIcon',
+    'RectangleStackIcon',
     'ClipboardDocumentCheckIcon',
     'ChatBubbleLeftIcon',
     'PuzzlePieceIcon',
@@ -20,7 +21,12 @@ test('chip icons exist on @heroicons/react/16/solid', () => {
   for (const name of needed) {
     assert.ok(name in lu, `${name} missing`)
   }
-  assert.ok(pickKindIcon('event'))
-  assert.ok(pickKindIcon('usage'))
-  assert.ok(pickKindIcon('session'))
+  assert.equal(pickKindIcon('session'), lu.CpuChipIcon)
+  assert.equal(pickKindIcon('message'), lu.ChatBubbleLeftIcon)
+  assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
+  assert.equal(pickKindIcon('task'), lu.ClipboardDocumentCheckIcon)
+  assert.equal(pickKindIcon('page'), lu.DocumentIcon)
+  assert.notEqual(pickKindIcon('collection'), pickKindIcon('usage'))
+  assert.equal(pickKindIcon('plugin'), lu.PuzzlePieceIcon)
+  assert.equal(pickKindIcon('unknown'), lu.TagIcon)
 })

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -23,12 +23,10 @@ export function apply(ctx: Context) {
   slots.place('header-tools', PickToggle, {
     key: 'pick-toggle',
     order: 10,
-    props: () => ({ placement: 'header' }),
   })
   slots.place('root-overlays', PickOverlay, {
     key: 'pick-overlay',
     order: 10,
-    props: () => ({}),
   })
   ctx.dock.register({
     id: 'pick',

--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -27,8 +27,7 @@ test('close button inside the chat overlay is not captured while picking', async
   panel.remove()
 })
 
-test('closing the chat overlay exits pick mode', () => {
-  assert.match(overlay, /biu:overlay-closed/)
+test('Escape exits pick mode', () => {
   assert.match(overlay, /pick.exit\(\)/)
 })
 

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -120,13 +120,6 @@ export function PickOverlay(_props: SlotProps) {
     return () => window.removeEventListener('keydown', onHotkey)
   }, [pick])
 
-  useEffect(() => {
-    if (!pick) return
-    const onClosed = () => pick.exit()
-    window.addEventListener('biu:overlay-closed', onClosed)
-    return () => window.removeEventListener('biu:overlay-closed', onClosed)
-  }, [pick])
-
   if (!picking) return null
   return (
     <>

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -2,8 +2,6 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect } from './resolve.ts'
 import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks } from './types.ts'
-import { pickKindIcon } from './chip.tsx'
-import { CpuChipIcon, ClipboardDocumentCheckIcon, ChatBubbleLeftIcon, PuzzlePieceIcon, TagIcon, DocumentIcon } from '@heroicons/react/16/solid'
 
 test('splitPickStream keeps text and chips in order', () => {
   const parts = splitPickStream('看 <pick kind="task" id="t1" label="写需求" /> 和 <pick kind="plugin" id="p1" label="Hello" /> 吧')
@@ -79,17 +77,6 @@ test('parsePicks recovers chips that markdown would strip', () => {
   assert.equal(parsed.refs[0]?.action, 'open')
   assert.equal(parsed.refs[0]?.label, '写需求')
   assert.equal(parsed.rest, '看这个')
-})
-
-test('kind maps to distinct icons', () => {
-  assert.equal(pickKindIcon('session'), CpuChipIcon)
-  assert.equal(pickKindIcon('message'), ChatBubbleLeftIcon)
-  assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
-  assert.equal(pickKindIcon('task'), ClipboardDocumentCheckIcon)
-  assert.equal(pickKindIcon('page'), DocumentIcon)
-  assert.notEqual(pickKindIcon('collection'), pickKindIcon('usage'))
-  assert.equal(pickKindIcon('plugin'), PuzzlePieceIcon)
-  assert.equal(pickKindIcon('unknown'), TagIcon)
 })
 
 function stubBox(el: HTMLElement, left: number, top: number, width: number, height: number) {

--- a/packages/cap-pick/src/web/resolve.ts
+++ b/packages/cap-pick/src/web/resolve.ts
@@ -5,7 +5,7 @@ const ID = 'data-biu-id'
 const ACTION = 'data-biu-action'
 const LABEL = 'data-biu-label'
 
-export function isPickIgnored(node: Element | null) {
+function isPickIgnored(node: Element | null) {
   return Boolean(node?.closest('[data-biu-ignore]'))
 }
 
@@ -62,7 +62,7 @@ export function resolvePickAtPoint(x: number, y: number, route: string) {
   return null
 }
 
-export type ClientBox = { left: number; top: number; width: number; height: number }
+type ClientBox = { left: number; top: number; width: number; height: number }
 
 export function boxFromPoints(ax: number, ay: number, bx: number, by: number): ClientBox {
   const left = Math.min(ax, bx)
@@ -70,7 +70,7 @@ export function boxFromPoints(ax: number, ay: number, bx: number, by: number): C
   return { left, top, width: Math.abs(bx - ax), height: Math.abs(by - ay) }
 }
 
-export function boxesOverlap(a: ClientBox, b: ClientBox) {
+function boxesOverlap(a: ClientBox, b: ClientBox) {
   return a.left < b.left + b.width && a.left + a.width > b.left && a.top < b.top + b.height && a.top + a.height > b.top
 }
 

--- a/packages/cap-pick/src/web/service.test.ts
+++ b/packages/cap-pick/src/web/service.test.ts
@@ -43,7 +43,7 @@ test('adding a pick while picking stays in pick mode so you can select again', (
   assert.equal(pick.refs.length, 2)
 })
 
-test('adding a pick notifies the overlay to open', () => {
+test('picking an object opens the chat overlay, including the same object again', () => {
   const ctx = new Context()
   const pick = new PickService(ctx)
   let attached = 0
@@ -51,29 +51,17 @@ test('adding a pick notifies the overlay to open', () => {
     attached += 1
   }
   window.addEventListener('biu:pick-attached', onAttached)
+  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
+  assert.equal(attached, 0)
   pick.enter()
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
-  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
-  window.removeEventListener('biu:pick-attached', onAttached)
-  assert.equal(attached, 1)
-})
-
-test('a new pick notifies once; the same pick does not notify again', () => {
-  const ctx = new Context()
-  const pick = new PickService(ctx)
-  let attached = 0
-  const onAttached = () => {
-    attached += 1
-  }
-  window.addEventListener('biu:pick-attached', onAttached)
-  pick.enter()
   pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
   pick.add({ kind: 'page', id: 'p2', label: '另一页', route: '/pages' })
   window.removeEventListener('biu:pick-attached', onAttached)
-  assert.equal(attached, 2)
+  assert.equal(attached, 3)
 })
 
-test('after overlay closes, more picks do not open the chat again', () => {
+test('after overlay closes, picks do not open the chat until pick mode is on again', () => {
   const ctx = new Context()
   const pick = new PickService(ctx)
   let attached = 0
@@ -87,8 +75,11 @@ test('after overlay closes, more picks do not open the chat again', () => {
   window.dispatchEvent(new Event('biu:overlay-closed'))
   assert.equal(pick.picking, false)
   pick.add({ kind: 'page', id: 'p2', label: '另一页', route: '/pages' })
-  window.removeEventListener('biu:pick-attached', onAttached)
   assert.equal(attached, 1)
+  pick.enter()
+  pick.add({ kind: 'page', id: 'p1', label: '页面', route: '/pages' })
+  window.removeEventListener('biu:pick-attached', onAttached)
+  assert.equal(attached, 2)
   assert.equal(pick.refs.length, 2)
 })
 

--- a/packages/cap-pick/src/web/service.ts
+++ b/packages/cap-pick/src/web/service.ts
@@ -72,13 +72,13 @@ export class PickService extends Service {
       this.bump()
       return
     }
-    const before = this.refs.length
     this.refs = dedupePicks([...this.refs, ...refs])
     this.hover = null
     this.marquee = null
     this.marqueeHits = []
     this.bump()
-    if (this.picking && this.refs.length > before && typeof window !== 'undefined') {
+    // 选取模式下点一次对象就打开聊天窗；关窗后 picking=false，草稿同步不会再弹窗。
+    if (this.picking && typeof window !== 'undefined') {
       window.dispatchEvent(new Event('biu:pick-attached'))
     }
   }

--- a/packages/cap-pick/src/web/toggle.tsx
+++ b/packages/cap-pick/src/web/toggle.tsx
@@ -2,10 +2,9 @@ import { CursorArrowRaysIcon } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/type-slots'
 import { getPick, usePickState } from './service.ts'
 
-export function PickToggle(props: SlotProps) {
+export function PickToggle(_props: SlotProps) {
   const pick = getPick()
   const { picking } = usePickState(pick)
-  const placement = String(props.placement ?? 'header')
   return (
     <button
       type="button"
@@ -13,7 +12,7 @@ export function PickToggle(props: SlotProps) {
       aria-label="选取对象"
       data-dock-tip="选取对象"
       aria-pressed={picking}
-      data-testid={placement === 'corner' ? 'corner-pick-toggle' : 'header-pick-toggle'}
+      data-testid="header-pick-toggle"
       data-biu-ignore
       onClick={() => pick?.toggle()}
     >

--- a/packages/cap-pick/src/web/types.ts
+++ b/packages/cap-pick/src/web/types.ts
@@ -10,7 +10,7 @@ export function pickKey(ref: PickRef) {
   return `${ref.kind}:${ref.id}:${ref.action ?? ''}`
 }
 
-export function objectKey(ref: PickRef) {
+function objectKey(ref: PickRef) {
   return `${ref.kind}:${ref.id}`
 }
 
@@ -80,10 +80,10 @@ export function formatPick(ref: PickRef) {
 /** 按原文顺序拆成文字段和 pick 块，供输入框混排还原。 */
 export function splitPickStream(text: string): Array<{ type: 'text'; value: string } | { type: 'pick'; ref: PickRef }> {
   const parts: Array<{ type: 'text'; value: string } | { type: 'pick'; ref: PickRef }> = []
-  const re = /<pick\b([^>]*)\/>/gi
+  PICK_TAG.lastIndex = 0
   let last = 0
   let match: RegExpExecArray | null
-  while ((match = re.exec(text))) {
+  while ((match = PICK_TAG.exec(text))) {
     if (match.index > last) parts.push({ type: 'text', value: text.slice(last, match.index) })
     const ref = parsePickAttrs(match[1] ?? '')
     if (ref) parts.push({ type: 'pick', ref })

--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -171,7 +171,7 @@ test('pick opens a compose-only overlay; send reveals the thread', () => {
   assert.equal(getOverlayThread(), false)
 })
 
-test('closeChatOverlay notifies even if the overlay was already closed', () => {
+test('closeChatOverlay is a no-op when already closed', () => {
   setChatOverlay(false)
   let closed = 0
   const onClosed = () => {
@@ -181,7 +181,7 @@ test('closeChatOverlay notifies even if the overlay was already closed', () => {
   closeChatOverlay()
   window.removeEventListener('biu:overlay-closed', onClosed)
   assert.equal(getChatOverlay(), false)
-  assert.equal(closed, 1)
+  assert.equal(closed, 0)
 })
 
 test('closing the overlay notifies pick to exit', () => {

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -128,9 +128,7 @@ function notifyOverlayClosed() {
   window.dispatchEvent(new Event('biu:overlay-closed'))
 }
 
-/** 关掉浮窗并退出选取。已经关着也会再通知一次。 */
 export function closeChatOverlay() {
-  notifyOverlayClosed()
   setChatOverlay(false)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取弹聊天窗的规则收成三条，不再靠「芯片有没有变多」「关窗再通知一次」叠状态。

**行为**
- 选取模式开着：点对象就打开聊天窗（同一对象再点也会打开）
- 关掉聊天窗：只在窗口从开到关时退出选取；已经关着不再重复广播
- 输入栏随浮窗重挂：正在选取时不清掉刚选中的芯片

关窗后同一轮抬手仍不会再次 attach（`pointerup` 时若已退出选取则忽略）。

`packages/cap-pick`、`cap-chat`、相关 overlay 测试 128 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e767bb2-74b6-4c05-a550-cb56d3f921df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e767bb2-74b6-4c05-a550-cb56d3f921df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

