### PR TITLE
feat(plugins): 沙箱和已安装合成一张插件表

### DIFF
--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -38,7 +38,6 @@ test('views and events are system collections; user tables sort first', () => {
   const { user, system } = sortDataCollections([
     { path: '/events' },
     { path: '/plugins' },
-    { path: '/plugin-sandboxes' },
     { path: '/views' },
     { path: '/sessions' },
     { path: '/pages' },
@@ -46,7 +45,7 @@ test('views and events are system collections; user tables sort first', () => {
   ])
   assert.deepEqual(
     user.map((item) => item.path),
-    ['/sessions', '/tasks', '/pages', '/plugins', '/plugin-sandboxes'],
+    ['/sessions', '/tasks', '/pages', '/plugins'],
   )
   assert.deepEqual(
     system.map((item) => item.path),

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -29,7 +29,7 @@ export function databaseRecordPath(collection: string, recordId: string): string
 export const VIEWS_COLLECTION_PATH = '/views'
 export const EVENTS_COLLECTION_PATH = '/events'
 
-const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/plugins', '/plugin-sandboxes'] as const
+const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/plugins'] as const
 
 /** 视图、事件由系统自己记下，侧栏归在系统数据。 */
 export function isSystemCollection(path: string) {

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
+  ArchiveBoxArrowDownIcon,
   ArrowPathIcon,
   Bars3BottomLeftIcon,
   CalendarDaysIcon,
@@ -38,6 +39,7 @@ export function actionIcon(id: string) {
   const cls = 'size-[14px]'
   if (id === 'start' || id === 'play' || id === 'run' || id === 'open') return <PlayIcon aria-hidden className={cls} />
   if (id === 'stop' || id === 'close' || id === 'pause') return <StopIcon aria-hidden className={cls} />
+  if (id === 'pack') return <ArchiveBoxArrowDownIcon aria-hidden className={cls} />
   if (id === 'uninstall' || id === 'delete' || id === 'remove') return <TrashGlyph aria-hidden className={cls} />
   if (id === 'edit' || id === 'rename') return <PencilSquareIcon aria-hidden className={cls} />
   if (id === 'refresh') return <ArrowPathIcon aria-hidden className={cls} />

--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -1,11 +1,11 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { DbRecord } from '@biu/type-file-system'
-import { pluginSandboxesCollection, pluginsCollection } from './collection.ts'
+import { pluginsCollection } from './collection.ts'
 import type { PluginStoreService } from './store.ts'
 import { defaultStoreShell } from '../shell.ts'
 
-test('pluginsCollection registers /plugins with store listing fields', async () => {
+test('pluginsCollection lists installed plugins and sandboxes in one table', async () => {
   const items: DbRecord[] = [{ id: 'demo', name: 'Demo', enabled: false }]
   const calls: string[] = []
   const spec = pluginsCollection({
@@ -29,41 +29,6 @@ test('pluginsCollection registers /plugins with store listing fields', async () 
           shell: defaultStoreShell(),
         },
       ]),
-    openPlugin(id: string) {
-      calls.push(`open:${id}`)
-      items[0]!.enabled = true
-    },
-    close(id: string) {
-      calls.push(`close:${id}`)
-      items[0]!.enabled = false
-    },
-    uninstall(id: string) {
-      calls.push(`uninstall:${id}`)
-    },
-  } as PluginStoreService)
-  assert.equal(spec.path, '/plugins')
-  assert.equal(spec.view?.moduleId, 'plugins')
-  const listed = await spec.list()
-  assert.equal(listed[0]?.shellWidth, defaultStoreShell().width)
-  assert.equal(listed[0]?.hasWeb, true)
-  assert.deepEqual(
-    spec.actions?.map((item) => item.id),
-    ['start', 'stop', 'uninstall'],
-  )
-  await spec.actions!.find((item) => item.id === 'start')!.run('demo', items[0]!)
-  assert.deepEqual(calls, ['open:demo'])
-  assert.equal(spec.update, undefined)
-  assert.deepEqual(spec.records, { update: false, create: false, delete: false })
-  assert.ok(spec.schema.columns?.includes('shellWidth'))
-  assert.ok(spec.schema.columns?.includes('enabled'))
-  assert.equal(spec.schema.fields.authorUrl?.type, 'url')
-  assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { running: false })
-  assert.deepEqual(spec.actions?.find((item) => item.id === 'stop')?.when, { running: true })
-})
-
-test('pluginSandboxesCollection registers .plugin-dev drafts', async () => {
-  const packed: string[] = []
-  const spec = pluginSandboxesCollection({
     listSandboxes: () =>
       Promise.resolve([
         {
@@ -79,14 +44,98 @@ test('pluginSandboxesCollection registers .plugin-dev drafts', async () => {
           updatedAt: 2,
         },
       ]),
+    openPlugin(id: string) {
+      calls.push(`open:${id}`)
+      items[0]!.enabled = true
+    },
+    close(id: string) {
+      calls.push(`close:${id}`)
+      items[0]!.enabled = false
+    },
     pack(id: string) {
-      packed.push(id)
+      calls.push(`pack:${id}`)
+    },
+    uninstall(id: string) {
+      calls.push(`uninstall:${id}`)
     },
   } as PluginStoreService)
-  assert.equal(spec.path, '/plugin-sandboxes')
-  assert.equal(spec.view?.title, '插件沙箱')
+  assert.equal(spec.path, '/plugins')
+  assert.equal(spec.view?.moduleId, 'plugins')
   const listed = await spec.list()
-  assert.equal(listed[0]?.id, 'draft-hello')
-  await spec.actions!.find((item) => item.id === 'pack')!.run('draft-hello', listed[0]!)
-  assert.deepEqual(packed, ['draft-hello'])
+  const demo = listed.find((row) => row.id === 'demo')
+  const draft = listed.find((row) => row.id === 'draft-hello')
+  assert.equal(demo?.installed, true)
+  assert.equal(demo?.sandbox, undefined)
+  assert.equal(demo?.shellWidth, defaultStoreShell().width)
+  assert.equal(demo?.hasWeb, true)
+  assert.equal(draft?.sandbox, true)
+  assert.equal(draft?.installed, undefined)
+  assert.equal(draft?.running, undefined)
+  assert.equal(draft?.bytes, undefined)
+  assert.equal(draft?.shellWidth, undefined)
+  assert.deepEqual(
+    spec.actions?.map((item) => item.id),
+    ['start', 'stop', 'pack', 'uninstall'],
+  )
+  await spec.actions!.find((item) => item.id === 'start')!.run('demo', demo!)
+  await spec.actions!.find((item) => item.id === 'pack')!.run('draft-hello', draft!)
+  assert.deepEqual(calls, ['open:demo', 'pack:draft-hello'])
+  assert.equal(spec.update, undefined)
+  assert.deepEqual(spec.records, { update: false, create: false, delete: false })
+  assert.ok(spec.schema.columns?.includes('sandbox'))
+  assert.ok(spec.schema.columns?.includes('installed'))
+  assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { installed: true, running: false })
+  assert.deepEqual(spec.actions?.find((item) => item.id === 'pack')?.when, { sandbox: true })
+  assert.deepEqual(spec.actions?.find((item) => item.id === 'uninstall')?.when, { installed: true })
+})
+
+test('same id with sandbox and install merges into one row', async () => {
+  const spec = pluginsCollection({
+    list: () =>
+      Promise.resolve([
+        {
+          id: 'echo',
+          name: 'Echo',
+          blurb: 'packed',
+          tags: [],
+          author: '',
+          authorUrl: '',
+          enabled: true,
+          running: true,
+          bytes: 40,
+          createdAt: 1,
+          updatedAt: 4,
+          lastRunAt: 3,
+          hasHost: true,
+          hasWeb: false,
+          shell: defaultStoreShell(),
+        },
+      ]),
+    listSandboxes: () =>
+      Promise.resolve([
+        {
+          id: 'echo',
+          name: 'Echo draft',
+          blurb: 'src',
+          tags: [],
+          author: '',
+          authorUrl: '',
+          hasHost: true,
+          hasWeb: false,
+          createdAt: 1,
+          updatedAt: 9,
+        },
+      ]),
+    openPlugin() {},
+    close() {},
+    pack() {},
+    uninstall() {},
+  } as PluginStoreService)
+  const listed = await spec.list()
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0]?.id, 'echo')
+  assert.equal(listed[0]?.installed, true)
+  assert.equal(listed[0]?.sandbox, true)
+  assert.equal(listed[0]?.running, true)
+  assert.equal(listed[0]?.updatedAt, 9)
 })

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -1,9 +1,22 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
 import type { PluginStoreService, StoreListing } from './store.ts'
 
-function asPluginRecord(row: StoreListing): DbRecord {
+type SandboxListing = Awaited<ReturnType<PluginStoreService['listSandboxes']>>[number]
+
+function omitEmpty(row: DbRecord): DbRecord {
+  const next: DbRecord = { id: row.id }
+  for (const [key, value] of Object.entries(row)) {
+    if (key === 'id') continue
+    if (value == null || value === '' || value === false) continue
+    if (Array.isArray(value) && value.length === 0) continue
+    next[key] = value
+  }
+  return next
+}
+
+function asInstalledRecord(row: StoreListing): DbRecord {
   const shell = row.shell
-  return {
+  return omitEmpty({
     id: row.id,
     name: row.name,
     title: row.name,
@@ -11,6 +24,7 @@ function asPluginRecord(row: StoreListing): DbRecord {
     tags: row.tags,
     author: row.author,
     authorUrl: row.authorUrl,
+    installed: true,
     enabled: row.enabled,
     running: row.running,
     bytes: row.bytes,
@@ -24,11 +38,49 @@ function asPluginRecord(row: StoreListing): DbRecord {
     shellMinWidth: shell.minWidth,
     shellMinHeight: shell.minHeight,
     shellResizable: shell.resizable,
+  })
+}
+
+function asSandboxRecord(row: SandboxListing): DbRecord {
+  return omitEmpty({
+    id: row.id,
+    name: row.name,
+    title: row.name,
+    blurb: row.blurb,
+    tags: row.tags,
+    author: row.author,
+    authorUrl: row.authorUrl,
+    sandbox: true,
+    hasHost: row.hasHost,
+    hasWeb: row.hasWeb,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  })
+}
+
+function mergeLifecycle(installed: StoreListing | undefined, sandbox: SandboxListing | undefined): DbRecord {
+  if (installed && sandbox) {
+    return omitEmpty({
+      ...asInstalledRecord(installed),
+      sandbox: true,
+      updatedAt: Math.max(installed.updatedAt, sandbox.updatedAt),
+    })
   }
+  if (installed) return asInstalledRecord(installed)
+  if (sandbox) return asSandboxRecord(sandbox)
+  throw new Error('empty plugin row')
 }
 
 export function pluginsCollection(store: PluginStoreService): CollectionSpec {
-  const list = async () => (await store.list()).map(asPluginRecord)
+  const list = async () => {
+    const [installed, sandboxes] = await Promise.all([store.list(), store.listSandboxes()])
+    const ids = new Set([...installed.map((row) => row.id), ...sandboxes.map((row) => row.id)])
+    const byInstalled = new Map(installed.map((row) => [row.id, row]))
+    const bySandbox = new Map(sandboxes.map((row) => [row.id, row]))
+    return [...ids]
+      .sort()
+      .map((id) => mergeLifecycle(byInstalled.get(id), bySandbox.get(id)))
+  }
   const find = async (id: string) => (await list()).find((row) => row.id === id) ?? null
   return {
     id: 'plugins',
@@ -39,7 +91,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       route: '/plugins',
       title: '插件',
       inspector: true,
-      blurb: '已安装到 .plugin 的商店插件：运行状态、体积、外壳尺寸和作者。',
+      blurb: '.plugin 已安装与 .plugin-dev 沙箱同一张表：没有的字段留空。',
       order: 30,
       icon: 'puzzle-piece',
     },
@@ -49,6 +101,8 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       columns: [
         'name',
         'blurb',
+        'installed',
+        'sandbox',
         'running',
         'enabled',
         'tags',
@@ -62,6 +116,8 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       fields: {
         name: { type: 'string', label: '名称' },
         blurb: { type: 'string', label: '简介' },
+        installed: { type: 'boolean', label: '已安装' },
+        sandbox: { type: 'boolean', label: '沙箱' },
         enabled: { type: 'boolean', label: '已打开' },
         running: { type: 'boolean', label: '运行中' },
         tags: { type: 'multi-select', label: '标签' },
@@ -86,7 +142,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       {
         id: 'start',
         label: '运行',
-        when: { running: false },
+        when: { installed: true, running: false },
         run: async (id) => {
           await store.openPlugin(id)
         },
@@ -94,77 +150,27 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       {
         id: 'stop',
         label: '停止',
-        when: { running: true },
+        when: { installed: true, running: true },
         run: async (id) => {
           await store.close(id)
+        },
+      },
+      {
+        id: 'pack',
+        label: '打包安装',
+        when: { sandbox: true },
+        run: async (id) => {
+          await store.pack(id)
         },
       },
       {
         id: 'uninstall',
         label: '卸载',
         tone: 'danger',
-        confirm: '确定卸载这个插件？代码会被删掉。',
+        confirm: '确定卸载这个插件？已安装的代码会被删掉。',
+        when: { installed: true },
         run: async (id) => {
           await store.uninstall(id)
-        },
-      },
-    ],
-  }
-}
-
-export function pluginSandboxesCollection(store: PluginStoreService): CollectionSpec {
-  const list = async () =>
-    (await store.listSandboxes()).map((row) => ({
-      id: row.id,
-      name: row.name,
-      title: row.name,
-      blurb: row.blurb,
-      tags: row.tags,
-      author: row.author,
-      authorUrl: row.authorUrl,
-      hasHost: row.hasHost,
-      hasWeb: row.hasWeb,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-    }))
-  const find = async (id: string) => (await list()).find((row) => row.id === id) ?? null
-  return {
-    id: 'plugin-sandboxes',
-    path: '/plugin-sandboxes',
-    label: '插件沙箱',
-    view: {
-      moduleId: 'plugin-sandboxes',
-      route: '/plugin-sandboxes',
-      title: '插件沙箱',
-      inspector: true,
-      blurb: '.plugin-dev 里的开发沙箱：源码还没打包进已安装插件。',
-      order: 31,
-      icon: 'puzzle-piece',
-    },
-    records: { update: false, create: false, delete: false },
-    schema: {
-      labelField: 'name',
-      columns: ['name', 'blurb', 'tags', 'author', 'hasHost', 'hasWeb', 'updatedAt'],
-      fields: {
-        name: { type: 'string', label: '名称' },
-        blurb: { type: 'string', label: '简介' },
-        tags: { type: 'multi-select', label: '标签' },
-        author: { type: 'string', label: '作者' },
-        authorUrl: { type: 'url', label: '作者链接' },
-        hasHost: { type: 'boolean', label: 'Host' },
-        hasWeb: { type: 'boolean', label: 'Web' },
-        createdAt: { type: 'datetime', label: '创建时间' },
-        updatedAt: { type: 'datetime', label: '更新时间' },
-      },
-    },
-    list,
-    get: find,
-    actions: [
-      {
-        id: 'pack',
-        label: '打包安装',
-        run: async (id) => {
-          await store.pack(id)
         },
       },
     ],

--- a/packages/core-plugin-system/src/host/index.ts
+++ b/packages/core-plugin-system/src/host/index.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'cordis'
-import { pluginsCollection, pluginSandboxesCollection } from './collection.ts'
+import { pluginsCollection } from './collection.ts'
 import { openStore } from './store.ts'
 
 export const name = 'core-plugin-system'
@@ -10,12 +10,11 @@ export {
   defaultPluginDir,
   defaultStatePath,
 } from './store.ts'
-export { pluginsCollection, pluginSandboxesCollection } from './collection.ts'
+export { pluginsCollection } from './collection.ts'
 
 export async function apply(ctx: Context) {
   const store = await openStore(ctx)
   ctx.inject(['database'], (inner) => {
     inner.database.register(pluginsCollection(store))
-    inner.database.register(pluginSandboxesCollection(store))
   })
 }

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -1,4 +1,4 @@
-import { PlayIcon, StopIcon } from '@heroicons/react/16/solid'
+import { ArchiveBoxArrowDownIcon, PlayIcon, StopIcon } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { asHttpHref } from '@biu/type-file-system'
 import type { CollectionChrome, FsActionProps, FsCellProps } from '@biu/type-file-system/ui'
@@ -8,6 +8,12 @@ function PluginTitle({ record, label }: { record: DbRecord; label: string }) {
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5">
       <span className="truncate font-medium">{label}</span>
+      {record.sandbox ? (
+        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">沙箱</span>
+      ) : null}
+      {record.installed ? (
+        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">已装</span>
+      ) : null}
       {record.hasHost ? (
         <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">Host</span>
       ) : null}
@@ -58,6 +64,8 @@ function PluginAction({ action, busy, run }: FsActionProps) {
       <StopIcon aria-hidden className="size-[14px]" />
     ) : action.id === 'uninstall' ? (
       <TrashGlyph aria-hidden className="size-[14px]" />
+    ) : action.id === 'pack' ? (
+      <ArchiveBoxArrowDownIcon aria-hidden className="size-[14px]" />
     ) : null
   return (
     <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
插件和沙箱本来就是同一条生命周期（`.plugin-dev` 写源码，打包进 `.plugin`），不必在文件系统里拆成两张表。

**现在**
- 只登记 `/plugins`
- 同一 `id` 一行：只有沙箱、只有已装、或两边都有
- 没有的字段不写（沙箱没有运行中/体积/窗口尺寸就空着）
- 操作按字段出现：已装可运行/停止/卸载，有沙箱可打包安装

侧栏不再出现单独的「插件沙箱」。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e767bb2-74b6-4c05-a550-cb56d3f921df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e767bb2-74b6-4c05-a550-cb56d3f921df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

