### PR TITLE
fix(fs): 去掉 bytes 字段类型，改用 number

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -18,7 +18,6 @@ const FIELD_TYPES: FieldType[] = [
   'select',
   'multi-select',
   'datetime',
-  'bytes',
   'url',
   'image',
   'attachment',

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -47,7 +47,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
         tags: { type: 'multi-select', label: '标签', writable: true, enum: [...COLORS, 'prod', 'lab'] },
         aliases: { type: 'string[]', label: '别名', writable: true },
         publishedAt: { type: 'datetime', label: '发布时间', writable: true },
-        size: { type: 'bytes', label: '体积', writable: true },
+        size: { type: 'number', label: '体积', writable: true },
         homepage: { type: 'url', label: '地址', writable: true },
         cover: { type: 'image', label: '封面', writable: true },
         pack: { type: 'attachment', label: '附件', writable: true },

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -177,7 +177,7 @@ function coerce(field: FieldSpec, value: unknown) {
   const kind = field.type === 'string[]' ? 'multi-select' : field.format && field.type === 'string' ? field.format : field.type
   if (kind === 'boolean') return value === true || value === 'true'
   if (kind === 'multi-select') return coerceList(value)
-  if (kind === 'number' || kind === 'datetime' || kind === 'bytes') {
+  if (kind === 'number' || kind === 'datetime') {
     if (value == null || value === '') return null
     const n = Number(value)
     if (!Number.isFinite(n)) throw new Error(`expected ${kind}`)

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -16,7 +16,7 @@ const schema: CollectionSchema = {
     status: { type: 'select', enum: ['todo', 'doing', 'done'] },
     tags: { type: 'multi-select' },
     dueAt: { type: 'datetime' },
-    size: { type: 'bytes' },
+    size: { type: 'number' },
   },
 }
 
@@ -24,7 +24,6 @@ test('resolveFieldType maps legacy aliases', () => {
   assert.equal(resolveFieldType({ type: 'string[]' }), 'multi-select')
   assert.equal(resolveFieldType({ type: 'string', enum: ['a'] }), 'select')
   assert.equal(resolveFieldType({ type: 'number', format: 'datetime' }), 'datetime')
-  assert.equal(resolveFieldType({ type: 'number', format: 'bytes' }), 'bytes')
   assert.equal(resolveFieldType({ type: 'string', format: 'url' }), 'url')
   assert.equal(resolveFieldType({ type: 'image' }), 'image')
   assert.equal(resolveFieldType({ type: 'attachment' }), 'attachment')
@@ -47,8 +46,8 @@ test('fieldHasValue hides missing list/card/board chips', () => {
   assert.equal(fieldHasValue({ type: 'url' }, 'https://example.com'), true)
 })
 
-test('formatField renders datetime bytes tags and media', () => {
-  assert.equal(formatField(schema.fields.size, 2048).endsWith('KB'), true)
+test('formatField renders datetime tags and media', () => {
+  assert.equal(formatField(schema.fields.size, 2048), '2048')
   assert.equal(formatField(schema.fields.tags, ['a', 'b']), 'a, b')
   assert.equal(formatField(schema.fields.dueAt, 0), '—')
   assert.equal(formatField({ type: 'url' }, 'https://example.com/x'), 'https://example.com/x')

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -19,7 +19,6 @@ export function resolveFieldType(field: FieldSpec): FieldType {
   if (field.type === 'string[]') return 'multi-select'
   if (field.type === 'string' && field.enum?.length) return 'select'
   if (field.type === 'number' && field.format === 'datetime') return 'datetime'
-  if (field.type === 'number' && field.format === 'bytes') return 'bytes'
   if (field.type === 'string' && (field.format === 'url' || field.format === 'image' || field.format === 'attachment' || field.format === 'file')) {
     return field.format
   }
@@ -154,13 +153,6 @@ export function formatField(field: FieldSpec | undefined, value: unknown): strin
       hour12: false,
     })
   }
-  if (kind === 'bytes') {
-    const n = Number(value)
-    if (!Number.isFinite(n)) return '—'
-    if (n < 1024) return `${n} B`
-    if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)} KB`
-    return `${(n / (1024 * 1024)).toFixed(1)} MB`
-  }
   if (kind === 'boolean') return value === true || value === 'true' ? '是' : '否'
   if (kind === 'url') return asHttpHref(value) || '—'
   if (kind === 'image') return asImageSrc(value) || '—'
@@ -278,7 +270,7 @@ export function matchesFilters(row: DbRecord, filters: Record<string, string>, s
 
 function compareValues(field: FieldSpec, a: unknown, b: unknown): number {
   const kind = resolveFieldType(field)
-  if (kind === 'number' || kind === 'datetime' || kind === 'bytes') return asTime(a) - asTime(b) || Number(a ?? 0) - Number(b ?? 0)
+  if (kind === 'number' || kind === 'datetime') return asTime(a) - asTime(b) || Number(a ?? 0) - Number(b ?? 0)
   if (kind === 'boolean') return Number(a === true || a === 'true') - Number(b === true || b === 'true')
   if (kind === 'select' && field.enum?.length) {
     return field.enum.indexOf(String(a ?? '')) - field.enum.indexOf(String(b ?? ''))

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -7,7 +7,6 @@ import {
   Bars3BottomLeftIcon,
   CalendarDaysIcon,
   CheckIcon,
-  CircleStackIcon,
   ClipboardDocumentListIcon,
   DocumentTextIcon,
   HashtagIcon,
@@ -112,7 +111,6 @@ export function FieldGlyph({ kind }: { kind: FieldType }) {
   if (kind === 'select') return <ListBulletIcon aria-hidden className={cls} />
   if (kind === 'multi-select') return <RectangleStackIcon aria-hidden className={cls} />
   if (kind === 'datetime') return <CalendarDaysIcon aria-hidden className={cls} />
-  if (kind === 'bytes') return <CircleStackIcon aria-hidden className={cls} />
   if (kind === 'number') return <HashtagIcon aria-hidden className={cls} />
   if (kind === 'url') return <LinkIcon aria-hidden className={cls} />
   if (kind === 'image') return <PhotoIcon aria-hidden className={cls} />
@@ -211,7 +209,7 @@ function ImageThumb({ src }: { src: string }) {
 export function parseFieldValue(field: FieldSpec, raw: string): unknown {
   const kind = resolveFieldType(field)
   if (kind === 'boolean') return raw === 'true'
-  if (kind === 'number' || kind === 'datetime' || kind === 'bytes') return raw === '' ? null : Number(raw)
+  if (kind === 'number' || kind === 'datetime') return raw === '' ? null : Number(raw)
   if (kind === 'multi-select') return asStringList(raw)
   if (kind === 'schema') {
     const trimmed = raw.trim()
@@ -312,7 +310,7 @@ export function DefaultCell({ field, value }: { field: FieldSpec; value: unknown
     return <FilePreview value={value} compact kind={kind} />
   }
   const text = formatField(field, value)
-  return <span className={kind === 'datetime' || kind === 'bytes' ? 'fsdb-meta' : undefined}>{text}</span>
+  return <span className={kind === 'datetime' ? 'fsdb-meta' : undefined}>{text}</span>
 }
 
 export function FieldEditor({

--- a/packages/core-file-system/src/web/schema-field.tsx
+++ b/packages/core-file-system/src/web/schema-field.tsx
@@ -22,7 +22,6 @@ const TYPE_LABEL: Record<AtomicFieldType, string> = {
   select: '单选',
   'multi-select': '多选',
   datetime: '时间',
-  bytes: '体积',
   url: '链接',
   image: '图片',
   attachment: '附件',

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -136,7 +136,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         enabled: { type: 'boolean', label: '已打开' },
         running: { type: 'boolean', label: '运行中' },
         tags: { type: 'multi-select', label: '标签' },
-        bytes: { type: 'bytes', label: '大小' },
+        bytes: { type: 'number', label: '大小' },
         createdAt: { type: 'datetime', label: '创建时间' },
         updatedAt: { type: 'datetime', label: '更新时间' },
         lastRunAt: { type: 'datetime', label: '上次运行' },

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -6,7 +6,6 @@ export type FieldType =
   | 'select'
   | 'multi-select'
   | 'datetime'
-  | 'bytes'
   | 'url'
   | 'image'
   | 'attachment'
@@ -19,7 +18,7 @@ export type FieldSpec = {
   label?: string
   writable?: boolean
   sortable?: boolean
-  format?: 'datetime' | 'bytes' | 'url' | 'image' | 'attachment' | 'file'
+  format?: 'datetime' | 'url' | 'image' | 'attachment' | 'file'
   /** select / multi-select 的选项 */
   enum?: string[]
   /** 由 list/get 计算写入记录，不能 PATCH。例如任务消耗。 */
@@ -96,7 +95,6 @@ export const ATOMIC_FIELD_TYPES = [
   'select',
   'multi-select',
   'datetime',
-  'bytes',
   'url',
   'image',
   'attachment',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉字段类型 `bytes` 以及 `format: 'bytes'`。插件表「大小」、页面表「体积」改为 `number`。附件对象上的 `bytes` 体积元数据保留。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

