### PR TITLE
feat(page): 用 Cordis pageEditor 让商店插件替换标题渲染

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ dist/
 .plugin-dev/*
 !.plugin-dev/store-heavy-ping/
 !.plugin-dev/store-heavy-ping/**
+!.plugin-dev/page-heading-cards/
+!.plugin-dev/page-heading-cards/**
 .workspace/
 *.log
 .DS_Store

--- a/.plugin-dev/page-heading-cards/host.ts
+++ b/.plugin-dev/page-heading-cards/host.ts
@@ -1,0 +1,3 @@
+export const name = 'page-heading-cards'
+
+export function apply() {}

--- a/.plugin-dev/page-heading-cards/manifest.json
+++ b/.plugin-dev/page-heading-cards/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "page-heading-cards",
+  "name": "页面标题卡片",
+  "blurb": "把页面编辑器里的 H1 / H2 / H3 换成左侧色条卡片。关掉插件即恢复原生标题。",
+  "tags": ["page", "editor", "theme"],
+  "author": "Biu",
+  "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
+  "shell": {
+    "width": 320,
+    "height": 200,
+    "minWidth": 280,
+    "minHeight": 160,
+    "resizable": true
+  }
+}

--- a/.plugin-dev/page-heading-cards/web.tsx
+++ b/.plugin-dev/page-heading-cards/web.tsx
@@ -1,0 +1,65 @@
+export const name = 'page-heading-cards'
+export const inject = ['pageEditor', 'slots']
+
+function card(level: 1 | 2 | 3, accent: string) {
+  return function HeadingCard({ Content }: { Content: () => unknown }) {
+    return (
+      <div
+        data-testid={`page-heading-card-${level}`}
+        style={{
+          borderLeft: `4px solid ${accent}`,
+          padding: '8px 12px',
+          margin: '2px 0',
+          background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+          borderRadius: 8,
+        }}
+      >
+        <div style={{ fontSize: 11, fontWeight: 700, opacity: 0.55, letterSpacing: '0.06em' }}>{`H${level}`}</div>
+        <Content />
+      </div>
+    )
+  }
+}
+
+function Panel() {
+  return (
+    <div
+      data-testid="page-heading-cards-panel"
+      style={{
+        boxSizing: 'border-box',
+        width: '100%',
+        height: '100%',
+        padding: 16,
+        font: '13px/1.5 ui-sans-serif, system-ui, sans-serif',
+      }}
+    >
+      已替换页面正文的 H1 / H2 / H3。在页面里输入 / 插入标题即可看到卡片样式。关掉本插件后恢复原生标题。
+    </div>
+  )
+}
+
+function Icon(props: { className?: string }) {
+  const className = props.className ?? 'size-5'
+  return (
+    <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M3 3h10v2H3V3Zm0 4h7v2H3V7Zm0 4h10v2H3v-2Z" />
+    </svg>
+  )
+}
+
+export function apply(ctx: {
+  pageEditor: {
+    replaceHeading: (level: 1 | 2 | 3, spec: { View: (props: { Content: () => unknown }) => unknown }) => void
+  }
+  slots: {
+    place: (slot: string, Comp: unknown, options: { key: string; props: () => { Icon: unknown } }) => void
+  }
+}) {
+  ctx.pageEditor.replaceHeading(1, { View: card(1, '#7c5cfc') })
+  ctx.pageEditor.replaceHeading(2, { View: card(2, '#3b82f6') })
+  ctx.pageEditor.replaceHeading(3, { View: card(3, '#22c55e') })
+  ctx.slots.place('plugin-store-extras', Panel, {
+    key: 'page-heading-cards',
+    props: () => ({ Icon }),
+  })
+}

--- a/.plugin/page-heading-cards/host.js
+++ b/.plugin/page-heading-cards/host.js
@@ -1,0 +1,8 @@
+// host.ts
+var name = "page-heading-cards";
+function apply() {
+}
+export {
+  apply,
+  name
+};

--- a/.plugin/page-heading-cards/manifest.json
+++ b/.plugin/page-heading-cards/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "page-heading-cards",
+  "name": "页面标题卡片",
+  "blurb": "把页面编辑器里的 H1 / H2 / H3 换成左侧色条卡片。关掉插件即恢复原生标题。",
+  "tags": ["page", "editor", "theme"],
+  "author": "Biu",
+  "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
+  "shell": {
+    "width": 320,
+    "height": 200,
+    "minWidth": 280,
+    "minHeight": 160,
+    "resizable": true
+  }
+}

--- a/.plugin/page-heading-cards/web.js
+++ b/.plugin/page-heading-cards/web.js
@@ -1,0 +1,57 @@
+const React = globalThis.React
+// web.tsx
+var name = "page-heading-cards";
+var inject = ["pageEditor", "slots"];
+function card(level, accent) {
+  return function HeadingCard({ Content }) {
+    return /* @__PURE__ */ React.createElement(
+      "div",
+      {
+        "data-testid": `page-heading-card-${level}`,
+        style: {
+          borderLeft: `4px solid ${accent}`,
+          padding: "8px 12px",
+          margin: "2px 0",
+          background: `color-mix(in srgb, ${accent} 14%, transparent)`,
+          borderRadius: 8
+        }
+      },
+      /* @__PURE__ */ React.createElement("div", { style: { fontSize: 11, fontWeight: 700, opacity: 0.55, letterSpacing: "0.06em" } }, `H${level}`),
+      /* @__PURE__ */ React.createElement(Content, null)
+    );
+  };
+}
+function Panel() {
+  return /* @__PURE__ */ React.createElement(
+    "div",
+    {
+      "data-testid": "page-heading-cards-panel",
+      style: {
+        boxSizing: "border-box",
+        width: "100%",
+        height: "100%",
+        padding: 16,
+        font: "13px/1.5 ui-sans-serif, system-ui, sans-serif"
+      }
+    },
+    "\u5DF2\u66FF\u6362\u9875\u9762\u6B63\u6587\u7684 H1 / H2 / H3\u3002\u5728\u9875\u9762\u91CC\u8F93\u5165 / \u63D2\u5165\u6807\u9898\u5373\u53EF\u770B\u5230\u5361\u7247\u6837\u5F0F\u3002\u5173\u6389\u672C\u63D2\u4EF6\u540E\u6062\u590D\u539F\u751F\u6807\u9898\u3002"
+  );
+}
+function Icon(props) {
+  const className = props.className ?? "size-5";
+  return /* @__PURE__ */ React.createElement("svg", { viewBox: "0 0 16 16", fill: "currentColor", className, "aria-hidden": "true" }, /* @__PURE__ */ React.createElement("path", { d: "M3 3h10v2H3V3Zm0 4h7v2H3V7Zm0 4h10v2H3v-2Z" }));
+}
+function apply(ctx) {
+  ctx.pageEditor.replaceHeading(1, { View: card(1, "#7c5cfc") });
+  ctx.pageEditor.replaceHeading(2, { View: card(2, "#3b82f6") });
+  ctx.pageEditor.replaceHeading(3, { View: card(3, "#22c55e") });
+  ctx.slots.place("plugin-store-extras", Panel, {
+    key: "page-heading-cards",
+    props: () => ({ Icon })
+  });
+}
+export {
+  apply,
+  inject,
+  name
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@heroicons/react": "^2.2.0",
         "@tanstack/react-virtual": "^3.14.10",
         "@tiptap/extension-bubble-menu": "^3.30.5",
+        "@tiptap/extension-heading": "^3.30.5",
         "@tiptap/extension-placeholder": "^3.30.5",
         "@tiptap/markdown": "^3.30.5",
         "@tiptap/pm": "^3.30.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@heroicons/react": "^2.2.0",
     "@tanstack/react-virtual": "^3.14.10",
     "@tiptap/extension-bubble-menu": "^3.30.5",
+    "@tiptap/extension-heading": "^3.30.5",
     "@tiptap/extension-placeholder": "^3.30.5",
     "@tiptap/markdown": "^3.30.5",
     "@tiptap/pm": "^3.30.5",

--- a/packages/cap-page/src/web/heading-view.tsx
+++ b/packages/cap-page/src/web/heading-view.tsx
@@ -1,0 +1,25 @@
+import type { NodeViewProps } from '@tiptap/react'
+import { NodeViewContent, NodeViewWrapper } from '@tiptap/react'
+import { getPageEditor } from './service.ts'
+
+function HeadingContent() {
+  return <NodeViewContent as="span" className="page-h-plugin-content" />
+}
+
+export function PluginHeadingView(props: NodeViewProps) {
+  const level = (Number(props.node.attrs.level) || 1) as 1 | 2 | 3
+  const View = getPageEditor()?.headingView(level)?.View
+  if (!View) {
+    const Tag = (`h${level}` as const)
+    return (
+      <NodeViewWrapper as={Tag} className={`page-h page-h${level}`}>
+        <NodeViewContent />
+      </NodeViewWrapper>
+    )
+  }
+  return (
+    <NodeViewWrapper as="div" className={`page-h-plugin page-h${level}`} data-heading-plugin={level}>
+      <View Content={HeadingContent} />
+    </NodeViewWrapper>
+  )
+}

--- a/packages/cap-page/src/web/index.test.ts
+++ b/packages/cap-page/src/web/index.test.ts
@@ -34,4 +34,5 @@ test('page web paints /pages content chrome', async () => {
   await ctx.plugin(pageUi)
   assert.equal(ui.last?.path, '/pages')
   assert.equal(ui.last?.chrome.Content, pagesChrome.Content)
+  assert.ok(ctx.pageEditor)
 })

--- a/packages/cap-page/src/web/index.ts
+++ b/packages/cap-page/src/web/index.ts
@@ -1,12 +1,17 @@
 import type { Context } from 'cordis'
 import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { pagesChrome } from './chrome.tsx'
+import { PageEditorService } from './service.ts'
 import { PAGE_EDITOR_STYLE } from './style.ts'
+
+export { PageEditorService, getPageEditor, usePageEditorVersion } from './service.ts'
+export type { HeadingReplacement, HeadingViewProps, SlashCommandSpec, SlashInsert } from './service.ts'
 
 export const name = 'page-ui'
 export const inject = ['databaseUi']
 
 export function apply(ctx: Context) {
+  new PageEditorService(ctx)
   const ui = ctx.get('databaseUi') as DatabaseUi
   ctx.effect(() => ui.decorate('/pages', pagesChrome).dispose)
 }

--- a/packages/cap-page/src/web/kit.ts
+++ b/packages/cap-page/src/web/kit.ts
@@ -1,13 +1,28 @@
 import { Markdown } from '@tiptap/markdown'
+import Heading from '@tiptap/extension-heading'
 import Placeholder from '@tiptap/extension-placeholder'
+import { ReactNodeViewRenderer } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import { PluginHeadingView } from './heading-view.tsx'
+import { getPageEditor } from './service.ts'
 import { slashCommand } from './slash.ts'
 
 export function pageEditorExtensions() {
+  const editor = getPageEditor()
+  const patched = Boolean(editor?.headingView(1) || editor?.headingView(2) || editor?.headingView(3))
   return [
     StarterKit.configure({
-      heading: { levels: [1, 2, 3] },
+      heading: patched ? false : { levels: [1, 2, 3] },
     }),
+    ...(patched
+      ? [
+          Heading.extend({
+            addNodeView() {
+              return ReactNodeViewRenderer(PluginHeadingView)
+            },
+          }).configure({ levels: [1, 2, 3] }),
+        ]
+      : []),
     Markdown,
     Placeholder.configure({
       placeholder: ({ node }) => {

--- a/packages/cap-page/src/web/page-editor.test.tsx
+++ b/packages/cap-page/src/web/page-editor.test.tsx
@@ -1,7 +1,9 @@
 import { render, waitFor } from '@testing-library/react'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { Context } from 'cordis'
 import { PageEditor } from './page-editor.tsx'
+import { PageEditorService } from './service.ts'
 
 test('page editor paints markdown headings without a chrome toolbar', async () => {
   const { container, rerender } = render(
@@ -28,4 +30,29 @@ test('page editor paints markdown headings without a chrome toolbar', async () =
     />,
   )
   assert.equal(container.querySelector('h1')?.textContent?.trim(), '欢迎')
+})
+
+test('page editor uses plugin heading views when pageEditor has replacements', async () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  ctx.pageEditor.replaceHeading(1, {
+    View: ({ Content }) => (
+      <div data-testid="h1-plugin">
+        <Content />
+      </div>
+    ),
+  })
+  const { container } = render(
+    <PageEditor
+      record={{ id: 'home' }}
+      field="notes"
+      spec={{ type: 'file', label: '正文', writable: true }}
+      value={'# 欢迎'}
+      writable
+    />,
+  )
+  await waitFor(() => {
+    assert.ok(container.querySelector('[data-testid="h1-plugin"]'))
+  })
+  assert.match(container.querySelector('[data-testid="h1-plugin"]')?.textContent ?? '', /欢迎/)
 })

--- a/packages/cap-page/src/web/page-editor.tsx
+++ b/packages/cap-page/src/web/page-editor.tsx
@@ -4,6 +4,7 @@ import { BubbleMenu } from '@tiptap/react/menus'
 import type { Editor } from '@tiptap/core'
 import type { FsContentProps } from '@biu/type-file-system/ui'
 import { pageEditorExtensions } from './kit.ts'
+import { usePageEditorVersion } from './service.ts'
 
 function asMarkdown(value: unknown) {
   if (value == null) return ''
@@ -43,6 +44,7 @@ function Bubble({ editor }: { editor: Editor }) {
 export function PageEditor({ record, value, writable, onChange }: FsContentProps) {
   const saved = useRef(asMarkdown(value))
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const kitVersion = usePageEditorVersion()
 
   const editor = useEditor(
     {
@@ -83,7 +85,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
         })
       },
     },
-    [record.id],
+    [record.id, kitVersion],
   )
 
   useEffect(() => {

--- a/packages/cap-page/src/web/service.test.ts
+++ b/packages/cap-page/src/web/service.test.ts
@@ -1,0 +1,40 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import { PageEditorService, getPageEditor } from './service.ts'
+import { filterSlashItems } from './slash.ts'
+
+test('replaceHeading is scoped to the calling plugin fiber', async () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  assert.ok(getPageEditor())
+  const View = () => null
+  const fiber = ctx.plugin({
+    name: 'theme',
+    inject: ['pageEditor'],
+    apply(inner) {
+      inner.pageEditor.replaceHeading(1, { View })
+    },
+  })
+  await fiber
+  assert.equal(ctx.pageEditor.headingView(1)?.View, View)
+  await fiber.dispose()
+  assert.equal(ctx.pageEditor.headingView(1), undefined)
+})
+
+test('slash extras override built-in labels and dispose', async () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  const fiber = ctx.plugin({
+    name: 'slash-theme',
+    inject: ['pageEditor'],
+    apply(inner) {
+      inner.pageEditor.slash({ id: 'h1', label: '封面标题', hint: '插件', aliases: ['cover'] })
+    },
+  })
+  await fiber
+  const hit = filterSlashItems('cover').find((item) => item.id === 'h1')
+  assert.equal(hit?.label, '封面标题')
+  await fiber.dispose()
+  assert.equal(filterSlashItems('cover').some((item) => item.id === 'h1'), false)
+})

--- a/packages/cap-page/src/web/service.ts
+++ b/packages/cap-page/src/web/service.ts
@@ -1,0 +1,111 @@
+import { useSyncExternalStore, type ComponentType } from 'react'
+import { Service, type Context } from 'cordis'
+
+export type HeadingViewProps = {
+  Content: ComponentType
+}
+
+export type HeadingReplacement = {
+  View: ComponentType<HeadingViewProps>
+}
+
+export type SlashInsert =
+  | 'paragraph'
+  | 'heading1'
+  | 'heading2'
+  | 'heading3'
+  | 'bullet'
+  | 'ordered'
+  | 'quote'
+  | 'code'
+  | 'divider'
+
+export type SlashCommandSpec = {
+  id: string
+  label?: string
+  hint?: string
+  aliases?: string[]
+  insert?: SlashInsert
+}
+
+export type HeadingLevel = 1 | 2 | 3
+
+let bound: PageEditorService | undefined
+
+export function getPageEditor() {
+  return bound
+}
+
+export class PageEditorService extends Service {
+  private headings = new Map<HeadingLevel, HeadingReplacement>()
+  private extras: SlashCommandSpec[] = []
+  private seq = 0
+  private listeners = new Set<() => void>()
+
+  constructor(ctx: Context) {
+    super(ctx, 'pageEditor')
+    bound = this
+    ctx.effect(() => () => {
+      if (bound === this) bound = undefined
+    })
+  }
+
+  subscribe = (fn: () => void) => {
+    this.listeners.add(fn)
+    return () => this.listeners.delete(fn)
+  }
+
+  version = () => this.seq
+
+  headingView(level: number) {
+    return this.headings.get(level as HeadingLevel)
+  }
+
+  slashCommands() {
+    return [...this.extras]
+  }
+
+  /** 用商店插件的 React 组件替换原生 H1 / H2 / H3 外观。卸载插件后恢复。 */
+  replaceHeading(level: HeadingLevel, spec: HeadingReplacement) {
+    return this.ctx.effect(() => {
+      this.headings.set(level, spec)
+      this.bump()
+      return () => {
+        if (this.headings.get(level) === spec) this.headings.delete(level)
+        this.bump()
+      }
+    })
+  }
+
+  /** 增补或覆盖斜杠菜单项。不要传 TipTap 对象，只用 insert 声明要变成哪种块。 */
+  slash(spec: SlashCommandSpec) {
+    return this.ctx.effect(() => {
+      this.extras = [...this.extras.filter((item) => item.id !== spec.id), spec]
+      this.bump()
+      return () => {
+        this.extras = this.extras.filter((item) => item !== spec)
+        this.bump()
+      }
+    })
+  }
+
+  private bump() {
+    this.seq += 1
+    for (const fn of this.listeners) fn()
+  }
+}
+
+export function usePageEditorVersion(editor?: PageEditorService) {
+  const svc = editor ?? bound
+  return useSyncExternalStore(
+    (fn) => (svc ? svc.subscribe(fn) : () => undefined),
+    () => svc?.version() ?? 0,
+    () => 0,
+  )
+}
+
+declare module 'cordis' {
+  interface Context {
+    pageEditor: PageEditorService
+  }
+}

--- a/packages/cap-page/src/web/slash.ts
+++ b/packages/cap-page/src/web/slash.ts
@@ -3,6 +3,7 @@ import type { Editor, Range } from '@tiptap/core'
 import { ReactRenderer } from '@tiptap/react'
 import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion'
 import { SlashList } from './slash-list.tsx'
+import { getPageEditor, type SlashInsert } from './service.ts'
 
 export type SlashItem = {
   id: string
@@ -96,10 +97,43 @@ export const SLASH_ITEMS: SlashItem[] = [
   },
 ]
 
+function runInsert(editor: Editor, range: Range, insert: SlashInsert) {
+  const chain = editor.chain().focus().deleteRange(range)
+  if (insert === 'paragraph') return chain.toggleNode('paragraph', 'paragraph').run()
+  if (insert === 'heading1') return chain.setNode('heading', { level: 1 }).run()
+  if (insert === 'heading2') return chain.setNode('heading', { level: 2 }).run()
+  if (insert === 'heading3') return chain.setNode('heading', { level: 3 }).run()
+  if (insert === 'bullet') return chain.toggleBulletList().run()
+  if (insert === 'ordered') return chain.toggleOrderedList().run()
+  if (insert === 'quote') return chain.toggleNode('paragraph', 'paragraph').toggleBlockquote().run()
+  if (insert === 'code') return chain.toggleCodeBlock().run()
+  return chain.setHorizontalRule().run()
+}
+
+export function slashCatalog(): SlashItem[] {
+  const extras = getPageEditor()?.slashCommands() ?? []
+  if (!extras.length) return SLASH_ITEMS
+  const map = new Map(SLASH_ITEMS.map((item) => [item.id, item]))
+  for (const extra of extras) {
+    const prev = map.get(extra.id)
+    map.set(extra.id, {
+      id: extra.id,
+      label: extra.label ?? prev?.label ?? extra.id,
+      hint: extra.hint ?? prev?.hint ?? '',
+      aliases: extra.aliases ?? prev?.aliases ?? [],
+      command: extra.insert
+        ? ({ editor, range }) => runInsert(editor, range, extra.insert!)
+        : (prev?.command ?? (({ editor, range }) => editor.chain().focus().deleteRange(range).run())),
+    })
+  }
+  return [...map.values()]
+}
+
 export function filterSlashItems(query: string) {
+  const items = slashCatalog()
   const needle = query.trim().toLowerCase()
-  if (!needle) return SLASH_ITEMS
-  return SLASH_ITEMS.filter((item) => {
+  if (!needle) return items
+  return items.filter((item) => {
     const hay = [item.id, item.label, item.hint, ...item.aliases].join(' ').toLowerCase()
     return hay.includes(needle)
   })

--- a/packages/cap-page/src/web/style.ts
+++ b/packages/cap-page/src/web/style.ts
@@ -7,6 +7,8 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .tiptap h1{font-size:1.875em;font-weight:700;line-height:1.3;margin-top:.9em}
 .page-editor .tiptap h2{font-size:1.5em;font-weight:650;line-height:1.3;margin-top:.75em}
 .page-editor .tiptap h3{font-size:1.25em;font-weight:650;line-height:1.3;margin-top:.6em}
+.page-editor .page-h-plugin{margin:4px 0}
+.page-editor .page-h-plugin .page-h-plugin-content{display:block;outline:none;min-height:1.2em}
 .page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em}
 .page-editor .tiptap li{margin:1px 0}
 .page-editor .tiptap blockquote{margin-left:0;padding-left:14px;border-left:3px solid var(--dsw-border);color:var(--dsw-label-2)}

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -216,6 +216,37 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   assert.match(descriptions.join('\n'), /shellWidth/)
 })
 
+test('pack web jsx uses globalThis.React instead of bundling npm react', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-pack-jsx-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'store.json'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await store.initSandbox({
+      id: 'store-jsx',
+      name: 'JSX',
+      shell: { width: 320, height: 200 },
+    })
+    const sandbox = join(dir, '.plugin-dev', 'store-jsx')
+    await writeFile(
+      join(sandbox, 'web.tsx'),
+      `export const name = 'store-jsx'\nexport const inject = ['slots']\nfunction Hi() { return <div data-testid="hi">hi</div> }\nexport function apply(ctx: { slots: { place: (name: string, Comp: unknown, opt: unknown) => void } }) {\n  ctx.slots.place('plugin-store-extras', Hi, { key: 'store-jsx' })\n}\n`,
+    )
+    await store.pack('store-jsx')
+    const webJs = await readFile(join(dir, '.plugin', 'store-jsx', 'web.js'), 'utf8')
+    assert.match(webJs, /globalThis\.React/)
+    assert.match(webJs, /createElement/)
+    assert.doesNotMatch(webJs, /node_modules\/react/)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('compileStoreModule strips TypeScript in-process', async () => {
   const code = await compileStoreModule(
     `export const name = 'store-echo'\nexport function apply(ctx: { ok: boolean }) { return ctx.ok }`,

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -97,6 +97,7 @@ export async function compileStoreModule(source: string, kind: 'host' | 'web') {
     jsx: 'transform',
     jsxFactory: 'React.createElement',
     jsxFragment: 'React.Fragment',
+    tsconfigRaw: '{"compilerOptions":{"jsx":"react"}}',
     sourcemap: false,
   })
   return finishBundle(result.code, kind)
@@ -116,6 +117,7 @@ export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') 
     jsx: 'transform',
     jsxFactory: 'React.createElement',
     jsxFragment: 'React.Fragment',
+    tsconfigRaw: '{"compilerOptions":{"jsx":"react"}}',
     logLevel: 'silent',
   })
   const text = result.outputFiles?.[0]?.text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
已快进合并进 `text-editor`（`2d6ca08..baf826b`）并推送。本 PR 相对 `text-editor` 已无额外提交；后续看 https://github.com/helloooooooooooooo97/biu-harness/pull/379 即可。

页面编辑器现在是 Cordis 服务 `pageEditor`，商店插件可以 `inject: ['pageEditor']` 后调用 `replaceHeading` / `slash`。示例插件：`.plugin/page-heading-cards/`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

