### PR TITLE
fix(inspector): 移出光标后展开/关闭按钮不再占位

### DIFF
--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -49,6 +49,8 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /inspector-add-owner\$\{headerTabs\.length \? ' has-open' : ''\}/)
   assert.doesNotMatch(inspector, /添加\$\{item\.label\}/)
   assert.match(css, /\.inspector-crumb-close/)
+  assert.match(css, /\.inspector-crumb-actions\s*\{[^}]*display:\s*none/s)
+  assert.match(css, /\.inspector-crumb-tab:hover \.inspector-crumb-actions[\s\S]*display:\s*inline-flex/)
   assert.match(css, /\.inspector-crumb-full \.fsdb-crumb-btn\.is-static/)
   assert.match(css, /\.inspector-add-close/)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -685,10 +685,15 @@ body {
 }
 
 .inspector-crumb-actions {
-  display: inline-flex;
+  display: none;
   align-items: center;
   flex: none;
   margin-left: 2px;
+}
+
+.inspector-crumb-tab:hover .inspector-crumb-actions,
+.inspector-crumb-tab:focus-within .inspector-crumb-actions {
+  display: inline-flex;
 }
 
 .inspector-crumb-toggle,
@@ -705,19 +710,7 @@ body {
   background: transparent;
   box-shadow: none;
   color: var(--dsw-sidebar-fg);
-  opacity: 0;
-  pointer-events: none;
   cursor: pointer;
-}
-
-.inspector-crumb-tab:hover .inspector-crumb-toggle,
-.inspector-crumb-tab:hover .inspector-crumb-close,
-.inspector-crumb-tab.is-crumb-open .inspector-crumb-toggle,
-.inspector-crumb-tab.is-crumb-open .inspector-crumb-close,
-.inspector-crumb-tab:focus-within .inspector-crumb-toggle,
-.inspector-crumb-tab:focus-within .inspector-crumb-close {
-  opacity: 1;
-  pointer-events: auto;
 }
 
 .inspector-crumb-toggle:hover,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
检查器数据库 tab 右侧的展开/关闭按钮原先用 `opacity: 0` 隐藏，仍会占 16px 宽度。改为默认 `display: none`，只有悬停或键盘聚焦时才展开占位。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

