### PR TITLE
Unify database property styles and search menus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,10 @@
       "resolved": "packages/core-task-system",
       "link": true
     },
+    "node_modules/@biu/database-ui": {
+      "resolved": "packages/database-ui",
+      "link": true
+    },
     "node_modules/@biu/host-agent-loop": {
       "resolved": "packages/host-agent-loop",
       "link": true
@@ -8507,6 +8511,7 @@
       "name": "@biu/core-file-system",
       "version": "0.1.0",
       "dependencies": {
+        "@biu/database-ui": "0.1.0",
         "@biu/public-ui": "0.1.0",
         "@biu/type-file-system": "0.1.0",
         "@biu/web-session-view": "0.1.0",
@@ -8522,6 +8527,7 @@
       "name": "@biu/core-plugin-system",
       "version": "0.1.0",
       "dependencies": {
+        "@biu/public-ui": "0.1.0",
         "@biu/type-file-system": "0.1.0",
         "@biu/type-slots": "0.1.0",
         "@biu/web-session-view": "0.1.0",
@@ -8536,12 +8542,24 @@
       "name": "@biu/core-task-system",
       "version": "0.1.0",
       "dependencies": {
+        "@biu/database-ui": "0.1.0",
         "@biu/public-mascot": "0.1.0",
+        "@biu/public-ui": "0.1.0",
         "@biu/type-file-system": "0.1.0",
         "@xyflow/react": "^12.11.3"
       },
       "peerDependencies": {
         "cordis": "4.0.0-rc.8",
+        "react": "^19.1.1"
+      }
+    },
+    "packages/database-ui": {
+      "name": "@biu/database-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "@biu/public-ui": "0.1.0"
+      },
+      "peerDependencies": {
         "react": "^19.1.1"
       }
     },

--- a/packages/core-file-system/package.json
+++ b/packages/core-file-system/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@biu/type-file-system": "0.1.0",
     "@biu/public-ui": "0.1.0",
+    "@biu/database-ui": "0.1.0",
     "@biu/web-session-view": "0.1.0",
     "@biu/web-snapshot": "0.1.0"
   },

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -51,7 +51,9 @@ import {
   fieldHasValue,
   type ViewMode,
 } from './fields.ts'
+import { DbMenu, DbSearchOption } from '@biu/database-ui'
 import { AppDialog, CellSelect, CheckRow, LocalText } from './controls.tsx'
+import { PropertyRow } from './property-row.tsx'
 import { DataSidebar } from './data-sidebar.tsx'
 import { buildCrumbs, type CrumbTarget } from './sidebar-nav.ts'
 import { CrumbTrail } from './crumb-trail.tsx'
@@ -1348,31 +1350,66 @@ export function CollectionBrowser({
 
   function RecordActions({ row, place }: { row: DbRecord; place: 'row' | 'detail' }) {
     const actions = visibleActions(schema, row, place)
+    const [moreOpen, setMoreOpen] = useState(false)
+    const moreRef = useRef<HTMLButtonElement>(null)
     if (!actions.length) return null
     const Action = chrome?.Action
+    const shown = actions.filter((action) => action.id === 'open-split' || action.id === 'open-page')
+    const overflow = actions.filter((action) => action.id !== 'open-split' && action.id !== 'open-page')
+    const busy = Boolean(busyKey?.endsWith(`:${row.id}`))
+    const renderOne = (action: CollectionActionInfo) => {
+      const run = () => void runAction(row, action)
+      if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
+      const glyph = actionIcon(action.id)
+      return (
+        <button
+          key={action.id}
+          type="button"
+          className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
+          title={action.label}
+          aria-label={`${action.label} ${labelOf(row)}`}
+          disabled={busy}
+          onClick={run}
+        >
+          {glyph ?? action.label}
+        </button>
+      )
+    }
     return (
       <div className="tasks-row-actions" data-biu-ignore onClick={(event) => event.stopPropagation()}>
-        {actions.map((action) => {
-          const busy = Boolean(busyKey?.endsWith(`:${row.id}`))
-          const run = () => void runAction(row, action)
-          if (Action) {
-            return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
-          }
-          const glyph = actionIcon(action.id)
-          return (
+        {shown.map(renderOne)}
+        {overflow.length ? (
+          <>
             <button
-              key={action.id}
+              ref={moreRef}
               type="button"
-              className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
-              title={action.label}
-              aria-label={`${action.label} ${labelOf(row)}`}
+              className="tasks-icon-btn"
+              title="更多"
+              aria-label="更多操作"
+              aria-expanded={moreOpen}
               disabled={busy}
-              onClick={run}
+              onClick={() => setMoreOpen((open) => !open)}
             >
-              {glyph ?? action.label}
+              <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
             </button>
-          )
-        })}
+            {moreOpen ? (
+              <DbMenu anchor={moreRef.current} onClose={() => setMoreOpen(false)}>
+                {overflow.map((action) => (
+                  <DbSearchOption
+                    key={action.id}
+                    onClick={() => {
+                      setMoreOpen(false)
+                      void runAction(row, action)
+                    }}
+                  >
+                    {actionIcon(action.id)}
+                    {action.label}
+                  </DbSearchOption>
+                ))}
+              </DbMenu>
+            ) : null}
+          </>
+        ) : null}
       </div>
     )
   }
@@ -1387,9 +1424,9 @@ export function CollectionBrowser({
     return (
       <div className="fsdb-proplist">
         {cols.map((col) => (
-          <span key={col.key} className="fsdb-propchip">
-            <span className="fsdb-propchip-v">{renderCell(row, col.key, col.field)}</span>
-          </span>
+          <PropertyRow key={col.key} field={col.field} fieldKey={col.key}>
+            {renderCell(row, col.key, col.field)}
+          </PropertyRow>
         ))}
       </div>
     )

--- a/packages/core-file-system/src/web/controls.tsx
+++ b/packages/core-file-system/src/web/controls.tsx
@@ -1,114 +1,9 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { CheckCircleIcon, ChevronDownIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/16/solid'
-import { AnchorMenu } from '@biu/public-ui'
+import { CheckCircleIcon } from '@heroicons/react/16/solid'
+import { CellMulti } from '@biu/database-ui'
 
-function useDismiss(open: boolean, onClose: () => void, ref: { current: HTMLElement | null }) {
-  useEffect(() => {
-    if (!open) return
-    const onDown = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) onClose()
-    }
-    document.addEventListener('mousedown', onDown)
-    return () => document.removeEventListener('mousedown', onDown)
-  }, [open, onClose, ref])
-}
-
-export function CellSelect({
-  value,
-  options,
-  onSelect,
-  placeholder = '选择',
-  variant = 'cell',
-}: {
-  value: string
-  options: Array<{ value: string; label: string }>
-  onSelect: (value: string) => void
-  placeholder?: string
-  variant?: 'cell' | 'field'
-}) {
-  const [open, setOpen] = useState(false)
-  const [query, setQuery] = useState('')
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const searchRef = useRef<HTMLInputElement>(null)
-  const current = options.find((item) => item.value === value)
-  const q = query.trim().toLowerCase()
-  const filtered = options.filter((item) => !q || item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q))
-
-  useEffect(() => {
-    if (!open) {
-      setQuery('')
-      return
-    }
-    const id = window.setTimeout(() => searchRef.current?.focus(), 0)
-    return () => window.clearTimeout(id)
-  }, [open])
-
-  const close = () => setOpen(false)
-
-  return (
-    <div
-      className={`fsdb-cellselect is-${variant}${open ? ' is-open' : ''}`}
-      onClick={(event) => event.stopPropagation()}
-      onMouseDown={(event) => event.stopPropagation()}
-    >
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`fsdb-cellselect-trigger${current ? '' : ' is-empty'}`}
-        data-open={open || undefined}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={(event) => {
-          event.stopPropagation()
-          setOpen((v) => !v)
-        }}
-      >
-        <span className={`fsdb-cellselect-label${current ? '' : ' is-empty'}`}>{current?.label ?? placeholder}</span>
-        {variant === 'field' ? <ChevronDownIcon aria-hidden className="size-[14px] fsdb-cellselect-caret" /> : null}
-      </button>
-      {open ? (
-        <AnchorMenu anchor={triggerRef.current} onClose={close}>
-          <label className="fsdb-cellselect-search">
-            <MagnifyingGlassIcon aria-hidden className="size-[14px]" />
-            <input
-              ref={searchRef}
-              value={query}
-              placeholder="搜索"
-              onChange={(event) => setQuery(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === 'Escape') close()
-                if (event.key === 'Enter' && filtered[0]) {
-                  event.preventDefault()
-                  onSelect(filtered[0].value)
-                  close()
-                }
-              }}
-            />
-          </label>
-          <div className="fsdb-cellselect-options">
-            {filtered.map((item) => (
-              <button
-                key={item.value}
-                type="button"
-                className={`fsdb-cellselect-option${item.value === value ? ' is-selected' : ''}`}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onSelect(item.value)
-                  close()
-                }}
-              >
-                <span className="fsdb-tag">{item.label}</span>
-                {item.value === value ? <CheckCircleIcon aria-hidden className="size-[14px]" /> : null}
-              </button>
-            ))}
-            {!filtered.length ? <div className="fsdb-cellselect-empty">没有匹配项</div> : null}
-          </div>
-        </AnchorMenu>
-      ) : null}
-    </div>
-  )
-}
+export { CellSelect } from '@biu/database-ui'
 
 export function TokenMultiSelect({
   values,
@@ -121,95 +16,13 @@ export function TokenMultiSelect({
   onChange: (next: string[]) => void
   allowCreate?: boolean
 }) {
-  const [open, setOpen] = useState(false)
-  const [draft, setDraft] = useState('')
-  const ref = useRef<HTMLDivElement>(null)
-  useDismiss(open, () => setOpen(false), ref)
-  const q = draft.trim().toLowerCase()
-  const available = options.filter((item) => !values.includes(item) && (!q || item.toLowerCase().includes(q)))
-  const canCreate = allowCreate && draft.trim() && !values.includes(draft.trim()) && !options.includes(draft.trim())
   return (
-    <div className="fsdb-tokens" ref={ref}>
-      <div
-        className="fsdb-tokens-box"
-        onClick={() => {
-          setOpen(true)
-          ref.current?.querySelector('input')?.focus()
-        }}
-      >
-        {values.map((tag) => (
-          <span key={tag} className="fsdb-token">
-            {tag}
-            <button
-              type="button"
-              className="fsdb-token-x"
-              aria-label={`移除 ${tag}`}
-              onClick={(event) => {
-                event.stopPropagation()
-                onChange(values.filter((item) => item !== tag))
-              }}
-            >
-              <XMarkIcon aria-hidden className="size-3" />
-            </button>
-          </span>
-        ))}
-        <input
-          className="fsdb-tokens-input"
-          value={draft}
-          placeholder={values.length ? '搜索' : '搜索或添加'}
-          onFocus={() => setOpen(true)}
-          onChange={(event) => {
-            setDraft(event.target.value)
-            setOpen(true)
-          }}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === ',') {
-              event.preventDefault()
-              const next = draft.trim()
-              if (!next) return
-              if (!values.includes(next)) onChange([...values, next])
-              setDraft('')
-            } else if (event.key === 'Backspace' && !draft && values.length) {
-              onChange(values.slice(0, -1))
-            } else if (event.key === 'Escape') {
-              setOpen(false)
-            }
-          }}
-        />
-      </div>
-      {open ? (
-        <div className="fsdb-tokens-menu" role="listbox">
-          {available.map((item) => (
-            <button
-              key={item}
-              type="button"
-              className="fsdb-tokens-option"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => {
-                onChange([...values, item])
-                setDraft('')
-              }}
-            >
-              {item}
-            </button>
-          ))}
-          {canCreate ? (
-            <button
-              type="button"
-              className="fsdb-tokens-option"
-              onMouseDown={(event) => event.preventDefault()}
-              onClick={() => {
-                onChange([...values, draft.trim()])
-                setDraft('')
-              }}
-            >
-              添加「{draft.trim()}」
-            </button>
-          ) : null}
-          {!available.length && !canCreate ? <div className="fsdb-tokens-empty">没有匹配项</div> : null}
-        </div>
-      ) : null}
-    </div>
+    <CellMulti
+      values={values}
+      options={options.map((item) => ({ value: item, label: item }))}
+      onChange={onChange}
+      allowCreate={allowCreate}
+    />
   )
 }
 

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -35,7 +35,7 @@ describe('顶栏三级标题', () => {
 
   it('中间顶栏面包屑字重和颜色与侧栏标题对齐', () => {
     expect(style).toContain('.fsdb-crumb-btn{display:inline-flex')
-    expect(style).toMatch(/\.fsdb-crumb-btn\{[^}]*color:var\(--dsw-sidebar-fg\)/)
+    expect(style).toMatch(/\.fsdb-crumb-btn\{[^}]*color:#F0EFED/)
     expect(style).toMatch(/\.fsdb-crumb-btn\{[^}]*font-weight:600/)
     expect(style).toMatch(/\.fsdb-crumb-option\{[^}]*font-weight:600/)
   })

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -8,9 +8,10 @@ const CSS = `
 .fsdb-right .chat-view-header{flex:none}
 .fsdb-crumbs{display:flex;min-width:0;align-items:center;gap:0}
 .fsdb-crumb{display:inline-flex;min-width:0;align-items:center;gap:0}
-.fsdb-crumb-sep{flex:none;padding:0 8px;color:var(--dsw-sidebar-fg);opacity:.5;font-size:14px;font-weight:600}
-.fsdb-crumb-btn{display:inline-flex;min-width:0;max-width:180px;align-items:center;gap:6px;height:26px;border:0;border-radius:6px;background:transparent;padding:0 4px;color:var(--dsw-sidebar-fg);font-size:14px;font-weight:600;cursor:pointer}
-.fsdb-crumb-btn:hover,.fsdb-crumb-btn.is-open{background:var(--dsw-hover);color:var(--dsw-sidebar-fg-active)}
+.fsdb-crumb-sep{flex:none;padding:0 8px;color:#F0EFED;opacity:.5;font-size:14px;font-weight:600}
+.fsdb-crumb-btn{display:inline-flex;min-width:0;max-width:180px;align-items:center;gap:6px;height:26px;border:0;border-radius:6px;background:transparent;padding:0 4px;color:#F0EFED;font-size:14px;font-weight:600;cursor:pointer}
+.fsdb-crumb-btn:hover,.fsdb-crumb-btn.is-open{background:var(--dsw-hover);color:#F0EFED}
+.fsdb-crumb svg,.fsdb-crumb-btn svg{color:#F0EFED}
 .fsdb-crumb-btn .chat-view-project-name,.fsdb-crumb-option .chat-view-project-name{font-size:14px;font-weight:600;color:inherit}
 .fsdb-crumb-pick{position:relative;flex:none}
 .fsdb-crumb-menu{position:absolute;left:0;top:calc(100% + 4px);z-index:80;display:flex;flex-direction:column;min-width:220px;max-width:280px;max-height:280px;overflow:hidden;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-surface);padding:4px;box-shadow:0 8px 24px rgba(0,0,0,.16)}
@@ -150,7 +151,7 @@ const CSS = `
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
 .fsdb-page .tasks-tree-count{pointer-events:none}
 .fsdb-page .tasks-table.is-truncate:not(.is-wrap) .fsdb-cell{max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-propchip-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-propchip-v:has(.tasks-cellselect){overflow:visible}
+.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-proprow-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-proprow-v:has(.tasks-cellselect){overflow:visible}
 .fsdb-page .tasks-table.is-wrap .fsdb-cell{white-space:normal;overflow-wrap:anywhere;word-break:break-word;max-width:100%;align-items:flex-start}
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden}
 .fsdb-page .tasks-table th,.fsdb-page .tasks-table td{overflow:visible}
@@ -199,8 +200,8 @@ const CSS = `
 .fsdb-page .tasks-queue-item .tasks-row-actions{flex:none;padding:2px}
 .fsdb-page .tasks-queue-item-title{flex:1;min-width:0;font-size:14px;font-weight:600;line-height:1.4;overflow:visible}
 .fsdb-page .tasks-queue-item-body > .fsdb-proplist{flex:1 1 12rem;width:auto;min-width:0;max-width:none;margin-left:0;flex-direction:row;flex-wrap:wrap;align-items:center;justify-content:flex-start;gap:4px 10px;padding:2px 0;overflow:visible;white-space:normal}
-.fsdb-page .tasks-queue-item-body .fsdb-propchip{width:auto;max-width:100%;min-width:0;min-height:18px;line-height:18px;white-space:nowrap}
-.fsdb-page .tasks-queue-item-body .fsdb-propchip-v{line-height:18px;white-space:nowrap;overflow:hidden;min-width:0}
+.fsdb-page .tasks-queue-item-body .fsdb-proprow{width:auto;max-width:100%;min-width:0;min-height:18px;white-space:nowrap}
+.fsdb-page .tasks-queue-item-body .fsdb-proprow-v{line-height:18px;white-space:nowrap;overflow:hidden;min-width:0}
 .fsdb-page .tasks-board{display:grid;gap:12px;overflow:auto;align-items:start;padding-bottom:8px}
 .fsdb-page .tasks-board-col{min-height:180px;background:transparent;padding:10px}
 .fsdb-page .tasks-board-colhead{display:flex;align-items:center;gap:6px;padding:4px 6px 10px;color:var(--dsw-label-2);font-weight:600;font-size:14px}
@@ -209,11 +210,9 @@ const CSS = `
 .fsdb-page .tasks-board-list{display:flex;flex-direction:column;gap:8px}
 .fsdb-page .tasks-board-col .tasks-minicard{background:#202020}
 .fsdb-page .fsdb-proplist{display:flex;flex-direction:row;flex-wrap:wrap;align-items:center;gap:4px 10px;min-width:0;max-width:100%;overflow:visible;height:auto}
-.fsdb-page .fsdb-propchip{display:inline-flex;align-items:center;flex-wrap:nowrap;gap:0;width:auto;max-width:100%;min-width:0;height:auto;min-height:20px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:14px;font-weight:500;line-height:20px}
-.fsdb-page .fsdb-propchip-k{display:none}
-.fsdb-page .fsdb-propchip-v{display:inline-flex;align-items:center;min-width:0;overflow:hidden;color:var(--dsw-label);font-weight:600;line-height:20px}
-.fsdb-page .fsdb-propchip-v:has(.fsdb-boolbox){overflow:visible;flex:none}
-.fsdb-page .fsdb-propchip .fsdb-pill,.fsdb-page .fsdb-propchip .fsdb-tag{padding:0;background:transparent;max-width:none}
+.fsdb-page .fsdb-proplist .fsdb-proprow{display:inline-grid;width:auto;max-width:100%;min-width:0;min-height:20px;grid-template-columns:max-content minmax(0,1fr)}
+.fsdb-page .fsdb-proplist .fsdb-proprow-v:has(.fsdb-boolbox){overflow:visible;flex:none}
+.fsdb-page .fsdb-proplist .fsdb-pill,.fsdb-page .fsdb-proplist .fsdb-tag{padding:0;background:transparent;max-width:none}
 .fsdb-workspace{display:flex;flex-direction:column;min-width:0;min-height:0;flex:1;overflow:hidden}
 .fsdb-pager{display:flex;align-items:center;gap:8px;flex:none;min-height:28px;padding:4px 0 0;color:var(--dsw-label-3);font-size:13px;font-weight:500}
 .fsdb-pager-meta{display:inline-flex;align-items:center;gap:4px;min-width:0;flex:1;overflow:hidden;white-space:nowrap;color:var(--dsw-label-3)}
@@ -261,10 +260,13 @@ const CSS = `
 .fsdb-page.is-sheet .fsdb-right-body{overflow:hidden}
 .fsdb-page:not(.inspector-database-page) .fsdb-detail-main{padding:80px 24px 24px}
 .fsdb-detail-aside{display:flex;flex-direction:column;gap:2px;padding:8px 0 12px}
-.fsdb-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;font-size:14px;color:var(--dsw-label-3)}
-.fsdb-prop>span:first-child{font-size:14px;font-weight:600;color:var(--dsw-label-3);display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.fsdb-prop.is-stack{align-items:flex-start;flex-wrap:wrap}
-.fsdb-prop.is-stack>span:first-child{padding-top:6px}
+.fsdb-proprow,.fsdb-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;font-size:14px;color:#7B7B79}
+.fsdb-proprow-k,.fsdb-prop>span:first-child{font-size:14px;font-weight:500;color:#7B7B79;display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.fsdb-proprow-k svg,.fsdb-prop>span:first-child svg,.fsdb-schema-prop-k svg{color:#7B7B79;opacity:1}
+.fsdb-proprow-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7B7B79}
+.fsdb-proprow-v,.fsdb-prop-val,.fsdb-detail-id{min-width:0;color:#7C7A76}
+.fsdb-proprow.is-stack,.fsdb-prop.is-stack{align-items:flex-start;flex-wrap:wrap}
+.fsdb-proprow.is-stack .fsdb-proprow-k,.fsdb-prop.is-stack>span:first-child{padding-top:6px}
 .fsdb-prop-val.is-schema{overflow:visible;white-space:normal;max-width:none}
 .fsdb-schema{display:flex;flex-direction:column;gap:2px;min-width:0;width:100%}
 .fsdb-schema-tokens{position:relative;min-width:0}
@@ -279,8 +281,8 @@ const CSS = `
 .fsdb-schema-pack-head{display:flex;align-items:center;min-height:24px;padding:0 4px 4px}
 .fsdb-schema-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;border-radius:6px;padding:0 4px}
 .fsdb-schema-prop:hover{background:var(--dsw-hover)}
-.fsdb-schema-prop-k{display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;font-weight:600;color:var(--dsw-label-3)}
-.fsdb-schema-prop-v{display:flex;align-items:center;gap:4px;min-width:0}
+.fsdb-schema-prop-k{display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px;font-weight:500;color:#7B7B79}
+.fsdb-schema-prop-v{display:flex;align-items:center;gap:4px;min-width:0;color:#7C7A76}
 .fsdb-schema-prop-v .fsdb-plain-input,.fsdb-schema-prop-v .fsdb-cellselect{flex:1;min-width:0}
 .fsdb-schema-prop-del{opacity:0;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-schema-prop:hover .fsdb-schema-prop-del{opacity:1}
@@ -310,7 +312,7 @@ const CSS = `
 .fsdb-schema-row-val{display:flex;align-items:center;gap:6px;min-width:0;flex:1;justify-content:flex-end}
 .fsdb-schema-del{display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
 .fsdb-schema-del:hover{background:var(--dsw-hover);color:var(--dsw-danger)}
-.fsdb-prop-val{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--dsw-label)}
+.fsdb-prop-val{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7C7A76}
 .fsdb-prop-val .fsdb-plain-input,.fsdb-prop-val .fsdb-link,.fsdb-prop-val .fsdb-meta,.fsdb-prop-val .fsdb-file,.fsdb-prop-val .fsdb-file-name,.fsdb-prop-val .fsdb-pill,.fsdb-prop-val .fsdb-tags{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-prop-val .fsdb-plain-input{text-overflow:ellipsis}
 .fsdb-prop-val .fsdb-plain-input:focus{text-overflow:clip}

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -25,8 +25,8 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.tasks-queue-item-body > \.fsdb-proplist\{[^}]*flex-wrap:wrap/)
   assert.match(css, /\.tasks-queue-item-body > \.fsdb-proplist\{[^}]*flex:1 1 12rem/)
   assert.match(css, /\.tasks-queue-item-body > \.fsdb-proplist\{[^}]*min-width:0/)
-  assert.match(css, /\.tasks-queue-item-body \.fsdb-propchip\{[^}]*white-space:nowrap/)
-  assert.match(css, /\.tasks-queue-item-body \.fsdb-propchip-v\{[^}]*white-space:nowrap/)
+  assert.match(css, /\.tasks-queue-item-body \.fsdb-proprow\{[^}]*white-space:nowrap/)
+  assert.match(css, /\.tasks-queue-item-body \.fsdb-proprow-v\{[^}]*white-space:nowrap/)
   assert.match(css, /\.tasks-board-col\{[^}]*background:transparent/)
   assert.match(css, /\.tasks-board-col \.tasks-minicard\{[^}]*background:#202020/)
   assert.match(css, /\.fsdb-cards\{[^}]*align-items:stretch/)
@@ -36,6 +36,12 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.tasks-viewtabs\{[^}]*overflow:hidden/)
   assert.match(css, /\.tasks-viewdd-item-actions\{[^}]*visibility:hidden/)
   assert.match(css, /\.tasks-viewdd-act\{[^}]*width:26px/)
+})
+
+test('list and detail properties share key and value colors', () => {
+  assert.match(css, /\.fsdb-proprow-k,\.fsdb-prop>span:first-child\{[^}]*color:#7B7B79/)
+  assert.match(css, /\.fsdb-proprow-v,\.fsdb-prop-val,\.fsdb-detail-id\{[^}]*color:#7C7A76/)
+  assert.match(css, /\.fsdb-schema-prop-k\{[^}]*color:#7B7B79/)
 })
 
 test('usage figures in collection cells match the table font size', () => {

--- a/packages/core-file-system/src/web/property-row.tsx
+++ b/packages/core-file-system/src/web/property-row.tsx
@@ -1,0 +1,28 @@
+import { type ReactNode } from 'react'
+import type { FieldSpec } from '@biu/type-file-system'
+import { resolveFieldType } from './fields.ts'
+import { FieldGlyph } from './fsdb-cells.tsx'
+
+export function PropertyRow({
+  field,
+  fieldKey,
+  stacked,
+  children,
+}: {
+  field: FieldSpec
+  fieldKey?: string
+  stacked?: boolean
+  children: ReactNode
+}) {
+  const kind = resolveFieldType(field)
+  const label = field.label ?? fieldKey ?? ''
+  return (
+    <div className={`fsdb-proprow${stacked ? ' is-stack' : ''}`}>
+      <span className="fsdb-proprow-k" title={label}>
+        <FieldGlyph kind={kind} />
+        <span className="fsdb-proprow-label">{label}</span>
+      </span>
+      <span className="fsdb-proprow-v">{children}</span>
+    </div>
+  )
+}

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -5,7 +5,8 @@ import { HashtagIcon } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { contentFieldKey, formatField, resolveFieldType, uniqueValues } from './fields.ts'
 import { LocalText } from './controls.tsx'
-import { FieldEditor, FieldGlyph, FilePreview } from './fsdb-cells.tsx'
+import { FieldEditor, FilePreview } from './fsdb-cells.tsx'
+import { PropertyRow } from './property-row.tsx'
 import { SchemaFieldEditor } from './schema-field.tsx'
 import { RecordEmojiBoard } from '@biu/public-ui'
 import { TableGlyph } from './nav-glyphs.tsx'
@@ -197,11 +198,7 @@ export function RecordDetail({
                     if (kind === 'schema' && !field.writable) return null
                     if (kind === 'schema') {
                       return (
-                        <div key={key} className="fsdb-prop is-stack">
-                          <span title={field.label ?? key}>
-                            <FieldGlyph kind={kind} />
-                            {field.label ?? key}
-                          </span>
+                        <PropertyRow key={key} field={field} fieldKey={key} stacked>
                           <div className="fsdb-prop-val is-schema">
                             <SchemaFieldEditor
                               collectionPath={collectionPath}
@@ -211,15 +208,11 @@ export function RecordDetail({
                               onChange={(next) => void writePatch(selected, { [key]: next })}
                             />
                           </div>
-                        </div>
+                        </PropertyRow>
                       )
                     }
                     return (
-                      <div key={key} className="fsdb-prop">
-                        <span title={field.label ?? key}>
-                          <FieldGlyph kind={kind} />
-                          {field.label ?? key}
-                        </span>
+                      <PropertyRow key={key} field={field} fieldKey={key}>
                         <div className="fsdb-prop-val" title={formatField(field, selected[key])}>
                         {field.writable ? (
                           <FieldEditor
@@ -236,7 +229,7 @@ export function RecordDetail({
                           renderCell(selected, key, field)
                         )}
                         </div>
-                      </div>
+                      </PropertyRow>
                     )
                   })}
                 </div>

--- a/packages/core-task-system/package.json
+++ b/packages/core-task-system/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@biu/public-ui": "0.1.0",
+    "@biu/database-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0",
     "@biu/public-mascot": "0.1.0",
     "@xyflow/react": "^12.11.3"

--- a/packages/core-task-system/src/web/chrome.tsx
+++ b/packages/core-task-system/src/web/chrome.tsx
@@ -13,6 +13,7 @@ import {
   XMarkIcon,
 } from '@heroicons/react/16/solid'
 import { TagChip, TagChips } from '@biu/public-ui'
+import { CellSelect } from '@biu/database-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import type { DbRecord } from '@biu/type-file-system'
 import type { CollectionChrome, FsCellProps } from '@biu/type-file-system/ui'
@@ -169,43 +170,14 @@ function ChipSelect({
   valueClass?: string
   onSelect: (value: string) => void
 }) {
-  const [open, setOpen] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const current = options.find((item) => item.value === value)
   return (
-    <div className="tasks-cellselect" onClick={(event) => event.stopPropagation()} onMouseDown={(event) => event.stopPropagation()}>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`tasks-cellselect-trigger ${valueClass ?? ''}`}
-        data-open={open || undefined}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        onClick={() => setOpen((prev) => !prev)}
-      >
-        {current?.icon}
-        <span className="tasks-chip-text">{current?.label ?? value}</span>
-      </button>
-      {open ? (
-        <FloatMenu anchor={triggerRef.current} onClose={() => setOpen(false)}>
-          {options.map((item) => (
-            <button
-              key={item.value}
-              type="button"
-              className={`tasks-cellselect-option${item.value === value ? ' is-selected' : ''}`}
-              role="option"
-              onClick={() => {
-                if (item.value !== value) onSelect(item.value)
-                setOpen(false)
-              }}
-            >
-              {item.icon}
-              {item.label}
-            </button>
-          ))}
-        </FloatMenu>
-      ) : null}
-    </div>
+    <CellSelect
+      className="tasks-cellselect"
+      value={value}
+      options={options}
+      onSelect={onSelect}
+      triggerClassName={`tasks-cellselect-trigger ${valueClass ?? ''}`}
+    />
   )
 }
 

--- a/packages/core-task-system/src/web/index.tsx
+++ b/packages/core-task-system/src/web/index.tsx
@@ -59,7 +59,8 @@ if (typeof document !== 'undefined') {
 .tasks-assignee-option:hover,.tasks-cellselect-option:hover{background:var(--dsw-hover)}
 .tasks-assignee-option.is-selected,.tasks-cellselect-option.is-selected{background:color-mix(in srgb,var(--dsw-business) 14%,transparent)}
 .tasks-assignee-loading{display:flex;align-items:center;gap:6px;padding:6px;color:var(--dsw-label-3);font-size:11px}
-.tasks-cellselect{position:relative;display:inline-flex;min-width:0;width:100%}
+.tasks-cellselect{position:relative;display:inline-flex;min-width:0;width:100%;max-width:none}
+.tasks-cellselect .db-cell-select-trigger,.tasks-cellselect.db-cell-select .db-cell-select-trigger{max-width:none;width:100%;height:auto;background:transparent}
 .tasks-cellselect-trigger{display:inline-flex;align-items:center;gap:5px;width:100%;min-width:0;border:0;border-radius:6px;padding:3px 7px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:600;cursor:pointer;text-align:left}
 .tasks-cellselect-trigger:hover,.tasks-cellselect-trigger[data-open]{background:var(--dsw-hover)}
 .tasks-cellselect-trigger.is-todo{color:var(--dsw-label-3)}

--- a/packages/database-ui/package.json
+++ b/packages/database-ui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@biu/database-ui",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Database 共用 cell / 搜索弹出层",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@biu/public-ui": "0.1.0"
+  },
+  "peerDependencies": {
+    "react": "^19.1.1"
+  }
+}

--- a/packages/database-ui/src/cell-multi.tsx
+++ b/packages/database-ui/src/cell-multi.tsx
@@ -1,0 +1,102 @@
+import { useRef, useState } from 'react'
+import { TagChip, TagChips } from '@biu/public-ui'
+import { DbSearchMenu, DbSearchOption, ensureDbSearchStyle } from './search-menu.tsx'
+
+export function CellMulti({
+  values,
+  options,
+  onChange,
+  allowCreate = true,
+  placeholder,
+}: {
+  values: string[]
+  options: Array<{ value: string; label: string }>
+  onChange: (next: string[]) => void
+  allowCreate?: boolean
+  placeholder?: string
+}) {
+  ensureDbSearchStyle()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const boxRef = useRef<HTMLDivElement>(null)
+  const q = query.trim().toLowerCase()
+  const byValue = new Map(options.map((item) => [item.value, item]))
+  const available = options.filter(
+    (item) => !values.includes(item.value) && (!q || item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q)),
+  )
+  const canCreate =
+    allowCreate && Boolean(query.trim()) && !values.includes(query.trim()) && !options.some((item) => item.value === query.trim() || item.label === query.trim())
+  const close = () => setOpen(false)
+  const add = (value: string) => {
+    if (!values.includes(value)) onChange([...values, value])
+    setQuery('')
+  }
+  return (
+    <div
+      className="db-cell-multi fsdb-tokens"
+      ref={boxRef}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <div
+        className="db-cell-multi-box fsdb-tokens-box"
+        onClick={() => setOpen(true)}
+      >
+        <TagChips>
+          {values.map((value) => (
+            <TagChip
+              key={value}
+              id={value}
+              label={byValue.get(value)?.label ?? value}
+              onRemove={() => onChange(values.filter((item) => item !== value))}
+            />
+          ))}
+        </TagChips>
+        <input
+          className="db-cell-multi-input fsdb-tokens-input"
+          value={query}
+          placeholder={placeholder ?? (values.length ? '' : '搜索或添加')}
+          onFocus={() => setOpen(true)}
+          onChange={(event) => {
+            setQuery(event.target.value)
+            setOpen(true)
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              if (available[0]) add(available[0].value)
+              else if (canCreate) add(query.trim())
+            } else if (event.key === 'Backspace' && !query && values.length) {
+              onChange(values.slice(0, -1))
+            } else if (event.key === 'Escape') close()
+          }}
+        />
+      </div>
+      {open ? (
+        <DbSearchMenu
+          anchor={boxRef.current}
+          onClose={close}
+          query={query}
+          onQuery={(next) => {
+            setQuery(next)
+            setOpen(true)
+          }}
+          onEnter={() => {
+            if (available[0]) add(available[0].value)
+            else if (canCreate) add(query.trim())
+          }}
+          empty={!available.length && !canCreate ? <div className="db-search-empty">没有匹配项</div> : null}
+        >
+          {available.map((item) => (
+            <DbSearchOption key={item.value} onClick={() => add(item.value)}>
+              {item.label}
+            </DbSearchOption>
+          ))}
+          {canCreate ? (
+            <DbSearchOption onClick={() => add(query.trim())}>添加「{query.trim()}」</DbSearchOption>
+          ) : null}
+        </DbSearchMenu>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/database-ui/src/cell-select.tsx
+++ b/packages/database-ui/src/cell-select.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { DbSearchMenu, DbSearchOption, ensureDbSearchStyle } from './search-menu.tsx'
+
+function CheckMark() {
+  return (
+    <svg aria-hidden viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M12.207 4.793a1 1 0 0 1 0 1.414l-5 5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.5 9.086l4.293-4.293a1 1 0 0 1 1.414 0Z" />
+    </svg>
+  )
+}
+
+function CaretMark() {
+  return (
+    <svg aria-hidden viewBox="0 0 16 16" width="14" height="14" fill="currentColor" className="db-cell-select-caret">
+      <path d="M4.22 6.22a.75.75 0 0 1 1.06 0L8 8.94l2.72-2.72a.75.75 0 1 1 1.06 1.06l-3.25 3.25a.75.75 0 0 1-1.06 0L4.22 7.28a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+  )
+}
+
+export type CellSelectOption = { value: string; label: string; icon?: ReactNode }
+
+export function CellSelect({
+  value,
+  options,
+  onSelect,
+  placeholder = '选择',
+  variant = 'cell',
+  triggerClassName,
+  className,
+}: {
+  value: string
+  options: CellSelectOption[]
+  onSelect: (value: string) => void
+  placeholder?: string
+  variant?: 'cell' | 'field'
+  triggerClassName?: string
+  className?: string
+}) {
+  ensureDbSearchStyle()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const current = options.find((item) => item.value === value)
+  const q = query.trim().toLowerCase()
+  const filtered = options.filter(
+    (item) => !q || item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q),
+  )
+  useEffect(() => {
+    if (!open) setQuery('')
+  }, [open])
+  const close = () => setOpen(false)
+  return (
+    <div
+      className={`db-cell-select fsdb-cellselect is-${variant}${open ? ' is-open' : ''}${className ? ` ${className}` : ''}`}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`db-cell-select-trigger fsdb-cellselect-trigger${current ? '' : ' is-empty'}${triggerClassName ? ` ${triggerClassName}` : ''}`}
+        data-open={open || undefined}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={(event) => {
+          event.stopPropagation()
+          setOpen((v) => !v)
+        }}
+      >
+        {current?.icon}
+        <span className={`db-cell-select-label fsdb-cellselect-label${current ? '' : ' is-empty'}`}>{current?.label ?? placeholder}</span>
+        {variant === 'field' ? <CaretMark /> : null}
+      </button>
+      {open ? (
+        <DbSearchMenu
+          anchor={triggerRef.current}
+          onClose={close}
+          query={query}
+          onQuery={setQuery}
+          onEnter={() => {
+            if (!filtered[0]) return
+            onSelect(filtered[0].value)
+            close()
+          }}
+          empty={!filtered.length ? <div className="db-search-empty">没有匹配项</div> : null}
+        >
+          {filtered.map((item) => (
+            <DbSearchOption
+              key={item.value}
+              selected={item.value === value}
+              mark={item.value === value ? <CheckMark /> : null}
+              onClick={() => {
+                onSelect(item.value)
+                close()
+              }}
+            >
+              {item.icon}
+              {item.label}
+            </DbSearchOption>
+          ))}
+        </DbSearchMenu>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/database-ui/src/index.test.ts
+++ b/packages/database-ui/src/index.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+test('database-ui ships one search menu for select and multi-select', () => {
+  const menu = readFileSync(resolve(import.meta.dirname, './search-menu.tsx'), 'utf8')
+  const select = readFileSync(resolve(import.meta.dirname, './cell-select.tsx'), 'utf8')
+  const multi = readFileSync(resolve(import.meta.dirname, './cell-multi.tsx'), 'utf8')
+  assert.match(menu, /function DbSearchMenu/)
+  assert.match(menu, /db-search-menu/)
+  assert.match(menu, /className="db-search-field"/)
+  assert.match(select, /<DbSearchMenu/)
+  assert.match(multi, /<DbSearchMenu/)
+  assert.match(multi, /TagChip/)
+})

--- a/packages/database-ui/src/index.ts
+++ b/packages/database-ui/src/index.ts
@@ -1,0 +1,3 @@
+export { DbMenu, DbSearchMenu, DbSearchOption, ensureDbSearchStyle } from './search-menu.tsx'
+export { CellSelect, type CellSelectOption } from './cell-select.tsx'
+export { CellMulti } from './cell-multi.tsx'

--- a/packages/database-ui/src/search-menu.tsx
+++ b/packages/database-ui/src/search-menu.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, type ReactNode, type RefObject } from 'react'
+import { AnchorMenu } from '@biu/public-ui'
+
+const STYLE_ID = 'biu-database-ui-search'
+const CSS = `
+.db-search-menu{box-sizing:border-box;padding:6px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:4px}
+.db-search-field{display:flex;align-items:center;gap:6px;border:1px solid var(--dsw-border);border-radius:8px;padding:4px 8px;color:var(--dsw-label-3);background:var(--dsw-input)}
+.db-search-field input{flex:1;min-width:0;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;outline:none}
+.db-search-list{display:flex;flex-direction:column;gap:1px;max-height:220px;overflow:auto}
+.db-search-option{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;border:0;border-radius:6px;padding:5px 6px;background:transparent;color:var(--dsw-label);font:inherit;cursor:pointer;text-align:left}
+.db-search-option:hover,.db-search-option.is-selected,.db-search-option.is-active{background:color-mix(in srgb,var(--dsw-business) 12%,transparent)}
+.db-search-option-main{display:inline-flex;align-items:center;gap:6px;min-width:0}
+.db-search-empty{padding:8px;color:var(--dsw-label-3);font-size:14px}
+.db-search-foot{border-top:1px solid var(--dsw-border);margin-top:4px;padding-top:4px}
+.db-cell-select{display:inline-flex;position:relative;min-width:0;max-width:100%;box-sizing:border-box;vertical-align:middle}
+.db-cell-select-trigger{display:inline-flex;align-items:center;gap:5px;max-width:110px;height:22px;border:0;border-radius:4px;padding:0 6px;background:rgba(255,255,255,.08);color:var(--dsw-label);font:inherit;font-size:14px;font-weight:500;line-height:22px;cursor:pointer;text-align:left}
+.db-cell-select-trigger:hover,.db-cell-select-trigger[data-open]{background:rgba(255,255,255,.12)}
+.db-cell-select-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.db-cell-select-caret{flex:none;opacity:.55;color:var(--dsw-label-2)}
+.db-cell-select-trigger.is-empty{max-width:none;color:var(--dsw-label-3);background:var(--dsw-hover);font-weight:500}
+.db-cell-select.is-field{display:block;width:100%}
+.db-cell-select.is-field .db-cell-select-trigger{display:flex;justify-content:space-between;gap:6px;width:100%;max-width:none;min-height:28px;border:1px solid var(--dsw-border);border-radius:7px;padding:5px 8px;background:var(--dsw-input);color:var(--dsw-label)}
+.db-cell-select.is-field .db-cell-select-trigger:hover,.db-cell-select.is-field .db-cell-select-trigger[data-open]{background:var(--dsw-hover);filter:none}
+.db-cell-select.is-field .db-cell-select-trigger.is-empty{color:var(--dsw-label-3)}
+.db-cell-multi{position:relative;min-width:0}
+.db-cell-multi-box{display:flex;flex-wrap:wrap;align-items:center;gap:4px;min-height:28px;border-radius:6px;padding:2px 4px;cursor:text}
+.db-cell-multi-box:hover,.db-cell-multi-box:focus-within{background:var(--dsw-hover)}
+.db-cell-multi-input{flex:1;min-width:64px;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;outline:none;padding:2px 0}
+`
+
+export function ensureDbSearchStyle() {
+  if (typeof document === 'undefined') return
+  let style = document.getElementById(STYLE_ID) as HTMLStyleElement | null
+  if (!style) {
+    style = document.createElement('style')
+    style.id = STYLE_ID
+    document.head.appendChild(style)
+  }
+  if (style.textContent !== CSS) style.textContent = CSS
+}
+
+function SearchMark() {
+  return (
+    <svg aria-hidden viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path
+        fillRule="evenodd"
+        d="M11.5 7a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Zm-.82 4.26a6 6 0 1 1 1.06-1.06l3.04 3.04a.75.75 0 1 1-1.06 1.06l-3.04-3.04Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+export function DbMenu({
+  anchor,
+  onClose,
+  children,
+  footer,
+  className,
+  ...rest
+}: {
+  anchor: HTMLElement | null
+  onClose: () => void
+  children: ReactNode
+  footer?: ReactNode
+  className?: string
+} & Record<string, unknown>) {
+  ensureDbSearchStyle()
+  return (
+    <AnchorMenu
+      anchor={anchor}
+      onClose={onClose}
+      className={className ? `db-search-menu ${className}` : 'db-search-menu'}
+      {...rest}
+    >
+      {children}
+      {footer ? <div className="db-search-foot">{footer}</div> : null}
+    </AnchorMenu>
+  )
+}
+
+export function DbSearchMenu({
+  anchor,
+  onClose,
+  query,
+  onQuery,
+  placeholder = '搜索',
+  children,
+  empty,
+  footer,
+  onEnter,
+  searchRef,
+  ...rest
+}: {
+  anchor: HTMLElement | null
+  onClose: () => void
+  query: string
+  onQuery: (next: string) => void
+  placeholder?: string
+  children: ReactNode
+  empty?: ReactNode
+  footer?: ReactNode
+  onEnter?: () => void
+  searchRef?: RefObject<HTMLInputElement | null>
+} & Record<string, unknown>) {
+  const innerRef = useRef<HTMLInputElement>(null)
+  const inputRef = searchRef ?? innerRef
+  useEffect(() => {
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [inputRef])
+  return (
+    <DbMenu anchor={anchor} onClose={onClose} footer={footer} {...rest}>
+      <label className="db-search-field">
+        <SearchMark />
+        <input
+          ref={inputRef}
+          value={query}
+          placeholder={placeholder}
+          aria-label={placeholder}
+          onChange={(event) => onQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault()
+              onClose()
+              return
+            }
+            if (event.key === 'Enter') {
+              event.preventDefault()
+              onEnter?.()
+            }
+          }}
+        />
+      </label>
+      <div className="db-search-list">
+        {children}
+        {empty}
+      </div>
+    </DbMenu>
+  )
+}
+
+export function DbSearchOption({
+  selected,
+  onClick,
+  children,
+  mark,
+}: {
+  selected?: boolean
+  onClick: () => void
+  children: ReactNode
+  mark?: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      className={`db-search-option${selected ? ' is-selected' : ''}`}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={(event) => {
+        event.stopPropagation()
+        onClick()
+      }}
+    >
+      <span className="db-search-option-main">{children}</span>
+      {mark}
+    </button>
+  )
+}

--- a/packages/public-ui/src/anchor-menu.tsx
+++ b/packages/public-ui/src/anchor-menu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type HTMLAttributes, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 
 export function AnchorMenu({
@@ -8,6 +8,7 @@ export function AnchorMenu({
   className = 'fsdb-cellselect-menu',
   role = 'listbox',
   zIndex = 80,
+  ...rest
 }: {
   anchor: HTMLElement | null
   onClose: () => void
@@ -15,7 +16,7 @@ export function AnchorMenu({
   className?: string
   role?: string
   zIndex?: number
-}) {
+} & Omit<HTMLAttributes<HTMLDivElement>, 'role' | 'className' | 'children'>) {
   const menuRef = useRef<HTMLDivElement>(null)
   const [box, setBox] = useState({ top: 0, left: 0, width: 200 })
 
@@ -54,6 +55,7 @@ export function AnchorMenu({
       className={className}
       role={role}
       style={{ position: 'fixed', top: box.top, left: box.left, width: box.width, zIndex }}
+      {...rest}
     >
       {children}
     </div>,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
列表/卡片和页面详情共用同一套属性行：icon + key `#7B7B79`，值 `#7C7A76`。单选/多选弹出层抽到 `@biu/database-ui`。行上除「放大 / 在右侧打开」外的 action 收到 `⋯`。面包屑 icon/文字为 `#F0EFED`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

