### PR TITLE
feat(chat): 聊天浮窗布局按钮，贴边后随窗口缩放

### DIFF
--- a/packages/web-app-shell/src/web/chat-overlay.test.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.test.ts
@@ -27,7 +27,12 @@ import {
   clampOverlayChatHeight,
   clampOverlayWinGeom,
   defaultOverlayWinGeom,
+  overlayLayoutGeom,
+  parseOverlayLayout,
+  readOverlayWinState,
+  writeOverlayWinState,
   OVERLAY_CHAT_HEIGHT_MIN,
+  OVERLAY_DOCK_CLEARANCE,
   OVERLAY_WIN_MIN_H,
   OVERLAY_WIN_MIN_W,
   inspectorTabFromEvent,
@@ -208,10 +213,38 @@ test('overlay window geom clamps and sits above the dock by default', () => {
   const def = defaultOverlayWinGeom(1280, 800)
   assert.ok(def.w >= OVERLAY_WIN_MIN_W)
   assert.ok(def.h >= OVERLAY_WIN_MIN_H)
-  assert.ok(def.y + def.h <= 800 - 80)
+  assert.ok(def.y + def.h <= 800 - OVERLAY_DOCK_CLEARANCE)
   const tiny = clampOverlayWinGeom({ x: -400, y: -20, w: 10, h: 10 }, 1280, 800)
   assert.equal(tiny.w, OVERLAY_WIN_MIN_W)
   assert.equal(tiny.h, OVERLAY_WIN_MIN_H)
+})
+
+test('layout presets pin the overlay to the viewport', () => {
+  const prev = { x: 100, y: 80, w: 420, h: 400 }
+  const center = overlayLayoutGeom('center', prev, 1280, 800)
+  assert.equal(center.x, Math.round((1280 - 420) / 2))
+  const left = overlayLayoutGeom('left', prev, 1280, 800)
+  assert.equal(left.x, 12)
+  assert.equal(left.y, 12)
+  const right = overlayLayoutGeom('right', prev, 1280, 800)
+  assert.equal(right.x, 1280 - 420 - 12)
+  const bottom = overlayLayoutGeom('bottom', prev, 1280, 800)
+  assert.equal(bottom.x, 12)
+  assert.equal(bottom.w, 1280 - 24)
+  assert.ok(bottom.y + bottom.h <= 800 - OVERLAY_DOCK_CLEARANCE + 1)
+})
+
+test('saved layout recomputes when the viewport changes', () => {
+  writeOverlayWinState({ x: 12, y: 12, w: 420, h: 500, layout: 'right' })
+  const original = { innerWidth: window.innerWidth, innerHeight: window.innerHeight }
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1600 })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 900 })
+  const state = readOverlayWinState()
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: original.innerWidth })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: original.innerHeight })
+  assert.equal(state.layout, 'right')
+  assert.equal(state.x, 1600 - state.w - 12)
+  assert.equal(parseOverlayLayout('nope'), 'free')
 })
 
 test('overlay chat height clamps', () => {

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -302,13 +302,29 @@ export const OVERLAY_CHAT_HEIGHT_MIN = 96
 export const OVERLAY_CHAT_HEIGHT_DEFAULT = 200
 
 export type OverlayWinGeom = { x: number; y: number; w: number; h: number }
+export type OverlayLayout = 'free' | 'center' | 'left' | 'right' | 'bottom'
+export type OverlayWinState = OverlayWinGeom & { layout: OverlayLayout }
 
 export const OVERLAY_WIN_MIN_W = 320
 export const OVERLAY_WIN_MIN_H = 280
 export const OVERLAY_WIN_DEFAULT_W = 420
 export const OVERLAY_WIN_DEFAULT_H = 520
+export const OVERLAY_DOCK_CLEARANCE = 80
 const OVERLAY_WIN_GEOM_KEY = 'cordis.overlay.geom'
-const OVERLAY_DOCK_CLEARANCE = 80
+const OVERLAY_MARGIN = 12
+
+export const OVERLAY_LAYOUTS: Array<{ id: OverlayLayout; label: string }> = [
+  { id: 'center', label: '居中' },
+  { id: 'left', label: '靠左' },
+  { id: 'right', label: '靠右' },
+  { id: 'bottom', label: '靠底' },
+]
+
+export function parseOverlayLayout(value: unknown): OverlayLayout {
+  return value === 'center' || value === 'left' || value === 'right' || value === 'bottom' || value === 'free'
+    ? value
+    : 'free'
+}
 
 export function defaultOverlayWinGeom(vw = 1280, vh = 800): OverlayWinGeom {
   const w = Math.min(OVERLAY_WIN_DEFAULT_W, Math.max(OVERLAY_WIN_MIN_W, vw - 40))
@@ -317,7 +333,7 @@ export function defaultOverlayWinGeom(vw = 1280, vh = 800): OverlayWinGeom {
     w,
     h,
     x: Math.round((vw - w) / 2),
-    y: Math.max(12, Math.round(vh - h - OVERLAY_DOCK_CLEARANCE)),
+    y: Math.max(OVERLAY_MARGIN, Math.round(vh - h - OVERLAY_DOCK_CLEARANCE)),
   }
 }
 
@@ -325,33 +341,86 @@ export function clampOverlayWinGeom(geom: OverlayWinGeom, vw = 1280, vh = 800): 
   const w = Math.min(vw - 24, Math.max(OVERLAY_WIN_MIN_W, Math.round(geom.w)))
   const h = Math.min(vh - 24, Math.max(OVERLAY_WIN_MIN_H, Math.round(geom.h)))
   const x = Math.min(vw - 48, Math.max(12 - (w - 48), Math.round(geom.x)))
-  const y = Math.min(vh - 48, Math.max(12, Math.round(geom.y)))
+  const y = Math.min(vh - 48, Math.max(OVERLAY_MARGIN, Math.round(geom.y)))
   return { x, y, w, h }
 }
 
-export function readOverlayWinGeom(): OverlayWinGeom {
+export function overlayLayoutGeom(
+  layout: OverlayLayout,
+  prev: OverlayWinGeom,
+  vw = 1280,
+  vh = 800,
+): OverlayWinGeom {
+  const maxW = Math.max(OVERLAY_WIN_MIN_W, vw - OVERLAY_MARGIN * 2)
+  const maxH = Math.max(OVERLAY_WIN_MIN_H, vh - OVERLAY_DOCK_CLEARANCE - OVERLAY_MARGIN)
+  const w = Math.min(Math.max(prev.w, OVERLAY_WIN_MIN_W), maxW)
+  const h = Math.min(Math.max(prev.h, OVERLAY_WIN_MIN_H), maxH)
+  if (layout === 'center') {
+    return clampOverlayWinGeom(
+      {
+        w,
+        h,
+        x: Math.round((vw - w) / 2),
+        y: Math.round(Math.max(OVERLAY_MARGIN, (vh - OVERLAY_DOCK_CLEARANCE - h) / 2)),
+      },
+      vw,
+      vh,
+    )
+  }
+  if (layout === 'left') {
+    return clampOverlayWinGeom({ x: OVERLAY_MARGIN, y: OVERLAY_MARGIN, w, h: maxH }, vw, vh)
+  }
+  if (layout === 'right') {
+    return clampOverlayWinGeom({ x: vw - w - OVERLAY_MARGIN, y: OVERLAY_MARGIN, w, h: maxH }, vw, vh)
+  }
+  if (layout === 'bottom') {
+    return clampOverlayWinGeom(
+      { x: OVERLAY_MARGIN, y: vh - OVERLAY_DOCK_CLEARANCE - h, w: maxW, h },
+      vw,
+      vh,
+    )
+  }
+  return clampOverlayWinGeom(prev, vw, vh)
+}
+
+export function readOverlayWinState(): OverlayWinState {
   const vw = typeof window === 'undefined' ? 1280 : window.innerWidth
   const vh = typeof window === 'undefined' ? 800 : window.innerHeight
-  const fallback = defaultOverlayWinGeom(vw, vh)
+  const fallback = { ...defaultOverlayWinGeom(vw, vh), layout: 'free' as const }
   try {
     const raw = localStorage.getItem(OVERLAY_WIN_GEOM_KEY)
     if (!raw) return fallback
-    const parsed = JSON.parse(raw) as Partial<OverlayWinGeom>
-    if (![parsed.x, parsed.y, parsed.w, parsed.h].every((n) => typeof n === 'number' && Number.isFinite(n))) {
-      return fallback
+    const parsed = JSON.parse(raw) as Partial<OverlayWinState>
+    const layout = parseOverlayLayout(parsed.layout)
+    const prev = {
+      x: Number(parsed.x),
+      y: Number(parsed.y),
+      w: Number(parsed.w),
+      h: Number(parsed.h),
     }
-    return clampOverlayWinGeom(parsed as OverlayWinGeom, vw, vh)
+    if (![prev.x, prev.y, prev.w, prev.h].every((n) => Number.isFinite(n))) return fallback
+    const geom = layout === 'free' ? clampOverlayWinGeom(prev, vw, vh) : overlayLayoutGeom(layout, prev, vw, vh)
+    return { ...geom, layout }
   } catch {
     return fallback
   }
 }
 
-export function writeOverlayWinGeom(geom: OverlayWinGeom): void {
+export function readOverlayWinGeom(): OverlayWinGeom {
+  const { layout: _layout, ...geom } = readOverlayWinState()
+  return geom
+}
+
+export function writeOverlayWinState(state: OverlayWinState): void {
   try {
-    localStorage.setItem(OVERLAY_WIN_GEOM_KEY, JSON.stringify(geom))
+    localStorage.setItem(OVERLAY_WIN_GEOM_KEY, JSON.stringify(state))
   } catch {
     /* ignore */
   }
+}
+
+export function writeOverlayWinGeom(geom: OverlayWinGeom, layout: OverlayLayout = 'free'): void {
+  writeOverlayWinState({ ...geom, layout })
 }
 
 export function requestOverlayFocus() {

--- a/packages/web-app-shell/src/web/overlay-window.test.ts
+++ b/packages/web-app-shell/src/web/overlay-window.test.ts
@@ -18,6 +18,11 @@ afterEach(() => {
   root = null
   host = null
   setChatOverlay(false)
+  try {
+    localStorage.removeItem('cordis.overlay.geom')
+  } catch {
+    /* ignore */
+  }
 })
 
 test('clicking the overlay close button actually closes the overlay', () => {
@@ -47,4 +52,34 @@ test('clicking the overlay close button actually closes the overlay', () => {
   })
   assert.equal(getChatOverlay(), false)
   closeChatOverlay()
+})
+
+test('layout button docks the overlay to the right', () => {
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1280 })
+  Object.defineProperty(window, 'innerHeight', { configurable: true, value: 800 })
+  act(() => {
+    root!.render(
+      createElement(OverlayChatWindow, {
+        header: createElement('div'),
+        thread: createElement('div'),
+        dock: createElement('div'),
+      }),
+    )
+  })
+  const toggle = document.querySelector('[data-testid="chat-overlay-layout-toggle"]')
+  assert.ok(toggle)
+  act(() => {
+    toggle!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+  const right = document.querySelector('[data-testid="chat-overlay-layout-right"]')
+  assert.ok(right)
+  act(() => {
+    right!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+  const panel = document.querySelector('[data-testid="chat-overlay-panel"]') as HTMLElement
+  assert.equal(panel.getAttribute('data-overlay-layout'), 'right')
+  assert.ok(Number.parseFloat(panel.style.left) > 700)
 })

--- a/packages/web-app-shell/src/web/overlay-window.tsx
+++ b/packages/web-app-shell/src/web/overlay-window.tsx
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react'
+import { Squares2X2Icon } from '@heroicons/react/16/solid'
 import {
   clampOverlayWinGeom,
-  readOverlayWinGeom,
-  writeOverlayWinGeom,
   closeChatOverlay,
+  overlayLayoutGeom,
+  readOverlayWinState,
+  writeOverlayWinState,
+  OVERLAY_LAYOUTS,
+  type OverlayLayout,
   type OverlayWinGeom,
 } from './chat-overlay.ts'
 
@@ -20,17 +24,32 @@ export function OverlayChatWindow({
   thread: ReactNode
   dock: ReactNode
 }) {
-  const [geom, setGeom] = useState<OverlayWinGeom>(() => readOverlayWinGeom())
+  const initial = readOverlayWinState()
+  const [geom, setGeom] = useState<OverlayWinGeom>(initial)
+  const [layout, setLayout] = useState<OverlayLayout>(initial.layout)
+  const [menuOpen, setMenuOpen] = useState(false)
   const [z, setZ] = useState(overlayZ)
   const boxRef = useRef<HTMLDivElement>(null)
   const dragRef = useRef<{ px: number; py: number; x: number; y: number } | null>(null)
   const resizeRef = useRef<(OverlayWinGeom & ResizeEdge & { px: number; py: number }) | null>(null)
   const geomRef = useRef(geom)
+  const layoutRef = useRef(layout)
   geomRef.current = geom
+  layoutRef.current = layout
 
   const bringFront = useCallback(() => {
     overlayZ += 1
     setZ(overlayZ)
+  }, [])
+
+  const apply = useCallback((next: OverlayWinGeom, nextLayout: OverlayLayout, persist = true) => {
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const geom = nextLayout === 'free' ? clampOverlayWinGeom(next, vw, vh) : overlayLayoutGeom(nextLayout, next, vw, vh)
+    setGeom(geom)
+    setLayout(nextLayout)
+    if (persist) writeOverlayWinState({ ...geom, layout: nextLayout })
+    return geom
   }, [])
 
   useEffect(() => {
@@ -55,18 +74,15 @@ export function OverlayChatWindow({
 
   useEffect(() => {
     const onMove = (event: PointerEvent) => {
-      const drag = dragRef.current
-      if (drag) {
-        setGeom(
-          clampOverlayWinGeom(
-            {
-              ...geomRef.current,
-              x: drag.x + event.clientX - drag.px,
-              y: drag.y + event.clientY - drag.py,
-            },
-            window.innerWidth,
-            window.innerHeight,
-          ),
+      if (dragRef.current) {
+        apply(
+          {
+            ...geomRef.current,
+            x: dragRef.current.x + event.clientX - dragRef.current.px,
+            y: dragRef.current.y + event.clientY - dragRef.current.py,
+          },
+          'free',
+          false,
         )
         return
       }
@@ -85,27 +101,46 @@ export function OverlayChatWindow({
         h = resize.h - dy
         y = resize.y + dy
       }
-      setGeom(clampOverlayWinGeom({ x, y, w, h }, window.innerWidth, window.innerHeight))
+      apply({ x, y, w, h }, 'free', false)
     }
     const onUp = () => {
-      if (dragRef.current || resizeRef.current) writeOverlayWinGeom(geomRef.current)
+      if (dragRef.current || resizeRef.current) {
+        writeOverlayWinState({ ...geomRef.current, layout: layoutRef.current })
+      }
       dragRef.current = null
       resizeRef.current = null
+    }
+    const onResize = () => {
+      apply(geomRef.current, layoutRef.current)
     }
     window.addEventListener('pointermove', onMove)
     window.addEventListener('pointerup', onUp)
     window.addEventListener('pointercancel', onUp)
+    window.addEventListener('resize', onResize)
     return () => {
       window.removeEventListener('pointermove', onMove)
       window.removeEventListener('pointerup', onUp)
       window.removeEventListener('pointercancel', onUp)
+      window.removeEventListener('resize', onResize)
     }
-  }, [])
+  }, [apply])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDown = (event: PointerEvent) => {
+      const target = event.target
+      if (target instanceof Element && target.closest('[data-testid="chat-overlay-layout"]')) return
+      setMenuOpen(false)
+    }
+    window.addEventListener('pointerdown', onDown)
+    return () => window.removeEventListener('pointerdown', onDown)
+  }, [menuOpen])
 
   const startDrag = (event: ReactPointerEvent) => {
     if ((event.target as HTMLElement).closest('button, input, textarea, [contenteditable="true"]')) return
     event.preventDefault()
     bringFront()
+    setMenuOpen(false)
     dragRef.current = { px: event.clientX, py: event.clientY, x: geom.x, y: geom.y }
   }
 
@@ -113,6 +148,7 @@ export function OverlayChatWindow({
     event.preventDefault()
     event.stopPropagation()
     bringFront()
+    setMenuOpen(false)
     const el = boxRef.current
     const r = el?.getBoundingClientRect()
     resizeRef.current = {
@@ -142,10 +178,45 @@ export function OverlayChatWindow({
       ref={boxRef}
       className="chat-overlay-panel"
       data-testid="chat-overlay-panel"
+      data-overlay-layout={layout}
       data-biu-ignore
       style={{ top: geom.y, left: geom.x, width: geom.w, height: geom.h, zIndex: z }}
       onPointerDown={bringFront}
     >
+      <div className="chat-overlay-layout" data-testid="chat-overlay-layout">
+        <button
+          type="button"
+          className={`chat-view-header-expand${menuOpen ? ' is-active' : ''}`}
+          title="窗口布局"
+          aria-label="窗口布局"
+          aria-expanded={menuOpen}
+          data-testid="chat-overlay-layout-toggle"
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={() => setMenuOpen((open) => !open)}
+        >
+          <Squares2X2Icon className="size-4 shrink-0" />
+        </button>
+        {menuOpen ? (
+          <div className="chat-overlay-layout-menu" role="menu" data-testid="chat-overlay-layout-menu">
+            {OVERLAY_LAYOUTS.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                role="menuitem"
+                className={layout === item.id ? 'is-active' : undefined}
+                data-testid={`chat-overlay-layout-${item.id}`}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={() => {
+                  apply(geomRef.current, item.id)
+                  setMenuOpen(false)
+                }}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        ) : null}
+      </div>
       <div className="chat-overlay-drag" data-testid="chat-overlay-drag" onPointerDown={startDrag}>
         {header}
       </div>

--- a/web/style.css
+++ b/web/style.css
@@ -1076,6 +1076,43 @@ body {
   flex: none;
 }
 
+.chat-overlay-layout {
+  position: absolute;
+  top: 6px;
+  right: 36px;
+  z-index: 12;
+}
+
+.chat-overlay-layout-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  min-width: 7.5rem;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--dsw-surface);
+  box-shadow: var(--dsw-shadow-lv2);
+}
+
+.chat-overlay-layout-menu button {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--dsw-sidebar-fg);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-overlay-layout-menu button:hover,
+.chat-overlay-layout-menu button.is-active {
+  background: var(--dsw-hover);
+  color: var(--dsw-sidebar-fg-active);
+}
+
 .chat-overlay-drag:active {
   cursor: grabbing;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天浮窗标题栏增加布局按钮（九宫格），打开后可选：

- **居中**
- **靠左**（拉满可用高度）
- **靠右**
- **靠底**（拉满宽度，留出底栏）

选中的布局会存下来。浏览器窗口变大变小时按视口重算位置，不必再手拖。手动拖动或拉伸会回到自由位置。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e767bb2-74b6-4c05-a550-cb56d3f921df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e767bb2-74b6-4c05-a550-cb56d3f921df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

