### PR TITLE
feat(fs): 集合页顶栏可切换全宽与最大宽度

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -5,6 +5,7 @@ import {
   ArrowPathIcon,
   ArrowUpIcon,
   ArrowsPointingOutIcon,
+  ArrowsPointingInIcon,
   ArrowsUpDownIcon,
   AdjustmentsHorizontalIcon,
   Bars3BottomLeftIcon,
@@ -90,6 +91,12 @@ import {
   viewsKey,
   withViewDisplay,
 } from './view-storage.ts'
+import {
+  getPageWidth,
+  getPageWidthVersion,
+  persistPageWidth,
+  subscribePageWidth,
+} from './page-width.ts'
 import { listCollection, readJson } from './db-client.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
 import { mergeCatalogViews, mergeTableViews, catalogRowOpenTarget } from '../catalog-views.ts'
@@ -223,6 +230,7 @@ export function CollectionBrowser({
   const [configOpen, setConfigOpen] = useState(false)
   const [groupOpen, setGroupOpen] = useState(false)
   const [pageSizeOpen, setPageSizeOpen] = useState(false)
+  const [layoutOpen, setLayoutOpen] = useState(false)
   const [wrapCells, setWrapCells] = useState(!!initialView?.wrap)
   const [truncateCells, setTruncateCells] = useState(initialView?.truncate !== false)
   const [groupBy, setGroupBy] = useState(initialView?.groupBy ?? '')
@@ -258,6 +266,7 @@ export function CollectionBrowser({
   const configRef = useRef<HTMLDivElement>(null)
   const groupRef = useRef<HTMLDivElement>(null)
   const pageSizeRef = useRef<HTMLDivElement>(null)
+  const layoutRef = useRef<HTMLDivElement>(null)
   const pageSizeMenuRef = useRef<HTMLDivElement>(null)
   const [pageSizeMenuPos, setPageSizeMenuPos] = useState<{ right: number; bottom: number } | null>(null)
   const searchRef = useRef<HTMLDivElement>(null)
@@ -337,7 +346,8 @@ export function CollectionBrowser({
         configRef.current?.contains(target) ||
         groupRef.current?.contains(target) ||
         pageSizeRef.current?.contains(target) ||
-        pageSizeMenuRef.current?.contains(target)
+        pageSizeMenuRef.current?.contains(target) ||
+        layoutRef.current?.contains(target)
       ) {
         return
       }
@@ -350,6 +360,7 @@ export function CollectionBrowser({
       setConfigOpen(false)
       setGroupOpen(false)
       setPageSizeOpen(false)
+      setLayoutOpen(false)
     }
     document.addEventListener('mousedown', onPointer)
     return () => document.removeEventListener('mousedown', onPointer)
@@ -372,7 +383,7 @@ export function CollectionBrowser({
     if (searchOpen) searchInputRef.current?.focus()
   }, [searchOpen])
 
-  function toggleMenu(which: 'view' | 'mode' | 'sort' | 'columns' | 'filter' | 'config' | 'group' | 'pageSize') {
+  function toggleMenu(which: 'view' | 'mode' | 'sort' | 'columns' | 'filter' | 'config' | 'group' | 'pageSize' | 'layout') {
     setViewMenuOpen(which === 'view' && !viewMenuOpen)
     setModeMenuOpen(which === 'mode' && !modeMenuOpen)
     setSortMenuOpen(which === 'sort' && !sortMenuOpen)
@@ -381,6 +392,7 @@ export function CollectionBrowser({
     setConfigOpen(which === 'config' && !configOpen)
     setGroupOpen(which === 'group' && !groupOpen)
     setPageSizeOpen(which === 'pageSize' && !pageSizeOpen)
+    setLayoutOpen(which === 'layout' && !layoutOpen)
   }
 
   const reload = useCallback(async () => {
@@ -666,7 +678,9 @@ export function CollectionBrowser({
   const filterActive = Object.values(filters).some(Boolean)
   const activeView = views.find((view) => view.id === activeViewId)
   useSyncExternalStore(subscribeStarredViews, getStarredViewsVersion, () => 0)
+  useSyncExternalStore(subscribePageWidth, getPageWidthVersion, () => 0)
   const viewStarred = Boolean(activeViewId && isViewStarred(getStarredViews(), collectionPath, activeViewId))
+  const pageWidth = getPageWidth()
 
   useEffect(() => {
     hydratedDetail.current = ''
@@ -1497,7 +1511,7 @@ export function CollectionBrowser({
 
   return (
     <div
-      className={`fsdb-page tasks-root${embed ? ' inspector-database-page' : ''}`}
+      className={`fsdb-page tasks-root${embed ? ' inspector-database-page' : ''}${pageWidth === 'full' ? ' is-full-width' : ''}`}
       data-testid={embed ? 'inspector-database' : undefined}
     >
       {!embed ? (
@@ -1583,6 +1597,48 @@ export function CollectionBrowser({
                 <StarIcon aria-hidden className={`size-4${viewStarred ? ' text-[#f5b700]' : ''}`} />
               </button>
             ) : null}
+            <div className="fsdb-layout-wrap" ref={layoutRef}>
+              <button
+                type="button"
+                className={`chat-view-header-expand${layoutOpen ? ' is-active' : ''}`}
+                title="配置"
+                aria-label="配置"
+                aria-haspopup="menu"
+                aria-expanded={layoutOpen}
+                data-testid="fsdb-layout-toggle"
+                onClick={() => toggleMenu('layout')}
+              >
+                <AdjustmentsHorizontalIcon aria-hidden className="size-4" />
+              </button>
+              {layoutOpen ? (
+                <div className="fsdb-layout-menu" role="menu" data-testid="fsdb-layout-menu">
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    className={`fsdb-layout-opt${pageWidth === 'max' ? ' is-active' : ''}`}
+                    title="最大宽度"
+                    aria-label="最大宽度"
+                    aria-checked={pageWidth === 'max'}
+                    data-testid="fsdb-layout-max"
+                    onClick={() => persistPageWidth('max')}
+                  >
+                    <ArrowsPointingInIcon aria-hidden className="size-4" />
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitemradio"
+                    className={`fsdb-layout-opt${pageWidth === 'full' ? ' is-active' : ''}`}
+                    title="全宽"
+                    aria-label="全宽"
+                    aria-checked={pageWidth === 'full'}
+                    data-testid="fsdb-layout-full"
+                    onClick={() => persistPageWidth('full')}
+                  >
+                    <ArrowsPointingOutIcon aria-hidden className="size-4" />
+                  </button>
+                </div>
+              ) : null}
+            </div>
             <button
               type="button"
               className={`chat-view-header-expand${inspectorOpen ? ' is-active' : ''}`}

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -36,6 +36,7 @@ const CSS = `
 .fsdb-collection-name{font-size:14px;font-weight:650;color:var(--dsw-label);line-height:1.35;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-collection-head .fsdb-footnote{margin:4px 0 0;font-size:14px;font-weight:400;line-height:1.45;color:var(--dsw-label-3);display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;overflow:hidden}
 .fsdb-main{box-sizing:border-box;width:100%;max-width:var(--dsw-chat-max-width);margin-inline:auto;display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;gap:10px;padding:20px 24px 16px;overflow:hidden}
+.fsdb-page.is-full-width .fsdb-main,.fsdb-page.is-full-width .fsdb-detail-main{max-width:none}
 .fsdb-page:not(.inspector-database-page) .fsdb-main{padding-bottom:var(--brand-corner-clearance,60px)}
 .inspector-database-page .fsdb-main{padding-bottom:0}
 .fsdb-main > .fsdb-detail-title{flex:none}
@@ -43,6 +44,11 @@ const CSS = `
 .fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:none;min-width:0}
 .fsdb-locked-filter{display:inline-flex;align-items:center;height:26px;padding:0 8px;border-radius:8px;background:color-mix(in srgb,var(--dsw-business) 12%,transparent);color:var(--dsw-business);font-size:13px;font-weight:650;cursor:default}
 .fsdb-page .tasks-toolbar-right{display:flex;align-items:center;gap:2px;flex:none;margin-left:auto}
+.fsdb-layout-wrap{position:relative;display:inline-flex}
+.fsdb-layout-menu{position:absolute;top:calc(100% + 6px);right:0;z-index:40;display:flex;gap:2px;padding:4px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
+.fsdb-layout-opt{display:grid;place-items:center;width:32px;height:26px;border:0;border-radius:7px;background:transparent;color:var(--dsw-label-2);cursor:pointer}
+.fsdb-layout-opt:hover{background:var(--dsw-hover);color:var(--dsw-label)}
+.fsdb-layout-opt.is-active{color:var(--dsw-business);background:color-mix(in srgb,var(--dsw-business) 10%,var(--dsw-input))}
 .fsdb-create-btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;margin-left:8px;padding:0 10px;border:0;border-radius:4px;background:var(--dsw-pick,#2383e2);color:#fff;cursor:pointer;font:inherit;font-size:14px;font-weight:600;white-space:nowrap}
 .fsdb-create-btn:hover{background:var(--dsw-pick,#2383e2);filter:brightness(.92)}
 .fsdb-page .tasks-search-wrap{display:inline-flex;align-items:center;gap:0;flex:none;min-width:0;padding:0;border:0;border-radius:8px;background:transparent;color:var(--dsw-label-2)}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -194,3 +194,13 @@ test('inspector no longer listens for add/copy view actions', () => {
   assert.doesNotMatch(browser, /detail === 'add-view'/)
   assert.doesNotMatch(browser, /detail === 'copy-view'/)
 })
+
+test('collection header has a layout config control next to the star', () => {
+  assert.match(browser, /data-testid="fsdb-layout-toggle"/)
+  assert.match(browser, /data-testid="fsdb-layout-menu"/)
+  assert.match(browser, /data-testid="fsdb-layout-max"/)
+  assert.match(browser, /data-testid="fsdb-layout-full"/)
+  assert.match(browser, /AdjustmentsHorizontalIcon/)
+  assert.match(browser, /persistPageWidth\('full'\)/)
+  assert.match(browser, /is-full-width/)
+})

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -14,6 +14,7 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.fsdb-detail-main\{[^}]*margin-inline:auto/)
   assert.match(css, /\.fsdb-detail-main\{[^}]*padding:20px 24px 24px/)
   assert.doesNotMatch(css, /\.fsdb-main\{[^}]*max-width:none/)
+  assert.match(css, /\.fsdb-page\.is-full-width \.fsdb-main,\.fsdb-page\.is-full-width \.fsdb-detail-main\{[^}]*max-width:none/)
   assert.match(css, /\.tasks-queue-item-body\{[^}]*flex-wrap:nowrap/)
   assert.match(css, /\.tasks-queue-item-main\{[^}]*flex:1 1 12rem/)
   assert.match(css, /\.tasks-queue-item-main\{[^}]*width:auto/)

--- a/packages/core-file-system/src/web/page-width.test.ts
+++ b/packages/core-file-system/src/web/page-width.test.ts
@@ -1,0 +1,12 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { persistPageWidth, getPageWidth } from './page-width.ts'
+
+test('page width persists full and max', () => {
+  persistPageWidth('max')
+  assert.equal(getPageWidth(), 'max')
+  persistPageWidth('full')
+  assert.equal(getPageWidth(), 'full')
+  persistPageWidth('max')
+  assert.equal(getPageWidth(), 'max')
+})

--- a/packages/core-file-system/src/web/page-width.ts
+++ b/packages/core-file-system/src/web/page-width.ts
@@ -1,0 +1,42 @@
+export type PageWidth = 'max' | 'full'
+
+const KEY = 'fsdb.pageWidth'
+
+function readPageWidth(): PageWidth {
+  try {
+    return localStorage.getItem(KEY) === 'full' ? 'full' : 'max'
+  } catch {
+    return 'max'
+  }
+}
+
+let pageWidth: PageWidth = readPageWidth()
+let pageWidthVersion = 0
+const listeners = new Set<() => void>()
+
+export function getPageWidth() {
+  return pageWidth
+}
+
+export function getPageWidthVersion() {
+  return pageWidthVersion
+}
+
+export function subscribePageWidth(fn: () => void) {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+export function persistPageWidth(next: PageWidth) {
+  if (next === pageWidth) return
+  pageWidth = next
+  pageWidthVersion += 1
+  try {
+    localStorage.setItem(KEY, next)
+  } catch {
+    /* ignore */
+  }
+  for (const fn of listeners) fn()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
集合页顶栏收藏星标右侧增加配置按钮，图标与聊天顶栏配置按钮相同。点开后是一个只含图标的小菜单：向内箭头表示内容最大宽度居中，向外箭头表示全宽。选择会记住。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

