### PR TITLE
fix(chat): 工具卡片高亮与正文对齐 step bar

### DIFF
--- a/packages/cap-chat/src/web/tool-card.test.ts
+++ b/packages/cap-chat/src/web/tool-card.test.ts
@@ -3,9 +3,17 @@ import { resolve } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 
-test('bash command and output use the same panel tokens as json args', () => {
+test('tool panels match the step bar: sidebar fill, no border', () => {
   const source = readFileSync(resolve(import.meta.dirname, './tool-card.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.doesNotMatch(source, /#1e1f24|#e8eaed|#8ab4f8/)
-  assert.match(source, /parsed\.kind === 'bash'[\s\S]*bg-\(--dsw-tool\)[\s\S]*text-\(--dsw-label-2\)/)
-  assert.match(source, /detail\.kind === 'bash'[\s\S]*bg-\(--dsw-tool\)/)
+  assert.match(source, /parsed\.kind === 'bash'[\s\S]*bg-\(--dsw-sidebar\)[\s\S]*text-\(--dsw-label-2\)/)
+  assert.match(source, /detail\.kind === 'bash'[\s\S]*bg-\(--dsw-sidebar\)/)
+  assert.match(source, /prettyJsonString\(rawArguments\)[\s\S]*bg-\(--dsw-sidebar\)|bg-\(--dsw-sidebar\)[\s\S]*prettyJsonString/)
+  assert.equal((source.match(/border border-\(--dsw-border\)/g) || []).length, 0)
+  assert.match(css, /\.chat-step-bar\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)
+  assert.match(
+    css,
+    /\.tool-call-head:hover::before,\s*\.tool-call-head\.is-open::before\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s,
+  )
 })

--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -27,9 +27,9 @@ import {
 function DiffBlock({ lines, path }: { lines: DiffLine[]; path?: string }) {
   const stats = diffStats(lines)
   return (
-    <div className="overflow-hidden rounded-[10px] border border-(--dsw-border) bg-(--dsw-surface)">
+    <div className="overflow-hidden rounded-[10px] bg-(--dsw-sidebar)">
       {path ? (
-        <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) bg-(--dsw-tool) px-3 py-1.5">
+        <div className="flex items-center justify-between gap-2 px-3 py-1.5">
           <span className="min-w-0 truncate font-mono text-(length:--dsw-chat-ui-font-size) text-(--dsw-label-2)">{path}</span>
           <span className="shrink-0 font-mono text-(length:--dsw-chat-ui-font-size) tabular-nums text-(--dsw-label-3)">
             {stats.removed ? <span className="text-(--dsw-danger)">−{stats.removed}</span> : null}
@@ -88,8 +88,8 @@ function DetailView({ detail }: { detail: FormattedDetail }) {
     const artifacts = detail.artifacts ?? []
     return (
       <div className="space-y-2">
-        <div className="overflow-hidden rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool)">
-          <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) px-3 py-1.5">
+        <div className="overflow-hidden rounded-[10px] bg-(--dsw-sidebar)">
+          <div className="flex items-center justify-between gap-2 px-3 py-1.5">
             <span className="font-mono text-(length:--dsw-chat-ui-font-size) tracking-wide text-(--dsw-label-3) uppercase">output</span>
             <span
               className={`font-mono text-(length:--dsw-chat-ui-font-size) tabular-nums ${
@@ -113,14 +113,14 @@ function DetailView({ detail }: { detail: FormattedDetail }) {
 
   if (detail.kind === 'json') {
     return (
-      <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] bg-(--dsw-sidebar) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
         {detail.text}
       </pre>
     )
   }
 
   return (
-    <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label)">
+    <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-[10px] bg-(--dsw-sidebar) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label)">
       {detail.text}
     </pre>
   )
@@ -168,7 +168,7 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
   if (parsed.kind === 'bash') {
     return (
       <div className="space-y-2">
-        <pre className="overflow-x-auto rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
+        <pre className="overflow-x-auto rounded-[10px] bg-(--dsw-sidebar) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
           <span className="text-(--dsw-label-3)">$ </span>
           {parsed.command}
         </pre>
@@ -192,7 +192,7 @@ function ToolBody({ parsed, rawArguments, detail }: { parsed: ParsedToolCall; ra
   return (
     <div className="space-y-2">
       {rawArguments ? (
-        <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-[10px] border border-(--dsw-border) bg-(--dsw-tool) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
+        <pre className="max-h-56 overflow-auto whitespace-pre-wrap rounded-[10px] bg-(--dsw-sidebar) px-3 py-2 font-mono text-(length:--dsw-chat-ui-font-size) leading-5 text-(--dsw-label-2)">
           {prettyJsonString(rawArguments)}
         </pre>
       ) : null}

--- a/web/style.css
+++ b/web/style.css
@@ -3844,7 +3844,7 @@ body {
 
 .tool-call-head:hover::before,
 .tool-call-head.is-open::before {
-  background: var(--dsw-hover);
+  background: var(--dsw-sidebar);
 }
 
 .tool-call-toggle {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
工具调用展开/悬停高亮，以及参数/输出 `pre` 面板，统一用 `chat-step-bar` 的 `--dsw-sidebar` 背景，并去掉边框。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

