### PR TITLE
Header session mascot and sidebar collapse animation

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -141,11 +141,6 @@ export function ApprovalsRail(props: SlotProps) {
   const sessionView = props.sessionView as SessionViewService
   const sessionId = useSessionView((state) => state.sessionId)
   const sessions = useSessionView((state) => state.sessions)
-  const agentStatus = useSessionView((state) => state.agentStatus)
-  const currentSession = sessions.find((item) => item.id === sessionId)
-  const sessionIdentity = sessionId
-    ? resolveSessionMascot(sessionId, currentSession?.mascot)
-    : null
   const dispatchedTasksByTurn = useSessionView((state) => state.dispatchedTasksByTurn)
   const workerAgents = useMemo(
     () => activeWorkerAgents(dispatchedTasksByTurn, sessionId),
@@ -153,9 +148,6 @@ export function ApprovalsRail(props: SlotProps) {
   )
   const visibleWorkers = workerAgents.slice(0, DOCK_WORKER_CAP)
   const hiddenWorkerCount = Math.max(0, workerAgents.length - visibleWorkers.length)
-  const mainAgentName = sessionIdentity
-    ? dockAgentLabel(currentSession?.title, sessionIdentity.shape)
-    : ''
   const approvals = useSessionView((state) => state.approvals)
   const approvalMode = useSessionView((state) => state.approvalMode)
   const nodes = useSessionView((state) => state.nodes)
@@ -320,24 +312,8 @@ export function ApprovalsRail(props: SlotProps) {
             ) : null}
             <PaintBrushIcon className="size-4 relative z-1" aria-hidden />
           </button>
-          {sessionId && sessionIdentity ? (
+            {visibleWorkers.length ? (
             <span className="dock-agent-stack" data-testid="dock-agent-stack">
-              <span
-                className="dock-session-mascot"
-                data-testid="dock-session-mascot"
-                data-dock-tip={mainAgentName}
-                title={mainAgentName}
-                aria-label={mainAgentName || undefined}
-              >
-                <SidebarMascot
-                  size={28}
-                  sessionId={sessionId}
-                  identity={sessionIdentity}
-                  busy={agentStatus === 'running' || Boolean(currentSession?.busy)}
-                  animate={false}
-                  title=""
-                />
-              </span>
               {visibleWorkers.map((worker, index) => {
                 const identity = resolveSessionMascot(worker.sessionId, worker.mascot)
                 const listed = sessions.find((item) => item.id === worker.sessionId)

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -31,12 +31,15 @@ describe('composer dock stacking above sticky user', () => {
     expect(composer).toContain('biu:composer-focus')
   })
 
-  it('wakes the overlay composer on dock mascot hover, without an agent list', () => {
+  it('puts the session mascot after the header name, with the dock session picker', () => {
     const approvals = readFileSync(resolve(root, 'packages/cap-chat/src/web/approvals.tsx'), 'utf8')
+    const title = readFileSync(resolve(root, 'packages/web-app-shell/src/web/chat-session-title.tsx'), 'utf8')
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     const shell = readFileSync(resolve(root, 'packages/web-app-shell/src/web/index.tsx'), 'utf8')
     const overlayWin = readFileSync(resolve(root, 'packages/web-app-shell/src/web/overlay-window.tsx'), 'utf8')
-    expect(approvals).toContain('dock-session-mascot')
+    expect(title).toContain('BrandCornerMascot')
+    expect(title).toContain('variant="popover"')
+    expect(approvals).not.toContain('dock-session-mascot')
     expect(approvals).not.toContain('BrandAgentMenu')
     expect(approvals).not.toContain('setSessionPickerOpen')
     expect(shell).not.toMatch(/hit\.closest\('\.dock-agent-stack'\)/)

--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -4,13 +4,15 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 
 const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+const title = readFileSync(resolve(import.meta.dirname, './chat-session-title.tsx'), 'utf8')
 const chat = readFileSync(resolve(import.meta.dirname, './chat-sidebar.tsx'), 'utf8')
 const frame = readFileSync(resolve(import.meta.dirname, './shell-sidebar-frame.tsx'), 'utf8')
+const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
 
 test('brand mascot lives at the corner; sidebar head is title plus collapse', () => {
-  assert.match(shell, /BrandCornerMascot/)
-  assert.match(shell, /variant="popover"/)
   assert.match(shell, /DockSessionMascot/)
+  assert.match(title, /BrandCornerMascot/)
+  assert.match(title, /variant="popover"/)
   assert.match(frame, /data-testid="sidebar-collapse"/)
   assert.match(frame, /app-side-bar-head-brand/)
   assert.match(frame, /Biu Agent OS/)
@@ -29,7 +31,6 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.doesNotMatch(mascot, /brand-corner-dock/)
   assert.doesNotMatch(mascot, /brand-corner-chat-overlay/)
   assert.doesNotMatch(mascot, /onToggleOverlay/)
-  assert.match(shell, /<BrandCornerMascot/)
   assert.match(shell, /ShellDockPins/)
   assert.doesNotMatch(shell, /activeModule === 'agent' \? null : \(/)
   assert.doesNotMatch(shell, /activeModule !== 'agent' &&/)
@@ -37,7 +38,6 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.doesNotMatch(shell, /props.renderSlot\('corner-tools'\)/)
   assert.doesNotMatch(shell, /leading=\{activeModule === 'agent' \? null/)
   assert.doesNotMatch(shell, /onToggleOverlay/)
-  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(css, /\.brand-corner-mascot-btn\.is-active[\s\S]*?background:\s*transparent/)
   assert.match(css, /--brand-corner-clearance:\s*1\.25rem/)
   assert.match(css, /\.session-inspector\s*\{[^}]*padding-bottom:\s*var\(--brand-corner-clearance\)/s)
@@ -53,4 +53,15 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.match(css, /\.os-dock\s*\{/)
   assert.match(css, /\.os-dock-shelf-row\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s)
   assert.match(css, /\.os-dock-shelf-row\s*\{[^}]*backdrop-filter:\s*blur/s)
+})
+
+test('shell columns keep three tracks so sidebar and inspector can animate', () => {
+  assert.match(css, /\.app-shell-agent\s*\{[^}]*transition:\s*grid-template-columns/s)
+  assert.match(css, /\.app-shell-module\s*\{[^}]*transition:\s*grid-template-columns/s)
+  assert.match(
+    css,
+    /\.app-shell-agent\s*\{[^}]*grid-template-columns:\s*var\(--sidebar-col, 0px\) minmax\(0, 1fr\) var\(--inspector-width, 0px\)/s,
+  )
+  assert.doesNotMatch(css, /\.app-shell-agent\.is-sidebar-collapsed\s*\{/)
+  assert.match(frame, /is-closed flex/)
 })

--- a/packages/web-app-shell/src/web/chat-session-title.tsx
+++ b/packages/web-app-shell/src/web/chat-session-title.tsx
@@ -1,5 +1,7 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+import { BrandCornerMascot } from '@biu/web-mascot'
+import { ChatSidebar } from './chat-sidebar.tsx'
 
 export const ChatSessionTitle = memo(function ChatSessionTitle({
   useSessionView,
@@ -9,6 +11,7 @@ export const ChatSessionTitle = memo(function ChatSessionTitle({
   sessionView: SessionViewService
 }) {
   const sessionId = useSessionView((state) => state.sessionId)
+  const sessions = useSessionView((state) => state.sessions)
   const title = useSessionView((state) => {
     const id = state.sessionId
     if (!id) return ''
@@ -57,6 +60,21 @@ export const ChatSessionTitle = memo(function ChatSessionTitle({
           event.preventDefault()
           ;(event.target as HTMLInputElement).blur()
         }}
+      />
+      <BrandCornerMascot
+        agents={sessions}
+        activeId={sessionId}
+        size={22}
+        menu={(close) => (
+          <ChatSidebar
+            variant="popover"
+            visible
+            routeSessionId={sessionId}
+            useSessionView={useSessionView}
+            sessionView={sessionView}
+            onActivate={close}
+          />
+        )}
       />
     </div>
   )

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -351,6 +351,24 @@ function Shell(props: SlotProps) {
     }
     return 320
   })
+  const [columnResizing, setColumnResizing] = useState(false)
+  useEffect(() => {
+    const onDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+      if (!target.closest('.sidebar-resize, .inspector-resize')) return
+      setColumnResizing(true)
+    }
+    const onUp = () => setColumnResizing(false)
+    window.addEventListener('pointerdown', onDown)
+    window.addEventListener('pointerup', onUp)
+    window.addEventListener('pointercancel', onUp)
+    return () => {
+      window.removeEventListener('pointerdown', onDown)
+      window.removeEventListener('pointerup', onUp)
+      window.removeEventListener('pointercancel', onUp)
+    }
+  }, [])
   const toggleInspector = useCallback(() => {
     setInspectorOpen((prev) => {
       const next = !prev
@@ -600,16 +618,14 @@ function Shell(props: SlotProps) {
     <div
       className={`app-shell${leftPane
           ? ` app-shell-agent${leftHidden ? ' is-sidebar-collapsed' : ''}${sidebarNarrow && !leftHidden ? ' is-sidebar-narrow' : ''}${inspectorVisible ? ' is-inspector-open' : ''
-          }`
-          : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}`
+          }${columnResizing ? ' is-resizing' : ''}`
+          : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}${columnResizing ? ' is-resizing' : ''}`
         }${leftHidden ? ' is-left-hidden' : ''}`}
       data-testid="app-shell"
       style={
         {
           ['--sidebar-col' as string]: `${shellColumns.left}px`,
-          ...(inspectorVisible
-            ? { ['--inspector-width' as string]: `${shellColumns.inspector}px` }
-            : {}),
+          ['--inspector-width' as string]: `${shellColumns.inspector}px`,
         } as CSSProperties
       }
     >

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -292,13 +292,13 @@ export const SessionInspector = memo(function SessionInspector({
     if (tab === id) setTab(next.at(-1) ?? '')
   }
 
-  if (!open) return null
-
   return (
     <aside
-      className="session-inspector relative flex min-h-0 min-w-0 flex-col bg-(--dsw-bg) text-(--dsw-label)"
+      className={`session-inspector relative flex min-h-0 min-w-0 flex-col bg-(--dsw-bg) text-(--dsw-label)${open ? '' : ' is-closed'}`}
       data-testid="session-inspector"
       aria-label="会话检查器"
+      aria-hidden={!open}
+      inert={!open || undefined}
     >
       <div
         className="inspector-resize"

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -49,8 +49,9 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
 
   return (
     <aside
-      className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)${narrow ? ' is-narrow' : ''}${showTags ? ' is-wide' : ''} ${visible ? 'flex' : 'hidden'}`}
+      className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)${narrow ? ' is-narrow' : ''}${showTags ? ' is-wide' : ''}${visible ? ' flex' : ' is-closed flex'}`}
       aria-hidden={!visible}
+      inert={!visible || undefined}
       data-testid={testId}
     >
       {onWidthChange ? (

--- a/packages/web-mascot/src/web/brand-mascot.tsx
+++ b/packages/web-mascot/src/web/brand-mascot.tsx
@@ -90,12 +90,14 @@ export function BrandCornerMascot({
   onSelect,
   leading,
   menu,
+  size = 36,
 }: {
   agents?: CornerAgent[]
   activeId?: string | null
   onSelect?: (id: string) => void
   leading?: ReactNode
   menu?: ReactNode | ((close: () => void) => ReactNode)
+  size?: number
 }) {
   const [agentsOpen, setAgentsOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -150,7 +152,7 @@ export function BrandCornerMascot({
           onClick={() => setAgentsOpen((prev) => !prev)}
         >
           {identity && current ? (
-            <SidebarMascot size={36} sessionId={current.id} identity={identity} animate={false} title="" />
+            <SidebarMascot size={size} sessionId={current.id} identity={identity} animate={false} title="" />
           ) : (
             <BrandMascot className="size-9" />
           )}

--- a/web/style.css
+++ b/web/style.css
@@ -191,12 +191,37 @@ body {
 .chat-view-session-title-wrap {
   position: absolute;
   left: 50%;
-  z-index: 1;
+  z-index: 12;
   display: flex;
-  max-width: min(420px, calc(100% - 220px));
+  max-width: min(480px, calc(100% - 220px));
   min-width: 0;
+  align-items: center;
+  gap: 2px;
   transform: translateX(-50%);
   pointer-events: none;
+}
+
+.chat-view-session-title-wrap .brand-corner-cluster {
+  position: relative;
+  right: auto;
+  bottom: auto;
+  z-index: 2;
+  flex: none;
+  pointer-events: auto;
+}
+
+.chat-view-session-title-wrap .brand-corner-mascot-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+}
+
+.chat-view-session-title-wrap .brand-agent-menu {
+  top: calc(100% + 6px);
+  right: auto;
+  bottom: auto;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .chat-view-session-title {
@@ -1024,19 +1049,26 @@ body {
 }
 
 .app-shell-agent {
-  grid-template-columns: var(--sidebar-col, var(--dsw-sidebar-max)) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-col, 0px) minmax(0, 1fr) var(--inspector-width, 0px);
+  transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.app-shell-agent.is-sidebar-collapsed {
-  grid-template-columns: minmax(0, 1fr);
+.app-shell-agent.is-resizing {
+  transition: none;
 }
 
-.app-shell-agent.is-inspector-open {
-  grid-template-columns: var(--sidebar-col, var(--dsw-sidebar-max)) minmax(0, 1fr) var(--inspector-width, 320px);
+@media (prefers-reduced-motion: reduce) {
+  .app-shell-agent,
+  .app-shell-module {
+    transition: none;
+  }
 }
 
-.app-shell-agent.is-sidebar-collapsed.is-inspector-open {
-  grid-template-columns: minmax(0, 1fr) var(--inspector-width, 320px);
+.app-side-bar.is-closed,
+.session-inspector.is-closed {
+  overflow: hidden;
+  border-color: transparent;
+  pointer-events: none;
 }
 
 .session-inspector {
@@ -1297,11 +1329,12 @@ body {
 }
 
 .app-shell-module {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) var(--inspector-width, 0px);
+  transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.app-shell-module.is-inspector-open {
-  grid-template-columns: minmax(0, 1fr) var(--inspector-width, 320px);
+.app-shell-module.is-resizing {
+  transition: none;
 }
 
 .app-shell-module.is-inspector-open .chat-overlay-panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Move the 28px session mascot from the composer dock to immediately after the session title.
- Click opens the same mascot picker as the Docker bar, downward from the title.
- Left and right sidebars keep their grid tracks and animate width via CSS variables instead of appearing/disappearing instantly.

## Why
Without a transition, toggling rails felt like a hitch. Animating column widths makes collapse/expand feel continuous.

## Test
- `composer-stack`, `brand-corner` tests updated for the new placement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

