### PR TITLE
Lighten selected fill on glass chat popovers

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -44,6 +44,10 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.match(css, /\.brand-agent-menu\s*\{[^}]*width:\s*320px/s)
   assert.match(css, /\.brand-agent-menu\s*\{[^}]*border:\s*0/s)
   assert.match(css, /\.chat-sidebar-popover\s*\{/)
+  assert.match(
+    css,
+    /\.chat-sidebar-popover \.chat-session-row\.is-active::before\s*\{[^}]*background:\s*rgba\(242,\s*241,\s*237,\s*0\.12\)/s,
+  )
   assert.doesNotMatch(css, /\.os-dock-tile svg\s*\{/)
   assert.doesNotMatch(css, /\.brand-agent-menu svg[\s\S]{0,80}unset/)
   assert.doesNotMatch(css, /\.os-dock-tile \.brand-corner-mascot-btn svg\s*\{[^}]*width:\s*22px/s)

--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -45,6 +45,7 @@ test('message outline is a left rail of ticks with a hover menu', () => {
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*width:\s*6px/s)
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*height:\s*2px/s)
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*opacity:\s*0\.3/s)
+  assert.match(css, /\.chat-outline-item:hover,\s*\.chat-outline-item\.is-active\s*\{[^}]*background:\s*rgba\(242,\s*241,\s*237,\s*0\.12\)/s)
   assert.match(outline, /chat-outline-tick/)
   assert.match(outline, /hoverTick/)
   assert.match(outline, /hoverMenuItem/)

--- a/web/style.css
+++ b/web/style.css
@@ -600,6 +600,12 @@ body {
   color: var(--dsw-sidebar-fg);
 }
 
+/* 毛玻璃上的实心 --dsw-hover 会发闷；悬浮侧栏用更浅的选中膜 */
+.chat-sidebar-popover .chat-session-row:hover:not(.is-active)::before,
+.chat-sidebar-popover .chat-session-row.is-active::before {
+  background: rgba(242, 241, 237, 0.12);
+}
+
 /* 右侧检查器 tab：选中态与顶栏收起检查器按钮相同，无底边指示条 */
 .inspector-tabs {
   display: flex;
@@ -3803,7 +3809,7 @@ body {
 
 .chat-outline-item:hover,
 .chat-outline-item.is-active {
-  background: var(--dsw-hover);
+  background: rgba(242, 241, 237, 0.12);
   color: var(--dsw-sidebar-fg-active);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
悬浮聊天窗继续用 Dock 那套毛玻璃（半透明白 + blur）。

左侧会话悬浮列表、消息大纲菜单的选中/悬停从实心 `--dsw-hover`（`#2c2c2c`）改成 `rgba(242, 241, 237, 0.12)`，避免深色块盖在毛玻璃上发闷。固定左侧栏仍用原来的选中色。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

