### PR TITLE
fix(fsdb): 卡片/队列/看板补齐放大与右侧打开

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1259,45 +1259,47 @@ export function CollectionBrowser({
           )
         ) : null}
         <span className="fsdb-title-text">{body}</span>
-        {openDetail ? (
-          <span className="tasks-title-aside">
-            {!nested ? (
-              <button
-                type="button"
-                className="tasks-title-open"
-                data-testid="record-title-split"
-                aria-label="在右侧打开"
-                title="在右侧打开"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  showRecordInInspector(collectionPath, row.id)
-                }}
-              >
-                <ViewColumnsIcon aria-hidden className="size-[14px]" />
-              </button>
-            ) : null}
-            <span className="tasks-title-zoom">
-              {tree && kidCount > 0 ? (
-                <ChatCount count={kidCount} className="tasks-tree-count" title={`${kidCount} 项`} />
-              ) : null}
-              <button
-                type="button"
-                className="tasks-title-open"
-                data-testid="record-title-open"
-                data-biu-action="open"
-                aria-label="查看详情"
-                title="查看详情"
-                onClick={(event) => {
-                  event.stopPropagation()
-                  openRow(row)
-                }}
-              >
-                <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
-              </button>
-            </span>
-          </span>
-        ) : null}
+        {openDetail ? <RecordOpenControls row={row} kidCount={tree ? kidCount : 0} /> : null}
       </div>
+    )
+  }
+
+  function RecordOpenControls({ row, kidCount = 0 }: { row: DbRecord; kidCount?: number }) {
+    return (
+      <span className="tasks-title-aside">
+        {!nested ? (
+          <button
+            type="button"
+            className="tasks-title-open"
+            data-testid="record-title-split"
+            aria-label="在右侧打开"
+            title="在右侧打开"
+            onClick={(event) => {
+              event.stopPropagation()
+              showRecordInInspector(collectionPath, row.id)
+            }}
+          >
+            <ViewColumnsIcon aria-hidden className="size-[14px]" />
+          </button>
+        ) : null}
+        <span className="tasks-title-zoom">
+          {kidCount > 0 ? <ChatCount count={kidCount} className="tasks-tree-count" title={`${kidCount} 项`} /> : null}
+          <button
+            type="button"
+            className="tasks-title-open"
+            data-testid="record-title-open"
+            data-biu-action="open"
+            aria-label="查看详情"
+            title="查看详情"
+            onClick={(event) => {
+              event.stopPropagation()
+              openRow(row)
+            }}
+          >
+            <ArrowsPointingOutIcon aria-hidden className="size-[14px]" />
+          </button>
+        </span>
+      </span>
     )
   }
 
@@ -1424,7 +1426,10 @@ export function CollectionBrowser({
             </span>
           </button>
           <RecordProperties row={row} />
-          <RecordActions row={row} place="row" />
+          <div className="tasks-queue-item-tools">
+            <RecordActions row={row} place="row" />
+            <RecordOpenControls row={row} />
+          </div>
         </div>
       </li>
     )
@@ -1440,7 +1445,10 @@ export function CollectionBrowser({
               <RecordTitle row={row} openDetail={false} />
             </span>
           </button>
-          <RecordActions row={row} place="row" />
+          <div className="tasks-minicard-tools">
+            <RecordActions row={row} place="row" />
+            <RecordOpenControls row={row} />
+          </div>
         </div>
         <div className="tasks-minicard-foot">
           <RecordProperties row={row} />

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -160,8 +160,11 @@ const CSS = `
 .fsdb-page .tasks-minicard-open{display:flex;min-width:0;flex:1;border:0;padding:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
 .fsdb-page .tasks-minicard:hover{background:var(--dsw-hover)}
 .fsdb-page .tasks-minicard.is-active{background:var(--dsw-hover)}
-.fsdb-page .tasks-minicard-title{display:flex;align-items:flex-start;gap:6px;font-size:14px;font-weight:620;line-height:1.35}
+.fsdb-page .tasks-minicard-title{display:flex;align-items:center;gap:6px;font-size:14px;font-weight:620;line-height:1.35}
 .fsdb-page .tasks-minicard-titletext{flex:1;min-width:0;overflow-wrap:anywhere;word-break:break-word}
+.fsdb-page .tasks-minicard-tools,.fsdb-page .tasks-queue-item-tools{display:inline-flex;align-items:center;gap:2px;flex:none;margin-left:auto}
+.fsdb-page .tasks-minicard .tasks-title-open,.fsdb-page .tasks-queue-item .tasks-title-open,.fsdb-page .tasks-minicard .tasks-row-actions,.fsdb-page .tasks-queue-item .tasks-row-actions{opacity:0}
+.fsdb-page .tasks-minicard:hover .tasks-title-open,.fsdb-page .tasks-queue-item:hover .tasks-title-open,.fsdb-page .tasks-minicard .tasks-title-open:focus-visible,.fsdb-page .tasks-queue-item .tasks-title-open:focus-visible,.fsdb-page .tasks-minicard:hover .tasks-row-actions,.fsdb-page .tasks-queue-item:hover .tasks-row-actions,.fsdb-page .tasks-minicard .tasks-row-actions:focus-within,.fsdb-page .tasks-queue-item .tasks-row-actions:focus-within{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-minicard-foot{display:flex;flex-wrap:wrap;align-items:flex-start;gap:6px;min-width:0;width:100%;overflow:visible}
 .fsdb-page .tasks-minicard-foot > .fsdb-proplist{flex:1;flex-direction:row;flex-wrap:wrap;width:100%;min-width:0;align-items:center;justify-content:flex-start;gap:6px 10px}
 .fsdb-page .tasks-row-actions{display:inline-flex;align-items:center;gap:2px;flex:none}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -146,6 +146,16 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(css, /\.tasks-th\{[^}]*white-space:nowrap/)
 })
 
+test('card and queue rows expose split and expand like the table', () => {
+  assert.match(browser, /function RecordOpenControls/)
+  assert.match(browser, /function MiniCard[\s\S]*RecordOpenControls row=\{row\}/)
+  assert.match(browser, /function QueueRow[\s\S]*RecordOpenControls row=\{row\}/)
+  assert.match(browser, /tasks-minicard-tools/)
+  const style = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
+  assert.match(style, /tasks-minicard-tools/)
+  assert.match(style, /tasks-queue-item-tools/)
+})
+
 test('filesystem header expands the shared left sidebar and toggles the right inspector', () => {
   assert.match(browser, /cordis\.sidebar\.collapsed/)
   assert.match(browser, /!viewsOpen \?/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
卡片视图里插件 action 原先挤在换行标题旁边，位置很怪；放大和「在右侧打开」也只做在表格标题上。

现在卡片、看板（共用 MiniCard）和队列把 action 放到标题行右侧工具区，并复用表格同一套 split / expand 按钮；悬停才显示，避免常驻挡标题。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

