### PR TITLE
feat(page): 未引用附件一天后回收

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context, Service } from 'cordis'
@@ -9,7 +9,7 @@ import * as tools from '@biu/host-tools'
 import * as fsPlugin from '@biu/host-fs'
 import * as page from './index.ts'
 import { dumpMarkdown, splitMarkdown } from './markdown.ts'
-import { PAGE_ASSETS, PAGE_ROOT, PagesStore } from './store.ts'
+import { ASSET_GC_GRACE_MS, PAGE_ASSETS, PAGE_ROOT, PagesStore, collectPageAssetNames } from './store.ts'
 
 const FIELD_TYPES: FieldType[] = [
   'string',
@@ -129,4 +129,60 @@ test('PagesStore reads existing markdown files from .page', async () => {
   const onlyHome = await store.list(['home'])
   assert.equal(onlyHome.length, 1)
   assert.equal(onlyHome[0]?.id, 'home')
+})
+
+test('collectPageAssetNames picks page asset pointers', () => {
+  const names = collectPageAssetNames(
+    'cover: assets/hero.png\n',
+    ':::pageBlock {kind=excalidraw}\n{"file":"assets/excalidraw-aa.json"}\n:::\n',
+    { href: '/api/page/file/pack.zip' },
+  )
+  assert.equal(names.has('hero.png'), true)
+  assert.equal(names.has('excalidraw-aa.json'), true)
+  assert.equal(names.has('pack.zip'), true)
+  assert.equal(ASSET_GC_GRACE_MS, 24 * 60 * 60 * 1000)
+})
+
+test('gcAssets deletes unreferenced files after one day', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-gc-'))
+  await ctx.plugin(fsPlugin, { root })
+  const store = new PagesStore(ctx.fs.workspace as never)
+  const a = await store.create({
+    title: 'A',
+    notes: ':::pageBlock {kind=excalidraw}\n{"file":"assets/excalidraw-keep.json"}\n:::\n',
+  })
+  const b = await store.create({
+    title: 'B',
+    notes: ':::pageBlock {kind=excalidraw}\n{"file":"assets/excalidraw-drop.json"}\n:::\n',
+  })
+  await store.writeAsset('excalidraw-keep.json', '{"ok":1}')
+  await store.writeAsset('excalidraw-drop.json', '{"ok":2}')
+  await store.writeAsset('orphan.json', '{"ok":3}')
+  const stale = Date.now() / 1000 - 2 * 24 * 60 * 60
+  await utimes(join(root, PAGE_ASSETS, 'excalidraw-drop.json'), stale, stale)
+  await utimes(join(root, PAGE_ASSETS, 'orphan.json'), stale, stale)
+
+  await store.update(b.id, { notes: 'gone\n' })
+  await store.gcAssets({ now: Date.now() })
+
+  const dropGone = await readFile(join(root, PAGE_ASSETS, 'excalidraw-drop.json'), 'utf8').then(
+    () => false,
+    () => true,
+  )
+  const orphanGone = await readFile(join(root, PAGE_ASSETS, 'orphan.json'), 'utf8').then(
+    () => false,
+    () => true,
+  )
+  const kept = await readFile(join(root, PAGE_ASSETS, 'excalidraw-keep.json'), 'utf8')
+  assert.equal(dropGone, true)
+  assert.equal(orphanGone, true)
+  assert.match(kept, /ok/)
+
+  await store.writeAsset('fresh-orphan.json', '{}')
+  await store.gcAssets()
+  const fresh = await readFile(join(root, PAGE_ASSETS, 'fresh-orphan.json'), 'utf8')
+  assert.equal(fresh, '{}')
+  assert.equal(a.title, 'A')
 })

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -2,7 +2,7 @@ import type { Context } from 'cordis'
 import type { CollectionSpec } from '@biu/type-file-system'
 import { PagesStore, STATUS, type WorkspaceFs } from './store.ts'
 
-export { PAGE_ROOT, PAGE_ASSETS, PagesStore } from './store.ts'
+export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
 
 const COLORS = ['red', 'orange', 'yellow', 'green', 'blue'] as const
 

--- a/packages/cap-page/src/host/store.ts
+++ b/packages/cap-page/src/host/store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, unlink } from 'node:fs/promises'
+import { mkdir, readFile, stat, unlink } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
 import type { DbRecord, SchemaFieldValue } from '@biu/type-file-system'
 import { emptySchemaValue, normalizeSchemaValue } from '@biu/type-file-system'
@@ -6,6 +6,27 @@ import { dumpMarkdown, splitMarkdown } from './markdown.ts'
 
 export const PAGE_ROOT = '.page'
 export const PAGE_ASSETS = '.page/assets'
+/** 正文不再引用后，附件再留一天，避免撤销/未落盘指针误删。 */
+export const ASSET_GC_GRACE_MS = 24 * 60 * 60 * 1000
+
+const ID_RE = /^[A-Za-z0-9._-]+$/
+const ASSET_REF_RE = /(?:(?:\.page\/)?assets\/|\/api\/page\/file\/)([A-Za-z0-9._-]+)/g
+
+export function collectPageAssetNames(...chunks: unknown[]): Set<string> {
+  const names = new Set<string>()
+  const eat = (text: string) => {
+    for (const match of text.matchAll(ASSET_REF_RE)) {
+      const name = basename(match[1] ?? '')
+      if (name && name !== '.gitkeep' && ID_RE.test(name)) names.add(name)
+    }
+  }
+  for (const chunk of chunks) {
+    if (chunk == null) continue
+    if (typeof chunk === 'string') eat(chunk)
+    else eat(JSON.stringify(chunk))
+  }
+  return names
+}
 
 const STATUS = ['draft', 'live', 'archived'] as const
 
@@ -36,8 +57,6 @@ export type WorkspaceFs = {
   write: (rel: string, content: string) => Promise<unknown>
   list: (rel?: string) => Promise<string[]>
 }
-
-const ID_RE = /^[A-Za-z0-9._-]+$/
 
 function asStringList(value: unknown): string[] {
   if (!Array.isArray(value)) return []
@@ -293,6 +312,7 @@ export class PagesStore {
     if (!current) throw new Error(`unknown page: ${id}`)
     const next = applyPatch(current, patch)
     await this.write(next)
+    await this.gcAssets()
     return (await this.get(id))!
   }
 
@@ -313,6 +333,7 @@ export class PagesStore {
     row.updatedAt = ts
     if (typeof fields.title === 'string' && fields.title.trim()) row.title = fields.title.trim()
     await this.write(row)
+    await this.gcAssets()
     return (await this.get(id))!
   }
 
@@ -324,17 +345,7 @@ export class PagesStore {
     } catch {
       throw new Error(`unknown page: ${id}`)
     }
-    try {
-      const assets = await this.fs.list(PAGE_ASSETS)
-      for (const name of assets) {
-        if (name === '.gitkeep') continue
-        if (name.startsWith(`${id}-`) || name.startsWith(`${id}.`)) {
-          await unlink(this.fs.resolve(`${PAGE_ASSETS}/${name}`)).catch(() => undefined)
-        }
-      }
-    } catch {
-      // assets dir may be empty
-    }
+    await this.gcAssets()
   }
 
   async writeAsset(name: string, content: string) {
@@ -350,6 +361,32 @@ export class PagesStore {
     if (!file || file !== name.replace(/\\/g, '/')) throw new Error('invalid asset')
     const bytes = await readFile(this.fs.resolve(`${PAGE_ASSETS}/${file}`))
     return { bytes, type: mimeOf(file) }
+  }
+
+  async gcAssets(opts?: { graceMs?: number; now?: number }) {
+    const graceMs = opts?.graceMs ?? ASSET_GC_GRACE_MS
+    const now = opts?.now ?? Date.now()
+    let names: string[] = []
+    try {
+      names = await this.fs.list(PAGE_ASSETS)
+    } catch {
+      return
+    }
+    const live = new Set<string>()
+    for (const row of await this.list()) {
+      for (const name of collectPageAssetNames(dumpMarkdown(matterOf(row), row.notes ?? ''))) live.add(name)
+    }
+    for (const name of names) {
+      if (name === '.gitkeep' || live.has(name) || !ID_RE.test(name)) continue
+      const full = this.fs.resolve(`${PAGE_ASSETS}/${name}`)
+      try {
+        const info = await stat(full)
+        if (now - info.mtimeMs < graceMs) continue
+        await unlink(full)
+      } catch {
+        // gone or unreadable
+      }
+    }
   }
 
   private async write(row: PageRow) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`.page/assets` 是工作区共用目录。删画板块只会拿掉 Markdown 里的 `file` 指针，JSON 不会立刻消失。

## 做法
- 页面保存 / 删除后扫描全部 `.page/*.md`（封面、pack、正文里的 `assets/…` 和 `/api/page/file/…`）。
- 没被任何页面引用、且 **mtime 超过 24 小时** 的附件才 `unlink`。
- `.gitkeep` 和仍被引用的文件留下。

一天宽限用来覆盖：撤销、编辑器 400ms 才落盘、刚 PUT 还没写进正文的新画板。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

