### PR TITLE
fix(chat): 消息大纲改为居中触发的悬浮面板

### DIFF
--- a/packages/cap-chat/src/web/message-outline.tsx
+++ b/packages/cap-chat/src/web/message-outline.tsx
@@ -1,11 +1,9 @@
-import { memo, useMemo, useSyncExternalStore } from 'react'
+import { memo, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import {
   bindSessionView,
   deriveChatOutline,
   getChatOutlineFilter,
-  getChatOutlineOpen,
   requestChatOutlineGo,
-  setChatOutlineOpen,
   subscribeChatOutline,
   type ChatOutlineFilter,
   type SessionViewService,
@@ -28,61 +26,59 @@ export const ChatMessageOutline = memo(function ChatMessageOutline({
   sessionView?: SessionViewService
 }) {
   const nodes = useSessionView((state) => state.nodes)
-  const open = useSyncExternalStore(subscribeChatOutline, getChatOutlineOpen, () => true)
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLElement>(null)
   const filter = useSyncExternalStore(subscribeChatOutline, getChatOutlineFilter, (): ChatOutlineFilter => 'user')
   const items = useMemo(() => deriveChatOutline(nodes, filter), [nodes, filter])
 
-  if (!open) {
-    return (
-      <aside className="chat-outline is-collapsed" aria-label="消息大纲">
-        <button
-          type="button"
-          className="chat-outline-fab"
-          title="打开消息大纲"
-          aria-label="打开消息大纲"
-          data-testid="chat-outline-open"
-          onClick={() => setChatOutlineOpen(true)}
-        >
-          <OutlineGlyph className="size-4" />
-        </button>
-      </aside>
-    )
-  }
+  useEffect(() => {
+    if (!open) return
+    function onPointer(event: MouseEvent) {
+      const target = event.target as Node
+      if (rootRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', onPointer)
+    return () => document.removeEventListener('mousedown', onPointer)
+  }, [open])
 
   return (
-    <aside className="chat-outline" aria-label="消息大纲" data-testid="chat-outline">
-      <div className="chat-outline-head">
-        <span className="chat-outline-title">消息</span>
-        <button
-          type="button"
-          className="chat-outline-icon-btn"
-          title="收起消息大纲"
-          aria-label="收起消息大纲"
-          data-testid="chat-outline-close"
-          onClick={() => setChatOutlineOpen(false)}
-        >
-          <OutlineGlyph className="size-3.5" />
-        </button>
-      </div>
-      <nav className="chat-outline-list">
-        {items.length ? (
-          items.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              className={`chat-outline-item${item.robot ? ' is-robot' : ''}`}
-              title={item.text}
-              data-testid={`chat-outline-item-${item.id}`}
-              onClick={() => requestChatOutlineGo(item.id)}
-            >
-              <span className="chat-outline-dot" aria-hidden />
-              <span className="chat-outline-label">{item.text}</span>
-            </button>
-          ))
-        ) : (
-          <div className="chat-outline-empty">还没有消息</div>
-        )}
-      </nav>
+    <aside className="chat-outline" aria-label="消息大纲" ref={rootRef}>
+      <button
+        type="button"
+        className={`chat-outline-icon-btn${open ? ' is-open' : ''}`}
+        title={open ? '收起消息大纲' : '打开消息大纲'}
+        aria-label={open ? '收起消息大纲' : '打开消息大纲'}
+        aria-expanded={open}
+        data-testid="chat-outline-toggle"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <OutlineGlyph className="size-4" />
+      </button>
+      {open ? (
+        <nav className="chat-outline-panel" data-testid="chat-outline">
+          {items.length ? (
+            items.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className={`chat-outline-item${item.robot ? ' is-robot' : ''}`}
+                title={item.text}
+                data-testid={`chat-outline-item-${item.id}`}
+                onClick={() => {
+                  requestChatOutlineGo(item.id)
+                  setOpen(false)
+                }}
+              >
+                <span className="chat-outline-dot" aria-hidden />
+                <span className="chat-outline-label">{item.text}</span>
+              </button>
+            ))
+          ) : (
+            <div className="chat-outline-empty">还没有消息</div>
+          )}
+        </nav>
+      ) : null}
     </aside>
   )
 })

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -19,7 +19,6 @@ import type { Context } from 'cordis'
 import type { SlotProps } from '@biu/web-slots'
 import { bindSnapshot, type SnapshotService } from '@biu/web-snapshot'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
-import { getChatOutlineOpen, setChatOutlineOpen, subscribeChatOutline } from '@biu/web-session-view'
 import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 import { parseAppPath } from '@biu/web-session-view'
 import {
@@ -190,8 +189,8 @@ const AgentMainPanels = memo(function AgentMainPanels({
             <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-4 md:px-8 lg:px-10">
               {centerDock}
             </div>
+            {renderSlot('stage-aside')}
           </div>
-          {renderSlot('stage-aside')}
         </div>
       </div>
       {overlayNode}
@@ -270,7 +269,6 @@ function Shell(props: SlotProps) {
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsTab, setSettingsTab] = useState<string>('plugins')
   const [configOpen, setConfigOpen] = useState(false)
-  const outlineOpen = useSyncExternalStore(subscribeChatOutline, getChatOutlineOpen, () => true)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     try {
       return localStorage.getItem('cordis.sidebar.collapsed') === '1'
@@ -557,21 +555,6 @@ function Shell(props: SlotProps) {
       </div>
       <ChatSessionTitle useSessionView={useSessionView} sessionView={sessionView} />
       <div className="chat-view-header-right">
-        <button
-          type="button"
-          className={`chat-view-header-expand${outlineOpen ? ' is-active' : ''}`}
-          title={outlineOpen ? '收起消息大纲' : '打开消息大纲'}
-          aria-label={outlineOpen ? '收起消息大纲' : '打开消息大纲'}
-          aria-pressed={outlineOpen}
-          data-testid="header-outline-toggle"
-          onClick={() => setChatOutlineOpen(!outlineOpen)}
-        >
-          <svg viewBox="0 0 16 16" fill="none" aria-hidden className="size-4 shrink-0">
-            <rect x="1.25" y="3.4" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
-            <rect x="1.25" y="7.15" width="13.5" height="1.7" rx="0.85" fill="currentColor" />
-            <rect x="1.25" y="10.9" width="13.5" height="1.7" rx="0.85" fill="currentColor" opacity="0.38" />
-          </svg>
-        </button>
         <button
           type="button"
           className="chat-view-header-expand"

--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -1,5 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { deriveChatOutline, type ChatNode } from './index.ts'
 
 function user(id: string, text: string, sender?: Extract<ChatNode, { kind: 'user' }>['sender']): ChatNode {
@@ -25,4 +27,17 @@ test('deriveChatOutline can hide robot-initiated user nodes', () => {
       ['u-3', false],
     ],
   )
+})
+
+test('message outline floats beside a centered trigger', () => {
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  const outline = readFileSync(resolve(import.meta.dirname, '../../../cap-chat/src/web/message-outline.tsx'), 'utf8')
+  const shell = readFileSync(resolve(import.meta.dirname, '../../../web-app-shell/src/web/index.tsx'), 'utf8')
+  assert.match(css, /\.chat-outline\s*\{[^}]*position:\s*absolute/s)
+  assert.match(css, /\.chat-outline\s*\{[^}]*top:\s*50%/s)
+  assert.match(css, /\.chat-outline-panel\s*\{[^}]*position:\s*absolute/s)
+  assert.doesNotMatch(css, /min-width:\s*196px/)
+  assert.match(outline, /chat-outline-toggle/)
+  assert.doesNotMatch(outline, /chat-outline-title/)
+  assert.doesNotMatch(shell, /header-outline-toggle/)
 })

--- a/packages/web-session-view/src/web/chat-outline.ts
+++ b/packages/web-session-view/src/web/chat-outline.ts
@@ -26,11 +26,9 @@ export function subscribeChatOutline(fn: () => void) {
 
 export function getChatOutlineOpen(): boolean {
   try {
-    const raw = localStorage.getItem(OPEN_KEY)
-    if (raw == null) return true
-    return raw !== '0'
+    return localStorage.getItem(OPEN_KEY) === '1'
   } catch {
-    return true
+    return false
   }
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -3687,28 +3687,18 @@ body {
 }
 
 .chat-outline {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  z-index: 8;
   display: flex;
-  flex: none;
-  flex-direction: column;
-  width: 196px;
-  min-width: 196px;
-  min-height: 0;
-  border-left: 1px solid color-mix(in srgb, var(--dsw-border) 70%, transparent);
-  background: var(--dsw-sidebar);
-  color: var(--dsw-sidebar-fg);
-}
-
-.chat-outline.is-collapsed {
-  width: 36px;
-  min-width: 36px;
   align-items: center;
-  padding-top: 10px;
-  background: transparent;
-  border-left: 0;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
-.chat-outline-fab,
 .chat-outline-icon-btn {
+  pointer-events: auto;
   display: grid;
   place-items: center;
   width: 28px;
@@ -3721,32 +3711,30 @@ body {
   cursor: pointer;
 }
 
-.chat-outline-fab:hover,
-.chat-outline-icon-btn:hover {
+.chat-outline-icon-btn:hover,
+.chat-outline-icon-btn.is-open {
   color: var(--dsw-sidebar-fg-active);
   background: var(--dsw-hover);
 }
 
-.chat-outline-head {
+.chat-outline-panel {
+  pointer-events: auto;
+  position: absolute;
+  right: 36px;
+  top: 50%;
+  z-index: 9;
   display: flex;
-  flex: none;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px 10px 6px;
-}
-
-.chat-outline-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--dsw-sidebar-fg-active);
-}
-
-.chat-outline-list {
-  min-height: 0;
-  flex: 1;
+  flex-direction: column;
+  width: 220px;
+  max-height: min(72vh, 520px);
   overflow: auto;
-  padding: 4px 8px 16px;
+  transform: translateY(-50%);
+  border: 1px solid var(--dsw-border);
+  border-radius: 10px;
+  background: var(--dsw-sidebar);
+  padding: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  color: var(--dsw-sidebar-fg);
 }
 
 .chat-outline-item {
@@ -3759,7 +3747,7 @@ body {
   border: 0;
   border-radius: 6px;
   background: transparent;
-  padding: 4px 8px;
+  padding: 6px 8px;
   color: var(--dsw-sidebar-fg);
   font-size: 13px;
   font-weight: 500;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天窗不再占一条固定「消息」侧栏。默认只在舞台右侧垂直居中放三条横线按钮；点开后是悬浮列表，点外面或跳转后关闭。顶栏重复的大纲按钮已去掉。Details 压暗样式保持不动。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

