### PR TITLE
fix(web): 入口不用 top-level await，避免打包死锁

### DIFF
--- a/web/main.test.ts
+++ b/web/main.test.ts
@@ -1,6 +1,17 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { act } from 'react'
+
+test('web entry boots without top-level await', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './main.tsx'), 'utf8')
+  assert.match(src, /不用 top-level await/)
+  assert.match(src, /export const webBoot = \(async \(\) =>/)
+  assert.doesNotMatch(src, /^for \(const item of webRuntimeLoaders\) \{\n  const mod = await item.load\(\)/m)
+  assert.doesNotMatch(src, /const ctx = new Context\(\)\n\s*const ctx = new Context\(\)/)
+})
+
 
 test('boots into #app', async () => {
   document.body.innerHTML = '<div id="app"></div>'
@@ -12,7 +23,8 @@ test('boots into #app', async () => {
     services: [],
   }))) as typeof fetch
   await act(async () => {
-    await import('./main.tsx')
+    const { webBoot } = await import('./main.tsx')
+    await webBoot
   })
   assert.match(document.body.innerHTML, /data-os-dock/)
   assert.match(document.body.innerHTML, /Agent/)

--- a/web/main.tsx
+++ b/web/main.tsx
@@ -6,10 +6,13 @@ import { webRuntimeLoaders } from 'virtual:cordis-web-runtime'
 const el = document.querySelector<HTMLElement>('#app')
 if (!el) throw new Error('#app missing')
 
-const ctx = new Context()
-
-for (const item of webRuntimeLoaders) {
-  const mod = await item.load()
-  const extra = item.id === 'react-host' ? { el } : item.config ?? undefined
-  await ctx.plugin(mod, extra)
-}
+/** 不用 top-level await：入口 chunk 还 export 了 cordis Service，
+ *  异步分包会再 import 入口；TLA 未结束时 Chrome/Edge 会死锁，Safari 较宽松。 */
+export const webBoot = (async () => {
+  const ctx = new Context()
+  for (const item of webRuntimeLoaders) {
+    const mod = await item.load()
+    const extra = item.id === 'react-host' ? { el } : item.config ?? undefined
+    await ctx.plugin(mod, extra)
+  }
+})()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`web/main.tsx` 入口用了 top-level `await` 加载插件。打包后入口 chunk 还会带上 cordis 的 `Service` export，异步分包再 import 入口时，TLA 没结束 Chrome/Edge 会卡死。

改成一次 async IIFE（`webBoot`），模块同步求值结束再挂插件。不要重复 `new Context()` / 不要跑两遍 loader。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8f29ba8-3629-4833-95d8-e87029b91387?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8f29ba8-3629-4833-95d8-e87029b91387&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

