### PR TITLE
fix(fsdb): 视图平铺，工具成组，标签用 SuperTag 样式

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -74,7 +74,8 @@ import {
 } from './fsdb-cells.tsx'
 import { ensureFsdbStyle } from './fsdb-style.ts'
 import { RecordDetail } from './record-detail.tsx'
-import { TableGlyph } from './nav-glyphs.tsx'
+import { TableGlyph, ViewModeGlyph } from './nav-glyphs.tsx'
+import { countFittingViewTabs, splitVisibleViews } from './view-tabs.ts'
 import { getDatabaseUi } from './database-ui.ts'
 
 const EMPTY_VIEWS: CollectionViewType[] = []
@@ -299,6 +300,10 @@ export function CollectionBrowser({
   const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
   const crumbRef = useRef<HTMLElement>(null)
   const viewRef = useRef<HTMLDivElement>(null)
+  const toolbarRef = useRef<HTMLDivElement>(null)
+  const toolbarRightRef = useRef<HTMLDivElement>(null)
+  const viewMeasureRef = useRef<HTMLDivElement>(null)
+  const [viewTabFit, setViewTabFit] = useState(99)
   const modeRef = useRef<HTMLDivElement>(null)
   const sortRef = useRef<HTMLDivElement>(null)
   const columnRef = useRef<HTMLDivElement>(null)
@@ -405,6 +410,30 @@ export function CollectionBrowser({
     document.addEventListener('mousedown', onPointer)
     return () => document.removeEventListener('mousedown', onPointer)
   }, [query])
+
+  useLayoutEffect(() => {
+    if (sheet) return
+    function measure() {
+      const toolbar = toolbarRef.current
+      const right = toolbarRightRef.current
+      const row = viewMeasureRef.current
+      if (!toolbar || !right || !row) return
+      const more = row.querySelector('[data-view-measure-more]')
+      const tabs = [...row.querySelectorAll('[data-view-measure]')] as HTMLElement[]
+      const available = Math.max(0, toolbar.clientWidth - right.offsetWidth - 12)
+      const moreWidth = more instanceof HTMLElement ? more.offsetWidth : 32
+      setViewTabFit(countFittingViewTabs(tabs.map((el) => el.offsetWidth), moreWidth, available, 2))
+    }
+    measure()
+    const ro = new ResizeObserver(measure)
+    if (toolbarRef.current) ro.observe(toolbarRef.current)
+    if (toolbarRightRef.current) ro.observe(toolbarRightRef.current)
+    window.addEventListener('resize', measure)
+    return () => {
+      ro.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [sheet, views, searchExpanded])
 
   useLayoutEffect(() => {
     if (!pageSizeOpen) {
@@ -702,8 +731,7 @@ export function CollectionBrowser({
     const rows = grouping ? grouped.flatMap((group) => group.rows) : visible
     return flattenRows(rows).map((item) => item.row.id)
   }, [flattenRows, grouped, grouping, visible])
-  const tableColSpan =
-    Math.max(columns.length, 1) + (schema?.actions?.length ? 1 : 0) + (canDelete ? 1 : 0)
+  const tableColSpan = Math.max(columns.length, 1) + (canDelete ? 1 : 0)
 
   const selected =
     (detailId &&
@@ -1259,7 +1287,7 @@ export function CollectionBrowser({
           )
         ) : null}
         <span className="fsdb-title-text">{body}</span>
-        {openDetail ? <RecordOpenControls row={row} kidCount={tree ? kidCount : 0} /> : null}
+        {openDetail ? <RecordRowTools row={row} kidCount={tree ? kidCount : 0} /> : null}
       </div>
     )
   }
@@ -1303,6 +1331,15 @@ export function CollectionBrowser({
     )
   }
 
+  function RecordRowTools({ row, kidCount = 0 }: { row: DbRecord; kidCount?: number }) {
+    return (
+      <span className="tasks-row-tools">
+        <RecordActions row={row} place="row" />
+        <RecordOpenControls row={row} kidCount={kidCount} />
+      </span>
+    )
+  }
+
   function RecordActions({ row, place }: { row: DbRecord; place: 'row' | 'detail' }) {
     const actions = visibleActions(schema, row, place)
     if (!actions.length) return null
@@ -1334,11 +1371,12 @@ export function CollectionBrowser({
     )
   }
 
-  function RecordProperties({ row, omit }: { row: DbRecord; omit?: string }) {
+  function RecordProperties({ row, omit, skipBoolean }: { row: DbRecord; omit?: string; skipBoolean?: boolean }) {
     const hide = omit ?? activeGroup?.key
-    const cols = (hide ? propColumns.filter((item) => item.key !== hide) : propColumns).filter((item) =>
-      fieldHasValue(item.field, row[item.key]),
-    )
+    const cols = (hide ? propColumns.filter((item) => item.key !== hide) : propColumns).filter((item) => {
+      if (skipBoolean && resolveFieldType(item.field) === 'boolean') return false
+      return fieldHasValue(item.field, row[item.key])
+    })
     if (!cols.length) return null
     return (
       <div className="fsdb-proplist">
@@ -1427,8 +1465,7 @@ export function CollectionBrowser({
           </button>
           <RecordProperties row={row} />
           <div className="tasks-queue-item-tools">
-            <RecordActions row={row} place="row" />
-            <RecordOpenControls row={row} />
+            <RecordRowTools row={row} />
           </div>
         </div>
       </li>
@@ -1438,6 +1475,9 @@ export function CollectionBrowser({
   function MiniCard({ row }: { row: DbRecord }) {
     return (
       <div className={`tasks-minicard${row.id === detailId ? ' is-active' : ''}`} {...recordPick(row)}>
+        <div className="tasks-minicard-bar">
+          <RecordRowTools row={row} />
+        </div>
         <div className="tasks-minicard-title">
           <RowCheck id={row.id} />
           <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => openRow(row)}>
@@ -1445,13 +1485,9 @@ export function CollectionBrowser({
               <RecordTitle row={row} openDetail={false} />
             </span>
           </button>
-          <div className="tasks-minicard-tools">
-            <RecordActions row={row} place="row" />
-            <RecordOpenControls row={row} />
-          </div>
         </div>
         <div className="tasks-minicard-foot">
-          <RecordProperties row={row} />
+          <RecordProperties row={row} skipBoolean />
         </div>
       </div>
     )
@@ -1487,11 +1523,6 @@ export function CollectionBrowser({
                 )}
               </td>
             ))}
-            {schema?.actions?.length ? (
-              <td>
-                <RecordActions row={row} place="row" />
-              </td>
-            ) : null}
           </tr>
         ))}
       </>
@@ -1734,20 +1765,52 @@ export function CollectionBrowser({
           <h1 className="fsdb-detail-title">{title}</h1>
         </div>
         )}
-        <div className="tasks-toolbar" data-biu-ignore>
+        <div className="tasks-toolbar" ref={toolbarRef} data-biu-ignore>
           <div className="tasks-toolbar-left">
             {sheet ? null : (
             <div className="tasks-viewdd-wrap" ref={viewRef}>
+              <div className="tasks-viewtabs-measure" ref={viewMeasureRef} aria-hidden>
+                {views.map((view) => (
+                  <button key={view.id} type="button" className="tasks-viewdd-btn tasks-viewtab" tabIndex={-1} data-view-measure={view.id}>
+                    <ViewModeGlyph mode={view.mode} className="size-[14px]" />
+                    <span className="tasks-viewdd-name">{view.name}</span>
+                  </button>
+                ))}
+                <button type="button" className="tasks-viewdd-btn tasks-viewdd-more" tabIndex={-1} data-view-measure-more>
+                  <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
+                </button>
+              </div>
+              <div className="tasks-viewtabs">
+                {(views.length ? splitVisibleViews(views, viewTabFit, activeViewId).shown : []).map((view) => (
+                  <button
+                    key={view.id}
+                    type="button"
+                    className={`tasks-viewdd-btn tasks-viewtab${view.id === activeViewId ? ' is-active' : ''}`}
+                    data-testid="fsdb-view-tab"
+                    aria-pressed={view.id === activeViewId}
+                    onClick={() => selectView(view)}
+                  >
+                    <ViewModeGlyph mode={view.mode} className="size-[14px]" />
+                    <span className="tasks-viewdd-name">{view.name}</span>
+                  </button>
+                ))}
+                {!views.length ? (
+                  <button type="button" className="tasks-viewdd-btn tasks-viewtab is-active" disabled>
+                    <Squares2X2Icon aria-hidden className="size-[14px]" />
+                    <span className="tasks-viewdd-name">未保存</span>
+                  </button>
+                ) : null}
+              </div>
               <button
                 type="button"
-                className={`tasks-viewdd-btn${viewMenuOpen ? ' is-active' : ''}`}
-                aria-label="切换视图"
+                className={`tasks-viewdd-btn tasks-viewdd-more${viewMenuOpen ? ' is-active' : ''}`}
+                aria-label="视图菜单"
                 aria-haspopup="menu"
                 aria-expanded={viewMenuOpen}
+                data-testid="fsdb-view-more"
                 onClick={() => toggleMenu('view')}
               >
-                <Squares2X2Icon aria-hidden className="size-[14px]" />
-                <span className="tasks-viewdd-name">{activeView?.name ?? '未保存'}</span>
+                <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
               </button>
               {viewMenuOpen ? (
                 <div className="tasks-viewdd-menu" role="menu">
@@ -1793,7 +1856,7 @@ export function CollectionBrowser({
               </span>
             ) : null}
           </div>
-          <div className="tasks-toolbar-right">
+          <div className="tasks-toolbar-right" ref={toolbarRightRef}>
             <div className={`tasks-search-wrap${searchExpanded ? ' is-open' : ''}`} ref={searchRef}>
               <button
                 type="button"
@@ -2134,7 +2197,6 @@ export function CollectionBrowser({
                     </span>
                   </th>
                 ))}
-                      {schema?.actions?.length ? <th>操作</th> : null}
               </tr>
             </thead>
             <tbody>

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -41,7 +41,7 @@ const CSS = `
 .inspector-database-page .fsdb-main{padding-bottom:0}
 .fsdb-main > .fsdb-detail-title-row{flex:none}
 .fsdb-page .tasks-toolbar{display:flex;gap:12px;align-items:center;justify-content:space-between;min-width:0}
-.fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:none;min-width:0}
+.fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:1 1 auto;min-width:0}
 .fsdb-locked-filter{display:inline-flex;align-items:center;height:26px;padding:0 8px;border-radius:8px;background:color-mix(in srgb,var(--dsw-business) 12%,transparent);color:var(--dsw-business);font-size:13px;font-weight:650;cursor:default}
 .fsdb-page .tasks-toolbar-right{display:flex;align-items:center;gap:2px;flex:none;margin-left:auto}
 .fsdb-layout-wrap{position:relative;display:inline-flex}
@@ -70,7 +70,12 @@ const CSS = `
 .fsdb-col-item.is-active{color:var(--dsw-business)}
 .fsdb-col-item input{margin:0}
 .fsdb-page .tasks-viewdd-wrap,.fsdb-page .tasks-sort-wrap,.fsdb-page .tasks-filter-btn-wrap{position:relative;display:inline-flex}
-.fsdb-page .tasks-viewdd-btn{display:inline-flex;align-items:center;gap:6px;border:0;border-radius:8px;padding:5px 9px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:650;cursor:pointer}
+.fsdb-page .tasks-viewdd-wrap{flex:1;min-width:0;align-items:center;gap:2px}
+.fsdb-page .tasks-viewtabs{display:flex;align-items:center;gap:2px;min-width:0;flex:1;overflow:hidden}
+.fsdb-page .tasks-viewtabs-measure{position:absolute;left:0;top:0;visibility:hidden;pointer-events:none;display:flex;align-items:center;gap:2px;white-space:nowrap}
+.fsdb-page .tasks-viewdd-btn{display:inline-flex;align-items:center;gap:6px;border:0;border-radius:8px;padding:5px 9px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:650;cursor:pointer;flex:none}
+.fsdb-page .tasks-viewtab.is-active{background:var(--dsw-hover)}
+.fsdb-page .tasks-viewdd-more{padding:5px 6px}
 .fsdb-page .tasks-viewdd-btn:hover,.fsdb-page .tasks-viewdd-btn.is-active{background:var(--dsw-hover)}
 .fsdb-page .tasks-viewdd-name{max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-page .tasks-viewdd-menu,.fsdb-page .tasks-sort-menu,.fsdb-page .tasks-filter-menu{position:absolute;top:calc(100% + 6px);z-index:40;min-width:180px;padding:8px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:4px}
@@ -137,7 +142,9 @@ const CSS = `
 .fsdb-page .tasks-title-zoom{position:relative;display:grid;place-items:center;width:24px;height:24px}
 .fsdb-page .tasks-title-zoom .tasks-tree-count,.fsdb-page .tasks-title-zoom .tasks-title-open{grid-area:1/1}
 .fsdb-page .tasks-title-open{flex:none;width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:6px;cursor:pointer;padding:0;opacity:0;z-index:1}
-.fsdb-page .tasks-title-cell:hover .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible{opacity:1}
+.fsdb-page .tasks-title-cell:hover .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible,.fsdb-page .tasks-title-cell:hover .tasks-row-actions{opacity:1}
+.fsdb-page .tasks-title-cell .tasks-row-actions{opacity:0}
+.fsdb-page .tasks-row-tools{display:inline-flex;align-items:center;gap:2px;flex:none}
 .fsdb-page .tasks-title-cell:hover .tasks-tree-count,.fsdb-page .tasks-title-zoom:has(.tasks-title-open:focus-visible) .tasks-tree-count{opacity:0}
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
 .fsdb-page .tasks-tree-count{pointer-events:none}
@@ -160,11 +167,14 @@ const CSS = `
 .fsdb-page .tasks-minicard-open{display:flex;min-width:0;flex:1;border:0;padding:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
 .fsdb-page .tasks-minicard:hover{background:var(--dsw-hover)}
 .fsdb-page .tasks-minicard.is-active{background:var(--dsw-hover)}
+.fsdb-page .tasks-minicard-bar{display:flex;align-items:center;justify-content:flex-end;gap:2px;min-width:0;width:100%}
+.fsdb-page .tasks-minicard-bar .tasks-row-tools{margin-left:auto}
+.fsdb-page .tasks-minicard-bar .tasks-title-open,.fsdb-page .tasks-minicard-bar .tasks-row-actions{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-minicard-title{display:flex;align-items:center;gap:6px;font-size:14px;font-weight:620;line-height:1.35}
 .fsdb-page .tasks-minicard-titletext{flex:1;min-width:0;overflow-wrap:anywhere;word-break:break-word}
-.fsdb-page .tasks-minicard-tools,.fsdb-page .tasks-queue-item-tools{display:inline-flex;align-items:center;gap:2px;flex:none;margin-left:auto}
-.fsdb-page .tasks-minicard .tasks-title-open,.fsdb-page .tasks-queue-item .tasks-title-open,.fsdb-page .tasks-minicard .tasks-row-actions,.fsdb-page .tasks-queue-item .tasks-row-actions{opacity:0}
-.fsdb-page .tasks-minicard:hover .tasks-title-open,.fsdb-page .tasks-queue-item:hover .tasks-title-open,.fsdb-page .tasks-minicard .tasks-title-open:focus-visible,.fsdb-page .tasks-queue-item .tasks-title-open:focus-visible,.fsdb-page .tasks-minicard:hover .tasks-row-actions,.fsdb-page .tasks-queue-item:hover .tasks-row-actions,.fsdb-page .tasks-minicard .tasks-row-actions:focus-within,.fsdb-page .tasks-queue-item .tasks-row-actions:focus-within{opacity:1;pointer-events:auto}
+.fsdb-page .tasks-queue-item-tools{display:inline-flex;align-items:center;gap:2px;flex:none;margin-left:auto}
+.fsdb-page .tasks-queue-item .tasks-title-open,.fsdb-page .tasks-queue-item .tasks-row-actions{opacity:0}
+.fsdb-page .tasks-queue-item:hover .tasks-title-open,.fsdb-page .tasks-queue-item .tasks-title-open:focus-visible,.fsdb-page .tasks-queue-item:hover .tasks-row-actions,.fsdb-page .tasks-queue-item .tasks-row-actions:focus-within{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-minicard-foot{display:flex;flex-wrap:wrap;align-items:flex-start;gap:6px;min-width:0;width:100%;overflow:visible}
 .fsdb-page .tasks-minicard-foot > .fsdb-proplist{flex:1;flex-direction:row;flex-wrap:wrap;width:100%;min-width:0;align-items:center;justify-content:flex-start;gap:6px 10px}
 .fsdb-page .tasks-row-actions{display:inline-flex;align-items:center;gap:2px;flex:none}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -147,13 +147,16 @@ test('create record sits at the right of the toolbar with a blue label', () => {
 })
 
 test('card and queue rows expose split and expand like the table', () => {
-  assert.match(browser, /function RecordOpenControls/)
-  assert.match(browser, /function MiniCard[\s\S]*RecordOpenControls row=\{row\}/)
-  assert.match(browser, /function QueueRow[\s\S]*RecordOpenControls row=\{row\}/)
-  assert.match(browser, /tasks-minicard-tools/)
+  assert.match(browser, /function RecordRowTools/)
+  assert.match(browser, /function MiniCard[\s\S]*RecordRowTools row=\{row\}/)
+  assert.match(browser, /function QueueRow[\s\S]*RecordRowTools row=\{row\}/)
+  assert.match(browser, /function RecordTitle[\s\S]*RecordRowTools row=\{row\}/)
+  assert.match(browser, /tasks-minicard-bar/)
+  assert.doesNotMatch(browser, /<th>操作<\/th>/)
   const style = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
-  assert.match(style, /tasks-minicard-tools/)
+  assert.match(style, /tasks-minicard-bar/)
   assert.match(style, /tasks-queue-item-tools/)
+  assert.match(style, /tasks-row-tools/)
 })
 
 test('filesystem header expands the shared left sidebar and toggles the right inspector', () => {

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -33,6 +33,7 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.fsdb-cards\{[^}]*grid-auto-rows:auto/)
   assert.match(css, /\.fsdb-cards > \.tasks-minicard\{[^}]*height:100%/)
   assert.match(css, /\.tasks-viewdd-menu\{[^}]*min-width:320px/)
+  assert.match(css, /\.tasks-viewtabs\{[^}]*overflow:hidden/)
   assert.match(css, /\.tasks-viewdd-item-actions\{[^}]*visibility:hidden/)
   assert.match(css, /\.tasks-viewdd-act\{[^}]*width:26px/)
 })

--- a/packages/core-file-system/src/web/view-tabs.test.ts
+++ b/packages/core-file-system/src/web/view-tabs.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { countFittingViewTabs, splitVisibleViews } from './view-tabs.ts'
+
+test('fits every tab when the strip is wide enough', () => {
+  assert.equal(countFittingViewTabs([80, 80, 80], 36, 400, 2), 3)
+})
+
+test('stops before colliding with the reserved more control', () => {
+  assert.equal(countFittingViewTabs([80, 80, 80, 80], 36, 220, 2), 2)
+})
+
+test('keeps at least one tab even when space is tight', () => {
+  assert.equal(countFittingViewTabs([120, 120], 36, 80, 2), 1)
+})
+
+test('pins the active view into the last visible slot when it would overflow', () => {
+  const views = [{ id: 'a' }, { id: 'b' }, { id: 'c' }]
+  assert.deepEqual(splitVisibleViews(views, 2, 'c'), {
+    shown: [{ id: 'a' }, { id: 'c' }],
+    hidden: [{ id: 'b' }],
+  })
+})

--- a/packages/core-file-system/src/web/view-tabs.ts
+++ b/packages/core-file-system/src/web/view-tabs.ts
@@ -1,0 +1,36 @@
+export function countFittingViewTabs(
+  tabWidths: number[],
+  moreWidth: number,
+  available: number,
+  gap: number,
+): number {
+  const n = tabWidths.length
+  if (n === 0) return 0
+  const widthOf = (count: number) => {
+    let w = moreWidth
+    for (let i = 0; i < count; i++) w += tabWidths[i] + gap
+    return w
+  }
+  if (widthOf(n) <= available) return n
+  let count = 0
+  while (count < n && widthOf(count + 1) <= available) count += 1
+  return Math.max(1, count)
+}
+
+export function splitVisibleViews<T extends { id: string }>(
+  views: T[],
+  visibleCount: number,
+  activeId: string | undefined,
+): { shown: T[]; hidden: T[] } {
+  if (visibleCount >= views.length) return { shown: views, hidden: [] }
+  const take = Math.max(1, Math.min(visibleCount, views.length))
+  const head = views.slice(0, take)
+  if (!activeId || head.some((view) => view.id === activeId)) {
+    return { shown: head, hidden: views.slice(take) }
+  }
+  const active = views.find((view) => view.id === activeId)
+  if (!active) return { shown: head, hidden: views.slice(take) }
+  const shown = [...views.slice(0, take - 1), active]
+  const ids = new Set(shown.map((view) => view.id))
+  return { shown, hidden: views.filter((view) => !ids.has(view.id)) }
+}

--- a/packages/core-plugin-system/package.json
+++ b/packages/core-plugin-system/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.1"
   },
   "dependencies": {
+    "@biu/public-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0",
     "@biu/type-slots": "0.1.0",
     "@biu/web-slots": "0.1.0",

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -1,30 +1,12 @@
 import { ArchiveBoxArrowDownIcon, PlayIcon, StopIcon } from '@heroicons/react/16/solid'
+import { TagChip, TagChips } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { asHttpHref } from '@biu/type-file-system'
 import type { CollectionChrome, FsActionProps, FsCellProps } from '@biu/type-file-system/ui'
 import type { DbRecord } from '@biu/type-file-system'
 
-function PluginTitle({ record, label }: { record: DbRecord; label: string }) {
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1.5">
-      <span className="truncate font-medium">{label}</span>
-      {record.sandbox ? (
-        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">沙箱</span>
-      ) : null}
-      {record.installed ? (
-        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">已装</span>
-      ) : null}
-      {record.hasHost ? (
-        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">Host</span>
-      ) : null}
-      {record.hasWeb ? (
-        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">Web</span>
-      ) : null}
-      {record.headless ? (
-        <span className="shrink-0 rounded px-1 text-[10px] font-semibold tracking-wide text-(--dsw-label-3)">无头</span>
-      ) : null}
-    </span>
-  )
+function PluginTitle({ label }: { record: DbRecord; label: string }) {
+  return <span className="truncate font-medium">{label}</span>
 }
 
 function PluginAuthorCell({ record, fallback }: FsCellProps) {
@@ -49,13 +31,11 @@ function PluginTagsCell({ value, fallback }: FsCellProps) {
   const tags = Array.isArray(value) ? value.map(String) : fallback === '—' ? [] : fallback.split(', ')
   if (!tags.length) return <span className="text-(--dsw-label-3)">—</span>
   return (
-    <span className="inline-flex flex-wrap gap-1">
+    <TagChips>
       {tags.map((tag) => (
-        <span key={tag} className="rounded-full bg-(--dsw-hover) px-1.5 py-0.5 text-[11px] text-(--dsw-label)">
-          #{tag}
-        </span>
+        <TagChip key={tag} id={tag} label={tag} />
       ))}
-    </span>
+    </TagChips>
   )
 }
 

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -62,6 +62,16 @@ test('plugin system web passes name/tags/action chrome into databaseUi', async (
   assert.equal(typeof ui.last?.chrome.Action, 'function')
 })
 
+test('plugin title is the name only and tags use public-ui TagChip', async () => {
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  const chrome = readFileSync(resolve(import.meta.dirname, './chrome.tsx'), 'utf8')
+  assert.match(chrome, /TagChip/)
+  assert.match(chrome, /TagChips/)
+  assert.doesNotMatch(chrome, /已装/)
+  assert.doesNotMatch(chrome, /rounded-full/)
+})
+
 test('plugin window sizes from manifest.shell instead of measuring DOM', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')

--- a/packages/core-task-system/package.json
+++ b/packages/core-task-system/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.1"
   },
   "dependencies": {
+    "@biu/public-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0",
     "@biu/public-mascot": "0.1.0",
     "@xyflow/react": "^12.11.3"

--- a/packages/core-task-system/src/web/chrome.tsx
+++ b/packages/core-task-system/src/web/chrome.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import {
   ArrowPathIcon,
@@ -12,6 +12,7 @@ import {
   UserIcon,
   XMarkIcon,
 } from '@heroicons/react/16/solid'
+import { TagChip, TagChips } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import type { DbRecord } from '@biu/type-file-system'
 import type { CollectionChrome, FsCellProps } from '@biu/type-file-system/ui'
@@ -49,13 +50,6 @@ type ActorBits = {
 }
 
 type ChipOption = { value: string; label: string; icon?: ReactNode }
-
-function tagColor(tag: string) {
-  const palette = ['#3b6fd9', '#8a5fd3', '#2f9e8f', '#d9822b', '#c94f4f', '#4b8f4b', '#b15b8e', '#5b6fb1', '#a07b3f', '#3f8fb1']
-  let h = 0
-  for (let i = 0; i < tag.length; i++) h = (h * 31 + tag.charCodeAt(i)) >>> 0
-  return palette[h % palette.length]!
-}
 
 function asTags(value: unknown) {
   return Array.isArray(value) ? value.map(String) : []
@@ -435,18 +429,16 @@ function TagsCell({ record, value }: FsCellProps) {
   const [draft, setDraft] = useState('')
   return (
     <span className="tasks-tags" onClick={(event) => event.stopPropagation()} onMouseDown={(event) => event.stopPropagation()}>
+      <TagChips>
       {tags.map((tag) => (
-        <button
+        <TagChip
           key={tag}
-          type="button"
-          className="tasks-tag"
-          style={{ '--tag': tagColor(tag) } as CSSProperties}
-          title={`移除 ${tag}`}
-          onClick={() => void patchRecord(record.id, { tags: tags.filter((item) => item !== tag) })}
-        >
-          {tag}
-        </button>
+          id={tag}
+          label={tag}
+          onRemove={() => void patchRecord(record.id, { tags: tags.filter((item) => item !== tag) })}
+        />
       ))}
+      </TagChips>
       <input
         className="tasks-tag-input"
         value={draft}

--- a/packages/core-task-system/src/web/index.test.ts
+++ b/packages/core-task-system/src/web/index.test.ts
@@ -46,3 +46,13 @@ test('task-system web paints /tasks chrome without importing file-system', async
   assert.equal(ui.registered[0]?.view.id, 'graph')
   assert.equal(ui.registered[0]?.view.label, '依赖图')
 })
+
+test('task tags use public-ui TagChip', async () => {
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  const chrome = readFileSync(resolve(import.meta.dirname, './chrome.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.match(chrome, /TagChip/)
+  assert.doesNotMatch(chrome, /className="tasks-tag"/)
+  assert.doesNotMatch(css, /\.tasks-tag\{/)
+})

--- a/packages/core-task-system/src/web/index.tsx
+++ b/packages/core-task-system/src/web/index.tsx
@@ -42,8 +42,7 @@ if (typeof document !== 'undefined') {
 .tasks-graph-status.is-doing{color:var(--dsw-business)}
 .tasks-graph-status.is-done{color:#2f7d4c}
 .tasks-proj-tag{display:inline-block;padding:1px 8px;border-radius:999px;font-size:14px;font-weight:600;color:var(--dsw-label-2);background:color-mix(in srgb,var(--dsw-border) 55%,transparent);white-space:nowrap}
-.tasks-tags{display:inline-flex;flex-wrap:wrap;gap:3px;vertical-align:middle}
-.tasks-tag{display:inline-flex;align-items:center;padding:1px 8px;border-radius:999px;font-size:14px;font-weight:600;color:var(--tag,#3b6fd9);background:color-mix(in srgb,var(--tag,#3b6fd9) 12%,transparent);white-space:nowrap;max-width:110px;overflow:hidden;text-overflow:ellipsis}
+.tasks-tags{display:inline-flex;flex-wrap:wrap;gap:4px;vertical-align:middle;align-items:center}
 .tasks-status-cell{display:inline-flex;align-items:center;gap:5px;min-width:0}
 .tasks-actor{display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%}
 .tasks-actor.is-empty{color:var(--dsw-label-3)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
视图少时在工具栏平铺，挤到右侧搜索/筛选再收进 `⋯` 菜单（添加/重命名仍在菜单里）。

任意视图里 action、在右侧打开、放大收成同一组 `RecordRowTools`：表格在标题旁，卡片单独一行顶栏，队列在行尾。插件标题不再跟「沙箱 / 已装 / Host / Web」。插件和任务的标签都改用 public-ui 的 TagChip（SuperTag 同款）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

