### PR TITLE
fix(pick): 检查器框选不再误选中间列同一高度的行

### DIFF
--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -7,7 +7,7 @@ import { PickOverlay } from './overlay.tsx'
 export { PickService, usePickState } from './service.ts'
 export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, pickDomAttrs, type PickRef } from './types.ts'
 export { PickChipLabel, PickKindGlyph, pickKindIcon } from './chip.tsx'
-export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect } from './resolve.ts'
+export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 
 export const name = 'pick-ui'
 export const inject = ['slots', 'dock']

--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -43,3 +43,7 @@ test('Command/Ctrl+Q toggles pick mode', () => {
   assert.match(overlay, /event.metaKey \|\| event.ctrlKey/)
   assert.match(overlay, /key === 'q'/)
 })
+
+test('pick highlight uses the visible clipped box, not the raw layout box', () => {
+  assert.match(overlay, /visiblePickBox/)
+})

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import type { SlotProps } from '@biu/type-slots'
 import { getPick, usePickState } from './service.ts'
-import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect } from './resolve.ts'
+import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 
 const DRAG_PX = 6
 
@@ -15,7 +15,7 @@ export function ignorePickCapture(target: EventTarget | null, event?: Event) {
 }
 
 function hoverBox(el: HTMLElement) {
-  const box = el.getBoundingClientRect()
+  const box = visiblePickBox(el) ?? el.getBoundingClientRect()
   return { top: box.top, left: box.left, width: box.width, height: box.height }
 }
 

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect } from './resolve.ts'
+import { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks } from './types.ts'
 
 test('splitPickStream keeps text and chips in order', () => {
@@ -145,6 +145,33 @@ test('marquee skips ignored subtrees and inner action buttons', () => {
   assert.equal(hits[0]?.ref.action, undefined)
   card.remove()
   ignored.remove()
+})
+
+test('marquee in the inspector does not take center-pane rows at the same height', () => {
+  const center = document.createElement('div')
+  center.style.overflow = 'hidden'
+  const row = document.createElement('div')
+  row.setAttribute('data-biu-kind', 'task')
+  row.setAttribute('data-biu-id', 'center-row')
+  center.append(row)
+  const inspector = document.createElement('div')
+  inspector.setAttribute('data-biu-kind', 'task')
+  inspector.setAttribute('data-biu-id', 'inspector-row')
+  document.body.append(center, inspector)
+  stubBox(center, 80, 0, 120, 80)
+  stubBox(row, 80, 10, 400, 20)
+  stubBox(inspector, 220, 10, 80, 20)
+  const hits = resolvePicksInRect({ left: 220, top: 8, width: 60, height: 24 }, '/tasks')
+  assert.deepEqual(
+    hits.map((item) => item.ref.id),
+    ['inspector-row'],
+  )
+  const vis = visiblePickBox(row)
+  assert.ok(vis)
+  assert.equal(vis.left, 80)
+  assert.equal(vis.width, 120)
+  center.remove()
+  inspector.remove()
 })
 
 test('dedupePicks keeps one chip per kind+id', () => {

--- a/packages/cap-pick/src/web/resolve.ts
+++ b/packages/cap-pick/src/web/resolve.ts
@@ -79,6 +79,41 @@ function boxOf(el: Element): ClientBox {
   return { left: r.left, top: r.top, width: r.width, height: r.height }
 }
 
+function intersectBoxes(a: ClientBox, b: ClientBox): ClientBox | null {
+  const left = Math.max(a.left, b.left)
+  const top = Math.max(a.top, b.top)
+  const width = Math.min(a.left + a.width, b.left + b.width) - left
+  const height = Math.min(a.top + a.height, b.top + b.height) - top
+  if (width <= 0 || height <= 0) return null
+  return { left, top, width, height }
+}
+
+function axisClips(computed: string, inline: string) {
+  const value = computed && computed !== 'visible' ? computed : inline
+  return Boolean(value && value !== 'visible')
+}
+
+function clipsOverflow(node: HTMLElement) {
+  const style = getComputedStyle(node)
+  return (
+    axisClips(style.overflowX, node.style.overflowX || node.style.overflow) ||
+    axisClips(style.overflowY, node.style.overflowY || node.style.overflow)
+  )
+}
+
+/** 框选只看露在本栏里的那一块。宽表格行的布局盒会伸进检查器，不能拿来当命中。 */
+export function visiblePickBox(el: Element): ClientBox | null {
+  let box: ClientBox | null = boxOf(el)
+  let node: Element | null = el.parentElement
+  while (box && node && node !== document.documentElement) {
+    if (node instanceof HTMLElement && clipsOverflow(node)) {
+      box = intersectBoxes(box, boxOf(node))
+    }
+    node = node.parentElement
+  }
+  return box
+}
+
 /**
  * 框选：命中所有带 kind+id 的对象节点（不采内部 action）。
  * 点选仍走 resolvePickFromNode，可以打到按钮上的 action。
@@ -89,7 +124,8 @@ export function resolvePicksInRect(box: ClientBox, route: string, root: ParentNo
   const hits: { el: HTMLElement; ref: PickRef }[] = []
   for (const node of Array.from(nodes)) {
     if (!(node instanceof HTMLElement) || isPickIgnored(node)) continue
-    if (!boxesOverlap(box, boxOf(node))) continue
+    const vis = visiblePickBox(node)
+    if (!vis || !boxesOverlap(box, vis)) continue
     const hit = resolvePickFromNode(node, route)
     if (!hit) continue
     const key = `${hit.ref.kind}:${hit.ref.id}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据页中间列表格行的布局盒会伸进右侧检查器。在 C 栏框选时，只按本栏真正露出来的区域命中，不再把 B 栏同一高度的行选进去。聊天页没有宽表格，本来就不受影响。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

