### PR TITLE
fix(chat): Bash 工具块背景与其它工具面板对齐

### DIFF
--- a/packages/cap-chat/src/web/tool-card.test.ts
+++ b/packages/cap-chat/src/web/tool-card.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+test('bash command and output use the same panel tokens as json args', () => {
+  const source = readFileSync(resolve(import.meta.dirname, './tool-card.tsx'), 'utf8')
+  assert.doesNotMatch(source, /#1e1f24|#e8eaed|#8ab4f8/)
+  assert.match(source, /parsed\.kind === 'bash'[\s\S]*bg-\(--dsw-tool\)[\s\S]*text-\(--dsw-label-2\)/)
+  assert.match(source, /detail\.kind === 'bash'[\s\S]*bg-\(--dsw-tool\)/)
+})

--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -88,22 +88,22 @@ function DetailView({ detail }: { detail: FormattedDetail }) {
     const artifacts = detail.artifacts ?? []
     return (
       <div className="space-y-2">
-        <div className="overflow-hidden rounded-[10px] border border-(--dsw-border) bg-[#1e1f24]">
-          <div className="flex items-center justify-between gap-2 border-b border-white/10 px-3 py-1.5">
-            <span className="font-mono text-(length:--dsw-chat-ui-font-size) tracking-wide text-white/45 uppercase">output</span>
+        <div className="overflow-hidden rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool)">
+          <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) px-3 py-1.5">
+            <span className="font-mono text-(length:--dsw-chat-ui-font-size) tracking-wide text-(--dsw-label-3) uppercase">output</span>
             <span
               className={`font-mono text-(length:--dsw-chat-ui-font-size) tabular-nums ${
-                detail.code === 0 || detail.code == null ? 'text-[#7dcea0]' : 'text-[#f1948a]'
+                detail.code === 0 || detail.code == null ? 'text-(--dsw-ok)' : 'text-(--dsw-danger)'
               }`}
             >
               exit {detail.code ?? '—'}
             </span>
           </div>
-          <pre className="max-h-72 overflow-auto px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-[#e8eaed]">
+          <pre className="max-h-72 overflow-auto px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
             {hasOut ? <span className="whitespace-pre-wrap">{detail.stdout.replace(/\n$/, '')}</span> : null}
             {hasOut && hasErr ? '\n\n' : null}
-            {hasErr ? <span className="whitespace-pre-wrap text-[#f5b7b1]">{detail.stderr.replace(/\n$/, '')}</span> : null}
-            {!hasOut && !hasErr ? <span className="text-white/35">(empty)</span> : null}
+            {hasErr ? <span className="whitespace-pre-wrap text-(--dsw-danger)">{detail.stderr.replace(/\n$/, '')}</span> : null}
+            {!hasOut && !hasErr ? <span className="text-(--dsw-label-3)">(empty)</span> : null}
           </pre>
         </div>
         <ArtifactGallery artifacts={artifacts} />
@@ -168,8 +168,8 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
   if (parsed.kind === 'bash') {
     return (
       <div className="space-y-2">
-        <pre className="overflow-x-auto rounded-[10px] border border-(--dsw-border) bg-[#1e1f24] px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-[#e8eaed]">
-          <span className="text-[#8ab4f8]">$ </span>
+        <pre className="overflow-x-auto rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
+          <span className="text-(--dsw-label-3)">$ </span>
           {parsed.command}
         </pre>
         {formatted ? <DetailView detail={formatted} /> : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bash 命令块原先用硬编码 `#1e1f24` 背景，和 `tasks_list` 等工具的 `bg-(--dsw-tool)` 面板不一致。命令块与 bash OUTPUT 都改为 `--dsw-tool` / `--dsw-label-2`（以及主题里的 ok/danger 色），与其它工具正文对齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

