### PR TITLE
fix(chat): 工具检查按钮改用轨迹图标

### DIFF
--- a/packages/cap-chat/src/web/reply-details.test.tsx
+++ b/packages/cap-chat/src/web/reply-details.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { ChatNodeList, splitReplyForDisplay } from './thread.tsx'
 import type { ChatNode } from '@biu/web-session-view'
 import { resetMarkdownRenderForTests } from './markdown-render.ts'
@@ -84,5 +86,11 @@ describe('Details collapse UI', () => {
     expect(screen.getByTestId('user-tool-count').textContent).toBe('1')
     // 展开后最终 Message 所在 step 的统计也要有
     expect(screen.getByRole('group', { name: 'Step 2' })).toBeTruthy()
+  })
+
+  it('inspect button uses the trajectory map icon', () => {
+    const source = readFileSync(resolve(import.meta.dirname, './tool-card.tsx'), 'utf8')
+    expect(source).toContain('<MapIcon className="size-3.5" aria-hidden />')
+    expect(source).not.toContain('BugAntIcon')
   })
 })

--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -1,12 +1,12 @@
 import { useMemo, useState } from 'react'
 import { Image } from 'antd'
 import {
-  BugAntIcon,
   ChevronDownIcon,
   ChevronRightIcon,
   CheckCircleIcon,
   XCircleIcon,
   ArrowPathIcon,
+  MapIcon,
 } from '@heroicons/react/16/solid'
 import type { ChatToolPart } from '@biu/web-session-view'
 import { pickDomAttrs } from '@biu/cap-pick/web'
@@ -275,7 +275,7 @@ export function ToolCard({
           aria-label="在轨迹中查看"
           onClick={() => onInspect(node.callId)}
         >
-          <BugAntIcon className="size-3.5" aria-hidden />
+          <MapIcon className="size-3.5" aria-hidden />
         </button>
       </div>
       {!open && previewLines && previewLines.length > 0 ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
工具调用卡片上「在轨迹中查看」按钮原先用虫子图标。改为与右侧检查器「轨迹」分区相同的 MapIcon，避免看起来像 debug/bug。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

