### PR TITLE
feat(plugins): 商店可声明无头插件（无窗口、无操纵栏）

### DIFF
--- a/.plugin-dev/page-algorithm/manifest.json
+++ b/.plugin-dev/page-algorithm/manifest.json
@@ -5,11 +5,5 @@
   "tags": ["page", "editor", "leetcode"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
-  "shell": {
-    "width": 360,
-    "height": 220,
-    "minWidth": 280,
-    "minHeight": 160,
-    "resizable": true
-  }
+  "headless": true
 }

--- a/.plugin-dev/page-algorithm/web.tsx
+++ b/.plugin-dev/page-algorithm/web.tsx
@@ -1,5 +1,5 @@
 export const name = 'page-algorithm'
-export const inject = ['pageEditor', 'slots']
+export const inject = ['pageEditor']
 
 const DEFAULTS = {
   title: '1. Two Sum',
@@ -162,26 +162,6 @@ function AlgorithmCard({
   )
 }
 
-function Panel() {
-  return (
-    <div
-      data-testid="page-algorithm-panel"
-      style={{ boxSizing: 'border-box', width: '100%', height: '100%', padding: 16, font: '13px/1.5 ui-sans-serif, system-ui, sans-serif' }}
-    >
-      在页面正文输入 / 选「算法题」，插入 LeetCode 风卡片：左边题目，右边代码。
-    </div>
-  )
-}
-
-function Icon(props: { className?: string }) {
-  const className = props.className ?? 'size-5'
-  return (
-    <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
-      <path d="M3 2h6l4 4v8H3V2Zm6 1.4V6h2.6L9 3.4ZM5 9h6v1H5V9Zm0 2h6v1H5v-1Z" />
-    </svg>
-  )
-}
-
 export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
@@ -193,9 +173,6 @@ export function apply(ctx: {
       View: (props: { data: Record<string, unknown>; update: (patch: Record<string, unknown>) => void; writable: boolean }) => unknown
     }) => void
   }
-  slots: {
-    place: (slot: string, Comp: unknown, options: { key: string; props: () => { Icon: unknown } }) => void
-  }
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'algorithm',
@@ -204,9 +181,5 @@ export function apply(ctx: {
     aliases: ['leetcode', 'algo', '算法', 'lc'],
     defaults: DEFAULTS,
     View: AlgorithmCard,
-  })
-  ctx.slots.place('plugin-store-extras', Panel, {
-    key: 'page-algorithm',
-    props: () => ({ Icon }),
   })
 }

--- a/.plugin-dev/page-heading-cards/manifest.json
+++ b/.plugin-dev/page-heading-cards/manifest.json
@@ -5,11 +5,5 @@
   "tags": ["page", "editor", "theme"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
-  "shell": {
-    "width": 320,
-    "height": 200,
-    "minWidth": 280,
-    "minHeight": 160,
-    "resizable": true
-  }
+  "headless": true
 }

--- a/.plugin-dev/page-heading-cards/web.tsx
+++ b/.plugin-dev/page-heading-cards/web.tsx
@@ -1,5 +1,5 @@
 export const name = 'page-heading-cards'
-export const inject = ['pageEditor', 'slots']
+export const inject = ['pageEditor']
 
 function card(level: 1 | 2 | 3, accent: string) {
   return {
@@ -14,45 +14,12 @@ function card(level: 1 | 2 | 3, accent: string) {
   }
 }
 
-function Panel() {
-  return (
-    <div
-      data-testid="page-heading-cards-panel"
-      style={{
-        boxSizing: 'border-box',
-        width: '100%',
-        height: '100%',
-        padding: 16,
-        font: '13px/1.5 ui-sans-serif, system-ui, sans-serif',
-      }}
-    >
-      已给页面 H1 / H2 / H3 套上卡片皮肤。标题仍是原生 heading，方向键可以上下移动。关掉本插件后恢复默认样式。
-    </div>
-  )
-}
-
-function Icon(props: { className?: string }) {
-  const className = props.className ?? 'size-5'
-  return (
-    <svg viewBox="0 0 16 16" fill="currentColor" className={className} aria-hidden="true">
-      <path d="M3 3h10v2H3V3Zm0 4h7v2H3V7Zm0 4h10v2H3v-2Z" />
-    </svg>
-  )
-}
-
 export function apply(ctx: {
   pageEditor: {
     replaceHeading: (level: 1 | 2 | 3, spec: { className?: string; style?: string; label?: string }) => void
-  }
-  slots: {
-    place: (slot: string, Comp: unknown, options: { key: string; props: () => { Icon: unknown } }) => void
   }
 }) {
   ctx.pageEditor.replaceHeading(1, card(1, '#7c5cfc'))
   ctx.pageEditor.replaceHeading(2, card(2, '#3b82f6'))
   ctx.pageEditor.replaceHeading(3, card(3, '#22c55e'))
-  ctx.slots.place('plugin-store-extras', Panel, {
-    key: 'page-heading-cards',
-    props: () => ({ Icon }),
-  })
 }

--- a/.plugin/page-algorithm/manifest.json
+++ b/.plugin/page-algorithm/manifest.json
@@ -2,14 +2,13 @@
   "id": "page-algorithm",
   "name": "算法题卡片",
   "blurb": "在页面里用 / 插入 LeetCode 风算法块：左边题目描述，右边代码。",
-  "tags": ["page", "editor", "leetcode"],
+  "tags": [
+    "page",
+    "editor",
+    "leetcode"
+  ],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
-  "shell": {
-    "width": 360,
-    "height": 220,
-    "minWidth": 280,
-    "minHeight": 160,
-    "resizable": true
-  }
+  "createdAt": 1788270674739,
+  "headless": true
 }

--- a/.plugin/page-algorithm/web.js
+++ b/.plugin/page-algorithm/web.js
@@ -1,7 +1,7 @@
 const React = globalThis.React
 // web.tsx
 var name = "page-algorithm";
-var inject = ["pageEditor", "slots"];
+var inject = ["pageEditor"];
 var DEFAULTS = {
   title: "1. Two Sum",
   difficulty: "Easy",
@@ -164,20 +164,6 @@ function AlgorithmCard({
     ))
   );
 }
-function Panel() {
-  return /* @__PURE__ */ React.createElement(
-    "div",
-    {
-      "data-testid": "page-algorithm-panel",
-      style: { boxSizing: "border-box", width: "100%", height: "100%", padding: 16, font: "13px/1.5 ui-sans-serif, system-ui, sans-serif" }
-    },
-    "\u5728\u9875\u9762\u6B63\u6587\u8F93\u5165 / \u9009\u300C\u7B97\u6CD5\u9898\u300D\uFF0C\u63D2\u5165 LeetCode \u98CE\u5361\u7247\uFF1A\u5DE6\u8FB9\u9898\u76EE\uFF0C\u53F3\u8FB9\u4EE3\u7801\u3002"
-  );
-}
-function Icon(props) {
-  const className = props.className ?? "size-5";
-  return /* @__PURE__ */ React.createElement("svg", { viewBox: "0 0 16 16", fill: "currentColor", className, "aria-hidden": "true" }, /* @__PURE__ */ React.createElement("path", { d: "M3 2h6l4 4v8H3V2Zm6 1.4V6h2.6L9 3.4ZM5 9h6v1H5V9Zm0 2h6v1H5v-1Z" }));
-}
 function apply(ctx) {
   ctx.pageEditor.registerBlock({
     kind: "algorithm",
@@ -186,10 +172,6 @@ function apply(ctx) {
     aliases: ["leetcode", "algo", "\u7B97\u6CD5", "lc"],
     defaults: DEFAULTS,
     View: AlgorithmCard
-  });
-  ctx.slots.place("plugin-store-extras", Panel, {
-    key: "page-algorithm",
-    props: () => ({ Icon })
   });
 }
 export {

--- a/.plugin/page-heading-cards/manifest.json
+++ b/.plugin/page-heading-cards/manifest.json
@@ -2,14 +2,13 @@
   "id": "page-heading-cards",
   "name": "页面标题卡片",
   "blurb": "把页面编辑器里的 H1 / H2 / H3 换成左侧色条卡片。关掉插件即恢复原生标题。",
-  "tags": ["page", "editor", "theme"],
+  "tags": [
+    "page",
+    "editor",
+    "theme"
+  ],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
-  "shell": {
-    "width": 320,
-    "height": 200,
-    "minWidth": 280,
-    "minHeight": 160,
-    "resizable": true
-  }
+  "createdAt": 1788270674728,
+  "headless": true
 }

--- a/.plugin/page-heading-cards/web.js
+++ b/.plugin/page-heading-cards/web.js
@@ -1,7 +1,6 @@
-const React = globalThis.React
 // web.tsx
 var name = "page-heading-cards";
-var inject = ["pageEditor", "slots"];
+var inject = ["pageEditor"];
 function card(level, accent) {
   return {
     label: `H${level}`,
@@ -14,34 +13,10 @@ function card(level, accent) {
     ].join(";")
   };
 }
-function Panel() {
-  return /* @__PURE__ */ React.createElement(
-    "div",
-    {
-      "data-testid": "page-heading-cards-panel",
-      style: {
-        boxSizing: "border-box",
-        width: "100%",
-        height: "100%",
-        padding: 16,
-        font: "13px/1.5 ui-sans-serif, system-ui, sans-serif"
-      }
-    },
-    "\u5DF2\u7ED9\u9875\u9762 H1 / H2 / H3 \u5957\u4E0A\u5361\u7247\u76AE\u80A4\u3002\u6807\u9898\u4ECD\u662F\u539F\u751F heading\uFF0C\u65B9\u5411\u952E\u53EF\u4EE5\u4E0A\u4E0B\u79FB\u52A8\u3002\u5173\u6389\u672C\u63D2\u4EF6\u540E\u6062\u590D\u9ED8\u8BA4\u6837\u5F0F\u3002"
-  );
-}
-function Icon(props) {
-  const className = props.className ?? "size-5";
-  return /* @__PURE__ */ React.createElement("svg", { viewBox: "0 0 16 16", fill: "currentColor", className, "aria-hidden": "true" }, /* @__PURE__ */ React.createElement("path", { d: "M3 3h10v2H3V3Zm0 4h7v2H3V7Zm0 4h10v2H3v-2Z" }));
-}
 function apply(ctx) {
   ctx.pageEditor.replaceHeading(1, card(1, "#7c5cfc"));
   ctx.pageEditor.replaceHeading(2, card(2, "#3b82f6"));
   ctx.pageEditor.replaceHeading(3, card(3, "#22c55e"));
-  ctx.slots.place("plugin-store-extras", Panel, {
-    key: "page-heading-cards",
-    props: () => ({ Icon })
-  });
 }
 export {
   apply,

--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -68,6 +68,7 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.equal(demo?.sandbox, undefined)
   assert.equal(demo?.shellWidth, defaultStoreShell().width)
   assert.equal(demo?.hasWeb, true)
+  assert.equal(demo?.headless, undefined)
   assert.equal(draft?.sandbox, true)
   assert.equal(draft?.installed, undefined)
   assert.equal(draft?.running, undefined)
@@ -88,6 +89,40 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { installed: true, running: false })
   assert.deepEqual(spec.actions?.find((item) => item.id === 'pack')?.when, { sandbox: true })
   assert.deepEqual(spec.actions?.find((item) => item.id === 'uninstall')?.when, { installed: true })
+})
+
+test('headless plugins omit shell columns', async () => {
+  const spec = pluginsCollection({
+    list: () =>
+      Promise.resolve([
+        {
+          id: 'skin',
+          name: 'Skin',
+          blurb: '',
+          tags: [],
+          author: '',
+          authorUrl: '',
+          enabled: true,
+          running: true,
+          bytes: 8,
+          createdAt: 1,
+          updatedAt: 2,
+          lastRunAt: null,
+          hasHost: false,
+          hasWeb: true,
+          headless: true,
+        },
+      ]),
+    listSandboxes: () => Promise.resolve([]),
+    openPlugin() {},
+    close() {},
+    pack() {},
+    uninstall() {},
+  } as PluginStoreService)
+  const listed = await spec.list()
+  assert.equal(listed[0]?.headless, true)
+  assert.equal(listed[0]?.shellWidth, undefined)
+  assert.ok(spec.schema.columns?.includes('headless'))
 })
 
 test('same id with sandbox and install merges into one row', async () => {

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -33,11 +33,16 @@ function asInstalledRecord(row: StoreListing): DbRecord {
     lastRunAt: row.lastRunAt,
     hasHost: row.hasHost,
     hasWeb: row.hasWeb,
-    shellWidth: shell.width,
-    shellHeight: shell.height,
-    shellMinWidth: shell.minWidth,
-    shellMinHeight: shell.minHeight,
-    shellResizable: shell.resizable,
+    headless: row.headless === true,
+    ...(row.headless || !shell
+      ? {}
+      : {
+          shellWidth: shell.width,
+          shellHeight: shell.height,
+          shellMinWidth: shell.minWidth,
+          shellMinHeight: shell.minHeight,
+          shellResizable: shell.resizable,
+        }),
   })
 }
 
@@ -53,6 +58,7 @@ function asSandboxRecord(row: SandboxListing): DbRecord {
     sandbox: true,
     hasHost: row.hasHost,
     hasWeb: row.hasWeb,
+    headless: row.headless === true,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   })
@@ -112,6 +118,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         'shellHeight',
         'hasHost',
         'hasWeb',
+        'headless',
       ],
       fields: {
         name: { type: 'string', label: '名称' },
@@ -127,6 +134,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         lastRunAt: { type: 'datetime', label: '上次运行' },
         hasHost: { type: 'boolean', label: 'Host' },
         hasWeb: { type: 'boolean', label: 'Web' },
+        headless: { type: 'boolean', label: '无头' },
         author: { type: 'string', label: '作者' },
         authorUrl: { type: 'url', label: '作者链接' },
         shellWidth: { type: 'number', label: '窗口宽' },

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -136,6 +136,48 @@ test('pack with web rejects sandbox manifest without shell size', async () => {
   }
 })
 
+test('create and pack allow web without shell when headless', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-headless-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'store.json'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await store.create({
+      id: 'store-skin',
+      name: 'Skin',
+      headless: true,
+      webJs: `export const name = 'store-skin'\nexport function apply() {}`,
+    })
+    const created = JSON.parse(await readFile(join(dir, '.plugin', 'store-skin', 'manifest.json'), 'utf8')) as {
+      headless?: boolean
+      shell?: unknown
+    }
+    assert.equal(created.headless, true)
+    assert.equal(created.shell, undefined)
+    const listed = await store.list()
+    assert.equal(listed[0]?.headless, true)
+    assert.equal(listed[0]?.shell, undefined)
+
+    await store.initSandbox({ id: 'store-skin-src', name: 'Skin Src', headless: true })
+    const sandbox = join(dir, '.plugin-dev', 'store-skin-src')
+    await writeFile(join(sandbox, 'web.tsx'), `export const name = 'store-skin-src'\nexport function apply() {}\n`)
+    await store.pack('store-skin-src')
+    const packed = JSON.parse(await readFile(join(dir, '.plugin', 'store-skin-src', 'manifest.json'), 'utf8')) as {
+      headless?: boolean
+      shell?: unknown
+    }
+    assert.equal(packed.headless, true)
+    assert.equal(packed.shell, undefined)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('initSandbox writes source; pack bundles into .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-create-'))
   try {
@@ -214,6 +256,7 @@ test('registers plugin_create, plugin_sandbox, plugin_pack', () => {
   assert.match(descriptions.join('\n'), /storeShellFromRecord/)
   assert.match(descriptions.join('\n'), /listing\.shell/)
   assert.match(descriptions.join('\n'), /shellWidth/)
+  assert.match(descriptions.join('\n'), /无头/)
 })
 
 test('pack web jsx uses globalThis.React instead of bundling npm react', async () => {

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -12,6 +12,7 @@ export type PluginCreateInput = {
   tags?: string[]
   author?: string
   authorUrl?: string
+  headless?: boolean
   shell?: StoreShell | Record<string, unknown>
   hostJs?: string
   webJs?: string
@@ -25,6 +26,7 @@ export type StoreManifestFields = {
   author: string
   authorUrl: string
   createdAt: number
+  headless?: boolean
   shell?: StoreShell
 }
 
@@ -38,11 +40,12 @@ export function parseTags(value: unknown): string[] {
 }
 
 export function buildStoreManifest(
-  input: Pick<PluginCreateInput, 'id' | 'name' | 'blurb' | 'tags' | 'author' | 'authorUrl' | 'shell'>,
+  input: Pick<PluginCreateInput, 'id' | 'name' | 'blurb' | 'tags' | 'author' | 'authorUrl' | 'shell' | 'headless'>,
   existing?: Partial<StoreManifestFields>,
   now = Date.now(),
 ): StoreManifestFields {
   const createdAt = Number(existing?.createdAt)
+  const headless = Boolean(input.headless ?? existing?.headless)
   return {
     id: String(input.id).trim(),
     name: String(input.name).trim(),
@@ -51,7 +54,8 @@ export function buildStoreManifest(
     author: String(input.author ?? existing?.author ?? '').trim(),
     authorUrl: String(input.authorUrl ?? existing?.authorUrl ?? '').trim(),
     createdAt: Number.isFinite(createdAt) && createdAt > 0 ? createdAt : now,
-    ...(declaredStoreShell(input.shell ?? existing?.shell)
+    ...(headless ? { headless: true } : {}),
+    ...(!headless && declaredStoreShell(input.shell ?? existing?.shell)
       ? { shell: parseStoreShell(input.shell ?? existing?.shell) }
       : {}),
   }
@@ -71,10 +75,11 @@ export function parseStoreManifest(raw: unknown): StoreManifestFields {
       tags: parseTags(data.tags),
       author: data.author != null ? String(data.author) : undefined,
       authorUrl: data.authorUrl != null ? String(data.authorUrl) : data.author_url != null ? String(data.author_url) : undefined,
+      headless: data.headless === true,
       shell: data.shell,
     },
     { createdAt },
-    Number.isFinite(createdAt) && createdAt > 0 ? createdAt : 0,
+    Number.isFinite(createdAt) && createdAt > 0 ? createdAt : Date.now(),
   )
 }
 
@@ -140,9 +145,10 @@ export async function readSandboxManifest(dir: string) {
 
 const CONTRACT = [
   '契约：id 与 export const name 相同。禁止 import npm / react / @biu/*。不要改 packages/ 或 cordis.plugins.json。',
-  'Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选，不传则 Dock 用默认拼图图标。运行窗口会给 extras 套 macOS 窗口框（关/缩/全屏），key 尽量用插件 id。',
-  '有 web 时必须在 manifest / 本工具 shell 参数里写 width 与 height（内容区像素）。可选 minWidth / minHeight / resizable。禁止省略让窗口猜尺寸。插件根节点铺满窗口，不要用 100vw。',
-  '/plugins 列表没有 listing.shell 对象，只有扁平字段 shellWidth、shellHeight、shellMinWidth、shellMinHeight、shellResizable。运行窗口必须用 storeShellFromRecord 读这些字段，禁止再读 listing.shell（undefined 会落到默认 480×360，操作栏会离开卡片）。',
+  '有窗口的 Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选。运行窗口会给 extras 套操纵栏（关/缩/全屏），key 尽量用插件 id。',
+  '无头插件：manifest 写 headless: true。有 web 也不要 shell，不要 place plugin-store-extras，不要操纵栏。只在 apply 里登记服务（如 pageEditor）。',
+  '有窗口的 web 必须在 manifest / 本工具 shell 参数里写 width 与 height。无头插件不要写 shell。',
+  '/plugins 列表没有 listing.shell 对象，只有扁平字段 shellWidth、shellHeight、shellMinWidth、shellMinHeight、shellResizable、headless。有窗口时用 storeShellFromRecord 读尺寸。',
 ].join(' ')
 
 const PLUGIN_CREATE_DESCRIPTION = [
@@ -160,7 +166,7 @@ const PLUGIN_SANDBOX_DESCRIPTION = [
 
 const PLUGIN_PACK_DESCRIPTION = [
   '把 .plugin-dev/<id>/ 沙箱打包进 .plugin/<id>/（manifest.json + bundle 后的 host.js / web.js）。',
-  '入口：host.ts|tsx|js 与 web.tsx|ts|js，至少要有一个。有 web 时 manifest.shell 必须已写 width/height，否则拒绝打包。已打开的插件会重新挂上。',
+  '入口：host.ts|tsx|js 与 web.tsx|ts|js，至少要有一个。有窗口的 web 必须已写 shell.width/height；无头插件写 headless: true 即可。已打开的插件会重新挂上。',
 ].join(' ')
 
 function createArgs(args: Record<string, unknown>): PluginCreateInput {
@@ -171,6 +177,7 @@ function createArgs(args: Record<string, unknown>): PluginCreateInput {
     tags: parseTags(args.tags),
     author: args.author != null ? String(args.author) : undefined,
     authorUrl: args.authorUrl != null ? String(args.authorUrl) : undefined,
+    headless: args.headless === true,
     shell: args.shell && typeof args.shell === 'object' ? (args.shell as Record<string, unknown>) : undefined,
     hostJs: args.hostJs != null ? String(args.hostJs) : undefined,
     webJs: args.webJs != null ? String(args.webJs) : undefined,
@@ -191,9 +198,13 @@ const ID_NAME_BLURB = {
   },
   author: { type: 'string', description: '作者名' },
   authorUrl: { type: 'string', description: '作者主页 / 仓库链接' },
+  headless: {
+    type: 'boolean',
+    description: '无头插件：有 web 也不弹窗口、不要操纵栏。true 时不要写 shell。',
+  },
   shell: {
     type: 'object',
-      description: '有 web 时必填。运行窗口内容区像素，对应 manifest.shell。必须给 width 和 height。/plugins 表里会拆成 shellWidth/shellHeight，窗口用 storeShellFromRecord 读取，不要读 listing.shell。',
+      description: '有窗口的 web 必填。无头插件不要传。运行窗口内容区像素，对应 manifest.shell。必须给 width 和 height。',
     properties: {
       width: { type: 'number', description: '内容区宽，必填' },
       height: { type: 'number', description: '内容区高，必填' },

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -33,7 +33,8 @@ export type StoreListing = {
   lastRunAt: number | null
   hasHost: boolean
   hasWeb: boolean
-  shell: StoreShell
+  headless?: boolean
+  shell?: StoreShell
 }
 
 export type StoreManifest = StoreManifestFields
@@ -211,7 +212,7 @@ export class PluginStoreService extends Service {
     const hostJs = String(input.hostJs ?? '').trim()
     const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     if (!hostJs && !webSrc) throw new Error('plugin_create needs hostJs and/or webJs')
-    requireDeclaredShell(input.shell, Boolean(webSrc), 'plugin_create')
+    requireDeclaredShell(input.shell, Boolean(webSrc), 'plugin_create', Boolean(input.headless))
     this.invalidateList()
     const dest = this.pluginPath(id)
     mkdirSync(dest, { recursive: true })
@@ -237,8 +238,8 @@ export class PluginStoreService extends Service {
     const hostJs = String(input.hostJs ?? '').trim()
     const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
     const hasWeb = Boolean(webSrc) || Boolean(findEntry(dest, WEB_ENTRIES))
-    requireDeclaredShell(input.shell, hasWeb, 'plugin_sandbox')
     const existing = existsSync(join(dest, 'manifest.json')) ? await readManifest(dest).catch(() => undefined) : undefined
+    requireDeclaredShell(input.shell, hasWeb, 'plugin_sandbox', Boolean(input.headless) || Boolean(existing?.headless))
     const manifest = buildStoreManifest(input, existing)
     await writeFile(join(dest, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
     if (hostJs) await writeFile(join(dest, 'host.ts'), hostJs.endsWith('\n') ? hostJs : `${hostJs}\n`)
@@ -260,6 +261,7 @@ export class PluginStoreService extends Service {
       raw && typeof raw === 'object' ? (raw as { shell?: unknown }).shell : undefined,
       Boolean(webEntry),
       'plugin_pack',
+      Boolean(manifest.headless),
     )
     this.invalidateList()
     const dest = this.pluginPath(manifest.id)
@@ -284,6 +286,7 @@ export class PluginStoreService extends Service {
       authorUrl: string
       hasHost: boolean
       hasWeb: boolean
+      headless?: boolean
       createdAt: number
       updatedAt: number
     }> = []
@@ -302,6 +305,7 @@ export class PluginStoreService extends Service {
         authorUrl: manifest.authorUrl,
         hasHost: Boolean(findEntry(dir, HOST_ENTRIES)),
         hasWeb: Boolean(findEntry(dir, WEB_ENTRIES)),
+        ...(manifest.headless ? { headless: true } : {}),
         createdAt: manifest.createdAt || stats.createdAt,
         updatedAt: stats.updatedAt,
       })
@@ -336,7 +340,7 @@ export class PluginStoreService extends Service {
         lastRunAt: this.state.lastRunAt[manifest.id] ?? null,
         hasHost: stats.hasHost,
         hasWeb: stats.hasWeb,
-        shell: parseStoreShell(manifest.shell),
+        ...(manifest.headless ? { headless: true } : { shell: parseStoreShell(manifest.shell) }),
       })
     }
     this.listCache = items

--- a/packages/core-plugin-system/src/shell.test.ts
+++ b/packages/core-plugin-system/src/shell.test.ts
@@ -1,6 +1,14 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { centeredGeom, declaredStoreShell, parseStoreShell, storeShellFromRecord, windowOuterSize } from './shell.ts'
+import {
+  centeredGeom,
+  declaredStoreShell,
+  listingIsHeadless,
+  parseStoreShell,
+  requireDeclaredShell,
+  storeShellFromRecord,
+  windowOuterSize,
+} from './shell.ts'
 
 test('parseStoreShell defaults and clamps declared content size', () => {
   const d = parseStoreShell(undefined)
@@ -59,4 +67,16 @@ test('declaredStoreShell is true only when width and height are set', () => {
   assert.equal(declaredStoreShell({}), false)
   assert.equal(declaredStoreShell({ width: 640 }), false)
   assert.equal(declaredStoreShell({ width: 640, height: 480 }), true)
+})
+
+test('requireDeclaredShell skips size when headless', () => {
+  assert.doesNotThrow(() => requireDeclaredShell(undefined, true, 'plugin_create', true))
+  assert.throws(() => requireDeclaredShell(undefined, true, 'plugin_create', false), /headless: true/)
+  assert.doesNotThrow(() => requireDeclaredShell(undefined, false, 'plugin_create', false))
+})
+
+test('listingIsHeadless reads flattened /plugins rows', () => {
+  assert.equal(listingIsHeadless({ headless: true }), true)
+  assert.equal(listingIsHeadless({ id: 'x', shellWidth: 320 }), false)
+  assert.equal(listingIsHeadless(undefined), false)
 })

--- a/packages/core-plugin-system/src/shell.ts
+++ b/packages/core-plugin-system/src/shell.ts
@@ -39,11 +39,16 @@ export function declaredStoreShell(value: unknown): boolean {
   return Number.isFinite(width) && Number.isFinite(height)
 }
 
-export function requireDeclaredShell(value: unknown, hasWeb: boolean, where: string) {
-  if (!hasWeb) return
+export function requireDeclaredShell(value: unknown, hasWeb: boolean, where: string, headless = false) {
+  if (!hasWeb || headless) return
   if (!declaredStoreShell(value)) {
-    throw new Error(`${where}: web plugins must set shell.width and shell.height (content pixels)`)
+    throw new Error(`${where}: web plugins must set shell.width and shell.height (content pixels), or set headless: true`)
   }
+}
+
+export function listingIsHeadless(row: unknown): boolean {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) return false
+  return (row as { headless?: unknown }).headless === true
 }
 
 /** /plugins 列表把 shell 拆成 shellWidth 等字段，窗口层要还原。 */

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -20,6 +20,9 @@ function PluginTitle({ record, label }: { record: DbRecord; label: string }) {
       {record.hasWeb ? (
         <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">Web</span>
       ) : null}
+      {record.headless ? (
+        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">无头</span>
+      ) : null}
     </span>
   )
 }

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -70,6 +70,8 @@ test('plugin window sizes from manifest.shell instead of measuring DOM', async (
   assert.match(src, /storeShellFromRecord/)
   assert.match(src, /dismissAndStop/)
   assert.match(src, /dismissed\[entry\.id\]/)
+  assert.match(src, /listingIsHeadless/)
+  assert.match(src, /extraProps\.headless === true/)
   assert.doesNotMatch(src, /measurePluginBox/)
   assert.doesNotMatch(src, /ResizeObserver/)
   const create = await readFile(resolve(import.meta.dirname, '../host/plugin-create.ts'), 'utf8')

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -11,6 +11,7 @@ import {
   WIN_CHROME_H,
   centeredGeom,
   clampGeom,
+  listingIsHeadless,
   storeShellFromRecord,
   type StoreShell,
   type WinGeom,
@@ -19,7 +20,7 @@ import {
 export const name = 'core-plugin-system-ui'
 export const inject = ['slots', 'databaseUi', 'dock']
 
-type StoreListing = { id: string; name: string; shell?: StoreShell }
+type StoreListing = { id: string; name: string; shell?: StoreShell; headless?: boolean }
 
 async function readJson<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(path, init)
@@ -364,11 +365,12 @@ function PluginExtrasLayer(props: SlotProps) {
     const live = new Set<string>()
     for (const entry of sorted) {
       if (dismissed[entry.id]) continue
+      const extraProps = entry.props?.() ?? {}
       const listing = resolveListing(entry.id, listings)
+      if (listingIsHeadless(listing) || extraProps.headless === true) continue
       const title = listing?.name ?? entry.id
       const dockId = `plugin:${entry.id}`
       live.add(dockId)
-      const extraProps = entry.props?.() ?? {}
       const ExtraIcon = extraProps.Icon as ((props: { className?: string }) => ReactNode) | undefined
       const Icon = ExtraIcon
         ? () => <ExtraIcon className="size-5" />
@@ -410,6 +412,8 @@ function PluginExtrasLayer(props: SlotProps) {
       {sorted.map((entry) => {
         if (minimized[entry.id] || dismissed[entry.id]) return null
         const listing = resolveListing(entry.id, listings)
+        const extraProps = entry.props?.() ?? {}
+        if (listingIsHeadless(listing) || extraProps.headless === true) return null
         const pluginId = listing?.id ?? entry.id
         const title = listing?.name ?? entry.id
         const shell = storeShellFromRecord(listing)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
商店插件可在 `manifest` 里写 `headless: true`：有 web 也不再要求 `shell`，运行时不弹出 `plugin-store-extras` 窗口、不注册 dock 操纵栏。

页面标题卡片、算法题卡片两个示例已改成无头，只通过 `pageEditor` 登记皮肤/块类型。

有窗口的 web 插件仍必须声明 `shell.width` / `shell.height`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

