### PR TITLE
记录图标同步，表格与详情同一套编辑交互

### DIFF
--- a/packages/cap-chat/src/web/sessions-chrome.test.ts
+++ b/packages/cap-chat/src/web/sessions-chrome.test.ts
@@ -4,15 +4,16 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { sessionsChrome } from './sessions-chrome.tsx'
 
-test('session table titles include the session mascot', () => {
+test('session table uses mascot as the standalone icon property, title is just the label', () => {
   assert.equal(typeof sessionsChrome.Title, 'function')
   assert.equal(typeof sessionsChrome.Icon, 'function')
   const chrome = readFileSync(resolve(import.meta.dirname, './sessions-chrome.tsx'), 'utf8')
   assert.match(chrome, /function SessionIcon/)
-  assert.match(chrome, /size=\{32\}/)
+  assert.match(chrome, /size=\{20\}/)
   assert.match(chrome, /SidebarMascot/)
   assert.match(chrome, /resolveSessionMascot/)
-  assert.match(chrome, /className="sessions-title"/)
+  assert.match(chrome, /sessions-title-label/)
+  assert.doesNotMatch(chrome, /className="sessions-title"/)
   assert.equal(typeof sessionsChrome.cells?.mascotShape, 'function')
   assert.equal(typeof sessionsChrome.Content, 'function')
   assert.match(chrome, /session-record-log/)

--- a/packages/cap-chat/src/web/sessions-chrome.tsx
+++ b/packages/cap-chat/src/web/sessions-chrome.tsx
@@ -26,17 +26,11 @@ function sessionMascot(record: DbRecord) {
 
 function SessionIcon({ record }: { record: DbRecord }) {
   const identity = resolveSessionMascot(String(record.id), sessionMascot(record))
-  return <SidebarMascot size={32} sessionId={String(record.id)} identity={identity} animate={false} title="" />
+  return <SidebarMascot size={20} sessionId={String(record.id)} identity={identity} animate={false} title="" />
 }
 
-function SessionTitle({ record, label }: { record: DbRecord; label: string }) {
-  const identity = resolveSessionMascot(String(record.id), sessionMascot(record))
-  return (
-    <span className="sessions-title">
-      <SidebarMascot size={20} sessionId={String(record.id)} identity={identity} animate={false} title={label} />
-      <span className="sessions-title-label">{label}</span>
-    </span>
-  )
+function SessionTitle({ label }: { record: DbRecord; label: string }) {
+  return <span className="sessions-title-label">{label}</span>
 }
 
 function MascotShapeCell({ value }: FsCellProps) {
@@ -128,8 +122,6 @@ if (typeof document !== 'undefined') {
   const style = document.getElementById(id) ?? document.createElement('style')
   style.id = id
   style.textContent = `
-.sessions-title{display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%;vertical-align:middle}
-.sessions-title .sidebar-mascot{flex:none}
 .sessions-title-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
 .sessions-log{display:flex;flex-direction:column;gap:16px;min-width:0;padding:8px 0 24px}
 .sessions-log-empty{margin:0;padding:8px 0;color:var(--dsw-label-3)}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -63,17 +63,16 @@ import { recordPreviewMascot, RecordMark } from './record-mark.tsx'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
 import {
   actionIcon,
-  BoolCell,
   DefaultCell,
   draftFromRecord,
   FieldEditor,
   FieldGlyph,
   FilePreview,
+  fieldDraftValue,
   ModeGlyph,
   parseFieldValue,
   VIEW_MODES,
   visibleActions,
-  boolOn,
 } from './fsdb-cells.tsx'
 import { ensureFsdbStyle } from './fsdb-style.ts'
 import { RecordDetail } from './record-detail.tsx'
@@ -110,7 +109,7 @@ import { listCollection, readJson } from './db-client.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
 import { mergeTableViews } from '../catalog-views.ts'
 import { showRecordInInspector } from './inspector-db-route.ts'
-import { SchemaChips } from './schema-field.tsx'
+import { SchemaChips, SchemaFieldEditor } from './schema-field.tsx'
 import { loadSchemaTags, pullSchemaTags } from './schema-tags.ts'
 
 type StatResult = { schema?: CollectionSchema }
@@ -1217,28 +1216,29 @@ export function CollectionBrowser({
     const Custom = chrome?.cells?.[key]
     const fallback = formatField(field, row[key])
     if (Custom) return <Custom field={key} spec={field} value={row[key]} record={row} fallback={fallback} />
-    if (resolveFieldType(field) === 'schema') {
+    const kind = resolveFieldType(field)
+    if (kind === 'schema') {
+      if (field.writable) {
+        return (
+          <SchemaFieldEditor
+            collectionPath={collectionPath}
+            record={row}
+            value={row[key]}
+            writable
+            onChange={(next) => void writePatch(row, { [key]: next })}
+          />
+        )
+      }
       return <SchemaChips value={row[key]} tags={loadSchemaTags()} />
     }
-    if (resolveFieldType(field) === 'select' && field.writable && field.enum?.length) {
+    if (field.writable && kind !== 'file') {
       return (
-        <CellSelect
-          value={String(row[key] ?? '')}
-          options={field.enum.map((item) => ({ value: item, label: item }))}
-          onSelect={(next) => void writeOne(row, key, field, next)}
-        />
-      )
-    }
-    if (resolveFieldType(field) === 'boolean') {
-      return (
-        <BoolCell
-          on={boolOn(row[key])}
-          writable={field.writable}
-          onToggle={
-            field.writable
-              ? () => void writeOne(row, key, field, boolOn(row[key]) ? 'false' : 'true')
-              : undefined
-          }
+        <FieldEditor
+          fieldKey={key}
+          field={field}
+          value={fieldDraftValue(field, row[key])}
+          options={uniqueValues(items, key, field)}
+          onChange={(next) => void writeOne(row, key, field, next)}
         />
       )
     }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -59,6 +59,7 @@ import { buildCrumbs, type CrumbTarget } from './sidebar-nav.ts'
 import { CrumbTrail } from './crumb-trail.tsx'
 import { pickDomAttrs, recordPickKind } from './pick-dom.ts'
 import { recordPreviewEmoji, crumbRecordLabel } from './sidebar-preview.ts'
+import { recordPreviewMascot, RecordMark } from './record-mark.tsx'
 import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
 import {
   actionIcon,
@@ -744,12 +745,14 @@ export function CollectionBrowser({
       id: row.id,
       label: crumbRecordLabel(row, schema?.labelField),
       emoji: recordPreviewEmoji(row),
+      mascot: recordPreviewMascot(row),
     }))
     if (selected && !rows.some((row) => row.id === selected.id)) {
       rows.push({
         id: selected.id,
         label: crumbRecordLabel(selected, schema?.labelField),
         emoji: recordPreviewEmoji(selected),
+        mascot: recordPreviewMascot(selected),
       })
     }
     rememberRecords(collectionPath, rows)
@@ -1201,6 +1204,7 @@ export function CollectionBrowser({
           id: row.id,
           label: crumbRecordLabel(row, schema?.labelField),
           emoji: recordPreviewEmoji(row),
+          mascot: recordPreviewMascot(row),
         })),
       }),
     [activeView?.name, activeViewId, collectionPath, items, routeViewId, schema?.labelField, selected, tables, title, views],
@@ -1266,6 +1270,11 @@ export function CollectionBrowser({
     const host = (
       <span className="fsdb-title-host">
         {openDetail ? <RowCheck id={row.id} /> : null}
+        <RecordMark
+          record={row}
+          tableIcon={currentTable?.view?.icon}
+          Icon={chrome?.Icon}
+        />
         <span className="fsdb-title-text">{body}</span>
       </span>
     )

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1213,9 +1213,6 @@ export function CollectionBrowser({
   const recordPick = (row: DbRecord) => pickDomAttrs(recordKind, row.id, labelOf(row))
 
   function renderCell(row: DbRecord, key: string, field: FieldSpec) {
-    const Custom = chrome?.cells?.[key]
-    const fallback = formatField(field, row[key])
-    if (Custom) return <Custom field={key} spec={field} value={row[key]} record={row} fallback={fallback} />
     const kind = resolveFieldType(field)
     if (kind === 'schema') {
       if (field.writable) {
@@ -1242,6 +1239,9 @@ export function CollectionBrowser({
         />
       )
     }
+    const Custom = chrome?.cells?.[key]
+    const fallback = formatField(field, row[key])
+    if (Custom) return <Custom field={key} spec={field} value={row[key]} record={row} fallback={fallback} />
     return <DefaultCell field={field} value={row[key]} />
   }
 
@@ -1260,13 +1260,16 @@ export function CollectionBrowser({
   }) {
     const key = schema?.labelField
     const field = key && schema ? schema.fields[key] : undefined
-    const body = chrome?.Title ? (
-      <chrome.Title record={row} label={labelOf(row)} />
-    ) : key && field ? (
-      renderCell(row, key, field)
-    ) : (
-      <>{labelOf(row)}</>
-    )
+    const body =
+      key && field?.writable ? (
+        renderCell(row, key, field)
+      ) : chrome?.Title ? (
+        <chrome.Title record={row} label={labelOf(row)} />
+      ) : key && field ? (
+        renderCell(row, key, field)
+      ) : (
+        <>{labelOf(row)}</>
+      )
     const host = (
       <span className="fsdb-title-host">
         {openDetail ? <RowCheck id={row.id} /> : null}
@@ -1423,10 +1426,13 @@ export function CollectionBrowser({
     )
   }
 
-  function RecordProperties({ row, omit, skipBoolean }: { row: DbRecord; omit?: string; skipBoolean?: boolean }) {
+  function RecordProperties({ row, omit }: { row: DbRecord; omit?: string }) {
     const hide = omit ?? activeGroup?.key
+    const bodyKey = contentFieldKey(schema)
     const cols = (hide ? propColumns.filter((item) => item.key !== hide) : propColumns).filter((item) => {
-      if (skipBoolean && resolveFieldType(item.field) === 'boolean') return false
+      if (item.key === schema?.labelField || item.key === bodyKey) return false
+      const kind = resolveFieldType(item.field)
+      if (item.field.writable && kind !== 'file') return true
       return fieldHasValue(item.field, row[item.key])
     })
     if (!cols.length) return null
@@ -1511,16 +1517,16 @@ export function CollectionBrowser({
         <div className="tasks-queue-item-body">
           <span className="fsdb-title-host tasks-queue-item-lead">
             <RowCheck id={row.id} />
-            <button type="button" className="tasks-queue-item-main" data-biu-action="open" onClick={() => openRow(row)}>
+            <div className="tasks-queue-item-main">
               <span className="tasks-queue-item-title">
                 <RecordTitle row={row} openDetail={false} />
               </span>
-            </button>
+            </div>
             <div className="tasks-queue-item-tools">
               <RecordRowTools row={row} />
             </div>
           </span>
-          <RecordProperties row={row} skipBoolean />
+          <RecordProperties row={row} />
         </div>
       </li>
     )
@@ -1534,14 +1540,14 @@ export function CollectionBrowser({
         </div>
         <div className="tasks-minicard-title fsdb-title-host">
           <RowCheck id={row.id} />
-          <button type="button" className="tasks-minicard-open" data-biu-action="open" onClick={() => openRow(row)}>
+          <div className="tasks-minicard-open">
             <span className="tasks-minicard-titletext">
               <RecordTitle row={row} openDetail={false} />
             </span>
-          </button>
+          </div>
         </div>
         <div className="tasks-minicard-foot">
-          <RecordProperties row={row} skipBoolean />
+          <RecordProperties row={row} />
         </div>
       </div>
     )
@@ -2426,7 +2432,6 @@ export function CollectionBrowser({
           schema={schema}
           chrome={chrome}
           draft={draft}
-          items={items}
           detailBody={detailBody}
           labelOf={labelOf}
           renderCell={renderCell}
@@ -2434,7 +2439,6 @@ export function CollectionBrowser({
           writeOne={writeOne}
           writePatch={writePatch}
           tableIcon={currentTable?.view?.icon}
-          collectionPath={collectionPath}
           onOpenRecord={(recordId, collection) => onOpenRecord?.(recordId, activeViewId, collection)}
           onDelete={canDelete && selected ? () => setDlg({ kind: 'delete-record', row: selected }) : undefined}
         />

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -12,6 +12,7 @@ describe('顶栏三级标题', () => {
     expect(trail).toContain("aria-haspopup={canPick ? 'menu' : undefined}")
     expect(trail).toContain('allowMenu')
     expect(trail).toContain('icon={crumb.icon ?? current?.icon}')
+    expect(trail).toContain('emoji={current?.emoji ?? crumb.emoji}')
     expect(trail).toContain('tableCrumb?.icon')
     expect(nav).toContain('builtinAllViewId(target.collection)')
     expect(browser).not.toContain('{ catalog: true }')

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -103,7 +103,15 @@ function CrumbMenu({
                 onOpenId(null)
               }}
             >
-              <CrumbItemGlyph kind={glyphKind} icon={choice.icon} mode={choice.mode} emoji={choice.emoji} />
+              <CrumbItemGlyph
+                kind={glyphKind}
+                icon={choice.icon}
+                mode={choice.mode}
+                emoji={choice.emoji}
+                mascot={choice.mascot}
+                collection={choice.target.kind === 'record' ? choice.target.collection : undefined}
+                recordId={choice.target.kind === 'record' ? choice.target.recordId : undefined}
+              />
               <span className="chat-view-project-name">{choice.label}</span>
             </button>
           )
@@ -187,7 +195,15 @@ export function CrumbTrail({
         const glyph = (
           <>
             {!allowMenu && crumb.kind === 'view' ? <TableGlyph icon={tableIcon} /> : null}
-            <CrumbItemGlyph kind={crumb.kind} icon={crumb.icon ?? current?.icon} mode={current?.mode} emoji={current?.emoji} />
+            <CrumbItemGlyph
+              kind={crumb.kind}
+              icon={crumb.icon ?? current?.icon}
+              mode={current?.mode}
+              emoji={current?.emoji ?? crumb.emoji}
+              mascot={current?.mascot ?? crumb.mascot}
+              collection={crumb.kind === 'record' && crumb.target.kind === 'record' ? crumb.target.collection : undefined}
+              recordId={crumb.kind === 'record' && crumb.target.kind === 'record' ? crumb.target.recordId : undefined}
+            />
             {rootLocked ? null : <span className="chat-view-project-name">{crumb.label}</span>}
           </>
         )

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -45,6 +45,8 @@ import {
 import { pickDomAttrs, recordPickKind, viewPickId } from './pick-dom.ts'
 import { toggleExpandedViewKey } from './sidebar-nav.ts'
 import { TableGlyph, ViewModeGlyph } from './nav-glyphs.tsx'
+import { getDatabaseUi } from './database-ui.ts'
+import { RecordMark } from './record-mark.tsx'
 
 const SIDEBAR_BRAND_GRADIENT =
   'linear-gradient(105deg, color-mix(in srgb, #0066B0 42%, var(--dsw-hover)), color-mix(in srgb, #5B3E90 40%, var(--dsw-hover)) 52%, color-mix(in srgb, #E22726 42%, var(--dsw-hover)))'
@@ -79,6 +81,7 @@ function ViewRecordPreview({
   const [pickerId, setPickerId] = useState<string | null>(null)
   const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null)
   const [emojiDraft, setEmojiDraft] = useState('')
+  const chromeIcon = getDatabaseUi()?.chrome(path).Icon
 
   useEffect(() => {
     if (!open) return
@@ -170,7 +173,11 @@ function ViewRecordPreview({
                     setEmojiDraft(emoji)
                   }}
                 >
-                  {emoji ? <span className="fsdb-record-emoji">{emoji}</span> : <TableGlyph icon={tableIcon} />}
+                  {emoji ? (
+                    <span className="fsdb-record-emoji">{emoji}</span>
+                  ) : (
+                    <RecordMark record={row} tableIcon={tableIcon} Icon={chromeIcon} />
+                  )}
                 </button>
                 {pickerId === row.id && pickerAnchor ? (
                   <RecordEmojiBoard

--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -25,6 +25,17 @@ test('decorate merges cells; later layer wins; dispose restores', () => {
   assert.equal(ui.chrome('/plugins').cells?.name, undefined)
 })
 
+test('decorate keeps Icon as the record mark, later layer wins', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  const IconA = () => null
+  const IconB = () => null
+  ui.decorate('/sessions', { Icon: IconA })
+  assert.equal(ui.chrome('/sessions').Icon, IconA)
+  ui.decorate('/sessions', { Icon: IconB })
+  assert.equal(ui.chrome('/sessions').Icon, IconB)
+})
+
 test('decorate notifies subscribers', () => {
   const ctx = new Context()
   const ui = new DatabaseUiService(ctx)

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -7,6 +7,7 @@ export { normalizeCollectionPath }
 function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   const cells: CollectionChrome['cells'] = {}
   let Action: CollectionChrome['Action']
+  let Icon: CollectionChrome['Icon']
   let Title: CollectionChrome['Title']
   let Board: CollectionChrome['Board']
   let Content: CollectionChrome['Content']
@@ -17,6 +18,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   for (const layer of layers) {
     Object.assign(cells, layer.cells)
     if (layer.Action) Action = layer.Action
+    if (layer.Icon) Icon = layer.Icon
     if (layer.Title) Title = layer.Title
     if (layer.Board) Board = layer.Board
     if (layer.Content) Content = layer.Content
@@ -31,7 +33,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
       }
     }
   }
-  return { cells, Action, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
+  return { cells, Action, Icon, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
 }
 
 function mergeViews(layers: CollectionViewType[]): CollectionViewType[] {

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -329,14 +329,17 @@ export function FieldEditor({
   options?: string[]
 }) {
   const kind = resolveFieldType(field)
-  if (kind === 'select' && field.enum) {
-    return (
-      <CellSelect
-        value={value}
-        options={field.enum.map((item) => ({ value: item, label: item }))}
-        onSelect={onChange}
-      />
-    )
+  if (kind === 'select') {
+    const list = [...(field.enum ?? []), ...(options ?? [])].filter((item, index, all) => all.indexOf(item) === index)
+    if (list.length) {
+      return (
+        <CellSelect
+          value={value}
+          options={[{ value: '', label: '未选择' }, ...list.map((item) => ({ value: item, label: item }))]}
+          onSelect={onChange}
+        />
+      )
+    }
   }
   if (kind === 'boolean') {
     return <BoolCell on={value === 'true'} writable onToggle={() => onChange(value === 'true' ? 'false' : 'true')} />

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -67,23 +67,27 @@ export const VIEW_MODES: Array<{ id: ViewMode; label: string }> = [
   { id: 'board', label: '看板' },
 ]
 
+export function fieldDraftValue(field: FieldSpec, value: unknown): string {
+  const kind = resolveFieldType(field)
+  if (kind === 'multi-select') return asStringList(value).join(', ')
+  if (kind === 'boolean') return value === true || value === 'true' ? 'true' : 'false'
+  if (kind === 'url') return asHttpHref(value)
+  if (kind === 'image') return asImageSrc(value)
+  if (kind === 'attachment') return asAttachment(value)?.href ?? ''
+  if (kind === 'file') {
+    if (value == null || value === '') return ''
+    if (typeof value === 'string') return value
+    return JSON.stringify(value, null, 2)
+  }
+  if (value == null) return ''
+  return String(value)
+}
+
 export function draftFromRecord(schema: CollectionSchema, row: DbRecord, bodyKey: string | null | undefined, detailBody: unknown) {
   const next: Record<string, string> = {}
   for (const [key, field] of Object.entries(schema.fields)) {
     const value = key === bodyKey ? detailBody : row[key]
-    const kind = resolveFieldType(field)
-    if (kind === 'multi-select') next[key] = asStringList(value).join(', ')
-    else if (kind === 'boolean') next[key] = value === true || value === 'true' ? 'true' : 'false'
-    else if (kind === 'url') next[key] = asHttpHref(value)
-    else if (kind === 'image') next[key] = asImageSrc(value)
-    else if (kind === 'attachment') next[key] = asAttachment(value)?.href ?? ''
-    else if (kind === 'file') {
-      if (value == null || value === '') next[key] = ''
-      else if (typeof value === 'string') next[key] = value
-      else next[key] = JSON.stringify(value, null, 2)
-    }
-    else if (value == null) next[key] = ''
-    else next[key] = String(value)
+    next[key] = fieldDraftValue(field, value)
   }
   return next
 }

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -138,7 +138,7 @@ const CSS = `
 .fsdb-page .tasks-tree-toggle.is-empty{cursor:default;pointer-events:none}
 .fsdb-page .tasks-tree-toggle.is-empty:hover{background:transparent}
 .fsdb-page .fsdb-title-text{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
-.fsdb-page .fsdb-title-host{position:relative;display:inline-flex;align-items:center;min-width:0;max-width:100%;flex:1}
+.fsdb-page .fsdb-title-host{position:relative;display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%;flex:1}
 .fsdb-page .tasks-table.is-wrap .fsdb-title-text{white-space:normal}
 .fsdb-page .tasks-title-aside{position:relative;flex:none;display:inline-flex;align-items:center}
 .fsdb-page .tasks-title-zoom{position:relative;display:grid;place-items:center;width:24px;height:24px}
@@ -324,6 +324,11 @@ const CSS = `
 button.fsdb-detail-title-icon{cursor:pointer}
 button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-label)}
 .fsdb-detail-title-icon .fsdb-record-emoji{font-size:28px;line-height:1}
+.fsdb-record-mark{display:inline-grid;place-items:center;flex:none;overflow:hidden;line-height:0}
+.fsdb-record-mark.is-sm{width:16px;height:16px}
+.fsdb-record-mark.is-lg{width:32px;height:32px}
+.fsdb-crumbs .fsdb-record-mark.is-sm,.fsdb-crumb-option .fsdb-record-mark.is-sm{width:14px;height:14px}
+.fsdb-record-mark .sidebar-mascot{display:block}
 .fsdb-detail-title{flex:1;min-width:0;margin:0;color:var(--dsw-label);font-size:32px;font-weight:700;line-height:1.2}
 .fsdb-detail-title-input{display:block;width:100%;margin:0;border:0;background:transparent;color:inherit;font:inherit;font-size:inherit;font-weight:inherit;line-height:inherit;outline:none;padding:0;resize:none}
 .fsdb-detail-title-row .fsdb-detail-title-input{flex:none}

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -151,7 +151,7 @@ const CSS = `
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
 .fsdb-page .tasks-tree-count{pointer-events:none}
 .fsdb-page .tasks-table.is-truncate:not(.is-wrap) .fsdb-cell{max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-tokens),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-plain-input),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-proprow-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-proprow-v:has(.tasks-cellselect),.fsdb-page .fsdb-proprow-v:has(.fsdb-tokens){overflow:visible}
+.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-tags),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.db-cell-select),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-tokens),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-boolbtn),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-plain-input),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-proprow-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-proprow-v:has(.tasks-cellselect),.fsdb-page .fsdb-proprow-v:has(.fsdb-cellselect),.fsdb-page .fsdb-proprow-v:has(.fsdb-tokens),.fsdb-page .fsdb-proprow-v:has(.fsdb-boolbtn){overflow:visible}
 .fsdb-page .tasks-table.is-wrap .fsdb-cell{white-space:normal;overflow-wrap:anywhere;word-break:break-word;max-width:100%;align-items:flex-start}
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden}
 .fsdb-page .tasks-table th,.fsdb-page .tasks-table td{overflow:visible}
@@ -166,7 +166,7 @@ const CSS = `
 .fsdb-page .tasks-table tr.fsdb-group-row:hover td{background:transparent}
 .fsdb-page .tasks-table tr.fsdb-group-row .tasks-queue-ghead{padding:2px 4px}
 .fsdb-page .tasks-minicard{display:flex;flex-direction:column;gap:8px;position:static;width:100%;min-width:0;height:auto;min-height:min-content;margin:0;overflow:visible;text-align:left;border:0;border-radius:8px;padding:10px 11px;background:var(--dsw-sidebar);color:var(--dsw-label);font:inherit;box-shadow:none;transition:background .12s ease}
-.fsdb-page .tasks-minicard-open{display:flex;min-width:0;flex:1;border:0;padding:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
+.fsdb-page .tasks-minicard-open{display:flex;min-width:0;flex:1;border:0;padding:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:default}
 .fsdb-page .tasks-minicard:hover{background:var(--dsw-hover)}
 .fsdb-page .tasks-minicard.is-active{background:var(--dsw-hover)}
 .fsdb-page .tasks-minicard-bar{display:flex;align-items:center;justify-content:flex-end;gap:2px;min-width:0;width:100%}
@@ -194,7 +194,7 @@ const CSS = `
 .fsdb-page .tasks-queue-item{display:block;min-width:0;width:100%}
 .fsdb-page .tasks-queue-item-body{display:flex;flex-wrap:nowrap;align-items:center;gap:6px;min-width:0;width:100%;box-sizing:border-box;border-radius:6px;padding:6px 6px 6px 0}
 .fsdb-page .tasks-queue-item-lead{display:inline-flex;align-items:center;gap:4px;flex:none;min-width:0;max-width:min(56%,32rem)}
-.fsdb-page .tasks-queue-item-main{display:flex;align-items:center;gap:10px;flex:none;width:auto;max-width:min(42%,22rem);min-width:0;box-sizing:border-box;overflow:visible;text-align:left;border:0;border-radius:6px;padding:2px 8px;background:transparent;color:var(--dsw-label);font:inherit;cursor:pointer;box-shadow:none}
+.fsdb-page .tasks-queue-item-main{display:flex;align-items:center;gap:10px;flex:none;width:auto;max-width:min(42%,22rem);min-width:0;box-sizing:border-box;overflow:visible;text-align:left;border:0;border-radius:6px;padding:2px 8px;background:transparent;color:var(--dsw-label);font:inherit;cursor:default;box-shadow:none}
 .fsdb-page .tasks-queue-item:hover .tasks-queue-item-body{background:var(--dsw-hover)}
 .fsdb-page .tasks-queue-item.is-active .tasks-queue-item-body{background:color-mix(in srgb,var(--dsw-hover) 85%,transparent)}
 .fsdb-page .tasks-queue-item .tasks-row-actions{flex:none;padding:2px}

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -151,7 +151,7 @@ const CSS = `
 .fsdb-page .tasks-title-open:hover{opacity:1;color:var(--dsw-label);background:var(--dsw-hover)}
 .fsdb-page .tasks-tree-count{pointer-events:none}
 .fsdb-page .tasks-table.is-truncate:not(.is-wrap) .fsdb-cell{max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-proprow-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-proprow-v:has(.tasks-cellselect){overflow:visible}
+.fsdb-page .tasks-table .fsdb-cell:has(.tasks-assignee-picker),.fsdb-page .tasks-table .fsdb-cell:has(.tasks-cellselect),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-tokens),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-plain-input),.fsdb-page .tasks-table .fsdb-cell:has(.fsdb-thumb-btn),.fsdb-page .fsdb-proprow-v:has(.tasks-assignee-picker),.fsdb-page .fsdb-proprow-v:has(.tasks-cellselect),.fsdb-page .fsdb-proprow-v:has(.fsdb-tokens){overflow:visible}
 .fsdb-page .tasks-table.is-wrap .fsdb-cell{white-space:normal;overflow-wrap:anywhere;word-break:break-word;max-width:100%;align-items:flex-start}
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-cell{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden}
 .fsdb-page .tasks-table th,.fsdb-page .tasks-table td{overflow:visible}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -121,6 +121,9 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(boolBox, /fsdb-boolbox/)
   assert.doesNotMatch(browser, /type="checkbox"/)
   assert.match(browser, /const canDelete = Boolean\(schema\?\.records\?\.delete\) && !subsetLocked/)
+  assert.match(browser, /if \(field.writable && kind !== 'file'\)/)
+  assert.match(browser, /<FieldEditor/)
+  assert.match(browser, /fieldDraftValue\(field, row\[key\]\)/)
 })
 
 test('create record sits at the right of the toolbar with a blue label', () => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -124,6 +124,10 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(browser, /if \(field.writable && kind !== 'file'\)/)
   assert.match(browser, /<FieldEditor/)
   assert.match(browser, /fieldDraftValue\(field, row\[key\]\)/)
+  assert.match(browser, /if \(field.writable && kind !== 'file'\)[\s\S]*const Custom = chrome\?\.cells/)
+  assert.match(browser, /function RecordProperties[\s\S]*item\.field\.writable && kind !== 'file'/)
+  assert.match(browser, /key && field\?\.writable \?/)
+  assert.doesNotMatch(browser, /skipBoolean/)
 })
 
 test('create record sits at the right of the toolbar with a blue label', () => {
@@ -163,6 +167,8 @@ test('card and queue rows expose split and expand like the table', () => {
   assert.match(browser, /function QueueRow[\s\S]*tasks-queue-item-tools[\s\S]*RecordProperties/)
   assert.doesNotMatch(browser, /fsdb-row-check-cell/)
   assert.doesNotMatch(browser, /<th>操作<\/th>/)
+  assert.doesNotMatch(browser, /tasks-queue-item-main" data-biu-action="open"/)
+  assert.doesNotMatch(browser, /tasks-minicard-open" data-biu-action="open"/)
   const style = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
   assert.match(style, /tasks-minicard-bar/)
   assert.match(style, /tasks-queue-item-tools/)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -210,6 +210,7 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(detail, /<Icon record=\{record\} \/>/)
   assert.match(detail, /writePatch\(selected, \{ emoji: next \}\)/)
   assert.match(detail, /fsdb:change/)
+  assert.match(browser, /<RecordMark/)
   assert.match(browser, /tableIcon=\{currentTable\?\.view\?\.icon\}/)
   assert.match(detail, /data-testid=\{`fsdb-pane-\$\{pane\.id\}`\}/)
   assert.match(style, /\.fsdb-fileview\{[^}]*min-height:0/)
@@ -253,7 +254,7 @@ test('collection reload does not follow callback identity', () => {
 })
 
 test('page collection uses a document glyph, not the table/database icon', () => {
-  const glyphs = readFileSync(resolve(import.meta.dirname, './nav-glyphs.tsx'), 'utf8')
+  const glyphs = readFileSync(resolve(import.meta.dirname, './table-glyph.tsx'), 'utf8')
   assert.match(glyphs, /name === 'document' \|\| name === 'document-text' \|\| name === 'page'/)
   assert.match(glyphs, /<DocumentIcon/)
 })

--- a/packages/core-file-system/src/web/nav-glyphs.tsx
+++ b/packages/core-file-system/src/web/nav-glyphs.tsx
@@ -1,13 +1,6 @@
 import {
   CircleStackIcon,
-  ClipboardDocumentListIcon,
-  ChatBubbleLeftRightIcon,
-  BoltIcon,
-  DocumentIcon,
-  EyeIcon,
-  TagIcon,
   ListBulletIcon,
-  PuzzlePieceIcon,
   ShareIcon,
   Squares2X2Icon,
   TableCellsIcon,
@@ -15,18 +8,10 @@ import {
 } from '@heroicons/react/16/solid'
 import type { ViewMode } from './fields.ts'
 import type { CrumbKind } from './sidebar-nav.ts'
-
-export function TableGlyph({ icon, className = 'size-4' }: { icon?: string; className?: string }) {
-  const name = (icon ?? '').trim().toLowerCase()
-  if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={className} />
-  if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={className} />
-  if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return <ChatBubbleLeftRightIcon aria-hidden className={className} />
-  if (name === 'document' || name === 'document-text' || name === 'page') return <DocumentIcon aria-hidden className={className} />
-  if (name === 'bolt') return <BoltIcon aria-hidden className={className} />
-  if (name === 'eye') return <EyeIcon aria-hidden className={className} />
-  if (name === 'tag') return <TagIcon aria-hidden className={className} />
-  return <TableCellsIcon aria-hidden className={className} />
-}
+import { RecordMark, recordMarkStub } from './record-mark.tsx'
+import { getDatabaseUi } from './database-ui.ts'
+import { TableGlyph } from './table-glyph.tsx'
+export { TableGlyph } from './table-glyph.tsx'
 
 export function ViewModeGlyph({ mode, className = 'size-4' }: { mode?: ViewMode; className?: string }) {
   if (mode === 'queue') return <ListBulletIcon aria-hidden className={className} />
@@ -40,16 +25,26 @@ export function CrumbItemGlyph({
   kind,
   icon,
   mode,
-  emoji: _emoji,
+  emoji,
+  mascot,
+  collection,
+  recordId,
   className = 'chat-view-project-icon',
 }: {
   kind: CrumbKind
   icon?: string
   mode?: ViewMode
   emoji?: string
+  mascot?: unknown
+  collection?: string
+  recordId?: string
   className?: string
 }) {
-  if (kind === 'record') return <TableGlyph icon={icon} className={className} />
+  if (kind === 'record') {
+    const Icon = collection ? getDatabaseUi()?.chrome(collection).Icon : undefined
+    const record = recordId ? recordMarkStub({ id: recordId, emoji, mascot }) : undefined
+    return <RecordMark record={record} emoji={emoji} tableIcon={icon} Icon={Icon} className={className} />
+  }
   if (kind === 'view') return <ViewModeGlyph mode={mode} className={className} />
   if (kind === 'collection') return <TableGlyph icon={icon} className={className} />
   return <CircleStackIcon aria-hidden className={className} />

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -3,11 +3,10 @@ import type { CollectionChrome } from '@biu/type-file-system/ui'
 import type { CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
 import { HashtagIcon } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
-import { contentFieldKey, formatField, resolveFieldType, uniqueValues } from './fields.ts'
+import { contentFieldKey, formatField, resolveFieldType } from './fields.ts'
 import { LocalText } from './controls.tsx'
-import { FieldEditor, FilePreview } from './fsdb-cells.tsx'
+import { FilePreview } from './fsdb-cells.tsx'
 import { PropertyRow } from './property-row.tsx'
-import { SchemaFieldEditor } from './schema-field.tsx'
 import { RecordEmojiBoard } from '@biu/public-ui'
 import { TableGlyph } from './nav-glyphs.tsx'
 import { normalizeRecordEmoji, recordPreviewEmoji } from './sidebar-preview.ts'
@@ -91,7 +90,6 @@ export function RecordDetail({
   schema,
   chrome,
   draft,
-  items,
   detailBody,
   labelOf,
   renderCell,
@@ -99,7 +97,6 @@ export function RecordDetail({
   writeOne,
   writePatch,
   tableIcon,
-  collectionPath,
   onOpenRecord,
   onDelete,
 }: {
@@ -107,7 +104,6 @@ export function RecordDetail({
   schema: CollectionSchema
   chrome?: CollectionChrome
   draft: Record<string, string>
-  items: DbRecord[]
   detailBody: unknown
   labelOf: (row: DbRecord) => string
   renderCell: (row: DbRecord, key: string, field: FieldSpec) => ReactNode
@@ -115,7 +111,6 @@ export function RecordDetail({
   writeOne: (row: DbRecord, key: string, field: FieldSpec, raw: string) => Promise<unknown> | void
   writePatch: (row: DbRecord, patch: Record<string, unknown>) => Promise<unknown> | void
   tableIcon?: string
-  collectionPath: string
   onOpenRecord?: (recordId: string, collection?: string) => void
   onDelete?: () => void
 }) {
@@ -198,38 +193,10 @@ export function RecordDetail({
                     if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return null
                     const kind = resolveFieldType(field)
                     if (kind === 'schema' && !field.writable) return null
-                    if (kind === 'schema') {
-                      return (
-                        <PropertyRow key={key} field={field} fieldKey={key} stacked>
-                          <div className="fsdb-prop-val is-schema">
-                            <SchemaFieldEditor
-                              collectionPath={collectionPath}
-                              record={selected}
-                              value={selected[key]}
-                              writable={field.writable}
-                              onChange={(next) => void writePatch(selected, { [key]: next })}
-                            />
-                          </div>
-                        </PropertyRow>
-                      )
-                    }
                     return (
-                      <PropertyRow key={key} field={field} fieldKey={key}>
-                        <div className="fsdb-prop-val" title={formatField(field, selected[key])}>
-                        {field.writable ? (
-                          <FieldEditor
-                            fieldKey={key}
-                            field={field}
-                            value={draft[key] ?? ''}
-                            options={uniqueValues(items, key, field)}
-                            onChange={(next) => {
-                              setDraft((prev) => ({ ...prev, [key]: next }))
-                              void writeOne(selected, key, field, next)
-                            }}
-                          />
-                        ) : (
-                          renderCell(selected, key, field)
-                        )}
+                      <PropertyRow key={key} field={field} fieldKey={key} stacked={kind === 'schema'}>
+                        <div className={kind === 'schema' ? 'fsdb-prop-val is-schema' : 'fsdb-prop-val'} title={formatField(field, selected[key])}>
+                          {renderCell(selected, key, field)}
                         </div>
                       </PropertyRow>
                     )

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -54,7 +54,9 @@ function DetailTitleIcon({
         {emoji ? (
           <span className="fsdb-record-emoji">{emoji}</span>
         ) : Icon ? (
-          <Icon record={record} />
+          <span className="fsdb-record-mark is-lg">
+            <Icon record={record} />
+          </span>
         ) : (
           <TableGlyph icon={tableIcon} className="size-8" />
         )}

--- a/packages/core-file-system/src/web/record-mark.tsx
+++ b/packages/core-file-system/src/web/record-mark.tsx
@@ -1,0 +1,53 @@
+import type { DbRecord } from '@biu/type-file-system'
+import type { CollectionChrome } from '@biu/type-file-system/ui'
+import { TableGlyph } from './table-glyph.tsx'
+import { recordPreviewEmoji } from './sidebar-preview.ts'
+
+export function recordPreviewMascot(row: Pick<DbRecord, 'id'> & Record<string, unknown> | DbRecord) {
+  const raw = row.mascot
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const mascot = raw as { shape?: unknown; color?: unknown; eye?: unknown }
+  if (typeof mascot.shape !== 'string' || typeof mascot.color !== 'string') return undefined
+  return {
+    shape: mascot.shape,
+    color: mascot.color,
+    ...(typeof mascot.eye === 'number' ? { eye: mascot.eye } : {}),
+  }
+}
+
+export function recordMarkStub(row: { id: string; emoji?: string; mascot?: unknown }): DbRecord {
+  const stub: DbRecord = { id: row.id }
+  const emoji = recordPreviewEmoji(row as DbRecord)
+  if (emoji) stub.emoji = emoji
+  const mascot = recordPreviewMascot(row as DbRecord)
+  if (mascot) stub.mascot = mascot
+  return stub
+}
+
+/** 记录的独立图标属性：有 emoji 用 emoji，否则用集合 Icon（会话小人），再否则表 glyph。 */
+export function RecordMark({
+  record,
+  emoji,
+  tableIcon,
+  Icon,
+  className,
+  size = 'sm',
+}: {
+  record?: DbRecord
+  emoji?: string
+  tableIcon?: string
+  Icon?: CollectionChrome['Icon']
+  className?: string
+  size?: 'sm' | 'lg'
+}) {
+  const mark = (emoji ?? (record ? recordPreviewEmoji(record) : '')).trim()
+  if (mark) return <span className="fsdb-record-emoji">{mark}</span>
+  if (Icon && record) {
+    return (
+      <span className={`fsdb-record-mark is-${size}`}>
+        <Icon record={record} />
+      </span>
+    )
+  }
+  return <TableGlyph icon={tableIcon} className={className ?? (size === 'lg' ? 'size-8' : 'size-4')} />
+}

--- a/packages/core-file-system/src/web/sidebar-nav.test.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.test.ts
@@ -203,6 +203,19 @@ test('表视图记录点标题一律出选择菜单', () => {
     records: [{ id: 'evt-194', label: '打开一条事件' }],
   })
   assert.equal(crumbs[2]!.choices[0]!.icon, 'clipboard')
+  const withEmoji = buildCrumbs({
+    collection: '/tasks',
+    collectionLabel: 'Task',
+    tables: [{ path: '/tasks', label: 'Task', icon: 'clipboard' }],
+    viewId: 'v1',
+    viewName: '默认视图',
+    views: [{ id: 'v1', name: '默认视图' }],
+    recordId: 't1',
+    recordLabel: '写文档',
+    records: [{ id: 't1', label: '写文档', emoji: '🔥' }],
+  })
+  assert.equal(withEmoji[2]!.emoji, '🔥')
+  assert.equal(withEmoji[2]!.choices[0]!.emoji, '🔥')
   assert.equal(crumbButtonAction(crumbs[2]!, crumbs[1]!), 'menu')
   assert.equal(crumbButtonAction(crumbs[1]!, crumbs[0]!), 'menu')
   assert.equal(crumbButtonAction(crumbs[0]!), 'menu')

--- a/packages/core-file-system/src/web/sidebar-nav.ts
+++ b/packages/core-file-system/src/web/sidebar-nav.ts
@@ -60,6 +60,7 @@ export type CrumbChoice = {
   icon?: string
   mode?: ViewMode
   emoji?: string
+  mascot?: unknown
 }
 
 export type Crumb = {
@@ -69,6 +70,8 @@ export type Crumb = {
   target: CrumbTarget
   choices: CrumbChoice[]
   icon?: string
+  emoji?: string
+  mascot?: unknown
 }
 
 export function pathForCenter(center: Pick<DataCenter, 'collection' | 'viewId' | 'recordId'>) {
@@ -94,7 +97,7 @@ export function buildCrumbs(input: {
   views?: Array<{ id: string; name: string; mode?: ViewMode }>
   recordId?: string
   recordLabel?: string
-  records?: Array<{ id: string; label: string; emoji?: string }>
+  records?: Array<{ id: string; label: string; emoji?: string; mascot?: unknown }>
 }): Crumb[] {
   const crumbs: Crumb[] = []
   if (!input.collection) return crumbs
@@ -130,15 +133,21 @@ export function buildCrumbs(input: {
   }
   if (input.recordId) {
     const tableIcon = input.tables.find((item) => item.path === input.collection)?.icon
+    const current = (input.records ?? []).find((row) => row.id === input.recordId)
     crumbs.push({
       kind: 'record',
       id: input.recordId,
       label: input.recordLabel || input.recordId,
+      icon: tableIcon,
+      emoji: current?.emoji,
+      mascot: current?.mascot,
       target: { kind: 'record', collection: input.collection, recordId: input.recordId },
       choices: (input.records ?? [{ id: input.recordId, label: input.recordLabel || input.recordId }]).map((row) => ({
         id: row.id,
         label: row.label,
         icon: tableIcon,
+        emoji: row.emoji,
+        mascot: row.mascot,
         target: { kind: 'record', collection: input.collection, recordId: row.id },
       })),
     })

--- a/packages/core-file-system/src/web/table-glyph.tsx
+++ b/packages/core-file-system/src/web/table-glyph.tsx
@@ -1,0 +1,22 @@
+import {
+  ClipboardDocumentListIcon,
+  ChatBubbleLeftRightIcon,
+  BoltIcon,
+  DocumentIcon,
+  EyeIcon,
+  TagIcon,
+  PuzzlePieceIcon,
+  TableCellsIcon,
+} from '@heroicons/react/16/solid'
+
+export function TableGlyph({ icon, className = 'size-4' }: { icon?: string; className?: string }) {
+  const name = (icon ?? '').trim().toLowerCase()
+  if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={className} />
+  if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={className} />
+  if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return <ChatBubbleLeftRightIcon aria-hidden className={className} />
+  if (name === 'document' || name === 'document-text' || name === 'page') return <DocumentIcon aria-hidden className={className} />
+  if (name === 'bolt') return <BoltIcon aria-hidden className={className} />
+  if (name === 'eye') return <EyeIcon aria-hidden className={className} />
+  if (name === 'tag') return <TagIcon aria-hidden className={className} />
+  return <TableCellsIcon aria-hidden className={className} />
+}

--- a/packages/core-file-system/src/web/table-glyph.tsx
+++ b/packages/core-file-system/src/web/table-glyph.tsx
@@ -1,5 +1,5 @@
 import {
-  ClipboardDocumentListIcon,
+  CheckCircleIcon,
   ChatBubbleLeftRightIcon,
   BoltIcon,
   DocumentIcon,
@@ -12,7 +12,9 @@ import {
 export function TableGlyph({ icon, className = 'size-4' }: { icon?: string; className?: string }) {
   const name = (icon ?? '').trim().toLowerCase()
   if (name === 'puzzle-piece' || name === 'puzzle') return <PuzzlePieceIcon aria-hidden className={className} />
-  if (name === 'clipboard-document-list' || name === 'clipboard') return <ClipboardDocumentListIcon aria-hidden className={className} />
+  if (name === 'check-circle' || name === 'check' || name === 'clipboard-document-list' || name === 'clipboard') {
+    return <CheckCircleIcon aria-hidden className={className} />
+  }
   if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return <ChatBubbleLeftRightIcon aria-hidden className={className} />
   if (name === 'document' || name === 'document-text' || name === 'page') return <DocumentIcon aria-hidden className={className} />
   if (name === 'bolt') return <BoltIcon aria-hidden className={className} />

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -28,7 +28,7 @@ export function loadViews(collectionPath: string): SavedView[] {
   return []
 }
 
-export type CrumbRecord = { id: string; label: string; emoji?: string }
+export type CrumbRecord = { id: string; label: string; emoji?: string; mascot?: unknown }
 
 const memoryRecords = new Map<string, CrumbRecord[]>()
 

--- a/packages/core-task-system/src/host/collection.test.ts
+++ b/packages/core-task-system/src/host/collection.test.ts
@@ -40,7 +40,7 @@ test('tasksCollection maps /tasks rows with rolled-up usage', async () => {
   assert.equal(spec.view?.route, '/tasks')
   assert.equal(spec.view?.title, '任务')
   assert.equal(spec.view?.inspector, true)
-  assert.equal(spec.view?.icon, 'clipboard-document-list')
+  assert.equal(spec.view?.icon, 'check-circle')
   assert.deepEqual(spec.schema.columns, ['title', 'status', 'priority', 'difficulty', 'usage', 'creator', 'assignee', 'project', 'tags', 'dueAt'])
   assert.equal(spec.schema.fields.usage?.computed, true)
   const listed = await spec.list()

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -167,7 +167,7 @@ export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActi
       inspector: true,
       blurb: 'Task table in File System; detail panes host scripts and progress reports.',
       order: 21,
-      icon: 'clipboard-document-list',
+      icon: 'check-circle',
     },
     schema: {
       labelField: 'title',

--- a/packages/type-file-system/src/ui.ts
+++ b/packages/type-file-system/src/ui.ts
@@ -33,7 +33,7 @@ export type FsDetailPane = {
 export type CollectionChrome = {
   cells?: Partial<Record<string, ComponentType<FsCellProps>>>
   Action?: ComponentType<FsActionProps>
-  /** 详情标题左侧图标。不传则用集合 glyph / 记录 emoji。 */
+  /** 记录独立图标属性。有 emoji 用 emoji；不传则详情/侧栏/面包屑用集合 glyph。 */
   Icon?: ComponentType<{ record: DbRecord }>
   Title?: ComponentType<{ record: DbRecord; label: string }>
   /** 详情标题下的主舞台（例如标签收集表）。不传则走字段概况 + 正文。 */

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -44,6 +44,7 @@ function PaneLeafIcon({
   kind,
   mode,
   icon,
+  emoji,
   Fallback,
 }: {
   kind?: string
@@ -52,6 +53,9 @@ function PaneLeafIcon({
   emoji?: string
   Fallback?: ComponentType<{ className?: string }>
 }) {
+  if (kind === 'record' && emoji) {
+    return <span className="fsdb-record-emoji">{emoji}</span>
+  }
   if (kind === 'record' || kind === 'collection') {
     const Glyph = captionTableIcon(icon)
     return <Glyph {...chromeIcon} />
@@ -418,7 +422,7 @@ export const SessionInspector = memo(function SessionInspector({
                       onClick={() => setTab(item.id)}
                       data-testid={`inspector-offer-${item.id}`}
                     >
-                      <PaneLeafIcon kind={caption?.kind} mode={caption?.mode} icon={caption?.icon} Fallback={item.Icon} />
+                      <PaneLeafIcon kind={caption?.kind} mode={caption?.mode} icon={caption?.icon} emoji={caption?.emoji} Fallback={item.Icon} />
                       <span className="min-w-0 flex-1 truncate">{caption?.label || item.label}</span>
                       <CheckCircleIcon aria-hidden className="size-4 shrink-0 inspector-add-check" />
                     </button>

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -8,7 +8,6 @@ import {
   XMarkIcon,
   TableCellsIcon,
   ViewColumnsIcon,
-  ClipboardDocumentListIcon,
   ChatBubbleLeftRightIcon,
   DocumentIcon,
   PuzzlePieceIcon,
@@ -32,7 +31,7 @@ function captionTableIcon(icon?: string) {
   const name = (icon ?? '').trim().toLowerCase()
   if (name === 'puzzle-piece' || name === 'puzzle') return PuzzlePieceIcon
   if (name === 'tag') return TagIcon
-  if (name === 'clipboard-document-list' || name === 'clipboard') return ClipboardDocumentListIcon
+  if (name === 'check-circle' || name === 'check' || name === 'clipboard-document-list' || name === 'clipboard') return CheckCircleIcon
   if (name === 'chat-bubble' || name === 'chat-bubble-left-right') return ChatBubbleLeftRightIcon
   if (name === 'document' || name === 'document-text' || name === 'page') return DocumentIcon
   if (name === 'bolt') return BoltIcon

--- a/packages/web-app-shell/src/web/shell-dock-nav.tsx
+++ b/packages/web-app-shell/src/web/shell-dock-nav.tsx
@@ -4,7 +4,7 @@ import {
   ArrowDownTrayIcon,
   ChatBubbleLeftIcon,
   ChatBubbleLeftRightIcon,
-  ClipboardDocumentListIcon,
+  CheckCircleIcon,
   Cog6ToothIcon,
   DocumentIcon,
   PuzzlePieceIcon,
@@ -19,7 +19,7 @@ import { requestInspectorOpen, requestInspectorTab, setChatOverlay } from './cha
 const INSPECTOR_DOCK_TOOLS = [
   { id: 'inspector:pages', title: '页面', tabId: 'database:/pages', order: 40, Icon: DocumentIcon },
   { id: 'inspector:sessions', title: '会话', tabId: 'database:/sessions', order: 41, Icon: ChatBubbleLeftRightIcon },
-  { id: 'inspector:tasks', title: '任务', tabId: 'database:/tasks', order: 42, Icon: ClipboardDocumentListIcon },
+  { id: 'inspector:tasks', title: '任务', tabId: 'database:/tasks', order: 42, Icon: CheckCircleIcon },
   { id: 'inspector:plugins', title: '插件', tabId: 'database:/plugins', order: 43, Icon: PuzzlePieceIcon },
   { id: 'inspector:tags', title: '标签', tabId: 'database:/supertags', order: 44, Icon: TagIcon },
   { id: 'inspector:traj', title: '轨迹', tabId: 'traj', order: 45, Icon: MapIcon },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
记录的图标是独立属性（内置 emoji；会话没有 emoji 时用 mascot），不塞进标题。侧栏、面包屑、列表、详情、检查器 tab 读同一份。

表格 / 列表 / 卡片与详情共用同一套字段编辑器：可写的单选、多选、布尔、时间、文本在格子里就能改，不必点进详情。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

