### PR TITLE
fix(chat): 压暗展开的 Details，和最终回复区分

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -3799,11 +3799,52 @@ body {
   font-size: 12px;
 }
 
-/* 折叠靠 hidden，不卸载，展开不再重建 Markdown/工具 DOM */
+/* 折叠靠 hidden，不卸载，展开不再重建 Markdown/工具 DOM。
+   色比最终回复暗一档，避免 Details 和最后一条正文抢对比度。 */
 .chat-reply-details {
   display: flex;
   flex-direction: column;
   gap: var(--dsw-chat-gap);
+  color: var(--dsw-label-2);
+}
+
+.chat-reply-details .chat-md,
+.chat-reply-details .chat-md-stream-pre,
+.chat-reply-details .chat-md p,
+.chat-reply-details .chat-md li,
+.chat-reply-details .chat-md h1,
+.chat-reply-details .chat-md h2,
+.chat-reply-details .chat-md h3,
+.chat-reply-details .chat-md h4,
+.chat-reply-details .chat-md code,
+.chat-reply-details .chat-md pre,
+.chat-reply-details .chat-md pre code {
+  color: var(--dsw-label-2);
+}
+
+.chat-reply-details .chat-md a {
+  color: var(--dsw-label-2);
+}
+
+.chat-reply-details .chat-step-bar {
+  background: color-mix(in srgb, var(--dsw-sidebar) 42%, var(--dsw-bg));
+}
+
+.chat-reply-details .chat-reply-meta,
+.chat-reply-details .chat-reply-meta-item,
+.chat-reply-details .chat-reply-meta-icon {
+  color: var(--dsw-label-3);
+}
+
+.chat-reply-details .tool-call,
+.chat-reply-details .tool-call-head,
+.chat-reply-details .tool-call-toggle {
+  color: var(--dsw-label-2);
+}
+
+.chat-reply-details .tool-call-head:hover::before,
+.chat-reply-details .tool-call-head.is-open::before {
+  background: color-mix(in srgb, var(--dsw-sidebar) 42%, var(--dsw-bg));
 }
 
 .chat-reply-details[hidden] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
展开 Details 时，中间步骤、工具摘要、过渡文案用 `--dsw-label-2` / `--dsw-label-3` 和更暗的 step bar，最终一条 assistant 回复仍用 `--dsw-label` 高对比。

只改 `.chat-reply-details` 及其内部，不影响折叠态和最终正文。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

