### PR TITLE
fix(inspector): 展开面包屑后去掉一级后的斜杠

### DIFF
--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -193,7 +193,7 @@ export function CrumbTrail({
         )
         return (
           <span key={crumb.id} className="fsdb-crumb">
-            {index ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
+            {index && !(lockRootCrumb && index === 1) ? <span className="fsdb-crumb-sep" aria-hidden>/</span> : null}
             <span className="fsdb-crumb-pick">
               {rootLocked ? (
                 <span className="fsdb-crumb-btn is-static" title={crumb.label} aria-label={crumb.label}>

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -238,6 +238,7 @@ test('inspector crumbs lock the first level to an icon', () => {
   assert.match(trail, /lockRootCrumb/)
   assert.match(trail, /rootLocked/)
   assert.match(trail, /fsdb-crumb-btn is-static/)
+  assert.match(trail, /lockRootCrumb && index === 1/)
   assert.doesNotMatch(browser, /lockRootCrumb/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器展开面包屑后，一级图标和二级（如「全部页面」）之间不再显示 `/`。中间顶栏面包屑分隔符不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

