### PR TITLE
feat(fs): 表格分栏按钮，记录在右侧检查器打开

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -94,6 +94,7 @@ import { listCollection, readJson } from './db-client.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
 import { mergeCatalogViews, mergeTableViews, catalogRowOpenTarget } from '../catalog-views.ts'
 import { VIEWS_COLLECTION_PATH } from './database-path.ts'
+import { showRecordInInspector } from './inspector-db-route.ts'
 
 type StatResult = { schema?: CollectionSchema }
 
@@ -1158,25 +1159,42 @@ export function CollectionBrowser({
         <span className="fsdb-title-text">{body}</span>
         {openDetail ? (
           <span className="tasks-title-aside">
-            {tree && kidCount > 0 ? (
-              <span className="sidebar-chat-count tasks-tree-count" title={`${kidCount} 项`}>
-                <span className="sidebar-chat-count-num">{kidCount}</span>
-              </span>
+            {!embed ? (
+              <button
+                type="button"
+                className="tasks-title-open"
+                data-testid="record-title-split"
+                aria-label="在右侧打开"
+                title="在右侧打开"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  showRecordInInspector(collectionPath, row.id)
+                }}
+              >
+                <ViewColumnsIcon aria-hidden className="size-[14px]" />
+              </button>
             ) : null}
-            <button
-              type="button"
-              className="tasks-title-open"
-              data-testid="record-title-open"
-              data-biu-action="open"
-              aria-label="查看详情"
-              title="查看详情"
-              onClick={(event) => {
-                event.stopPropagation()
-                openRow(row)
-              }}
-            >
-              <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
-            </button>
+            <span className="tasks-title-zoom">
+              {tree && kidCount > 0 ? (
+                <span className="sidebar-chat-count tasks-tree-count" title={`${kidCount} 项`}>
+                  <span className="sidebar-chat-count-num">{kidCount}</span>
+                </span>
+              ) : null}
+              <button
+                type="button"
+                className="tasks-title-open"
+                data-testid="record-title-open"
+                data-biu-action="open"
+                aria-label="查看详情"
+                title="查看详情"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  openRow(row)
+                }}
+              >
+                <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
+              </button>
+            </span>
           </span>
         ) : null}
       </div>

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -122,11 +122,12 @@ const CSS = `
 .fsdb-page .tasks-tree-toggle.is-empty:hover{background:transparent}
 .fsdb-page .fsdb-title-text{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
 .fsdb-page .tasks-table.is-wrap .fsdb-title-text{white-space:normal}
-.fsdb-page .tasks-title-aside{position:relative;flex:none;display:grid;place-items:center;width:24px;height:24px}
-.fsdb-page .tasks-title-aside .tasks-tree-count,.fsdb-page .tasks-title-aside .tasks-title-open{grid-area:1/1}
+.fsdb-page .tasks-title-aside{position:relative;flex:none;display:inline-flex;align-items:center}
+.fsdb-page .tasks-title-zoom{position:relative;display:grid;place-items:center;width:24px;height:24px}
+.fsdb-page .tasks-title-zoom .tasks-tree-count,.fsdb-page .tasks-title-zoom .tasks-title-open{grid-area:1/1}
 .fsdb-page .tasks-title-open{flex:none;width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:6px;cursor:pointer;padding:0;opacity:0;z-index:1}
 .fsdb-page .tasks-title-cell:hover .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible{opacity:1}
-.fsdb-page .tasks-title-cell:hover .tasks-tree-count,.fsdb-page .tasks-title-aside:has(.tasks-title-open:focus-visible) .tasks-tree-count{opacity:0}
+.fsdb-page .tasks-title-cell:hover .tasks-tree-count,.fsdb-page .tasks-title-zoom:has(.tasks-title-open:focus-visible) .tasks-tree-count{opacity:0}
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
 .fsdb-page .tasks-tree-count{pointer-events:none}
 .fsdb-page .tasks-table.is-truncate:not(.is-wrap) .fsdb-cell{max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -5,6 +5,7 @@ import {
   isInspectorDatabasePath,
   seedInspectorDbPath,
   setInspectorDbPath,
+  showRecordInInspector,
 } from './inspector-db-route.ts'
 
 test('inspector database path does not overwrite after first seed', () => {
@@ -34,4 +35,21 @@ test('each inspector database pane keeps its own path', () => {
   assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
   seedInspectorDbPath('database::a', '/database/events')
   assert.equal(getInspectorDbPath('database::a'), '/database/pages')
+})
+
+test('showRecordInInspector opens the inspector on this record', async () => {
+  const tabs: string[] = []
+  const onTab = (event: Event) => {
+    const detail = (event as CustomEvent).detail
+    if (typeof detail === 'string') tabs.push(detail)
+  }
+  window.addEventListener('biu:inspector-tab', onTab)
+  const opened = new Promise<void>((resolve) => {
+    window.addEventListener('biu:inspector-open', () => resolve(), { once: true })
+  })
+  showRecordInInspector('/pages', 'p1')
+  await opened
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
+  assert.deepEqual(tabs, ['database:/pages'])
+  window.removeEventListener('biu:inspector-tab', onTab)
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,6 +1,6 @@
 /** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
 
-import { DATA_MODULE_PATH } from './database-path.ts'
+import { DATA_MODULE_PATH, databaseRecordPath } from './database-path.ts'
 
 const DEFAULT_PANE = 'database'
 const listeners = new Set<() => void>()
@@ -39,6 +39,18 @@ export function setInspectorDbPath(paneId: string, next?: string) {
   if (!stored) paths.delete(id)
   else paths.set(id, stored)
   bump()
+}
+
+export function inspectorCollectionTabId(collection: string) {
+  return `database:${collection}`
+}
+
+/** 右侧检查器打开这条记录，中间主界面不动。 */
+export function showRecordInInspector(collection: string, recordId: string) {
+  const tabId = inspectorCollectionTabId(collection)
+  setInspectorDbPath(tabId, databaseRecordPath(collection, recordId))
+  window.dispatchEvent(new Event('biu:inspector-open'))
+  window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
 }
 
 export function seedInspectorDbPath(paneId: string, pathname?: string) {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -74,6 +74,8 @@ test('sidebar records paint detail immediately without reloading the view', () =
 
 test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
+  assert.match(browser, /data-testid="record-title-split"/)
+  assert.match(browser, /showRecordInInspector\(collectionPath, row.id\)/)
   assert.match(browser, /className="tasks-title-open"/)
   assert.match(browser, /tasks-title-aside/)
   assert.match(browser, /tasks-tree-count/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
文件系统表格标题放大按钮左侧增加分栏。点击后打开右侧检查器并展示这条记录，中间主界面不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

