### PR TITLE
fix(chat): 工具摘要改成可读一行，不再铺 JSON

### DIFF
--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -217,7 +217,7 @@ export function ToolCard({
     [node.result?.detail, parsed.kind],
   )
   const [open, setOpen] = useState(() => shouldAutoOpenTool(parsed, node.result?.detail))
-  const summary = toolSummary(parsed, node.result?.detail?.slice(0, 80) || node.arguments.slice(0, 80) || '…')
+  const summary = toolSummary(parsed, node.result?.detail || node.arguments || '…')
   const title = toolTitle(parsed, node.name)
   const previewLines = useMemo(() => {
     if (parsed.kind !== 'str_replace' || open) return null
@@ -263,7 +263,7 @@ export function ToolCard({
             {open ? <ChevronDownIcon className="size-3.5" /> : <ChevronRightIcon className="size-3.5" />}
           </span>
           <span className="tool-call-title">{title}</span>
-          <span className="tool-call-summary">{summary}</span>
+          {open ? null : <span className="tool-call-summary">{summary}</span>}
         </button>
         <span className={status.className} title={status.label} aria-label={status.label}>
           {status.icon}

--- a/packages/cap-chat/src/web/tool-format.test.ts
+++ b/packages/cap-chat/src/web/tool-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { diffStats, formatToolDetail, lineDiff, parseToolCall, prettyJsonString, toolSummary } from './tool-format.ts'
+import { diffStats, formatToolDetail, lineDiff, parseToolCall, prettyJsonString, compactJsonSummary, toolSummary } from './tool-format.ts'
 
 test('lineDiff marks removals and additions', () => {
   const lines = lineDiff('a\nb\nc', 'a\nx\nc')
@@ -92,4 +92,17 @@ test('formatToolDetail pretty-prints generic json objects', () => {
 
 test('prettyJsonString indents objects', () => {
   assert.match(prettyJsonString('{"x":1}'), /"x": 1/)
+})
+
+test('compactJsonSummary prefers titles over raw json', () => {
+  const tasks = JSON.stringify([
+    { id: 'task_1', title: '创建五子棋插件：极光五子棋（store-gomoku-aurora）', status: 'open' },
+    { id: 'task_2', title: '第二项', status: 'open' },
+  ])
+  assert.equal(compactJsonSummary(tasks), '2 条 · 创建五子棋插件：极光五子棋（store-gomoku-aurora）')
+  assert.equal(compactJsonSummary('{"views":[{"id":"v1","name":"表格"}]}'), '表格')
+  const parsed = parseToolCall('tasks_list', tasks)
+  assert.equal(parsed.kind, 'raw')
+  assert.equal(toolSummary(parsed, tasks), '2 条 · 创建五子棋插件：极光五子棋（store-gomoku-aurora）')
+  assert.doesNotMatch(toolSummary(parsed, tasks), /\[\{/)
 })

--- a/packages/cap-chat/src/web/tool-format.ts
+++ b/packages/cap-chat/src/web/tool-format.ts
@@ -221,6 +221,64 @@ export function parseToolCall(name: string, argumentsJson: string): ParsedToolCa
   return { kind: 'raw', label: name, raw: argumentsJson }
 }
 
+function clip(text: string, max = 72): string {
+  const one = text.replace(/\s+/g, ' ').trim()
+  return one.length > max ? `${one.slice(0, max)}…` : one
+}
+
+function recordLabel(value: Record<string, unknown>): string | undefined {
+  for (const key of ['title', 'name', 'label', 'path', 'query', 'command', 'id']) {
+    const text = asString(value[key])?.trim()
+    if (text) return text
+  }
+  return undefined
+}
+
+function summarizeList(items: unknown[]): string {
+  const labels = items
+    .map((item) => (item && typeof item === 'object' && !Array.isArray(item) ? recordLabel(item as Record<string, unknown>) : typeof item === 'string' ? item : undefined))
+    .filter((item): item is string => Boolean(item))
+  const head = labels[0]
+  if (!items.length) return '空列表'
+  if (items.length === 1) return clip(head || '1 条')
+  return clip(head ? `${items.length} 条 · ${head}` : `${items.length} 条`)
+}
+
+function summarizeRecord(value: Record<string, unknown>): string {
+  for (const key of ['items', 'tasks', 'views', 'records', 'rows', 'results', 'data', 'list']) {
+    const nested = value[key]
+    if (Array.isArray(nested)) return summarizeList(nested)
+  }
+  const parts: string[] = []
+  for (const key of Object.keys(value)) {
+    if (parts.length >= 3) break
+    const nested = value[key]
+    if (nested == null || nested === '') continue
+    if (typeof nested === 'string' || typeof nested === 'number' || typeof nested === 'boolean') {
+      parts.push(`${key} ${nested}`)
+      continue
+    }
+    if (Array.isArray(nested)) {
+      parts.push(summarizeList(nested))
+      continue
+    }
+    if (typeof nested === 'object') {
+      const label = recordLabel(nested as Record<string, unknown>)
+      if (label) parts.push(label)
+    }
+  }
+  return parts.length ? clip(parts.join(' · ')) : ''
+}
+
+/** 把 JSON 参数/结果收成一行可读摘要，避免把花括号铺在标题旁。 */
+export function compactJsonSummary(raw: string): string {
+  const parsed = parseJsonValue(raw.trim())
+  if (parsed === undefined) return clip(raw)
+  if (Array.isArray(parsed)) return summarizeList(parsed)
+  if (parsed && typeof parsed === 'object') return summarizeRecord(parsed as Record<string, unknown>)
+  return clip(String(parsed))
+}
+
 export function toolSummary(parsed: ParsedToolCall, fallback: string): string {
   switch (parsed.kind) {
     case 'str_replace':
@@ -235,10 +293,10 @@ export function toolSummary(parsed: ParsedToolCall, fallback: string): string {
         : `View ${parsed.path}`
     case 'bash': {
       const one = parsed.command.replace(/\s+/g, ' ').trim()
-      return one.length > 72 ? `${one.slice(0, 72)}…` : one || fallback
+      return one.length > 72 ? `${one.slice(0, 72)}…` : one || compactJsonSummary(fallback)
     }
     case 'raw':
-      return fallback
+      return compactJsonSummary(fallback) || '…'
   }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -3887,8 +3887,8 @@ body {
   min-width: 0;
   flex: 1;
   overflow: hidden;
-  font-family: var(--font-mono);
   font-size: var(--dsw-chat-ui-font-size);
+  font-weight: 500;
   color: var(--dsw-label-3);
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
折叠态的工具行不再把原始 JSON 铺在标题旁，而是收成「N 条 · 标题」这样的一行摘要。展开后完整参数/结果仍在正文里，标题行不再重复那段噪声。摘要改用界面字体，不用等宽。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

