### PR TITLE
docs(plugins): 工具说明写清 shellWidth，不要读 listing.shell

### DIFF
--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -91,7 +91,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       route: '/plugins',
       title: '插件',
       inspector: true,
-      blurb: '.plugin 已安装与 .plugin-dev 沙箱同一张表：没有的字段留空。',
+      blurb: '.plugin 已安装与 .plugin-dev 沙箱同一张表：没有的字段留空。窗口尺寸来自扁平列 shellWidth/shellHeight，不是 listing.shell。',
       order: 30,
       icon: 'puzzle-piece',
     },

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -196,9 +196,11 @@ test('pack bundles relative imports from sandbox', async () => {
 test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   const ctx = new Context()
   const names: string[] = []
-  ;(ctx as unknown as { tools: { register: (spec: { name: string }) => void } }).tools = {
+  const descriptions: string[] = []
+  ;(ctx as unknown as { tools: { register: (spec: { name: string; description?: string }) => void } }).tools = {
     register(spec) {
       names.push(spec.name)
+      if (spec.description) descriptions.push(spec.description)
     },
   }
   const store = new PluginStoreService(
@@ -209,6 +211,9 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   )
   registerPluginCreate(ctx, store)
   assert.deepEqual(names, ['plugin_create', 'plugin_sandbox', 'plugin_pack'])
+  assert.match(descriptions.join('\n'), /storeShellFromRecord/)
+  assert.match(descriptions.join('\n'), /listing\.shell/)
+  assert.match(descriptions.join('\n'), /shellWidth/)
 })
 
 test('compileStoreModule strips TypeScript in-process', async () => {

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -139,7 +139,8 @@ export async function readSandboxManifest(dir: string) {
 const CONTRACT = [
   '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。不要改 packages/ 或 cordis.plugins.json。',
   'Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选，不传则 Dock 用默认拼图图标。运行窗口会给 extras 套 macOS 窗口框（关/缩/全屏），key 尽量用插件 id。',
-  '有 web 时必须显式写 shell.width 与 shell.height（内容区像素）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
+  '有 web 时必须在 manifest / 本工具 shell 参数里写 width 与 height（内容区像素）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
+  '/plugins 列表没有 listing.shell 对象，只有扁平字段 shellWidth、shellHeight、shellMinWidth、shellMinHeight、shellResizable。运行窗口必须用 storeShellFromRecord 读这些字段，禁止再读 listing.shell（undefined 会落到默认 480×360，操作栏会离开卡片）。',
 ].join(' ')
 
 const PLUGIN_CREATE_DESCRIPTION = [
@@ -190,7 +191,7 @@ const ID_NAME_BLURB = {
   authorUrl: { type: 'string', description: '作者主页 / 仓库链接' },
   shell: {
     type: 'object',
-    description: '有 web 时必填。运行窗口内容区像素。必须给 width 和 height。',
+      description: '有 web 时必填。运行窗口内容区像素，对应 manifest.shell。必须给 width 和 height。/plugins 表里会拆成 shellWidth/shellHeight，窗口用 storeShellFromRecord 读取，不要读 listing.shell。',
     properties: {
       width: { type: 'number', description: '内容区宽，必填' },
       height: { type: 'number', description: '内容区高，必填' },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
改 `plugin_create` / `plugin_sandbox` 工具说明和插件表 blurb：写插件仍用 `manifest.shell.width/height`；`/plugins` 列表只有扁平的 `shellWidth` 等字段，运行窗口必须用 `storeShellFromRecord`，不要读 `listing.shell`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

