### PR TITLE
[codex] Support remote API model discovery

### DIFF
--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -4,7 +4,7 @@ import { Service, type Context } from 'cordis'
 import type { ChatMessage } from './chat-types.ts'
 import { isAgentToolMode, type AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
-import { probeLlmConnection } from '@biu/host-llm'
+import { probeLlmConnection, listLlmModels, type LlmModelInfo } from '@biu/host-llm'
 import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl } from './model-catalog.ts'
 import type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
 export type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
@@ -296,6 +296,7 @@ function allModels(config: ChatConfig): LlmModelDef[] {
   ]
 }
 
+
 function resolveEndpoint(config: ChatConfig, endpointId: string): LlmEndpointDef | undefined {
   return allEndpoints(config).find((e) => e.id === endpointId)
 }
@@ -324,6 +325,92 @@ function blockEndpoint(config: ChatConfig, id: string) {
 export class ChatService extends Service {
   private config = mergePersisted(defaults(), readPersisted())
 
+  /** 各入口已从上游 /models 拉取的模型（内存缓存，key/baseUrl 变更即失效）。 */
+  private remoteModels: Record<string, { models: LlmModelInfo[]; fetchedAt: number }> = {}
+
+  /** 静态目录 + 自定义 + 远端拉取（按 endpointId+model 去重，远端优先）。 */
+  private modelDefs(): LlmModelDef[] {
+    const remote: LlmModelDef[] = []
+    for (const [endpointId, cache] of Object.entries(this.remoteModels)) {
+      const ep = resolveEndpoint(this.config, endpointId)
+      const provider = ep?.provider ?? 'openai'
+      for (const m of cache.models) {
+        remote.push({
+          id: `remote-${endpointId}-${m.id}`.replace(/[^a-zA-Z0-9._:-]+/g, '-'),
+          label: m.id,
+          endpointId,
+          provider,
+          model: m.id,
+          category: 'remote',
+          note: m.ownedBy ? `来自 API · ${m.ownedBy}` : '来自 API',
+          builtin: false,
+        })
+      }
+    }
+    const staticModels = allModels(this.config)
+    const seen = new Set<string>()
+    const out: LlmModelDef[] = []
+    for (const m of [...remote, ...staticModels]) {
+      const key = `${m.endpointId}\x00${m.model}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push(m)
+    }
+    return out
+  }
+
+  /** 启动时静默预拉已配置入口的模型（失败静默，不阻塞、不落盘）。 */
+  preloadRemoteModels() {
+    for (const ep of allEndpoints(this.config)) {
+      if (endpointConfigured(this.config, ep) && ep.protocol !== 'anthropic') {
+        void this.refreshModels({ endpointId: ep.id }).catch(() => undefined)
+      }
+    }
+  }
+
+  /** 清除某入口（或全部）的远端模型缓存。 */
+  private invalidateRemoteModels(endpointId?: string) {
+    if (endpointId) delete this.remoteModels[endpointId]
+    else this.remoteModels = {}
+  }
+
+  /** 从上游 GET /models 拉取某入口的真实模型列表（写入内存缓存，不落盘）。 */
+  async refreshModels(opts?: { endpointId?: string; apiKey?: string; baseUrl?: string }) {
+    const endpointId = (opts?.endpointId || this.config.endpointId || this.config.provider).trim()
+    const endpoint = resolveEndpoint(this.config, endpointId)
+    if (!endpoint) return { ok: false as const, detail: `未知入口：${endpointId}`, endpointId }
+    if (endpoint.protocol === 'anthropic') {
+      return { ok: false as const, detail: 'Anthropic Messages 无模型列表接口，请手动添加模型', endpointId }
+    }
+    const draftKey = typeof opts?.apiKey === 'string' ? opts.apiKey.trim() : ''
+    const storedKey = (this.config.apiKeys[endpointId] ?? '').trim()
+    const apiKey = draftKey || storedKey || (isLocalEndpoint(endpoint) ? 'local' : '')
+    if (!apiKey) return { ok: false as const, detail: '未配置 API Key', endpointId }
+    const baseUrl =
+      (typeof opts?.baseUrl === 'string' && opts.baseUrl.trim() ? normalizeBaseUrl(opts.baseUrl) : '') ||
+      effectiveBaseUrl(this.config, endpoint)
+    try {
+      const models = await listLlmModels({ provider: endpoint.provider, apiKey, model: '', baseUrl })
+      if (!models) {
+        return { ok: false as const, detail: '该入口协议不支持模型列表', endpointId }
+      }
+      this.remoteModels[endpointId] = { models, fetchedAt: Date.now() }
+      return {
+        ok: true as const,
+        endpointId,
+        count: models.length,
+        fetchedAt: this.remoteModels[endpointId]!.fetchedAt,
+      }
+    } catch (error) {
+      return {
+        ok: false as const,
+        endpointId,
+        detail: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+
   constructor(ctx: Context) {
     super(ctx, 'chat')
     ctx.systemPrompt.register('chat.persona', () => {
@@ -340,7 +427,7 @@ export class ChatService extends Service {
 
   publicView() {
     const endpoints = allEndpoints(this.config)
-    const models = allModels(this.config)
+    const models = this.modelDefs()
     const current = resolveEndpoint(this.config, this.config.endpointId)
     const providers: Record<string, { label: string; configured: boolean; hint: string; baseUrl: string; group: string; protocol: string }> = {}
     for (const ep of endpoints) {
@@ -392,6 +479,13 @@ export class ChatService extends Service {
         note: ep.note,
         builtin: ep.builtin !== false && ep.group !== 'custom',
       })),
+      /** 各入口已从上游 /models 拉取的模型摘要（count/fetchedAt）。 */
+      remoteModels: Object.fromEntries(
+        Object.entries(this.remoteModels).map(([id, cache]) => [
+          id,
+          { count: cache.models.length, fetchedAt: cache.fetchedAt },
+        ]),
+      ),
       modelCatalog: models.map((m) => ({
         ...m,
         // 方便前端按入口过滤
@@ -422,7 +516,17 @@ export class ChatService extends Service {
     const provider = (config?.provider as ChatProvider | undefined) ?? defaultsView.provider
     const model = config?.model ?? defaultsView.model
     let endpointId = defaultsView.endpointId
-    const matched = allModels(this.config).find((m) => m.model === model && m.provider === provider)
+    // 同一个 model id 可能同时存在于官方目录与当前自定义中转入口（例如
+    // `gpt-4o-mini`）。先在默认入口下匹配，避免会话覆盖模型名时被错误路由回
+    // 官方 OpenAI 地址。使用合并后的远端模型目录，确保 API 拉取的模型也可路由。
+    const models = this.modelDefs()
+    const matched =
+      models.find(
+        (m) =>
+          m.model === model &&
+          m.provider === provider &&
+          m.endpointId === defaultsView.endpointId,
+      ) ?? models.find((m) => m.model === model && m.provider === provider)
     if (matched) endpointId = matched.endpointId
     else if (config?.provider && CHAT_PROVIDERS.includes(config.provider as ChatProvider)) {
       endpointId = config.provider as string
@@ -485,7 +589,7 @@ export class ChatService extends Service {
         : effectiveBaseUrl(this.config, endpoint)
     const model =
       (typeof opts?.model === 'string' && opts.model.trim()) ||
-      allModels(this.config).find((m) => m.endpointId === endpointId)?.model ||
+      this.modelDefs().find((m) => m.endpointId === endpointId)?.model ||
       this.config.model ||
       defaultModelFor(endpoint.provider)
 
@@ -505,6 +609,7 @@ export class ChatService extends Service {
   invalidateEndpoint(endpointId: string, opts?: { persist?: boolean }) {
     const id = endpointId.trim()
     if (!id) return this.publicView()
+    this.invalidateRemoteModels(id)
     blockEndpoint(this.config, id)
     if (this.config.endpointId === id) {
       const fallback =
@@ -514,7 +619,7 @@ export class ChatService extends Service {
         this.config.endpointId = fallback.id
         this.config.provider = fallback.provider
         this.config.model =
-          allModels(this.config).find((m) => m.endpointId === fallback.id)?.model ??
+          this.modelDefs().find((m) => m.endpointId === fallback.id)?.model ??
           defaultModelFor(fallback.provider)
       }
     }
@@ -533,6 +638,7 @@ export class ChatService extends Service {
   markEndpointReachable(endpointId: string, opts?: { persist?: boolean; apiKey?: string; baseUrl?: string }) {
     const id = endpointId.trim()
     if (!id) return this.publicView()
+    this.invalidateRemoteModels(id)
     unblockEndpoint(this.config, id)
     if (typeof opts?.apiKey === 'string' && opts.apiKey.trim()) {
       this.config.apiKeys[id] = opts.apiKey.trim()
@@ -586,7 +692,7 @@ export class ChatService extends Service {
       if (ep) this.config.provider = ep.provider
       // 未指定 model 时，切到该入口第一个模型
       if (typeof next.model !== 'string' || !next.model.trim()) {
-        const first = allModels(this.config).find((m) => m.endpointId === id)
+        const first = this.modelDefs().find((m) => m.endpointId === id)
         if (first) this.config.model = first.model
         else if (ep) this.config.model = defaultModelFor(ep.provider)
       }
@@ -612,6 +718,7 @@ export class ChatService extends Service {
           this.config.apiKeys[id] = key.trim()
           unblockEndpoint(this.config, id)
         }
+        this.invalidateRemoteModels(id)
       }
     }
     if (next.setBaseUrl && typeof next.setBaseUrl === 'object') {
@@ -621,12 +728,14 @@ export class ChatService extends Service {
         } else if (typeof url === 'string' && url.trim()) {
           this.config.baseUrls[id] = normalizeBaseUrl(url)
         }
+        this.invalidateRemoteModels(id)
       }
     }
     // 兼容旧调用：单一 apiKey 写入当前入口
     if (typeof next.apiKey === 'string' && next.apiKey.trim()) {
       this.config.apiKeys[this.config.endpointId] = next.apiKey.trim()
       unblockEndpoint(this.config, this.config.endpointId)
+      this.invalidateRemoteModels(this.config.endpointId)
     }
     if (next.addEndpoint && typeof next.addEndpoint === 'object') {
       const label = String(next.addEndpoint.label ?? '').trim()
@@ -658,10 +767,11 @@ export class ChatService extends Service {
         }
         if (existing >= 0) this.config.customEndpoints[existing] = def
         else this.config.customEndpoints.push(def)
+        this.invalidateRemoteModels(id)
         this.config.endpointId = id
         this.config.provider = provider
         // 自定义入口默认挂一批常用模型名，避免下拉空空如也
-        const hasModels = allModels(this.config).some((m) => m.endpointId === id)
+        const hasModels = this.modelDefs().some((m) => m.endpointId === id)
         if (!hasModels) {
           const seeds = [
             'gpt-4o',
@@ -720,6 +830,7 @@ export class ChatService extends Service {
       this.config.customModels = this.config.customModels.filter((m) => m.endpointId !== id)
       delete this.config.apiKeys[id]
       delete this.config.baseUrls[id]
+      this.invalidateRemoteModels(id)
       unblockEndpoint(this.config, id)
       if (this.config.endpointId === id) {
         this.config.endpointId = DEFAULT_PROVIDER
@@ -849,6 +960,8 @@ declare module 'cordis' {
 
 export function apply(ctx: Context) {
   const chat = new ChatService(ctx)
+  // 启动即静默拉取已配置入口的真实模型列表（失败静默降级静态目录）
+  chat.preloadRemoteModels()
   ctx.hub.register({
     id: 'chat',
     title: '对话',
@@ -906,7 +1019,20 @@ export function apply(ctx: Context) {
       route.send(500, { ok: false, detail: String(error) })
     }
   })
-  ctx.http.route('POST', '/api/sessions', async (route) => {
+  ctx.http.route('POST', '/api/chat/config/models/refresh', async (route) => {
+    const payload = ((await route.json().catch(() => null)) ?? {}) as {
+      endpointId?: string
+      apiKey?: string
+      baseUrl?: string
+    }
+    try {
+      const result = await chat.refreshModels(payload)
+      route.send(result.ok ? 200 : 400, { ...result, config: chat.publicView() })
+    } catch (error) {
+      route.send(500, { ok: false, detail: String(error) })
+    }
+  })
+    ctx.http.route('POST', '/api/sessions', async (route) => {
     const payload = ((await route.json().catch(() => null)) ?? {}) as {
       type?: string
       title?: string

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type FormEvent } from 'react'
-import { ArrowUpIcon, ChevronDownIcon, PlusIcon, Cog6ToothIcon } from '@heroicons/react/16/solid'
+import { ArrowUpIcon, ArrowPathIcon, ChevronDownIcon, PlusIcon, Cog6ToothIcon } from '@heroicons/react/16/solid'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { EditorContent, useEditor } from '@tiptap/react'
 import Placeholder from '@tiptap/extension-placeholder'
@@ -129,6 +129,7 @@ type ModelOption = {
   endpointId: string
   model: string
   note?: string
+  category?: string
 }
 
 type ToolCatalogItem = { name: string; description: string }
@@ -185,6 +186,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   })
   const [modelBusy, setModelBusy] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [refreshError, setRefreshError] = useState<string | null>(null)
+  const [refreshDone, setRefreshDone] = useState<string | null>(null)
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
@@ -192,6 +196,8 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const [modelProviders, setModelProviders] = useState<Record<string, boolean> | null>(null)
   /** 入口展示名 */
   const [endpointLabels, setEndpointLabels] = useState<Record<string, string>>({})
+  /** 入口分组（official/relay/local/custom）；local 默认本地服务，未启动不误报。 */
+  const [endpointGroups, setEndpointGroups] = useState<Record<string, string>>({})
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const pending = useSessionView((state) => state.pending)
   const inbox = useSessionView((state) => state.inbox)
@@ -211,6 +217,58 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     return () => window.removeEventListener('biu:open-model-config', open)
   }, [])
 
+  /** 从各已配置入口 GET /models 拉取真实模型列表，成功后触发配置重载。 */
+  async function refreshRemoteModels() {
+    if (refreshing) return
+    setRefreshing(true)
+    setRefreshError(null)
+    setRefreshDone(null)
+    try {
+      // 本地服务（ollama/lmstudio/vllm）默认未启动，不纳入刷新目标，避免日常误报失败
+      const ids = [
+        ...new Set(
+          Object.entries(modelProviders ?? {})
+            .filter(([, ok]) => ok)
+            .map(([id]) => id)
+            .filter((id) => endpointGroups[id] !== 'local'),
+        ),
+      ]
+      if (!ids.length) {
+        setRefreshError('暂无可刷新的已配置入口（本地服务已跳过）')
+        return
+      }
+      const results = await Promise.all(
+        ids.map(async (endpointId) => {
+          const res = await fetch('/api/chat/config/models/refresh', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ endpointId }),
+          })
+          const body = (await res.json().catch(() => null)) as {
+            ok?: boolean
+            detail?: string
+            count?: number
+          } | null
+          return { endpointId, ok: res.ok && body?.ok !== false, detail: body?.detail }
+        }),
+      )
+      const failed = results.filter((r) => !r.ok)
+      if (failed.length) {
+        // 网络类失败（fetch failed）多为入口未配通/外网受限，温和提示而非红色报错
+        setRefreshError(failed.map((f) => `${f.endpointId}: ${f.detail ?? '失败'}`).join('；'))
+      } else {
+        const okList = results.map((r) => r.endpointId)
+        setRefreshDone(`已刷新 ${results.length} 个入口`)
+      }
+      window.dispatchEvent(new Event('biu:chat-config-changed'))
+    } catch (error) {
+      setRefreshError(error instanceof Error ? error.message : String(error))
+      setRefreshDone(null)
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
   function openModelConfig() {
     setModelOpen(false)
     setConfigOpen(true)
@@ -227,7 +285,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       endpointId?: string
       model?: string
       providers?: Record<string, { configured?: boolean }>
-      endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
+      endpoints?: Array<{ id: string; label?: string; configured?: boolean; group?: string }>
       modelCatalog?: Array<{
         id: string
         label: string
@@ -235,6 +293,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         endpointId?: string
         model: string
         note?: string
+        category?: string
         endpointConfigured?: boolean
       }>
     }) {
@@ -248,6 +307,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           provider: m.provider as ChatProvider,
           endpointId: m.endpointId || m.provider,
           model: m.model,
+          category: m.category,
           ...(m.note ? { note: m.note } : {}),
         }))
         setAllModels(catalog)
@@ -262,10 +322,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         anthropic: 'Claude',
         openai: 'GPT',
       }
+      const groups: Record<string, string> = {}
       if (Array.isArray(data.endpoints)) {
         for (const ep of data.endpoints) {
           cfg[ep.id] = Boolean(ep?.configured)
           if (ep.label) labels[ep.id] = ep.label
+          if (ep.group) groups[ep.id] = ep.group
         }
       }
       if (data.providers) {
@@ -273,6 +335,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       }
       if (Object.keys(cfg).length) setModelProviders(cfg)
       setEndpointLabels(labels)
+      if (Object.keys(groups).length) setEndpointGroups(groups)
     }
 
     function reload() {
@@ -303,7 +366,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           provider?: string
           model?: string
           providers?: Record<string, { configured?: boolean }>
-          endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
+          endpoints?: Array<{ id: string; label?: string; configured?: boolean; group?: string }>
           modelCatalog?: Array<{
             id: string
             label: string
@@ -311,6 +374,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             endpointId?: string
             model: string
             note?: string
+            category?: string
           }>
         }) => {
           if (Array.isArray(data.modelCatalog) && data.modelCatalog.length) {
@@ -320,6 +384,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               provider: m.provider as ChatProvider,
               endpointId: m.endpointId || m.provider,
               model: m.model,
+              category: m.category,
               ...(m.note ? { note: m.note } : {}),
             }))
             setAllModels(catalog)
@@ -328,10 +393,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           }
           const cfg: Record<string, boolean> = {}
           const labels: Record<string, string> = { ...endpointLabels }
+          const groups: Record<string, string> = { ...endpointGroups }
           if (Array.isArray(data.endpoints)) {
             for (const ep of data.endpoints) {
               cfg[ep.id] = Boolean(ep?.configured)
               if (ep.label) labels[ep.id] = ep.label
+              if (ep.group) groups[ep.id] = ep.group
             }
           }
           if (data.providers) {
@@ -339,6 +406,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
           }
           if (Object.keys(cfg).length) setModelProviders(cfg)
           setEndpointLabels(labels)
+          if (Object.keys(groups).length) setEndpointGroups(groups)
         },
       )
       .catch(() => {
@@ -849,6 +917,16 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   <span className="composer-model-config-title">Models</span>
                   <button
                     type="button"
+                    className={`composer-model-config-entry${refreshing ? ' is-spinning' : ''}`}
+                    title="从 API 刷新模型列表"
+                    aria-label="从 API 刷新模型列表"
+                    disabled={refreshing}
+                    onClick={() => void refreshRemoteModels()}
+                  >
+                    <ArrowPathIcon className="size-3.5" />
+                  </button>
+                  <button
+                    type="button"
                     className="composer-model-config-entry"
                     data-testid="open-model-config"
                     title="配置模型"
@@ -858,14 +936,22 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                     <Cog6ToothIcon className="size-3.5" />
                   </button>
                 </div>
+                {refreshError ? (
+                  <div className="composer-model-refresh-error">{refreshError}</div>
+                ) : refreshDone ? (
+                  <div className="composer-model-refresh-success">{refreshDone}</div>
+                ) : null}
                 {(() => {
+                  // 只展示 API 真实拉取成功的模型（category === 'remote'）；
+                  // 若当前选中项来自静态目录（如默认模型），也一并保留，避免选中了却找不到。
+                  const currentId = modelOption.id
                   const visible = allModels.filter(
-                    (m) => modelProviders?.[m.endpointId] || modelProviders?.[m.provider],
+                    (m) => m.category === 'remote' || m.id === currentId,
                   )
                   if (!visible.length) {
                     return (
                       <div className="composer-model-empty">
-                        尚未配置可用模型。点击上方「配置模型」添加官方 Key 或第三方。
+                        暂无可用的 API 模型。点击上方刷新按钮「从 API 刷新模型列表」，或点配置添加 Key。
                       </div>
                     )
                   }
@@ -905,6 +991,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                             onClick={() => void selectModel(option)}
                           >
                             <span className="composer-model-item-label">{option.label}</span>
+                            {option.category === 'remote' ? (
+                              <span className="composer-model-item-badge">API</span>
+                            ) : null}
                             {option.note ? (
                               <span className="composer-model-item-note">{option.note}</span>
                             ) : null}

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -158,6 +158,72 @@ export async function probeLlmConnection(
   }
 }
 
+export interface LlmModelInfo {
+  id: string
+  ownedBy?: string
+}
+
+/**
+ * 列出上游可用模型。
+ * - OpenAI 兼容：GET {base}/models → { data: [{ id, owned_by }] }
+ * - Ollama / LM Studio：GET {base}/models → { models: [{ name }] }（无鉴权）
+ * - Anthropic：无模型列表接口，返回 null（调用方应跳过并提示）。
+ * 网络 / HTTP 失败抛 Error；成功但无 data 字段返回 []。
+ */
+export async function listLlmModels(
+  config: LlmConfig,
+  opts?: { signal?: AbortSignal },
+): Promise<LlmModelInfo[] | null> {
+  if (config.provider === 'anthropic') return null
+  const apiKey = config.apiKey?.trim() || ''
+  const url = resolveModelsListUrl(config.baseUrl, config.provider)
+  // 未显式传 signal 时给默认超时，避免启动预拉挂死
+  const signal =
+    opts?.signal ??
+    (typeof AbortSignal.timeout === 'function' ? AbortSignal.timeout(10_000) : undefined)
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+      accept: 'application/json',
+    },
+    signal,
+  })
+  if (!res.ok) {
+    let detail = `HTTP ${res.status}`
+    try {
+      const err = (await res.json()) as { error?: { message?: string } }
+      if (err.error?.message) detail = err.error.message
+    } catch {
+      /* ignore */
+    }
+    throw new Error(detail)
+  }
+  const body = (await res.json()) as {
+    data?: Array<{ id?: unknown; owned_by?: unknown }>
+    models?: Array<{ name?: unknown; model?: unknown }>
+  }
+  // OpenAI 兼容
+  if (Array.isArray(body.data)) {
+    return body.data
+      .map((m) => ({
+        id: String(m.id ?? '').trim(),
+        ...(typeof m.owned_by === 'string' && m.owned_by ? { ownedBy: m.owned_by } : {}),
+      }))
+      .filter((m): m is LlmModelInfo => Boolean(m.id))
+  }
+  // Ollama / LM Studio：{ models: [{ name }] }
+  if (Array.isArray(body.models)) {
+    return body.models
+      .map((m) => {
+        const id = String(m.name ?? m.model ?? '').trim()
+        return id ? { id } : null
+      })
+      .filter((m): m is LlmModelInfo => m !== null)
+  }
+  return []
+}
+
 /** DeepSeek 视觉模型：检测到图片输入时自动路由到它。 */
 export const DEEPSEEK_VISION_MODEL = 'deepseek-v4-flash-vision-exp'
 

--- a/packages/host-llm/src/host/llm.probe.test.ts
+++ b/packages/host-llm/src/host/llm.probe.test.ts
@@ -1,6 +1,23 @@
 import assert from 'node:assert/strict'
-import { test } from 'vitest'
-import { resolveModelsListUrl, resolveChatCompletionsUrl } from '@biu/host-llm'
+import { afterEach, test, vi } from 'vitest'
+import {
+  resolveModelsListUrl,
+  resolveChatCompletionsUrl,
+  listLlmModels,
+} from '@biu/host-llm'
+
+function mockFetch(body: unknown, status = 200) {
+  const fn = async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  vi.stubGlobal('fetch', fn)
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
 
 test('resolveModelsListUrl derives from baseUrl', () => {
   assert.equal(resolveModelsListUrl('https://api.openai.com/v1', 'openai'), 'https://api.openai.com/v1/models')
@@ -9,6 +26,36 @@ test('resolveModelsListUrl derives from baseUrl', () => {
     'https://api.closeai-asia.com/v1/models',
   )
   assert.equal(resolveModelsListUrl(undefined, 'deepseek'), 'https://api.deepseek.com/models')
+})
+
+test('listLlmModels parses openai-compat /models payload', async () => {
+  mockFetch({ data: [{ id: 'gpt-4o', owned_by: 'openai' }, { id: 'gpt-4o-mini' }] })
+  const models = await listLlmModels({ provider: 'openai', apiKey: 'sk-test', model: 'gpt-4o-mini' })
+  assert.deepEqual(models, [
+    { id: 'gpt-4o', ownedBy: 'openai' },
+    { id: 'gpt-4o-mini' },
+  ])
+})
+
+test('listLlmModels parses ollama /models payload (no auth)', async () => {
+  mockFetch({ models: [{ name: 'llama3.2' }, { name: 'qwen3' }] })
+  const models = await listLlmModels({ provider: 'openai', apiKey: '', model: 'qwen3', baseUrl: 'http://localhost:11434' })
+  assert.deepEqual(models, [{ id: 'llama3.2' }, { id: 'qwen3' }])
+})
+
+test('listLlmModels returns null for anthropic (no list endpoint)', async () => {
+  assert.equal(
+    await listLlmModels({ provider: 'anthropic', apiKey: 'sk-ant-test', model: 'claude-3-5-sonnet-20241022' }),
+    null,
+  )
+})
+
+test('listLlmModels throws on non-ok http status', async () => {
+  mockFetch({ error: { message: 'invalid api key' } }, 401)
+  await assert.rejects(
+    listLlmModels({ provider: 'deepseek', apiKey: 'bad', model: 'deepseek-chat' }),
+    /invalid api key/,
+  )
 })
 
 test('resolveChatCompletionsUrl still works alongside models url', () => {

--- a/packages/host-mcp/src/host/index.ts
+++ b/packages/host-mcp/src/host/index.ts
@@ -8,6 +8,23 @@ interface McpServer {
   dispose?(): void
 }
 
+type Pending = {
+  resolve: (value: unknown) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+function commandForHost(command: string, args: string[]) {
+  // Windows 的 npx/npm 是 .cmd 文件，Node 不能像普通 exe 一样直接 spawn。
+  // 通过 ComSpec 启动，同时保留普通 node/python/二进制 MCP 的直连路径。
+  if (process.platform === 'win32' && /^(npx|npm|pnpm|yarn)(?:\.cmd)?$/i.test(command)) {
+    const comspec = process.env.ComSpec || process.env.COMSPEC || 'cmd.exe'
+    const quote = (part: string) => (/^[A-Za-z0-9_./:@=-]+$/.test(part) ? part : `"${part.replace(/"/g, '\\"')}"`)
+    return { command: comspec, args: ['/d', '/s', '/c', [command.replace(/\.cmd$/i, ''), ...args].map(quote).join(' ')] }
+  }
+  return { command, args }
+}
+
 class InProcessEcho implements McpServer {
   id = 'echo'
   tools = [{ name: 'mcp_echo', description: 'echo arguments', inputSchema: { type: 'object', properties: { text: { type: 'string' } } } }]
@@ -22,16 +39,35 @@ class StdioMcp implements McpServer {
   tools: McpServer['tools'] = []
   private child: ChildProcessWithoutNullStreams
   private buf = Buffer.alloc(0)
+  private stderr = ''
   private seq = 0
-  private pending = new Map<number, (value: unknown) => void>()
+  private pending = new Map<number, Pending>()
 
-  constructor(id: string, command: string, args: string[]) {
+  constructor(id: string, command: string, args: string[], env?: Record<string, string>) {
     this.id = id
-    this.child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    const spec = commandForHost(command, args)
+    this.child = spawn(spec.command, spec.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+      windowsHide: true,
+    })
     this.child.stdout.on('data', (chunk) => this.push(chunk as Buffer))
+    this.child.stderr.on('data', (chunk) => {
+      this.stderr = `${this.stderr}${String(chunk)}`.slice(-8_000)
+    })
+    this.child.on('error', (error) => this.failPending(`MCP ${id} 无法启动：${error.message}`))
+    this.child.on('close', (code) => {
+      if (this.pending.size) this.failPending(`MCP ${id} 已退出（code ${code ?? 'unknown'}）：${this.stderr || '无错误输出'}`)
+    })
   }
 
   async init() {
+    await this.rpc('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'biu-harness', version: '0.1.0' },
+    })
+    this.notify('notifications/initialized', {})
     const listed = (await this.rpc('tools/list', {})) as { tools?: McpServer['tools'] }
     this.tools = listed.tools ?? []
   }
@@ -41,7 +77,7 @@ class StdioMcp implements McpServer {
   }
 
   dispose() {
-    for (const resolve of this.pending.values()) resolve(undefined)
+    this.failPending(`MCP ${this.id} 已卸载`)
     this.pending.clear()
     this.child.kill('SIGTERM')
   }
@@ -50,15 +86,66 @@ class StdioMcp implements McpServer {
     const id = ++this.seq
     const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params })
     const msg = `Content-Length: ${Buffer.byteLength(payload)}\r\n\r\n${payload}`
-    return new Promise((resolve, reject) => {
-      this.pending.set(id, resolve)
-      this.child.stdin.write(msg, (error) => error && reject(error))
+    // MCP 标准 stdio 传输是一行一个 JSON-RPC 消息；保留上面的旧变量，
+    // 让代码兼容已编译的历史调用路径，但实际写出 NDJSON。
+    const mcpMessage = `${payload}\n`
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`MCP ${this.id} 调用 ${method} 超时：${this.stderr || '服务未返回响应'}`))
+      }, 30_000)
+      this.pending.set(id, { resolve, reject, timer })
+      this.child.stdin.write(mcpMessage, (error) => {
+        if (!error) return
+        clearTimeout(timer)
+        this.pending.delete(id)
+        reject(new Error(`MCP ${this.id} 写入失败：${error.message}`))
+      })
     })
+  }
+
+  private notify(method: string, params: unknown) {
+    const payload = JSON.stringify({ jsonrpc: '2.0', method, params })
+    const msg = `Content-Length: ${Buffer.byteLength(payload)}\r\n\r\n${payload}`
+    const mcpMessage = `${payload}\n`
+    this.child.stdin.write(mcpMessage)
+  }
+
+  private failPending(detail: string) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error(detail))
+    }
+    this.pending.clear()
   }
 
   private push(chunk: Buffer) {
     this.buf = Buffer.concat([this.buf, chunk])
     while (true) {
+      // 现代 MCP stdio 使用 newline-delimited JSON-RPC。下面保留
+      // Content-Length 分支，以兼容旧式 server。
+      const newline = this.buf.indexOf(0x0a)
+      if (newline >= 0) {
+        const body = this.buf.subarray(0, newline).toString('utf8').trim()
+        this.buf = this.buf.subarray(newline + 1)
+        if (!body) continue
+        try {
+          const parsed = JSON.parse(body) as { id?: number; result?: unknown; error?: { message?: string } }
+          if (typeof parsed.id === 'number') {
+            const pending = this.pending.get(parsed.id)
+            if (pending) {
+              clearTimeout(pending.timer)
+              this.pending.delete(parsed.id)
+              if (parsed.error) pending.reject(new Error(`MCP ${this.id}：${parsed.error.message || 'JSON-RPC error'}`))
+              else pending.resolve(parsed.result)
+            }
+            continue
+          }
+        } catch {
+          // 若不是 JSON 行，继续尝试旧 Content-Length framing。
+          this.stderr = `${this.stderr}\nMCP stdout returned invalid JSON: ${body}`.slice(-8_000)
+        }
+      }
       const headerEnd = this.buf.indexOf('\r\n\r\n')
       if (headerEnd < 0) return
       const header = this.buf.subarray(0, headerEnd).toString('utf8')
@@ -69,8 +156,15 @@ class StdioMcp implements McpServer {
       if (this.buf.length < start + length) return
       const body = this.buf.subarray(start, start + length).toString('utf8')
       this.buf = this.buf.subarray(start + length)
-      const parsed = JSON.parse(body) as { id?: number; result?: unknown }
-      if (typeof parsed.id === 'number') this.pending.get(parsed.id)?.(parsed.result)
+      const parsed = JSON.parse(body) as { id?: number; result?: unknown; error?: { message?: string } }
+      if (typeof parsed.id === 'number') {
+        const pending = this.pending.get(parsed.id)
+        if (!pending) continue
+        clearTimeout(pending.timer)
+        this.pending.delete(parsed.id)
+        if (parsed.error) pending.reject(new Error(`MCP ${this.id}：${parsed.error.message || 'JSON-RPC error'}`))
+        else pending.resolve(parsed.result)
+      }
     }
   }
 }
@@ -87,12 +181,17 @@ export class McpService extends Service {
     }, 'mcp.dispose-all')
   }
 
-  async addStdio(id: string, command: string, args: string[]) {
+  async addStdio(id: string, command: string, args: string[], env?: Record<string, string>) {
     if (this.servers.has(id)) throw new Error(`mcp server already registered: ${id}`)
-    const server = new StdioMcp(id, command, args)
-    await server.init()
-    this.servers.set(id, server)
-    return this.listTools()
+    const server = new StdioMcp(id, command, args, env)
+    try {
+      await server.init()
+      this.servers.set(id, server)
+      return this.listTools()
+    } catch (error) {
+      server.dispose()
+      throw error
+    }
   }
 
   remove(id: string) {
@@ -156,11 +255,16 @@ export function apply(ctx: Context) {
         id: { type: 'string' },
         command: { type: 'string' },
         args: { type: 'array', items: { type: 'string' } },
+        env: { type: 'object', description: '传给 MCP 子进程的环境变量；例如 GITHUB_PERSONAL_ACCESS_TOKEN。不会写入 Biu 配置。' },
       },
       required: ['id', 'command'],
     },
-    execute: (args) =>
-      mcp.addStdio(String(args.id), String(args.command), Array.isArray(args.args) ? args.args.map(String) : []),
+    execute: (args) => {
+      const env = args.env && typeof args.env === 'object' && !Array.isArray(args.env)
+        ? Object.fromEntries(Object.entries(args.env as Record<string, unknown>).map(([key, value]) => [key, String(value)]))
+        : undefined
+      return mcp.addStdio(String(args.id), String(args.command), Array.isArray(args.args) ? args.args.map(String) : [], env)
+    },
   })
   ctx.tools.register({
     name: 'mcp_remove',

--- a/web/style.css
+++ b/web/style.css
@@ -17,6 +17,8 @@
   --dsw-surface: var(--dsw-bg);
   --dsw-danger: #cf2d56;
   --dsw-danger-soft: rgba(207, 45, 86, 0.14);
+  --dsw-warning: #f5a623;
+  --dsw-success: #30a46c;
   --dsw-ok: #1f8a65;
   --dsw-pick: #2383e2;
   --dsw-pick-fill: rgba(35, 131, 226, 0.18);
@@ -4292,6 +4294,48 @@ body {
 .composer-model-item-note {
   font-size: var(--dsw-chat-ui-font-size);
   color: var(--dsw-label-3);
+}
+
+.composer-model-item-badge {
+  flex: none;
+  border: 1px solid var(--dsw-border);
+  border-radius: 4px;
+  padding: 0 4px;
+  color: var(--dsw-business);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.composer-model-refresh-error {
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 6px 10px;
+  color: var(--dsw-warning, #f5a623);
+  font-size: var(--dsw-chat-ui-font-size);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.composer-model-refresh-success {
+  border-bottom: 1px solid var(--dsw-border);
+  padding: 6px 10px;
+  color: var(--dsw-success, #30a46c);
+  font-size: var(--dsw-chat-ui-font-size);
+  line-height: 1.5;
+}
+
+.composer-model-config-entry.is-spinning svg {
+  animation: composer-spin 0.9s linear infinite;
+}
+
+@keyframes composer-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .composer-model-empty {


### PR DESCRIPTION
## What changed

- Fetch the configured OpenAI-compatible endpoint's `/models` list into Biu's in-memory model catalog.
- Keep session routing on the currently selected custom endpoint when model IDs overlap with built-in providers.
- Improve stdio MCP startup on Windows and complete the MCP initialize handshake.

## Why

A single AIAPI key should expose the provider's actual model list in Biu, while sessions must continue using the selected AIAPI endpoint instead of being routed to the public OpenAI endpoint.

## Validation

- AIAPI model refresh: 128 remote models fetched successfully.
- `kimi-k3` connection test passed (668 ms).
- Targeted MCP and LLM tests: 8/8 passed.

Note: the upstream main branch currently has unrelated full TypeScript errors in new filesystem, picker, plugin, and task modules.