### PR TITLE
fix(fs): 内置视图可见列不再被刷新打回

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -456,12 +456,6 @@ export function CollectionBrowser({
         prev?.schema && JSON.stringify(prev.schema) === JSON.stringify(nextSchema) ? prev : { ...nextStat, schema: nextSchema },
       )
       setItems((prev) => (recordsFingerprint(prev) === recordsFingerprint(listed.items) ? prev : listed.items))
-      if (listed.schema) {
-        const current = viewsRef.current.find((view) => view.id === activeViewId)
-        if (current?.builtin) {
-          setColumnKeys(defaultColumnKeys(listed.schema, Object.keys(listed.schema.fields)))
-        }
-      }
       setTotal(listed.total)
       if (activeViewId) {
         rememberPreviewTotal(
@@ -621,6 +615,8 @@ export function CollectionBrowser({
   )
   const allColumnKeys = useMemo(() => allColumns.map((item) => item.key), [allColumns])
   const schemaDefaultKeys = useMemo(() => defaultColumnKeys(schema, allColumnKeys), [schema, allColumnKeys])
+  const schemaDefaultSig = schemaDefaultKeys.join('\0')
+  const prevSchemaDefaultSig = useRef('')
   const columns = useMemo(() => {
     const selected = allColumns.filter((item) => columnKeys.includes(item.key))
     const base = selected.length ? selected : allColumns.filter((item) => schemaDefaultKeys.includes(item.key))
@@ -657,15 +653,20 @@ export function CollectionBrowser({
 
   useEffect(() => {
     if (!schemaDefaultKeys.length) return
+    const prevDefaults = prevSchemaDefaultSig.current ? prevSchemaDefaultSig.current.split('\0').filter(Boolean) : []
+    prevSchemaDefaultSig.current = schemaDefaultSig
     setColumnKeys((prev) => {
-      if (!prev.length) return schemaDefaultKeys
       const allowed = new Set(allColumnKeys)
-      const kept = pinLabelColumn(schema, prev.filter((key) => allowed.has(key)))
-      if (!kept.length) return schemaDefaultKeys
+      const grown = prevDefaults.length ? schemaDefaultKeys.filter((key) => !prevDefaults.includes(key)) : []
+      const kept = pinLabelColumn(
+        schema,
+        [...prev.filter((key) => allowed.has(key)), ...grown.filter((key) => allowed.has(key) && !prev.includes(key))],
+      )
+      if (!prev.length || !kept.length) return schemaDefaultKeys
       if (kept.length === prev.length && kept.every((key, index) => key === prev[index])) return prev
       return kept
     })
-  }, [allColumnKeys, schema, schemaDefaultKeys])
+  }, [allColumnKeys, schema, schemaDefaultKeys, schemaDefaultSig])
 
   useEffect(() => {
     if (!schema || sortFields.some((item) => item.key === sortField)) return
@@ -990,7 +991,13 @@ export function CollectionBrowser({
     if (!pinned.length) return
     setColumnKeys(pinned)
     if (!activeViewId) return
-    if (views.find((view) => view.id === activeViewId)?.builtin) return
+    const current = views.find((view) => view.id === activeViewId)
+    if (!current) return
+    if (current.builtin) {
+      persistViewDisplay(collectionPath, current.id, { columns: pinned })
+      persistViews(views)
+      return
+    }
     persistViews(views.map((view) => (view.id === activeViewId ? { ...view, columns: pinned } : view)))
   }
 

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -6,6 +6,7 @@ import {
   seedInspectorDbPath,
   setInspectorDbPath,
   showRecordInInspector,
+  showInInspector,
 } from './inspector-db-route.ts'
 
 test('inspector database path does not overwrite after first seed', () => {
@@ -51,5 +52,22 @@ test('showRecordInInspector opens the inspector on this record', async () => {
   await opened
   assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
   assert.deepEqual(tabs, ['database:/pages'])
+  window.removeEventListener('biu:inspector-tab', onTab)
+})
+
+test('showInInspector opens a collection href in the inspector', async () => {
+  const tabs: string[] = []
+  const onTab = (event: Event) => {
+    const detail = (event as CustomEvent).detail
+    if (typeof detail === 'string') tabs.push(detail)
+  }
+  window.addEventListener('biu:inspector-tab', onTab)
+  const opened = new Promise<void>((resolve) => {
+    window.addEventListener('biu:inspector-open', () => resolve(), { once: true })
+  })
+  showInInspector('/supertags', '/database/supertags/view/builtin-all:/supertags?tag=dp')
+  await opened
+  assert.equal(getInspectorDbPath('database:/supertags'), '/database/supertags/view/builtin-all:/supertags?tag=dp')
+  assert.deepEqual(tabs, ['database:/supertags'])
   window.removeEventListener('biu:inspector-tab', onTab)
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -45,12 +45,17 @@ export function inspectorCollectionTabId(collection: string) {
   return `database:${collection}`
 }
 
-/** 右侧检查器打开这条记录，中间主界面不动。 */
-export function showRecordInInspector(collection: string, recordId: string) {
+/** 右侧检查器打开这条路径，中间主界面不动。 */
+export function showInInspector(collection: string, href: string) {
   const tabId = inspectorCollectionTabId(collection)
-  setInspectorDbPath(tabId, databaseRecordPath(collection, recordId))
+  setInspectorDbPath(tabId, href)
   window.dispatchEvent(new Event('biu:inspector-open'))
   window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
+}
+
+/** 右侧检查器打开这条记录，中间主界面不动。 */
+export function showRecordInInspector(collection: string, recordId: string) {
+  showInInspector(collection, databaseRecordPath(collection, recordId))
 }
 
 export function seedInspectorDbPath(paneId: string, pathname?: string) {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -140,6 +140,7 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(browser, /persistViewDisplay/)
   assert.match(browser, /withViewDisplay/)
   assert.doesNotMatch(browser, /if \(current\?\.builtin\) return/)
+  assert.doesNotMatch(browser, /setColumnKeys\(defaultColumnKeys\(listed\.schema/)
   assert.match(css, /\.tasks-table\.is-wrap\{[^}]*white-space:normal/)
   assert.match(css, /\.tasks-table th,\.fsdb-page \.tasks-table\.is-wrap th\{[^}]*white-space:nowrap/)
   assert.match(css, /\.tasks-th\{[^}]*white-space:nowrap/)

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -45,3 +45,26 @@ test('builtin view wrap is stored as display prefs and restored', () => {
   assert.equal(painted.name, '全部会话')
   assert.equal(viewForPath(path)?.wrap, true)
 })
+
+test('builtin view columns overlay survives withViewDisplay', () => {
+  const mem: Record<string, string> = {}
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => mem[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mem[key] = value
+      },
+      removeItem: (key: string) => {
+        delete mem[key]
+      },
+    },
+  })
+  const path = '/sessions'
+  const id = builtinAllViewId(path)
+  persistViewDisplay(path, id, { columns: ['title', 'project'] })
+  assert.deepEqual(withViewDisplay(path, builtinAllView({ path, label: '会话', view: { title: '会话' } })).columns, [
+    'title',
+    'project',
+  ])
+})

--- a/packages/web-app-shell/src/web/rail-pin.test.ts
+++ b/packages/web-app-shell/src/web/rail-pin.test.ts
@@ -19,6 +19,8 @@ test('activity bar is gone; modules register on the os dock', () => {
   assert.match(nav, /requestInspectorOpen\(\)/)
   assert.match(nav, /requestInspectorTab\(item\.tabId\)/)
   assert.match(nav, /database:\/pages/)
+  assert.match(nav, /tabId: 'database:\/supertags'/)
+  assert.match(nav, /title: '标签'/)
   assert.match(nav, /tabId: 'traj'/)
   assert.match(nav, /Icon: MapIcon/)
   assert.doesNotMatch(nav, /QueueListIcon/)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -12,6 +12,7 @@ import {
   ChatBubbleLeftRightIcon,
   DocumentIcon,
   PuzzlePieceIcon,
+  TagIcon,
   BoltIcon,
   EyeIcon,
 } from '@heroicons/react/16/solid'
@@ -30,6 +31,7 @@ import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 function captionTableIcon(icon?: string) {
   const name = (icon ?? '').trim().toLowerCase()
   if (name === 'puzzle-piece' || name === 'puzzle') return PuzzlePieceIcon
+  if (name === 'tag') return TagIcon
   if (name === 'clipboard-document-list' || name === 'clipboard') return ClipboardDocumentListIcon
   if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return ChatBubbleLeftRightIcon
   if (name === 'document' || name === 'document-text' || name === 'page') return DocumentIcon

--- a/packages/web-app-shell/src/web/shell-dock-nav.tsx
+++ b/packages/web-app-shell/src/web/shell-dock-nav.tsx
@@ -8,6 +8,7 @@ import {
   Cog6ToothIcon,
   DocumentIcon,
   PuzzlePieceIcon,
+  TagIcon,
   MapIcon,
   SignalIcon,
 } from '@heroicons/react/16/solid'
@@ -20,8 +21,9 @@ const INSPECTOR_DOCK_TOOLS = [
   { id: 'inspector:sessions', title: '会话', tabId: 'database:/sessions', order: 41, Icon: ChatBubbleLeftRightIcon },
   { id: 'inspector:tasks', title: '任务', tabId: 'database:/tasks', order: 42, Icon: ClipboardDocumentListIcon },
   { id: 'inspector:plugins', title: '插件', tabId: 'database:/plugins', order: 43, Icon: PuzzlePieceIcon },
-  { id: 'inspector:traj', title: '轨迹', tabId: 'traj', order: 44, Icon: MapIcon },
-  { id: 'inspector:usage', title: '用量', tabId: 'usage', order: 45, Icon: SignalIcon },
+  { id: 'inspector:tags', title: '标签', tabId: 'database:/supertags', order: 44, Icon: TagIcon },
+  { id: 'inspector:traj', title: '轨迹', tabId: 'traj', order: 45, Icon: MapIcon },
+  { id: 'inspector:usage', title: '用量', tabId: 'usage', order: 46, Icon: SignalIcon },
 ] as const
 
 function DockModuleIcon({ module }: { module: AppModule }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
可见列在内置「全部 xx」视图上勾掉后会被列表刷新改回：reload 每次把 columnKeys 重写成 schema 默认列（当初是为了标签收集表长出新字段）。

现在刷新不再覆盖用户勾选；内置视图的列选择写入 display overlay。schema 新增字段时只追加新列。

Dock 插件右侧加了「标签」，检查器加号里本来就会列出 inspector: true 的标签表；caption 补了 tag 图标。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

