### PR TITLE
Use #F0EFED for top-bar text and icons including overlay

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -65,6 +65,13 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.match(css, /\.os-dock\s*\{/)
   assert.match(css, /\.os-dock-shelf-row\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s)
   assert.match(css, /\.os-dock-shelf-row\s*\{[^}]*backdrop-filter:\s*blur/s)
+  assert.match(css, /\.chat-view-header-expand\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.chat-view-header-expand:hover\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.chat-view-header-expand\.is-active\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.chat-view-project\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.chat-view-session-title\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.chat-overlay-panel \.chat-view-header\s*\{[^}]*color:\s*#F0EFED/s)
+  assert.match(css, /\.inspector-tab\s*\{[^}]*color:\s*#F0EFED/s)
 })
 
 test('shell columns keep three tracks so sidebar and inspector can animate', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -231,7 +231,7 @@ body {
   border-radius: 6px;
   background: transparent;
   padding: 4px 10px;
-  color: var(--dsw-label);
+  color: #F0EFED;
   font-size: 13px;
   font-weight: 600;
   line-height: 1.2;
@@ -633,7 +633,7 @@ body {
   border-radius: 6px;
   background: transparent;
   padding: 0 8px;
-  color: var(--dsw-sidebar-fg);
+  color: #F0EFED;
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -642,12 +642,12 @@ body {
 
 .inspector-tab:hover {
   background: var(--dsw-hover);
-  color: var(--dsw-sidebar-fg-active);
+  color: #F0EFED;
 }
 
 .inspector-tab.is-active {
   background: var(--dsw-hover);
-  color: var(--dsw-sidebar-fg-active);
+  color: #F0EFED;
 }
 
 .inspector-tab-main {
@@ -718,7 +718,7 @@ body {
   border-radius: 4px;
   background: transparent;
   box-shadow: none;
-  color: var(--dsw-sidebar-fg);
+  color: #F0EFED;
   cursor: pointer;
 }
 
@@ -727,7 +727,7 @@ body {
 .inspector-crumb-close:hover {
   background: var(--dsw-hover);
   box-shadow: none;
-  color: var(--dsw-sidebar-fg-active);
+  color: #F0EFED;
 }
 
 .inspector-crumb-leaf,
@@ -1035,13 +1035,13 @@ body {
   border: 0;
   border-radius: 6px;
   background: transparent;
-  color: var(--dsw-sidebar-fg);
+  color: #F0EFED;
   cursor: pointer;
 }
 
 .chat-view-header-expand:hover {
   background: var(--dsw-hover);
-  color: var(--dsw-sidebar-fg-active);
+  color: #F0EFED;
 }
 
 .chat-view-project {
@@ -1050,14 +1050,14 @@ body {
   max-width: 220px;
   align-items: center;
   gap: 6px;
-  color: var(--dsw-sidebar-fg);
+  color: #F0EFED;
 }
 
 .chat-view-project-icon {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: var(--dsw-sidebar-fg);
+  color: #F0EFED;
 }
 
 .chat-view-project-name {
@@ -1202,6 +1202,7 @@ body {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   padding-inline: 4px;
+  color: #F0EFED;
 }
 
 .chat-overlay-panel .chat-view-header-left {
@@ -4985,7 +4986,7 @@ body {
 
 .chat-view-header-expand.is-active {
   background: var(--dsw-hover);
-  color: var(--dsw-sidebar-fg-active);
+  color: #F0EFED;
 }
 
 /* ===== Mascot Dance Stage（彩蛋）===== */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
顶部导航（对话、数据库、检查器 tab、悬浮聊天窗标题栏）的文字和图标统一为 `#F0EFED`，不再用侧栏灰色 `#BCBAB6`。悬停/选中只改背景，颜色保持不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

