### PR TITLE
Make sticky user wrapper background transparent

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -17,7 +17,7 @@ describe('composer dock stacking above sticky user', () => {
 
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
     expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)
-    expect(thread).toMatch(/sticky top-0 z-1/)
+    expect(thread).toMatch(/sticky top-0 z-1 bg-transparent/)
     expect(shell).toContain('chat-composer-dock')
     expect(shell).not.toMatch(/bottom-0 z-\[2\]/)
   })

--- a/packages/cap-chat/src/web/sticky-user.test.tsx
+++ b/packages/cap-chat/src/web/sticky-user.test.tsx
@@ -61,6 +61,8 @@ describe('sticky user message markers', () => {
     expect(turns[1]?.querySelectorAll('[data-chat-kind="user"]')).toHaveLength(1)
     expect(userRows[0]?.getAttribute('data-node-id')).toBe('u-1')
     expect(userRows[1]?.getAttribute('data-node-id')).toBe('u-2')
+    expect(userRows[0]?.className).toMatch(/bg-transparent/)
+    expect(userRows[0]?.className).not.toMatch(/bg-\(--dsw-bg\)/)
     expect(userRows[0]?.getAttribute('data-biu-kind')).toBe('message')
     expect(userRows[0]?.getAttribute('data-biu-id')).toBe('u-1')
     expect(document.querySelector('[data-testid="user-bubble"]')?.getAttribute('data-biu-kind')).toBe('message')

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -680,7 +680,7 @@ export const ChatNodeList = memo(function ChatNodeList({
                 replyNode?.turn != null ? dispatchedTasksByTurn[String(replyNode.turn)] : undefined
               const stickyUser =
                 node.kind === 'user'
-                  ? 'sticky top-0 z-1 bg-(--dsw-bg)'
+                  ? 'sticky top-0 z-1 bg-transparent'
                   : ''
               const skipPaint =
                 node.kind === 'reply' || node.kind === 'turn'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
用户消息贴顶仍用原来的外层 sticky 包裹，但背景从 `--dsw-bg` 改成透明，悬浮聊天窗的毛玻璃可以从卡片四周透出来。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

