### PR TITLE
Register collection-scoped filesystem view types

### DIFF
--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -32,6 +32,8 @@ test('viewsCollection lists saved views with source table', async () => {
   const written = await spec.update!(String(user?.id), { title: 'Doing' })
   assert.equal(written.title, 'Doing')
   assert.throws(() => spec.update!(String(all?.id), { title: '改掉' }), /read-only/)
+  const graphed = await spec.update!(String(user?.id), { mode: 'graph' })
+  assert.equal(graphed.mode, 'graph')
 })
 
 test('every registered table gets a builtin all-view even before the client syncs', async () => {

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -1,6 +1,7 @@
 import type { CollectionInfo, CollectionSpec, DbRecord } from '@biu/type-file-system'
 import { builtinAllView, isReadOnlyViewId } from '../catalog-views.ts'
 import type { SavedView } from '../web/saved-view.ts'
+import { isViewModeId } from '../web/fields.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
 export type StoredView = Partial<SavedView> & Pick<SavedView, 'id' | 'name'>
@@ -60,10 +61,7 @@ export class SavedViewsStore {
         ...cur,
         ...(typeof patch.title === 'string' ? { name: patch.title } : {}),
         ...(typeof patch.name === 'string' ? { name: patch.name } : {}),
-        ...(typeof patch.mode === 'string' &&
-        (patch.mode === 'queue' || patch.mode === 'table' || patch.mode === 'cards' || patch.mode === 'board')
-          ? { mode: patch.mode }
-          : {}),
+        ...(typeof patch.mode === 'string' && isViewModeId(patch.mode) ? { mode: patch.mode } : {}),
         ...(typeof patch.sortField === 'string' ? { sortField: patch.sortField } : {}),
         ...(patch.sortDir === 'asc' || patch.sortDir === 'desc' ? { sortDir: patch.sortDir } : {}),
         ...(typeof patch.query === 'string' ? { query: patch.query } : {}),
@@ -131,7 +129,7 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
         table: { type: 'string', label: '来源表' },
         tablePath: { type: 'string', label: '表路径' },
         viewId: { type: 'string', label: '视图 ID' },
-        mode: { type: 'select', label: '呈现', writable: true, enum: ['queue', 'table', 'cards', 'board'] },
+        mode: { type: 'select', label: '呈现', writable: true },
         sortField: { type: 'string', label: '排序字段', writable: true },
         sortDir: { type: 'select', label: '升降序', writable: true, enum: ['asc', 'desc'] },
         query: { type: 'string', label: '搜索', writable: true },

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -32,7 +32,7 @@ import {
   ViewColumnsIcon,
 } from '@heroicons/react/16/solid'
 import type { CollectionActionInfo, CollectionInfo, CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
-import type { CollectionChrome } from '@biu/type-file-system/ui'
+import type { CollectionChrome, CollectionViewType, DatabaseUi } from '@biu/type-file-system/ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { BoolBox, ChatCount } from '@biu/public-ui'
 import {
@@ -75,6 +75,9 @@ import {
 import { ensureFsdbStyle } from './fsdb-style.ts'
 import { RecordDetail } from './record-detail.tsx'
 import { TableGlyph } from './nav-glyphs.tsx'
+import { getDatabaseUi } from './database-ui.ts'
+
+const EMPTY_VIEWS: CollectionViewType[] = []
 import {
   activeViewStorageKey,
   getStarredViews,
@@ -164,12 +167,23 @@ export function CollectionBrowser({
   const [draft, setDraft] = useState<Record<string, string>>({})
   const [busyKey, setBusyKey] = useState<string | null>(null)
   const initialView = viewForPath(collectionPath, routeViewId)
+  const dbUi = getDatabaseUi()
+  const extraViews = useSyncExternalStore(
+    (fn) => (dbUi ? dbUi.subscribe(fn) : () => undefined),
+    () => dbUi?.views(collectionPath) ?? EMPTY_VIEWS,
+    () => dbUi?.views(collectionPath) ?? EMPTY_VIEWS,
+  )
+  const modeChoices = useMemo(
+    () => [...VIEW_MODES, ...extraViews.map((view) => ({ id: view.id, label: view.label }))],
+    [extraViews],
+  )
   const [query, setQuery] = useState(initialView?.query ?? '')
   const [page, setPage] = useState(0)
   const [pageSize, setPageSize] = useState(() => normalizePageSize(initialView?.pageSize))
   const [total, setTotal] = useState(0)
   const [fetchQuery, setFetchQuery] = useState(initialView?.query ?? '')
   const [mode, setMode] = useState<ViewMode>(initialView?.mode ?? 'table')
+  const customView = extraViews.find((view) => view.id === mode)
   const [sortField, setSortField] = useState(initialView?.sortField ?? 'id')
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>(initialView?.sortDir ?? 'asc')
   const [filters, setFilters] = useState<Record<string, string>>(initialView?.filters ?? {})
@@ -1759,18 +1773,18 @@ export function CollectionBrowser({
                 type="button"
                 className={`tasks-sort-btn${modeMenuOpen ? ' is-active' : ''}`}
                 aria-label="查看模式"
-                title={`模式：${VIEW_MODES.find((item) => item.id === mode)?.label}`}
+                title={`模式：${modeChoices.find((item) => item.id === mode)?.label ?? mode}`}
                 onClick={() => toggleMenu('mode')}
               >
-                <ModeGlyph id={mode} />
+                <ModeGlyph id={mode} extra={extraViews} />
               </button>
               {modeMenuOpen ? (
                 <div className="tasks-sort-menu" role="menu">
                   <div className="tasks-sort-head">查看模式</div>
-                  {VIEW_MODES.map((opt) => (
+                  {modeChoices.map((opt) => (
                     <CheckRow
                       key={opt.id}
-                      icon={<ModeGlyph id={opt.id} />}
+                      icon={<ModeGlyph id={opt.id} extra={extraViews} />}
                       label={opt.label}
                       on={mode === opt.id}
                       onToggle={() => {
@@ -2041,7 +2055,10 @@ export function CollectionBrowser({
 
         <div className="fsdb-workspace">
           <div className="fsdb-stage">
-            {mode === 'table' ? (
+            {customView ? (
+              <customView.View path={dataPath} rows={items} schema={schema} onOpen={openRow} />
+            ) : null}
+            {mode === 'table' && !customView ? (
               <div className="tasks-table-wrap">
                 <table className={`tasks-table${wrapCells ? ' is-wrap' : ''}${truncateCells ? ' is-truncate' : ''}`}>
             <thead>
@@ -2088,7 +2105,7 @@ export function CollectionBrowser({
         </div>
             ) : null}
 
-            {mode === 'cards' ? (
+            {mode === 'cards' && !customView ? (
               grouping ? (
                 <div className="fsdb-cards-stack">
                   {grouped.length ? (
@@ -2119,7 +2136,7 @@ export function CollectionBrowser({
               )
             ) : null}
 
-            {mode === 'queue' ? (
+            {mode === 'queue' && !customView ? (
               <div className="tasks-queue">
                 {visible.length ? (
                   grouping ? (
@@ -2148,7 +2165,7 @@ export function CollectionBrowser({
               </div>
             ) : null}
 
-            {mode === 'board' ? (
+            {mode === 'board' && !customView ? (
               <div className="tasks-board" style={{ gridTemplateColumns: `repeat(${Math.max(grouped.length, 1)}, minmax(240px, 1fr))` }}>
                 {grouped.map((group) => (
                   <div key={group.key || 'all'} className="tasks-board-col">

--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -51,3 +51,20 @@ test('decorate panes with the same id keep a single pane', () => {
   assert.equal(panes[0]?.label, '脚本 B')
   assert.equal(panes[0]?.Pane, PaneB)
 })
+
+test('registerView is scoped to the collection that registered it', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  const Graph = () => null
+  const first = ui.registerView('/tasks', { id: 'graph', label: '依赖图', View: Graph })
+  assert.equal(ui.views('/tasks').length, 1)
+  assert.equal(ui.views('/tasks')[0]?.id, 'graph')
+  assert.equal(ui.views('/plugins').length, 0)
+  const later = ui.registerView('/tasks', { id: 'graph', label: 'DAG', View: Graph })
+  assert.equal(ui.views('/tasks').length, 1)
+  assert.equal(ui.views('/tasks')[0]?.label, 'DAG')
+  later.dispose()
+  assert.equal(ui.views('/tasks')[0]?.label, '依赖图')
+  first.dispose()
+  assert.equal(ui.views('/tasks').length, 0)
+})

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -1,5 +1,5 @@
 import { Service, type Context } from 'cordis'
-import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
+import type { CollectionChrome, CollectionViewType, DatabaseUi } from '@biu/type-file-system/ui'
 import { normalizeCollectionPath } from '../paths.ts'
 
 export { normalizeCollectionPath }
@@ -26,6 +26,15 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   return { cells, Action, Title, Content, panes: panes.length ? panes : undefined }
 }
 
+function mergeViews(layers: CollectionViewType[]): CollectionViewType[] {
+  const byId = new Map<string, CollectionViewType>()
+  for (const view of layers) {
+    if (!view.id) continue
+    byId.set(view.id, view)
+  }
+  return [...byId.values()]
+}
+
 let boundDatabaseUi: DatabaseUiService | undefined
 
 export function getDatabaseUi() {
@@ -34,7 +43,9 @@ export function getDatabaseUi() {
 
 export class DatabaseUiService extends Service implements DatabaseUi {
   private layers = new Map<string, CollectionChrome[]>()
+  private viewLayers = new Map<string, CollectionViewType[]>()
   private snapshot = new Map<string, CollectionChrome>()
+  private viewSnapshot = new Map<string, CollectionViewType[]>()
   private listeners = new Set<() => void>()
 
   constructor(ctx: Context) {
@@ -58,12 +69,37 @@ export class DatabaseUiService extends Service implements DatabaseUi {
     }
   }
 
+  registerView(path: string, view: CollectionViewType) {
+    const key = normalizeCollectionPath(path)
+    const list = this.viewLayers.get(key) ?? []
+    list.push(view)
+    this.viewLayers.set(key, list)
+    this.emit()
+    return {
+      dispose: () => {
+        const next = (this.viewLayers.get(key) ?? []).filter((item) => item !== view)
+        if (next.length) this.viewLayers.set(key, next)
+        else this.viewLayers.delete(key)
+        this.emit()
+      },
+    }
+  }
+
   chrome(path: string): CollectionChrome {
     const key = normalizeCollectionPath(path)
     const cached = this.snapshot.get(key)
     if (cached) return cached
     const merged = mergeChrome(this.layers.get(key) ?? [])
     this.snapshot.set(key, merged)
+    return merged
+  }
+
+  views(path: string): CollectionViewType[] {
+    const key = normalizeCollectionPath(path)
+    const cached = this.viewSnapshot.get(key)
+    if (cached) return cached
+    const merged = mergeViews(this.viewLayers.get(key) ?? [])
+    this.viewSnapshot.set(key, merged)
     return merged
   }
 
@@ -76,6 +112,7 @@ export class DatabaseUiService extends Service implements DatabaseUi {
 
   private emit() {
     this.snapshot.clear()
+    this.viewSnapshot.clear()
     for (const fn of this.listeners) fn()
   }
 }

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -1,7 +1,13 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
-import { defaultColumnKeys, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, matchActionWhen, matchesFilters, parentFieldKey, resolveFieldType, sortRows } from './fields'
+import { defaultColumnKeys, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, isViewModeId, matchActionWhen, matchesFilters, parentFieldKey, resolveFieldType, sortRows } from './fields'
+
+test('isViewModeId accepts builtin and custom slugs', () => {
+  assert.equal(isViewModeId('table'), true)
+  assert.equal(isViewModeId('graph'), true)
+  assert.equal(isViewModeId('??'), false)
+})
 
 const schema: CollectionSchema = {
   labelField: 'title',

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -1,7 +1,18 @@
 import type { CollectionSchema, DbRecord, FieldSpec, FieldType } from '@biu/type-file-system'
 import { asAttachment, asHttpHref, asImageSrc, BUILTIN_FIELD_KEYS } from '@biu/type-file-system'
 
-export type ViewMode = 'queue' | 'table' | 'cards' | 'board'
+export const BUILTIN_VIEW_MODES = ['queue', 'table', 'cards', 'board'] as const
+export type BuiltinViewMode = (typeof BUILTIN_VIEW_MODES)[number]
+/** 内置四种 + 集合自己 registerView 的 id（如 graph）。 */
+export type ViewMode = BuiltinViewMode | (string & {})
+
+export function isBuiltinViewMode(mode: string): mode is BuiltinViewMode {
+  return (BUILTIN_VIEW_MODES as readonly string[]).includes(mode)
+}
+
+export function isViewModeId(mode: unknown): mode is ViewMode {
+  return typeof mode === 'string' && /^[a-z][a-z0-9-]{0,31}$/.test(mode)
+}
 
 export function resolveFieldType(field: FieldSpec): FieldType {
   if (field.type === 'string[]') return 'multi-select'

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -20,12 +20,14 @@ import {
   RectangleStackIcon,
   StopIcon,
   TableCellsIcon,
+  ShareIcon,
   Squares2X2Icon,
   ViewColumnsIcon,
 } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import type { CollectionSchema, DbRecord, FieldSpec, FieldType } from '@biu/type-file-system'
 import { asAttachment, asHttpHref, asImageSrc } from '@biu/type-file-system'
+import type { CollectionViewType } from '@biu/type-file-system/ui'
 import {
   asStringList,
   asTime,
@@ -47,12 +49,15 @@ export function actionIcon(id: string) {
   return null
 }
 
-export function ModeGlyph({ id }: { id: ViewMode }) {
+export function ModeGlyph({ id, extra }: { id: ViewMode; extra?: CollectionViewType[] }) {
   const cls = 'size-[14px]'
+  const Custom = extra?.find((item) => item.id === id)?.Icon
+  if (Custom) return <Custom className={cls} />
   if (id === 'queue') return <ListBulletIcon aria-hidden className={cls} />
   if (id === 'table') return <TableCellsIcon aria-hidden className={cls} />
   if (id === 'cards') return <Squares2X2Icon aria-hidden className={cls} />
-  return <ViewColumnsIcon aria-hidden className={cls} />
+  if (id === 'board') return <ViewColumnsIcon aria-hidden className={cls} />
+  return <ShareIcon aria-hidden className={cls} />
 }
 
 export const VIEW_MODES: Array<{ id: ViewMode; label: string }> = [

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -31,3 +31,11 @@ test('database page no longer registers collection shortcuts on the dock', () =>
   assert.match(page, /builtinAllViewId\(parsed.collection\)/)
   assert.doesNotMatch(page, /isCollectionHub/)
 })
+
+test('collection browser renders extra views registered for that path', () => {
+  const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+  const ui = readFileSync(resolve(import.meta.dirname, './database-ui.ts'), 'utf8')
+  assert.match(ui, /registerView\(path: string, view: CollectionViewType\)/)
+  assert.match(browser, /dbUi\?\.views\(collectionPath\)/)
+  assert.match(browser, /<customView\.View/)
+})

--- a/packages/core-file-system/src/web/nav-glyphs.tsx
+++ b/packages/core-file-system/src/web/nav-glyphs.tsx
@@ -7,6 +7,7 @@ import {
   EyeIcon,
   ListBulletIcon,
   PuzzlePieceIcon,
+  ShareIcon,
   Squares2X2Icon,
   TableCellsIcon,
   ViewColumnsIcon,
@@ -30,7 +31,7 @@ export function ViewModeGlyph({ mode, className = 'size-4' }: { mode?: ViewMode;
   if (mode === 'table') return <TableCellsIcon aria-hidden className={className} />
   if (mode === 'cards') return <Squares2X2Icon aria-hidden className={className} />
   if (mode === 'board') return <ViewColumnsIcon aria-hidden className={className} />
-  return <Squares2X2Icon aria-hidden className={className} />
+  return <ShareIcon aria-hidden className={className} />
 }
 
 export function CrumbItemGlyph({

--- a/packages/core-file-system/src/web/saved-view.test.ts
+++ b/packages/core-file-system/src/web/saved-view.test.ts
@@ -12,15 +12,17 @@ const base: SavedView = {
   columns: ['title', 'status'],
 }
 
-test('normalizeSavedView fills view config defaults', () => {
-  const next = normalizeSavedView({ id: '1', name: 'a', mode: 'graph' as SavedView['mode'], sortField: '', sortDir: 'asc', filters: {}, columns: [] })
-  assert.equal(next.mode, 'table')
-  assert.equal(next.sortField, 'id')
-  assert.equal(next.tree, true)
-  assert.equal(next.truncate, true)
-  assert.equal(next.wrap, false)
-  assert.equal(next.query, '')
-  assert.equal(next.pageSize, 50)
+test('normalizeSavedView keeps custom mode slugs and rejects junk', () => {
+  const graph = normalizeSavedView({ id: '1', name: 'a', mode: 'graph', sortField: '', sortDir: 'asc', filters: {}, columns: [] })
+  assert.equal(graph.mode, 'graph')
+  const junk = normalizeSavedView({ id: '1', name: 'a', mode: '???' as SavedView['mode'], sortField: '', sortDir: 'asc', filters: {}, columns: [] })
+  assert.equal(junk.mode, 'table')
+  assert.equal(junk.sortField, 'id')
+  assert.equal(junk.tree, true)
+  assert.equal(junk.truncate, true)
+  assert.equal(junk.wrap, false)
+  assert.equal(junk.query, '')
+  assert.equal(junk.pageSize, 50)
 })
 
 test('viewStateKey ignores name and treats missing query as empty', () => {

--- a/packages/core-file-system/src/web/saved-view.ts
+++ b/packages/core-file-system/src/web/saved-view.ts
@@ -1,4 +1,4 @@
-import type { ViewMode } from './fields.ts'
+import { isViewModeId, type ViewMode } from './fields.ts'
 
 export type SavedView = {
   id: string
@@ -18,12 +18,10 @@ export type SavedView = {
   builtin?: boolean
 }
 
-const MODES: ViewMode[] = ['queue', 'table', 'cards', 'board']
-
 export function normalizeSavedView(view: SavedView): SavedView {
   return {
     ...view,
-    mode: MODES.includes(view.mode) ? view.mode : 'table',
+    mode: isViewModeId(view.mode) ? view.mode : 'table',
     sortField: view.sortField || 'id',
     sortDir: view.sortDir === 'desc' ? 'desc' : 'asc',
     filters: view.filters && typeof view.filters === 'object' ? view.filters : {},

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { Context, Service } from 'cordis'
 import * as slots from '@biu/web-slots'
 import * as dock from '@biu/core-dock'
-import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
+import type { CollectionChrome, CollectionViewType, DatabaseUi } from '@biu/type-file-system/ui'
 import * as plugins2Ui from './index.tsx'
 
 class FakeDatabaseUi extends Service implements DatabaseUi {
@@ -17,6 +17,12 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
   }
   chrome() {
     return this.last?.chrome ?? {}
+  }
+  registerView() {
+    return { dispose() {} }
+  }
+  views() {
+    return [] as CollectionViewType[]
   }
   subscribe() {
     return () => undefined

--- a/packages/core-task-system/package.json
+++ b/packages/core-task-system/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@biu/type-file-system": "0.1.0",
-    "@biu/public-mascot": "0.1.0"
+    "@biu/public-mascot": "0.1.0",
+    "@xyflow/react": "^12.11.3"
   }
 }

--- a/packages/core-task-system/src/host/collection.test.ts
+++ b/packages/core-task-system/src/host/collection.test.ts
@@ -12,6 +12,7 @@ test('tasksCollection maps /tasks rows with rolled-up usage', async () => {
           title: '写方案',
           status: 'todo',
           parentId: 'p',
+          dependsOn: ['p'],
           reports: [{ sessionId: 's1', turn: 1, usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, totalTokens: 15 } }],
         },
       ]
@@ -43,6 +44,7 @@ test('tasksCollection maps /tasks rows with rolled-up usage', async () => {
   const child = listed.find((row) => row.id === 't1')
   const parent = listed.find((row) => row.id === 'p')
   assert.equal(child?.parentChain, '父任务')
+  assert.deepEqual(child?.dependsOn, ['p'])
   assert.equal(child?.usage, 15)
   assert.equal(parent?.usage, 15)
   assert.equal((parent?.usageParts as { aggregate?: boolean } | undefined)?.aggregate, true)

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -25,6 +25,7 @@ type TaskRow = DbRecord & {
   creator?: Actor | null
   assignee?: Actor | null
   parentId?: string | null
+  dependsOn?: string[]
   blocked?: boolean
   reports?: TaskReport[]
   usage?: Usage
@@ -112,6 +113,7 @@ function taskRecord(row: TaskRow, lookup: (id: string) => TaskRow | undefined, u
     assigneeSessionId: row.assignee?.sessionId ?? '',
     assigneeActor: row.assignee ?? null,
     parentId: row.parentId ?? null,
+    dependsOn: Array.isArray(row.dependsOn) ? row.dependsOn.map(String).filter(Boolean) : [],
     blocked: Boolean(row.blocked),
     parentChain: parentChain(row, lookup),
     usage: usage.totalTokens,
@@ -181,6 +183,7 @@ export function tasksCollection(tasks: TasksLike): CollectionSpec {
         creator: { type: 'string', label: '创建人' },
         assignee: { type: 'string', label: '承担者' },
         parentId: { type: 'string', label: '父任务', writable: true },
+        dependsOn: { type: 'multi-select', label: '依赖' },
       },
     },
     records: { update: true, create: true, delete: true },

--- a/packages/core-task-system/src/web/graph-layout.test.ts
+++ b/packages/core-task-system/src/web/graph-layout.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { asIdList, layoutTaskGraph } from './graph-layout.ts'
+
+test('layoutTaskGraph layers dependents after their dependsOn', () => {
+  const { nodes, edges } = layoutTaskGraph([
+    { id: 'a', title: 'A', status: 'done' },
+    { id: 'b', title: 'B', status: 'todo', dependsOn: ['a'] },
+    { id: 'c', title: 'C', status: 'todo', dependsOn: ['b'] },
+  ])
+  assert.deepEqual(
+    edges.map((edge) => `${edge.source}->${edge.target}`),
+    ['a->b', 'b->c'],
+  )
+  const byId = Object.fromEntries(nodes.map((node) => [node.id, node]))
+  assert.ok((byId.a?.x ?? 1) < (byId.b?.x ?? 0))
+  assert.ok((byId.b?.x ?? 1) < (byId.c?.x ?? 0))
+})
+
+test('asIdList reads arrays and json strings', () => {
+  assert.deepEqual(asIdList(['a', 'a', 'b']), ['a', 'b'])
+  assert.deepEqual(asIdList('["x","y"]'), ['x', 'y'])
+  assert.deepEqual(asIdList('p, q'), ['p', 'q'])
+})

--- a/packages/core-task-system/src/web/graph-layout.ts
+++ b/packages/core-task-system/src/web/graph-layout.ts
@@ -1,0 +1,77 @@
+import type { DbRecord } from '@biu/type-file-system'
+
+export type GraphNode = {
+  id: string
+  title: string
+  status: string
+  x: number
+  y: number
+}
+
+export type GraphEdge = {
+  id: string
+  source: string
+  target: string
+}
+
+export function asIdList(value: unknown): string[] {
+  if (Array.isArray(value)) return [...new Set(value.map(String).map((id) => id.trim()).filter(Boolean))]
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value) as unknown
+      if (Array.isArray(parsed)) return asIdList(parsed)
+    } catch {
+      /* plain */
+    }
+    return value
+      .split(/[,，]/)
+      .map((id) => id.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+/** 依赖边：source 先完成，target 才能开工。 */
+export function layoutTaskGraph(rows: DbRecord[]): { nodes: GraphNode[]; edges: GraphEdge[] } {
+  const ids = new Set(rows.map((row) => row.id))
+  const deps = new Map<string, string[]>()
+  const edges: GraphEdge[] = []
+  const seen = new Set<string>()
+  for (const row of rows) {
+    const list = asIdList(row.dependsOn).filter((id) => id !== row.id && ids.has(id))
+    deps.set(row.id, list)
+    for (const source of list) {
+      const key = `${source}->${row.id}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      edges.push({ id: key, source, target: row.id })
+    }
+  }
+  const layer = new Map<string, number>()
+  const visiting = new Set<string>()
+  const depthOf = (id: string): number => {
+    const hit = layer.get(id)
+    if (hit != null) return hit
+    if (visiting.has(id)) return 0
+    visiting.add(id)
+    const next = 1 + Math.max(0, ...(deps.get(id) ?? []).map(depthOf))
+    visiting.delete(id)
+    layer.set(id, next)
+    return next
+  }
+  for (const row of rows) depthOf(row.id)
+  const buckets = new Map<number, GraphNode[]>()
+  for (const row of rows) {
+    const col = layer.get(row.id) ?? 1
+    const list = buckets.get(col) ?? []
+    list.push({
+      id: row.id,
+      title: String(row.title ?? row.id),
+      status: String(row.status ?? ''),
+      x: (col - 1) * 240,
+      y: list.length * 88,
+    })
+    buckets.set(col, list)
+  }
+  return { nodes: [...buckets.values()].flat(), edges }
+}

--- a/packages/core-task-system/src/web/graph-view.tsx
+++ b/packages/core-task-system/src/web/graph-view.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react'
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
+} from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+import type { FsViewProps } from '@biu/type-file-system/ui'
+import { layoutTaskGraph } from './graph-layout.ts'
+
+function statusClass(status: string) {
+  if (status === 'doing') return 'is-doing'
+  if (status === 'done') return 'is-done'
+  return 'is-todo'
+}
+
+export function TaskDepGraph({ rows, onOpen }: FsViewProps) {
+  const laid = useMemo(() => layoutTaskGraph(rows), [rows])
+  const nodes: Node[] = useMemo(
+    () =>
+      laid.nodes.map((node) => ({
+        id: node.id,
+        position: { x: node.x, y: node.y },
+        data: { label: node.title, status: node.status },
+        className: `tasks-graph-node ${statusClass(node.status)}`,
+      })),
+    [laid],
+  )
+  const edges: Edge[] = useMemo(
+    () =>
+      laid.edges.map((edge) => ({
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+      })),
+    [laid],
+  )
+  const onNodeClick: NodeMouseHandler = (_event, node) => {
+    const row = rows.find((item) => item.id === node.id)
+    if (row) onOpen(row)
+  }
+  if (!rows.length) return <p className="fsdb-empty">暂无记录</p>
+  return (
+    <div className="tasks-dep-graph" data-testid="tasks-dep-graph">
+      <ReactFlow nodes={nodes} edges={edges} fitView onNodeClick={onNodeClick} proOptions={{ hideAttribution: true }}>
+        <Background gap={18} size={1} />
+        <Controls showInteractive={false} />
+        <MiniMap pannable zoomable />
+      </ReactFlow>
+    </div>
+  )
+}

--- a/packages/core-task-system/src/web/index.test.ts
+++ b/packages/core-task-system/src/web/index.test.ts
@@ -1,11 +1,12 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context, Service } from 'cordis'
-import type { CollectionChrome, DatabaseUi } from '@biu/type-file-system/ui'
+import type { CollectionChrome, CollectionViewType, DatabaseUi } from '@biu/type-file-system/ui'
 import * as taskSystemUi from './index.tsx'
 
 class FakeDatabaseUi extends Service implements DatabaseUi {
   last: { path: string; chrome: CollectionChrome } | null = null
+  registered: Array<{ path: string; view: CollectionViewType }> = []
   constructor(ctx: Context) {
     super(ctx, 'databaseUi')
   }
@@ -13,8 +14,15 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
     this.last = { path, chrome }
     return { dispose() {} }
   }
+  registerView(path: string, view: CollectionViewType) {
+    this.registered.push({ path, view })
+    return { dispose() {} }
+  }
   chrome() {
     return this.last?.chrome ?? {}
+  }
+  views(path: string) {
+    return this.registered.filter((item) => item.path === path).map((item) => item.view)
   }
   subscribe() {
     return () => undefined
@@ -34,4 +42,7 @@ test('task-system web paints /tasks chrome without importing file-system', async
   assert.equal(typeof ui.last?.chrome.cells?.creator, 'function')
   assert.equal(typeof ui.last?.chrome.cells?.assignee, 'function')
   assert.equal(ui.last?.chrome.panes?.map((pane) => pane.id).join(','), 'script,reports')
+  assert.equal(ui.registered[0]?.path, '/tasks')
+  assert.equal(ui.registered[0]?.view.id, 'graph')
+  assert.equal(ui.registered[0]?.view.label, '依赖图')
 })

--- a/packages/core-task-system/src/web/index.tsx
+++ b/packages/core-task-system/src/web/index.tsx
@@ -1,6 +1,8 @@
 import type { Context } from 'cordis'
+import { ShareIcon } from '@heroicons/react/16/solid'
 import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { tasksChrome } from './chrome.tsx'
+import { TaskDepGraph } from './graph-view.tsx'
 
 export const name = 'core-task-system-ui'
 export const inject = ['databaseUi']
@@ -8,6 +10,16 @@ export const inject = ['databaseUi']
 export function apply(ctx: Context) {
   const ui = ctx.get('databaseUi') as DatabaseUi
   ctx.effect(() => ui.decorate('/tasks', tasksChrome).dispose)
+  ctx.effect(() =>
+    ui
+      .registerView('/tasks', {
+        id: 'graph',
+        label: '依赖图',
+        Icon: ShareIcon,
+        View: TaskDepGraph,
+      })
+      .dispose,
+  )
 }
 
 if (typeof document !== 'undefined') {
@@ -129,6 +141,15 @@ if (typeof document !== 'undefined') {
 .tasks-report-note { color:var(--dsw-label-2); font-size:11px; line-height:1.5; white-space:normal; word-break:break-word; padding:8px 10px; border:1px solid var(--dsw-border); border-radius:8px; background:color-mix(in srgb, var(--dsw-muted-fill) 50%, transparent); }
 .tasks-report-usage { display:flex; align-items:center; justify-content:space-between; gap:12px; color:var(--dsw-label-3); font-size:12px; font-variant-numeric:tabular-nums; }
 .tasks-report-usage .traj-usage, .tasks-report-usage .traj-usage-empty { font-size:12px; }
+
+.tasks-dep-graph{flex:1;min-width:0;min-height:0;width:100%;height:100%;border-radius:10px;overflow:hidden}
+.tasks-dep-graph .react-flow{background:transparent}
+.tasks-dep-graph .react-flow__node{border:1px solid var(--dsw-border);border-radius:10px;padding:8px 10px;background:var(--dsw-sidebar);color:var(--dsw-label);font-size:13px;font-weight:650;box-shadow:none}
+.tasks-dep-graph .react-flow__node.tasks-graph-node.is-doing{box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--dsw-business) 45%,transparent)}
+.tasks-dep-graph .react-flow__node.tasks-graph-node.is-done{opacity:.8}
+.tasks-dep-graph .react-flow__controls{box-shadow:none;border:1px solid var(--dsw-border);overflow:hidden;border-radius:8px}
+.tasks-dep-graph .react-flow__controls-button{background:var(--dsw-sidebar);border-color:var(--dsw-border);fill:var(--dsw-label)}
+.tasks-dep-graph .react-flow__minimap{background:color-mix(in srgb,var(--dsw-sidebar) 80%,transparent)}
 
 /* ---- 依赖（DAG）视图 ---- */
 /* ---- DAG 依赖图（自绘 SVG + 缩放）---- */

--- a/packages/type-file-system/src/ui.ts
+++ b/packages/type-file-system/src/ui.ts
@@ -1,5 +1,5 @@
 import type { ComponentType } from 'react'
-import type { CollectionActionInfo, DbRecord, FieldSpec } from './index.ts'
+import type { CollectionActionInfo, CollectionSchema, DbRecord, FieldSpec } from './index.ts'
 
 /** 单元格：不传则 File System 按 FieldSpec.type 默认画。 */
 export type FsCellProps = {
@@ -34,6 +34,7 @@ export type CollectionChrome = {
   Action?: ComponentType<FsActionProps>
   /** 详情标题左侧图标。不传则用集合 glyph / 记录 emoji。 */
   Icon?: ComponentType<{ record: DbRecord }>
+  Title?: ComponentType<{ record: DbRecord; label: string }>
   /** 正文。不传则把 content 当文件默认渲染。结构由登记方自己解析。 */
   Content?: ComponentType<FsContentProps>
   /** 详情弹窗额外分区（概况之外）。旧任务详情的脚本/进度汇报走这里。 */
@@ -49,9 +50,27 @@ export type FsContentProps = {
   onChange?: (next: unknown) => void
 }
 
+/** 集合自定义呈现：谁 registerView(path)，谁才能在该 path 用这个 mode。 */
+export type FsViewProps = {
+  path: string
+  rows: DbRecord[]
+  schema?: CollectionSchema
+  onOpen: (row: DbRecord) => void
+}
+
+export type CollectionViewType = {
+  id: string
+  label: string
+  Icon?: ComponentType<{ className?: string }>
+  View: ComponentType<FsViewProps>
+}
+
 export interface DatabaseUi {
   decorate(path: string, chrome: CollectionChrome): { dispose: () => void }
+  /** 给指定集合登记一种查看模式。其它集合看不到、也不能选。 */
+  registerView(path: string, view: CollectionViewType): { dispose: () => void }
   chrome(path: string): CollectionChrome
+  views(path: string): CollectionViewType[]
   subscribe(listener: () => void): () => void
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
文件系统提供 `databaseUi.registerView(path, view)`：谁在哪个集合上登记，谁才能在那个集合的模式菜单里用对应视图。插件/会话表看不到任务的依赖图。

任务插件在 `/tasks` 登记 `graph`，用 `@xyflow/react` 画 `dependsOn` DAG，点节点打开记录。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

