### PR TITLE
feat(sessions): 会话表标题前列头像

### DIFF
--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -13,6 +13,8 @@ import { UsagePanel } from './usage-panel.tsx'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 import type { PickService } from '@biu/cap-pick/web'
 import { getChatOverlay, subscribeChatOverlay, setChatOverlay, closeChatOverlay, requestOverlayFocus } from '@biu/web-app-shell/chat-overlay'
+import type { DatabaseUi } from '@biu/type-file-system/ui'
+import { sessionsChrome } from './sessions-chrome.tsx'
 
 export const name = 'chat-ui'
 export const inject = ['slots', 'sessionView', 'projectView', 'dock']
@@ -104,4 +106,8 @@ export function apply(ctx: Context) {
       ctx.dock.patch('composer', { running: open, focused: open, minimized: false })
     }),
   )
+  ctx.inject(['databaseUi'], (inner) => {
+    const ui = inner.get('databaseUi') as DatabaseUi
+    return ui.decorate('/sessions', sessionsChrome).dispose
+  })
 }

--- a/packages/cap-chat/src/web/sessions-chrome.test.ts
+++ b/packages/cap-chat/src/web/sessions-chrome.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { sessionsChrome } from './sessions-chrome.tsx'
+
+test('session table titles include the session mascot', () => {
+  assert.equal(typeof sessionsChrome.Title, 'function')
+  const chrome = readFileSync(resolve(import.meta.dirname, './sessions-chrome.tsx'), 'utf8')
+  assert.match(chrome, /SidebarMascot/)
+  assert.match(chrome, /resolveSessionMascot/)
+  assert.match(chrome, /className="sessions-title"/)
+  const index = readFileSync(resolve(import.meta.dirname, './index.ts'), 'utf8')
+  assert.match(index, /decorate\('\/sessions', sessionsChrome\)/)
+})

--- a/packages/cap-chat/src/web/sessions-chrome.tsx
+++ b/packages/cap-chat/src/web/sessions-chrome.tsx
@@ -1,0 +1,41 @@
+import { SidebarMascot, resolveSessionMascot } from '@biu/web-mascot'
+import type { CollectionChrome } from '@biu/type-file-system/ui'
+import type { DbRecord } from '@biu/type-file-system'
+
+function sessionMascot(record: DbRecord) {
+  const raw = record.mascot
+  if (!raw || typeof raw !== 'object') return undefined
+  const mascot = raw as { shape?: unknown; color?: unknown; eye?: unknown }
+  if (typeof mascot.shape !== 'string' || typeof mascot.color !== 'string') return undefined
+  return {
+    shape: mascot.shape,
+    color: mascot.color,
+    ...(typeof mascot.eye === 'number' ? { eye: mascot.eye } : {}),
+  }
+}
+
+function SessionTitle({ record, label }: { record: DbRecord; label: string }) {
+  const identity = resolveSessionMascot(String(record.id), sessionMascot(record))
+  return (
+    <span className="sessions-title">
+      <SidebarMascot size={20} sessionId={String(record.id)} identity={identity} animate={false} title={label} />
+      <span className="sessions-title-label">{label}</span>
+    </span>
+  )
+}
+
+export const sessionsChrome: CollectionChrome = {
+  Title: SessionTitle,
+}
+
+if (typeof document !== 'undefined') {
+  const id = 'biu-sessions-chrome-style'
+  const style = document.getElementById(id) ?? document.createElement('style')
+  style.id = id
+  style.textContent = `
+.sessions-title{display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%;vertical-align:middle}
+.sessions-title .sidebar-mascot{flex:none}
+.sessions-title-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
+`
+  document.head.appendChild(style)
+}

--- a/packages/host-sessions/src/host/sessions-collection.test.ts
+++ b/packages/host-sessions/src/host/sessions-collection.test.ts
@@ -13,6 +13,7 @@ test('sessionsCollection maps summaries and writes title/pinned/tags', async () 
         title: 'hello',
         updatedAt: 100,
         type: 'chat',
+        mascot: { shape: 'pebble', color: 'orange', eye: 1 },
         config: { pinned: false, tags: ['a'] },
       },
     ],
@@ -28,6 +29,7 @@ test('sessionsCollection maps summaries and writes title/pinned/tags', async () 
   const rows = await spec.list()
   assert.equal(rows[0]?.id, 's1')
   assert.equal(rows[0]?.title, 'hello')
+  assert.deepEqual(rows[0]?.mascot, { shape: 'pebble', color: 'orange', eye: 1 })
   assert.deepEqual(rows[0]?.tags, ['a'])
   await spec.update?.('s1', { title: 'renamed', pinned: true, tags: ['b', 'c'] })
   assert.deepEqual(calls, [

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -17,6 +17,7 @@ function asRecord(row: SessionSummary): DbRecord {
     eventCount: row.eventCount,
     project: row.project?.name ?? '',
     updatedAt: row.updatedAt,
+    ...(row.mascot ? { mascot: row.mascot } : {}),
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话表标题列在文字前加上该会话自己的 mascot 头像（和侧栏同一套）。记录列表会带上 persisted mascot，没有也能按 session id 稳定回退。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

