### PR TITLE
fix(inspector): 右侧面包屑一级只显示图标且不可选

### DIFF
--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -17,6 +17,8 @@ describe('顶栏三级标题', () => {
     expect(browser).not.toContain('{ catalog: true }')
     expect(trail).not.toContain("crumb.kind === 'collection' && index < crumbs.length - 1")
     expect(trail).toContain('crumbButtonAction(crumb')
+    expect(trail).toContain('lockRootCrumb')
+    expect(browser).not.toContain('lockRootCrumb')
     expect(browser).toContain('<CrumbTrail')
     const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
     expect(page).toMatch(/onOpenView=\{\(viewId\) => go\(\{ collection: currentPath, viewId \}\)/)

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -143,6 +143,7 @@ export function CrumbTrail({
   className,
   label,
   allowMenu = true,
+  lockRootCrumb = false,
 }: {
   crumbs: Crumb[]
   openId: string | null
@@ -157,6 +158,8 @@ export function CrumbTrail({
   label?: string
   /** 收起时只激活面板，不弹出某一级的选择菜单 */
   allowMenu?: boolean
+  /** 右侧检查器：一级只显示图标且不可点选，从第二级开始切换 */
+  lockRootCrumb?: boolean
 }) {
   const btnRefs = useRef(new Map<string, HTMLButtonElement>())
   const [menuPos, setMenuPos] = useState<{ left: number; top: number } | null>(null)
@@ -177,13 +180,26 @@ export function CrumbTrail({
   return (
     <nav className={className ?? 'fsdb-crumbs'} aria-label={label ?? '位置'} ref={navRef}>
       {crumbs.map((crumb, index) => {
-        const canPick = allowMenu && canOpenCrumbMenu(crumb)
+        const rootLocked = lockRootCrumb && index === 0 && crumbs.length > 1
+        const canPick = allowMenu && !rootLocked && canOpenCrumbMenu(crumb)
         const open = openId === crumb.id
         const current = crumb.choices.find((item) => item.id === crumb.id)
+        const glyph = (
+          <>
+            {!allowMenu && crumb.kind === 'view' ? <TableGlyph icon={tableIcon} /> : null}
+            <CrumbItemGlyph kind={crumb.kind} icon={crumb.icon ?? current?.icon} mode={current?.mode} emoji={current?.emoji} />
+            {rootLocked ? null : <span className="chat-view-project-name">{crumb.label}</span>}
+          </>
+        )
         return (
           <span key={crumb.id} className="fsdb-crumb">
             {index ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
             <span className="fsdb-crumb-pick">
+              {rootLocked ? (
+                <span className="fsdb-crumb-btn is-static" title={crumb.label} aria-label={crumb.label}>
+                  {glyph}
+                </span>
+              ) : (
               <button
                 type="button"
                 ref={(el) => {
@@ -211,10 +227,9 @@ export function CrumbTrail({
                   onOpenId(null)
                 }}
               >
-                {!allowMenu && crumb.kind === 'view' ? <TableGlyph icon={tableIcon} /> : null}
-                <CrumbItemGlyph kind={crumb.kind} icon={crumb.icon ?? current?.icon} mode={current?.mode} emoji={current?.emoji} />
-                <span className="chat-view-project-name">{crumb.label}</span>
+                {glyph}
               </button>
+              )}
             </span>
           </span>
         )

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -231,6 +231,7 @@ export function DatabaseInspectorTab({
           onOpenId={setCrumbOpen}
           onActivate={onActivate}
           allowMenu={trailOpen}
+          lockRootCrumb
           onPick={(target) => {
             onActivate?.()
             goInspector(id, target)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -230,6 +230,17 @@ test('database inspector tab has a close control beside crumb expand', () => {
   assert.match(tab, /data-testid="inspector-crumb-toggle"/)
 })
 
+test('inspector crumbs lock the first level to an icon', () => {
+  const tab = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
+  const trail = readFileSync(resolve(import.meta.dirname, './crumb-trail.tsx'), 'utf8')
+  const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+  assert.match(tab, /lockRootCrumb/)
+  assert.match(trail, /lockRootCrumb/)
+  assert.match(trail, /rootLocked/)
+  assert.match(trail, /fsdb-crumb-btn is-static/)
+  assert.doesNotMatch(browser, /lockRootCrumb/)
+})
+
 test('collection header has a layout config control next to the star', () => {
   assert.match(browser, /data-testid="fsdb-layout-toggle"/)
   assert.match(browser, /data-testid="fsdb-layout-menu"/)

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -49,6 +49,7 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /inspector-add-owner\$\{headerTabs\.length \? ' has-open' : ''\}/)
   assert.doesNotMatch(inspector, /添加\$\{item\.label\}/)
   assert.match(css, /\.inspector-crumb-close/)
+  assert.match(css, /\.inspector-crumb-full \.fsdb-crumb-btn\.is-static/)
   assert.match(css, /\.inspector-add-close/)
 })
 

--- a/web/style.css
+++ b/web/style.css
@@ -738,6 +738,16 @@ body {
   overflow: visible;
 }
 
+.inspector-crumb-full .fsdb-crumb-btn.is-static {
+  cursor: default;
+  pointer-events: none;
+}
+
+.inspector-crumb-full .fsdb-crumb-btn.is-static:hover {
+  background: transparent;
+  color: inherit;
+}
+
 .inspector-crumb-full .fsdb-crumb-btn {
   max-width: 140px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器展开面包屑后，集合一级（如「页面」）只保留图标、隐藏文字，且不可打开菜单或切换。从第二级（如「全部页面」）开始才可改。中间顶栏面包屑行为不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

