### PR TITLE
feat(chat): 右侧消息大纲（Notion 风格）

### DIFF
--- a/packages/cap-chat/src/web/index.test.ts
+++ b/packages/cap-chat/src/web/index.test.ts
@@ -25,6 +25,7 @@ test('one plugin fills thread, trajectory, composer and approvals dock', async (
   await ctx.plugin(shell)
   assert.equal(ctx.slots.list('composer')[0]?.id, 'chat')
   assert.equal(ctx.slots.list('stage').some((item) => item.id === 'chat-thread'), true)
+  assert.equal(ctx.slots.list('stage-aside').some((item) => item.id === 'chat-outline'), true)
   assert.equal(ctx.slots.list('trajectory').some((item) => item.id === 'trajectory'), true)
   assert.equal(ctx.slots.list('project').length, 0)
   assert.equal(ctx.slots.list('dock').some((item) => item.id === 'approvals'), true)

--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -8,6 +8,7 @@ import { ChatComposer } from './composer.tsx'
 import { ChatConfigBanner } from './config-banner.tsx'
 import { ChatLiveHud } from './live-hud.tsx'
 import { ChatThread } from './thread.tsx'
+import { ChatMessageOutline } from './message-outline.tsx'
 import { TrajectoryView } from './trajectory.tsx'
 import { UsagePanel } from './usage-panel.tsx'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
@@ -49,6 +50,7 @@ export function apply(ctx: Context) {
   }
   const props = () => slotProps
   ctx.slots.place('stage', ChatThread, { key: 'chat-thread', order: 1, props })
+  ctx.slots.place('stage-aside', ChatMessageOutline, { key: 'chat-outline', order: 1, props })
   ctx.slots.place('trajectory', TrajectoryView, { key: 'trajectory', order: 1, props })
   ctx.slots.place('composer', ChatComposer, {
     key: 'chat',

--- a/packages/cap-chat/src/web/message-outline.tsx
+++ b/packages/cap-chat/src/web/message-outline.tsx
@@ -1,0 +1,88 @@
+import { memo, useMemo, useSyncExternalStore } from 'react'
+import {
+  bindSessionView,
+  deriveChatOutline,
+  getChatOutlineFilter,
+  getChatOutlineOpen,
+  requestChatOutlineGo,
+  setChatOutlineOpen,
+  subscribeChatOutline,
+  type ChatOutlineFilter,
+  type SessionViewService,
+} from '@biu/web-session-view'
+
+function OutlineGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden className={className}>
+      <rect x="1.25" y="3.4" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
+      <rect x="1.25" y="7.15" width="13.5" height="1.7" rx="0.85" fill="currentColor" />
+      <rect x="1.25" y="10.9" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
+    </svg>
+  )
+}
+
+export const ChatMessageOutline = memo(function ChatMessageOutline({
+  useSessionView,
+}: {
+  useSessionView: ReturnType<typeof bindSessionView>
+  sessionView?: SessionViewService
+}) {
+  const nodes = useSessionView((state) => state.nodes)
+  const open = useSyncExternalStore(subscribeChatOutline, getChatOutlineOpen, () => true)
+  const filter = useSyncExternalStore(subscribeChatOutline, getChatOutlineFilter, (): ChatOutlineFilter => 'user')
+  const items = useMemo(() => deriveChatOutline(nodes, filter), [nodes, filter])
+
+  if (!open) {
+    return (
+      <aside className="chat-outline is-collapsed" aria-label="消息大纲">
+        <button
+          type="button"
+          className="chat-outline-fab"
+          title="打开消息大纲"
+          aria-label="打开消息大纲"
+          data-testid="chat-outline-open"
+          onClick={() => setChatOutlineOpen(true)}
+        >
+          <OutlineGlyph className="size-4" />
+        </button>
+      </aside>
+    )
+  }
+
+  return (
+    <aside className="chat-outline" aria-label="消息大纲" data-testid="chat-outline">
+      <div className="chat-outline-head">
+        <span className="chat-outline-title">消息</span>
+        <button
+          type="button"
+          className="chat-outline-icon-btn"
+          title="收起消息大纲"
+          aria-label="收起消息大纲"
+          data-testid="chat-outline-close"
+          onClick={() => setChatOutlineOpen(false)}
+        >
+          <OutlineGlyph className="size-3.5" />
+        </button>
+      </div>
+      <nav className="chat-outline-list">
+        {items.length ? (
+          items.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={`chat-outline-item${item.robot ? ' is-robot' : ''}`}
+              title={item.text}
+              data-testid={`chat-outline-item-${item.id}`}
+              onClick={() => requestChatOutlineGo(item.id)}
+            >
+              <span className="chat-outline-dot" aria-hidden />
+              <span className="chat-outline-label">{item.text}</span>
+            </button>
+          ))
+        ) : (
+          <div className="chat-outline-empty">还没有消息</div>
+        )}
+      </nav>
+    </aside>
+  )
+})

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -19,6 +19,7 @@ import {
 } from '@heroicons/react/16/solid'
 import { ImageThumbs } from './image-thumbs.tsx'
 import { bindSessionView, type SessionListItem, type SessionViewService } from '@biu/web-session-view'
+import { nodeIdFromOutlineEvent } from '@biu/web-session-view'
 import {
   formatTokens,
   type ChatNode,
@@ -48,6 +49,7 @@ import {
   revealStartForMemory,
   shouldRevealFast,
   sliceTurnsFrom,
+  turnIndexContaining,
 } from './thread-reveal.ts'
 
 export { groupNodesIntoTurns } from './thread-reveal.ts'
@@ -789,6 +791,30 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       navigate(`/s/${id}`)
     })
   }, [sessionView, navigate])
+
+  const outlineTargetRef = useRef<string | null>(null)
+  useEffect(() => {
+    const onGo = (event: Event) => {
+      const id = nodeIdFromOutlineEvent(event)
+      if (!id) return
+      const idx = turnIndexContaining(nodes, id)
+      if (idx < 0) return
+      outlineTargetRef.current = id
+      setRevealStart((start) => Math.min(start, idx))
+    }
+    window.addEventListener('biu:chat-outline-go', onGo)
+    return () => window.removeEventListener('biu:chat-outline-go', onGo)
+  }, [nodes])
+
+  useLayoutEffect(() => {
+    const id = outlineTargetRef.current
+    if (!id) return
+    const escaped = typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(id) : id
+    const el = document.querySelector<HTMLElement>(`[data-node-id="${escaped}"]`)
+    if (!el) return
+    outlineTargetRef.current = null
+    el.scrollIntoView({ block: 'start', behavior: 'smooth' })
+  }, [mountedNodes, revealStart])
 
   useLayoutEffect(() => {
     const parent = findScrollParent(rootRef.current)

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -25,6 +25,7 @@ test('declares generic module slots, not plugin ids', async () => {
   assert.equal(ctx.slots.specOf('app-modules')?.kind, 'list')
   assert.equal(ctx.slots.specOf('inspector-panels')?.kind, 'list')
   assert.equal(ctx.slots.specOf('header-tools')?.kind, 'list')
+  assert.equal(ctx.slots.specOf('stage-aside')?.kind, 'single')
   assert.equal(ctx.slots.specOf('corner-tools')?.kind, 'list')
   assert.equal(ctx.slots.specOf('root-overlays')?.kind, 'list')
   assert.equal(ctx.slots.specOf('tasks'), undefined)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -19,6 +19,7 @@ import type { Context } from 'cordis'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSnapshot, type SnapshotService } from '@biu/web-snapshot'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
+import { getChatOutlineOpen, setChatOutlineOpen, subscribeChatOutline } from '@biu/web-session-view'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 import { parseAppPath } from '@biu/web-session-view'
 import {
@@ -184,12 +185,13 @@ const AgentMainPanels = memo(function AgentMainPanels({
         data-testid="agent-center"
       >
         <div className="absolute inset-0 z-1 flex min-h-0 overflow-hidden">
-          <div className="relative flex min-h-0 w-full flex-1 flex-col overflow-hidden">
+          <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {centerStage}
             <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-4 md:px-8 lg:px-10">
               {centerDock}
             </div>
           </div>
+          {renderSlot('stage-aside')}
         </div>
       </div>
       {overlayNode}
@@ -268,6 +270,7 @@ function Shell(props: SlotProps) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string>('plugins')
   const [configOpen, setConfigOpen] = useState(false)
+  const outlineOpen = useSyncExternalStore(subscribeChatOutline, getChatOutlineOpen, () => true)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     try {
       return localStorage.getItem('cordis.sidebar.collapsed') === '1'
@@ -556,6 +559,21 @@ function Shell(props: SlotProps) {
       <div className="chat-view-header-right">
         <button
           type="button"
+          className={`chat-view-header-expand${outlineOpen ? ' is-active' : ''}`}
+          title={outlineOpen ? '收起消息大纲' : '打开消息大纲'}
+          aria-label={outlineOpen ? '收起消息大纲' : '打开消息大纲'}
+          aria-pressed={outlineOpen}
+          data-testid="header-outline-toggle"
+          onClick={() => setChatOutlineOpen(!outlineOpen)}
+        >
+          <svg viewBox="0 0 16 16" fill="none" aria-hidden className="size-4 shrink-0">
+            <rect x="1.25" y="3.4" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
+            <rect x="1.25" y="7.15" width="13.5" height="1.7" rx="0.85" fill="currentColor" />
+            <rect x="1.25" y="10.9" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
+          </svg>
+        </button>
+        <button
+          type="button"
           className="chat-view-header-expand"
           title="配置"
           aria-label="配置"
@@ -788,6 +806,7 @@ export function apply(ctx: Context) {
       demos: { kind: 'list' },
       dock: { kind: 'list' },
       stage: { kind: 'list' },
+      'stage-aside': { kind: 'single' },
       trajectory: { kind: 'list' },
       project: { kind: 'single' },
       composer: { kind: 'single' },

--- a/packages/web-session-view/src/web/chat-outline-fields.tsx
+++ b/packages/web-session-view/src/web/chat-outline-fields.tsx
@@ -1,0 +1,34 @@
+import { memo, useSyncExternalStore } from 'react'
+import {
+  getChatOutlineFilter,
+  setChatOutlineFilter,
+  subscribeChatOutline,
+  type ChatOutlineFilter,
+} from './chat-outline.ts'
+
+export const ChatOutlineFilterFields = memo(function ChatOutlineFilterFields() {
+  const filter = useSyncExternalStore(subscribeChatOutline, getChatOutlineFilter, (): ChatOutlineFilter => 'user')
+  return (
+    <fieldset className="m-0 flex flex-col gap-1.5 border-0 p-0" data-testid="chat-outline-filter">
+      <legend className="mb-1 text-[11px] text-(--dsw-label-3)">消息大纲</legend>
+      <label className="flex items-center gap-2 text-[12px] text-(--dsw-label-2)">
+        <input
+          type="radio"
+          name="chat-outline-filter"
+          checked={filter === 'user'}
+          onChange={() => setChatOutlineFilter('user')}
+        />
+        只显示我发的消息
+      </label>
+      <label className="flex items-center gap-2 text-[12px] text-(--dsw-label-2)">
+        <input
+          type="radio"
+          name="chat-outline-filter"
+          checked={filter === 'all'}
+          onChange={() => setChatOutlineFilter('all')}
+        />
+        显示全部消息（含机器人主动发出的）
+      </label>
+    </fieldset>
+  )
+})

--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { deriveChatOutline, type ChatNode } from './index.ts'
+
+function user(id: string, text: string, sender?: Extract<ChatNode, { kind: 'user' }>['sender']): ChatNode {
+  return { id, kind: 'user', text, ...(sender ? { sender } : {}) }
+}
+
+test('deriveChatOutline can hide robot-initiated user nodes', () => {
+  const nodes: ChatNode[] = [
+    user('u-1', 'hello from me'),
+    { id: 'r-1', kind: 'reply', parts: [], copyText: 'ok' },
+    user('u-2', 'wake from live', { type: 'session', sessionId: 's-live' }),
+    user('u-3', 'another human'),
+  ]
+  assert.deepEqual(
+    deriveChatOutline(nodes, 'user').map((item) => item.id),
+    ['u-1', 'u-3'],
+  )
+  assert.deepEqual(
+    deriveChatOutline(nodes, 'all').map((item) => [item.id, item.robot]),
+    [
+      ['u-1', false],
+      ['u-2', true],
+      ['u-3', false],
+    ],
+  )
+})

--- a/packages/web-session-view/src/web/chat-outline.ts
+++ b/packages/web-session-view/src/web/chat-outline.ts
@@ -1,0 +1,91 @@
+import type { ChatNode } from './session-project.ts'
+
+export type ChatOutlineFilter = 'user' | 'all'
+
+export type ChatOutlineItem = {
+  id: string
+  text: string
+  robot: boolean
+}
+
+const OPEN_KEY = 'cordis.chatOutline.open'
+const FILTER_KEY = 'cordis.chatOutline.filter'
+
+const outlineListeners = new Set<() => void>()
+
+function emitOutlineChange() {
+  for (const fn of outlineListeners) fn()
+}
+
+export function subscribeChatOutline(fn: () => void) {
+  outlineListeners.add(fn)
+  return () => {
+    outlineListeners.delete(fn)
+  }
+}
+
+export function getChatOutlineOpen(): boolean {
+  try {
+    const raw = localStorage.getItem(OPEN_KEY)
+    if (raw == null) return true
+    return raw !== '0'
+  } catch {
+    return true
+  }
+}
+
+export function setChatOutlineOpen(open: boolean) {
+  try {
+    localStorage.setItem(OPEN_KEY, open ? '1' : '0')
+  } catch {
+    /* ignore */
+  }
+  emitOutlineChange()
+}
+
+export function getChatOutlineFilter(): ChatOutlineFilter {
+  try {
+    return localStorage.getItem(FILTER_KEY) === 'all' ? 'all' : 'user'
+  } catch {
+    return 'user'
+  }
+}
+
+export function setChatOutlineFilter(filter: ChatOutlineFilter) {
+  try {
+    localStorage.setItem(FILTER_KEY, filter)
+  } catch {
+    /* ignore */
+  }
+  emitOutlineChange()
+}
+
+export function outlinePreview(text: string, max = 48): string {
+  const one = text.replace(/\s+/g, ' ').trim()
+  if (!one) return '空消息'
+  return one.length > max ? `${one.slice(0, max)}…` : one
+}
+
+export function isHumanUserNode(node: Extract<ChatNode, { kind: 'user' }>): boolean {
+  return !node.sender || node.sender.type === 'user'
+}
+
+export function deriveChatOutline(nodes: ChatNode[], filter: ChatOutlineFilter): ChatOutlineItem[] {
+  const items: ChatOutlineItem[] = []
+  for (const node of nodes) {
+    if (node.kind !== 'user') continue
+    const robot = !isHumanUserNode(node)
+    if (filter === 'user' && robot) continue
+    items.push({ id: node.id, text: outlinePreview(node.text), robot })
+  }
+  return items
+}
+
+export function requestChatOutlineGo(nodeId: string) {
+  window.dispatchEvent(new CustomEvent('biu:chat-outline-go', { detail: { nodeId } }))
+}
+
+export function nodeIdFromOutlineEvent(event: Event): string | undefined {
+  const detail = (event as CustomEvent<{ nodeId?: unknown }>).detail
+  return typeof detail?.nodeId === 'string' && detail.nodeId ? detail.nodeId : undefined
+}

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -58,6 +58,18 @@ export {
 } from './session-groups.ts'
 export { useSidebarCollapseStore } from './sidebar-collapse-store.ts'
 export {
+  subscribeChatOutline,
+  getChatOutlineOpen,
+  setChatOutlineOpen,
+  getChatOutlineFilter,
+  setChatOutlineFilter,
+  deriveChatOutline,
+  requestChatOutlineGo,
+  nodeIdFromOutlineEvent,
+  type ChatOutlineFilter,
+  type ChatOutlineItem,
+} from './chat-outline.ts'
+export {
   SIDEBAR_MASCOT_INTRO_MS,
   markSidebarMascotFresh,
   remainingSidebarMascotIntroMs,

--- a/packages/web-session-view/src/web/session-config-dialog.tsx
+++ b/packages/web-session-view/src/web/session-config-dialog.tsx
@@ -4,6 +4,7 @@ import {
   bindSessionView,
   type SessionViewService,
 } from './index.ts'
+import { ChatOutlineFilterFields } from './chat-outline-fields.tsx'
 
 type ToolSourceId = 'minimal' | 'live' | 'plugin' | 'store'
 type AgentMode = 'standard' | 'minimal' | 'create'
@@ -174,6 +175,8 @@ export const SessionConfigDialog = memo(function SessionConfigDialog({
               <p className="m-0 text-[11px] leading-[1.45] text-(--dsw-label-3)">
                 名称、提示词和工具只作用于当前 session；未改的字段沿用全局默认。
               </p>
+
+              <ChatOutlineFilterFields />
 
               <label className="flex flex-col gap-1 text-[11px] text-(--dsw-label-3)">
                 <span>名称</span>

--- a/web/style.css
+++ b/web/style.css
@@ -3672,6 +3672,119 @@ body {
   max-width: var(--dsw-chat-max-width);
 }
 
+.chat-outline {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  width: 196px;
+  min-width: 196px;
+  min-height: 0;
+  border-left: 1px solid color-mix(in srgb, var(--dsw-border) 70%, transparent);
+  background: var(--dsw-sidebar);
+  color: var(--dsw-sidebar-fg);
+}
+
+.chat-outline.is-collapsed {
+  width: 36px;
+  min-width: 36px;
+  align-items: center;
+  padding-top: 10px;
+  background: transparent;
+  border-left: 0;
+}
+
+.chat-outline-fab,
+.chat-outline-icon-btn {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--dsw-sidebar) 88%, #000);
+  color: var(--dsw-sidebar-fg);
+  cursor: pointer;
+}
+
+.chat-outline-fab:hover,
+.chat-outline-icon-btn:hover {
+  color: var(--dsw-sidebar-fg-active);
+  background: var(--dsw-hover);
+}
+
+.chat-outline-head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 10px 6px;
+}
+
+.chat-outline-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--dsw-sidebar-fg-active);
+}
+
+.chat-outline-list {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+  padding: 4px 8px 16px;
+}
+
+.chat-outline-item {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  padding: 4px 8px;
+  color: var(--dsw-sidebar-fg);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: left;
+  cursor: pointer;
+}
+
+.chat-outline-item:hover {
+  background: var(--dsw-hover);
+  color: var(--dsw-sidebar-fg-active);
+}
+
+.chat-outline-item.is-robot {
+  opacity: 0.78;
+}
+
+.chat-outline-dot {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.45;
+}
+
+.chat-outline-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-outline-empty {
+  padding: 8px;
+  color: var(--dsw-label-3);
+  font-size: 12px;
+}
+
 /* 折叠靠 hidden，不卸载，展开不再重建 Markdown/工具 DOM */
 .chat-reply-details {
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在对话主区右侧增加 Notion 风格消息大纲，从当前 session 的 `user` 节点派生。默认只列出真人发送的消息；配置页可改为显示全部（含 Live/机器人主动写入的 user 节点）。点击条目会滚到对应气泡。不占用检查器列。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

