### PR TITLE
Hover-only row picks matching boolean boxes

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1343,18 +1343,22 @@ export function CollectionBrowser({
     const list = id ? [id] : (ids ?? [])
     const on = list.length > 0 && list.every((item) => pickedIds.includes(item))
     return (
-      <label
-        className="fsdb-row-check"
-        onClick={(event) => event.stopPropagation()}
+      <button
+        type="button"
+        className={`fsdb-boolbtn fsdb-row-check${on ? ' is-on' : ''}`}
+        aria-pressed={on}
+        aria-label={id ? (on ? '取消选择记录' : '选择记录') : on ? '取消全选' : '全选'}
+        title={id ? (on ? '取消选择' : '选择') : on ? '取消全选' : '全选'}
+        onClick={(event) => {
+          event.stopPropagation()
+          togglePicked(list, !on)
+        }}
         onPointerDown={(event) => event.stopPropagation()}
       >
-        <input
-          type="checkbox"
-          checked={on}
-          aria-label={id ? '选择记录' : '全选'}
-          onChange={() => togglePicked(list, !on)}
-        />
-      </label>
+        <span className={`fsdb-boolbox${on ? ' is-on' : ''}`}>
+          {on ? <CheckIcon aria-hidden className="size-3" /> : null}
+        </span>
+      </button>
     )
   }
 

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -147,8 +147,8 @@ const CSS = `
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden}
 .fsdb-page .tasks-table th{padding:6px 6px;color:var(--dsw-label-2);font-size:14px;font-weight:600;position:sticky;top:0;background:var(--dsw-surface);z-index:1;white-space:nowrap}
 .fsdb-row-check-cell{width:28px;padding:6px 4px !important}
-.fsdb-row-check{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;flex:none;cursor:pointer}
-.fsdb-row-check input{margin:0;accent-color:var(--dsw-pick,#2383e2);cursor:pointer}
+.fsdb-row-check{display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;flex:none;opacity:0;pointer-events:none}
+.tasks-table tbody tr:hover .fsdb-row-check,.tasks-table thead tr:hover .fsdb-row-check,.tasks-queue-item:hover .fsdb-row-check,.tasks-minicard:hover .fsdb-row-check,.fsdb-row-check.is-on,.fsdb-row-check:focus-visible{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-th{display:inline-flex;align-items:center;gap:5px;font-weight:600;white-space:nowrap;flex-wrap:nowrap}
 .fsdb-page .tasks-table tr{cursor:default}
 .fsdb-page .tasks-table tr:hover td{background:color-mix(in srgb,var(--dsw-hover) 55%,transparent)}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -90,7 +90,9 @@ test('table title opens record from the title-side button', () => {
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(browser, /data-testid="fsdb-bulk-delete"/)
   assert.match(browser, /kind: 'delete-records'/)
-  assert.match(browser, /className="fsdb-row-check"/)
+  assert.match(browser, /className=\{\`fsdb-boolbtn fsdb-row-check\$\{on \? ' is-on' : ''\}\`\}/)
+  assert.match(browser, /fsdb-boolbox/)
+  assert.doesNotMatch(browser, /type="checkbox"/)
   assert.match(browser, /const canDelete = Boolean\(schema\?\.records\?\.delete\)/)
 })
 
@@ -106,6 +108,8 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(css, /\.fsdb-create-btn\{[^}]*border-radius:4px/)
   assert.match(css, /\.fsdb-create-btn\{[^}]*background:var\(--dsw-pick/)
   assert.match(css, /\.fsdb-boolbox\.is-on\{[^}]*background:var\(--dsw-pick/)
+  assert.match(css, /\.fsdb-row-check\{[^}]*opacity:0/)
+  assert.match(css, /tr:hover \.fsdb-row-check/)
   assert.match(browser, /persistViewDisplay/)
   assert.match(browser, /withViewDisplay/)
   assert.doesNotMatch(browser, /if \(current\?\.builtin\) return/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Table/queue/card row selection uses the same gray `fsdb-boolbox` as boolean fields (empty square, blue check when on).
- The box is hidden until the row (or table header) is hovered. Checked boxes stay visible.

## Why
Native checkboxes always sat in the first column and did not match boolean styling.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366ba5d6-812d-47b3-b697-745f46e4d0fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366ba5d6-812d-47b3-b697-745f46e4d0fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

