### PR TITLE
feat(inspector): 标签和加号菜单用关闭按钮收起栏

### DIFF
--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from 'react'
-import { ChevronLeftIcon, ChevronRightIcon, CircleStackIcon } from '@heroicons/react/16/solid'
+import { ChevronLeftIcon, ChevronRightIcon, CircleStackIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
@@ -162,11 +162,13 @@ function goInspector(paneId: string, target: CrumbTarget) {
 export function DatabaseInspectorTab({
   active,
   onActivate,
+  onClose,
   paneId,
   seedCollection,
 }: {
   active?: boolean
   onActivate?: () => void
+  onClose?: () => void
   paneId?: string
   seedCollection?: string
 }) {
@@ -243,31 +245,49 @@ export function DatabaseInspectorTab({
           <span className="chat-view-project-name">数据</span>
         </span>
       )}
-      {crumbs.length > 1 ? (
-        <button
-          type="button"
-          className={`inspector-crumb-toggle${trailOpen ? ' is-open' : ''}`}
-          title={trailOpen ? '收起面包屑' : '展开面包屑'}
-          aria-label={trailOpen ? '收起面包屑' : '展开面包屑'}
-          aria-expanded={trailOpen}
-          data-testid="inspector-crumb-toggle"
-          onClick={(event) => {
-            event.preventDefault()
-            event.stopPropagation()
-            onActivate?.()
-            setTrailOpen((open) => {
-              if (open) setCrumbOpen(null)
-              return !open
-            })
-          }}
-        >
-          {trailOpen ? (
-            <ChevronLeftIcon aria-hidden className="size-3" />
-          ) : (
-            <ChevronRightIcon aria-hidden className="size-3" />
-          )}
-        </button>
-      ) : null}
+      <span className="inspector-crumb-actions">
+        {crumbs.length > 1 ? (
+          <button
+            type="button"
+            className={`inspector-crumb-toggle${trailOpen ? ' is-open' : ''}`}
+            title={trailOpen ? '收起面包屑' : '展开面包屑'}
+            aria-label={trailOpen ? '收起面包屑' : '展开面包屑'}
+            aria-expanded={trailOpen}
+            data-testid="inspector-crumb-toggle"
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              onActivate?.()
+              setTrailOpen((open) => {
+                if (open) setCrumbOpen(null)
+                return !open
+              })
+            }}
+          >
+            {trailOpen ? (
+              <ChevronLeftIcon aria-hidden className="size-3" />
+            ) : (
+              <ChevronRightIcon aria-hidden className="size-3" />
+            )}
+          </button>
+        ) : null}
+        {onClose ? (
+          <button
+            type="button"
+            className="inspector-crumb-close"
+            title="关闭"
+            aria-label="关闭此栏"
+            data-testid="inspector-tab-close"
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              onClose()
+            }}
+          >
+            <XMarkIcon aria-hidden className="size-3" />
+          </button>
+        ) : null}
+      </span>
     </div>
   )
 }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -194,3 +194,13 @@ test('inspector no longer listens for add/copy view actions', () => {
   assert.doesNotMatch(browser, /detail === 'add-view'/)
   assert.doesNotMatch(browser, /detail === 'copy-view'/)
 })
+
+test('database inspector tab has a close control beside crumb expand', () => {
+  const tab = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
+  assert.match(tab, /onClose\?: \(\) => void/)
+  assert.match(tab, /data-testid="inspector-tab-close"/)
+  assert.match(tab, /inspector-crumb-close/)
+  assert.match(tab, /XMarkIcon/)
+  assert.match(tab, /inspector-crumb-actions/)
+  assert.match(tab, /data-testid="inspector-crumb-toggle"/)
+})

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -35,7 +35,9 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /paneId=\{item.id\}/)
   assert.match(inspector, /paneId=\{extraActive.id\}/)
   assert.doesNotMatch(inspector, /displayTabs.find\(\(item\) => item.id === tab\)/)
-  assert.match(inspector, /inspector-add-trash/)
+  assert.match(inspector, /inspector-add-close/)
+  assert.match(inspector, /XMarkIcon/)
+  assert.match(inspector, /onClose=\{\(\) => closeOpenedTab\(item.id\)\}/)
   assert.match(inspector, /closeOpenedTab/)
   assert.match(inspector, /inspector-tab-remove-\$\{item.id\}/)
   assert.doesNotMatch(inspector, /item\.repeatable \? \(/)
@@ -46,6 +48,8 @@ test('plus menu can add another database tab', () => {
   assert.match(css, /\.inspector-add-owner\.has-open\s*\{[^}]*border-bottom:\s*1px solid var\(--dsw-border\)/s)
   assert.match(inspector, /inspector-add-owner\$\{headerTabs\.length \? ' has-open' : ''\}/)
   assert.doesNotMatch(inspector, /添加\$\{item\.label\}/)
+  assert.match(css, /\.inspector-crumb-close/)
+  assert.match(css, /\.inspector-add-close/)
 })
 
 test('inspector header tabs sit on the same vertical center as the main header', () => {

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -5,6 +5,7 @@ import {
   ListBulletIcon,
   PlusIcon,
   Squares2X2Icon,
+  XMarkIcon,
   TableCellsIcon,
   ViewColumnsIcon,
   ClipboardDocumentListIcon,
@@ -15,7 +16,6 @@ import {
   EyeIcon,
 } from '@heroicons/react/16/solid'
 import { chromeIcon } from './chrome-icon.ts'
-import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import {
   bindSessionView,
   type SessionViewService,
@@ -324,9 +324,10 @@ export const SessionInspector = memo(function SessionInspector({
               return (
                 <Tab
                   key={item.id}
+                  {...inspectorViewProps(raw)}
                   active={active}
                   onActivate={() => setTab(item.id)}
-                  {...inspectorViewProps(raw)}
+                  onClose={() => closeOpenedTab(item.id)}
                   paneId={item.id}
                 />
               )
@@ -401,9 +402,9 @@ export const SessionInspector = memo(function SessionInspector({
                     </button>
                     <button
                       type="button"
-                      className="inspector-add-trash"
-                      title="从检查器移除"
-                      aria-label="从检查器移除"
+                      className="inspector-add-close"
+                      title="关闭"
+                      aria-label="关闭此栏"
                       data-testid={`inspector-tab-remove-${item.id}`}
                       onClick={(event) => {
                         event.preventDefault()
@@ -411,7 +412,7 @@ export const SessionInspector = memo(function SessionInspector({
                         closeOpenedTab(item.id)
                       }}
                     >
-                      <TrashGlyph {...chromeIcon} />
+                      <XMarkIcon {...chromeIcon} />
                     </button>
                   </div>
                 )

--- a/web/style.css
+++ b/web/style.css
@@ -640,7 +640,7 @@ body {
   max-width: none;
   min-width: max-content;
   overflow: visible;
-  padding-right: 18px;
+  padding-right: 4px;
 }
 
 .inspector-crumb-tab .inspector-crumb-full .fsdb-crumb:not(:last-child) {
@@ -659,10 +659,15 @@ body {
   display: inline;
 }
 
-.inspector-crumb-toggle {
-  position: absolute;
-  right: 2px;
-  top: 50%;
+.inspector-crumb-actions {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  margin-left: 2px;
+}
+
+.inspector-crumb-toggle,
+.inspector-crumb-close {
   z-index: 4;
   display: grid;
   place-items: center;
@@ -671,26 +676,29 @@ body {
   margin: 0;
   padding: 0;
   border: 0;
-  border-radius: 0;
+  border-radius: 4px;
   background: transparent;
   box-shadow: none;
   color: var(--dsw-sidebar-fg);
   opacity: 0;
   pointer-events: none;
-  transform: translateY(-50%);
   cursor: pointer;
 }
 
 .inspector-crumb-tab:hover .inspector-crumb-toggle,
+.inspector-crumb-tab:hover .inspector-crumb-close,
 .inspector-crumb-tab.is-crumb-open .inspector-crumb-toggle,
-.inspector-crumb-tab:focus-within .inspector-crumb-toggle {
+.inspector-crumb-tab.is-crumb-open .inspector-crumb-close,
+.inspector-crumb-tab:focus-within .inspector-crumb-toggle,
+.inspector-crumb-tab:focus-within .inspector-crumb-close {
   opacity: 1;
   pointer-events: auto;
 }
 
 .inspector-crumb-toggle:hover,
-.inspector-crumb-toggle.is-open {
-  background: transparent;
+.inspector-crumb-toggle.is-open,
+.inspector-crumb-close:hover {
+  background: var(--dsw-hover);
   box-shadow: none;
   color: var(--dsw-sidebar-fg-active);
 }
@@ -939,7 +947,7 @@ body {
   color: inherit;
 }
 
-.inspector-add-trash {
+.inspector-add-close {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
检查器「全部会话」这类数据库标签在展开面包屑旁边增加叉号，可以立刻关掉这一栏。加号菜单里已打开栏右侧的垃圾桶改成关闭图标，语义是关掉检查器标签，不是删会话。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

