### PR TITLE
fix(page): 再进页面时把已保存的 Markdown 灌进编辑器

### DIFF
--- a/packages/cap-page/src/web/page-editor.test.tsx
+++ b/packages/cap-page/src/web/page-editor.test.tsx
@@ -82,3 +82,47 @@ test('page editor paints a registered algorithm block', async () => {
   assert.equal(container.querySelector('[data-testid="algo-view"]')?.textContent, 'Two Sum')
 })
 
+test('page editor hydrates markdown after content fetch', async () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  ctx.pageEditor.registerBlock({
+    kind: 'algorithm',
+    label: '算法题',
+    defaults: { title: 'Two Sum' },
+    View: ({ data }) => <div data-testid="algo-view">{String(data.title ?? '')}</div>,
+  })
+  const src = `:::pageBlock {kind=algorithm}
+{"title":"Two Sum"}
+:::
+
+一段正文
+`
+  const { container, rerender } = render(
+    <PageEditor
+      record={{ id: 'home' }}
+      field="notes"
+      spec={{ type: 'file', label: '正文', writable: true }}
+      value={null}
+      writable
+    />,
+  )
+  await waitFor(() => {
+    assert.ok(container.querySelector('[data-testid="page-editor"]'))
+  })
+  assert.equal(container.querySelector('[data-testid="algo-view"]'), null)
+  rerender(
+    <PageEditor
+      record={{ id: 'home' }}
+      field="notes"
+      spec={{ type: 'file', label: '正文', writable: true }}
+      value={src}
+      writable
+    />,
+  )
+  await waitFor(() => {
+    assert.ok(container.querySelector('[data-testid="algo-view"]'))
+  })
+  assert.equal(container.querySelector('[data-testid="algo-view"]')?.textContent, 'Two Sum')
+  assert.match(container.textContent ?? '', /一段正文/)
+})
+

--- a/packages/cap-page/src/web/page-editor.tsx
+++ b/packages/cap-page/src/web/page-editor.tsx
@@ -43,6 +43,7 @@ function Bubble({ editor }: { editor: Editor }) {
 export function PageEditor({ record, value, writable, onChange }: FsContentProps) {
   const saved = useRef(asMarkdown(value))
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hydratedId = useRef<string | null>(null)
 
   const editor = useEditor(
     {
@@ -61,6 +62,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
         },
       },
       onUpdate: ({ editor: current }) => {
+        if (hydratedId.current !== record.id) return
         if (timer.current) clearTimeout(timer.current)
         timer.current = setTimeout(() => {
           queueMicrotask(() => {
@@ -73,6 +75,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
         }, 400)
       },
       onBlur: ({ editor: current }) => {
+        if (hydratedId.current !== record.id) return
         if (timer.current) clearTimeout(timer.current)
         queueMicrotask(() => {
           if (current.isDestroyed) return
@@ -85,6 +88,20 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
     },
     [record.id],
   )
+
+  useEffect(() => {
+    hydratedId.current = null
+  }, [record.id])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    if (value == null) return
+    if (hydratedId.current === record.id) return
+    const md = asMarkdown(value)
+    saved.current = md
+    hydratedId.current = record.id
+    editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
+  }, [editor, record.id, value])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开页面时，正文接口还没返回，编辑器先用空字符串建好；之后 `notes` 到了也不会 `setContent`。所以磁盘上的 Markdown（含算法块 / 画板 `:::pageBlock`）是有的，再点进去却是空白。

现在等 content 返回后再按 markdown 灌进编辑器，并且灌入时不触发保存，避免把空文档写回去。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

