### PR TITLE
fix(ui): 轨迹改用地图路径图标

### DIFF
--- a/packages/cap-chat/src/web/index.test.ts
+++ b/packages/cap-chat/src/web/index.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context } from 'cordis'
+import { MapIcon } from '@heroicons/react/16/solid'
 import '@biu/type-host-context'
 import * as slots from '@biu/web-slots'
 import * as dock from '@biu/core-dock'
@@ -32,7 +33,7 @@ test('one plugin fills thread, trajectory, composer and approvals dock', async (
   assert.equal(ctx.slots.list('models').length, 0)
   const traj = ctx.slots.list('inspector-panels').find((item) => item.id === 'chat-traj')
   const usage = ctx.slots.list('inspector-panels').find((item) => item.id === 'chat-usage')
-  assert.ok(traj)
+  assert.equal(traj.props?.().tabIcon, MapIcon)
   assert.ok(usage)
   assert.equal(traj.props?.().requiresSession, true)
   assert.equal(usage.props?.().requiresSession, true)

--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -1,6 +1,6 @@
 import { createElement } from 'react'
 import type { Context } from 'cordis'
-import { SignalIcon, QueueListIcon, ChatBubbleBottomCenterTextIcon } from '@heroicons/react/16/solid'
+import { SignalIcon, MapIcon, ChatBubbleBottomCenterTextIcon } from '@heroicons/react/16/solid'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import type { SlotProps } from '@biu/web-slots'
 import { ApprovalsRail } from './approvals.tsx'
@@ -63,7 +63,7 @@ export function apply(ctx: Context) {
       ...slotProps,
       tabId: 'traj',
       tabLabel: '轨迹',
-      tabIcon: QueueListIcon,
+      tabIcon: MapIcon,
       ensureTrajectory: true,
       focusOnCall: true,
       requiresSession: true,

--- a/packages/web-app-shell/src/web/rail-pin.test.ts
+++ b/packages/web-app-shell/src/web/rail-pin.test.ts
@@ -20,6 +20,8 @@ test('activity bar is gone; modules register on the os dock', () => {
   assert.match(nav, /requestInspectorTab\(item\.tabId\)/)
   assert.match(nav, /database:\/pages/)
   assert.match(nav, /tabId: 'traj'/)
+  assert.match(nav, /Icon: MapIcon/)
+  assert.doesNotMatch(nav, /QueueListIcon/)
   assert.match(nav, /tabId: 'usage'/)
   assert.doesNotMatch(nav, /dock.patch\('pick'/)
   assert.match(nav, /dock.patch\('composer'/)

--- a/packages/web-app-shell/src/web/shell-dock-nav.tsx
+++ b/packages/web-app-shell/src/web/shell-dock-nav.tsx
@@ -8,7 +8,7 @@ import {
   Cog6ToothIcon,
   DocumentIcon,
   PuzzlePieceIcon,
-  QueueListIcon,
+  MapIcon,
   SignalIcon,
 } from '@heroicons/react/16/solid'
 import type { AppModule } from '@biu/web-app-modules'
@@ -20,7 +20,7 @@ const INSPECTOR_DOCK_TOOLS = [
   { id: 'inspector:sessions', title: '会话', tabId: 'database:/sessions', order: 41, Icon: ChatBubbleLeftRightIcon },
   { id: 'inspector:tasks', title: '任务', tabId: 'database:/tasks', order: 42, Icon: ClipboardDocumentListIcon },
   { id: 'inspector:plugins', title: '插件', tabId: 'database:/plugins', order: 43, Icon: PuzzlePieceIcon },
-  { id: 'inspector:traj', title: '轨迹', tabId: 'traj', order: 44, Icon: QueueListIcon },
+  { id: 'inspector:traj', title: '轨迹', tabId: 'traj', order: 44, Icon: MapIcon },
   { id: 'inspector:usage', title: '用量', tabId: 'usage', order: 45, Icon: SignalIcon },
 ] as const
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
轨迹图标从 QueueList（像待办清单）换成 MapIcon，码头和右侧检查器 Tab 保持一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

