### PR TITLE
feat(fs): require icon, timestamps, and SuperTag on collection fields

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -103,7 +103,8 @@ describe('composer dock stacking above sticky user', () => {
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     expect(css).toMatch(/\.traj-root\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)
     expect(css).toMatch(/\[data-testid='session-inspector'\] \.usage-panel\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)
-    expect(css).toMatch(/\.session-inspector\s*\{[^}]*background:\s*#202020/s)
+    expect(css).toMatch(/\.session-inspector\s*\{[^}]*background:\s*#191919/s)
+    expect(css).toMatch(/\.session-inspector \.app-side-bar-head\s*\{[^}]*background:\s*#191919/s)
     expect(css).toMatch(/\[data-testid='session-inspector'\] \.traj-root[\s\S]*background:\s*var\(--dsw-sidebar\)/)
   })
 

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -1,5 +1,6 @@
 import type { Context } from 'cordis'
 import type { CollectionSpec } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { PagesStore, STATUS, type WorkspaceFs } from './store.ts'
 
 export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
@@ -39,6 +40,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
         'publishedAt',
       ],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题', writable: true },
         blurb: { type: 'string', label: '摘要', writable: true },
         count: { type: 'number', label: '计数', writable: true },

--- a/packages/cap-page/src/host/store.ts
+++ b/packages/cap-page/src/host/store.ts
@@ -52,6 +52,7 @@ export type PageRow = DbRecord & {
   score: number
   parentId: string | null
   schema: SchemaFieldValue
+  emoji: string
   createdAt: number
   updatedAt: number
 }
@@ -175,6 +176,7 @@ function matterOf(row: PageRow): Record<string, unknown> {
     score: row.score,
     parentId: row.parentId,
     schema: row.schema,
+    emoji: row.emoji,
     createdAt: new Date(row.createdAt).toISOString(),
     updatedAt: new Date(row.updatedAt).toISOString(),
   }
@@ -208,6 +210,7 @@ function rowFromFile(id: string, raw: string): PageRow {
     score: Number(matter.score) || 0,
     parentId: matter.parentId == null || matter.parentId === '' ? null : String(matter.parentId),
     schema: normalizeSchemaValue(matter.schema),
+    emoji: String(matter.emoji ?? ''),
     createdAt,
     updatedAt,
   }
@@ -232,6 +235,7 @@ function emptyRow(id: string, ts: number): PageRow {
     score: 0,
     parentId: null,
     schema: emptySchemaValue(),
+    emoji: '',
     createdAt: ts,
     updatedAt: ts,
   }
@@ -259,6 +263,7 @@ function applyPatch(current: PageRow, patch: Record<string, unknown>): PageRow {
       ? patch.parentId == null || patch.parentId === '' ? null : String(patch.parentId)
       : current.parentId,
     schema: 'schema' in patch ? normalizeSchemaValue(patch.schema) : current.schema,
+    emoji: 'emoji' in patch ? String(patch.emoji ?? '') : current.emoji,
     score: current.score,
     createdAt: current.createdAt,
     updatedAt: Date.now(),

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -4,6 +4,7 @@ import { Context, Service } from 'cordis'
 import * as tools from '@biu/host-tools'
 import { DatabaseService, apply as applyFileSystem } from './index.ts'
 import type { CollectionSpec } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { superTagsCollection } from './super-tags-collection.ts'
 
 function notesCollection(): CollectionSpec {
@@ -17,6 +18,7 @@ function notesCollection(): CollectionSpec {
     schema: {
       labelField: 'title',
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', writable: true },
         status: { type: 'string', writable: true, enum: ['open', 'done'] },
         pinned: { type: 'boolean' },
@@ -85,6 +87,7 @@ test('computed fields come from list and cannot be written', async () => {
     path: '/stats',
     schema: {
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', writable: true },
         score: { type: 'number', computed: true },
       },
@@ -156,6 +159,7 @@ test('update accepts url image and attachment values', async () => {
     path: '/media',
     schema: {
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', writable: true },
         link: { type: 'url', writable: true },
         cover: { type: 'image', writable: true },
@@ -196,6 +200,7 @@ test('content is omitted from list/read and served on its own path', async () =>
     path: '/docs',
     schema: {
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', writable: true },
         content: { type: 'file', writable: true },
       },
@@ -229,7 +234,7 @@ test('list paginates collection records and reports total', async () => {
   db.register({
     id: 'paged',
     path: '/paged',
-    schema: { fields: { title: { type: 'string', writable: true } } },
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string', writable: true } } },
     list: () => [...rows.values()],
     get: (id) => rows.get(id) ?? null,
   })
@@ -297,7 +302,7 @@ test('allowMissing actions can run before the record exists', async () => {
   db.register({
     id: 'notes',
     path: '/notes',
-    schema: { fields: { title: { type: 'string' } } },
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' } } },
     list: () => [...rows.values()],
     get: (id) => rows.get(id) ?? null,
     actions: [
@@ -339,7 +344,7 @@ test('create and delete follow records caps declared at register', async () => {
   db.register({
     id: 'notes',
     path: '/notes',
-    schema: { fields: { title: { type: 'string', writable: true } } },
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string', writable: true } } },
     records: { create: true, delete: true },
     list: () => [...rows.values()],
     get: (id) => rows.get(id) ?? null,
@@ -379,7 +384,7 @@ test('SuperTag catalog is workspace-wide and collect uses sqlite stamps', async 
   db.register({
     id: 'pages',
     path: '/pages',
-    schema: { fields: { title: { type: 'string', writable: true } } },
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string', writable: true } } },
     records: { update: true },
     list: () => [...pages.values()] as { id: string }[],
     get: (id) => pages.get(id) as { id: string } | undefined,
@@ -427,7 +432,7 @@ test('SuperTag list filter asks the collection only for stamped ids', async () =
   db.register({
     id: 'notes',
     path: '/notes',
-    schema: { fields: { title: { type: 'string', writable: true } } },
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string', writable: true } } },
     records: { update: true },
     list: (query) => {
       listed = query?.ids
@@ -470,7 +475,7 @@ test('tables without records.create/delete reject create and delete', async () =
       db.register({
         id: 'broken',
         path: '/broken',
-        schema: { fields: {} },
+        schema: { fields: { ...REQUIRED_RECORD_FIELDS } },
         records: { create: true },
         list: () => [],
         get: () => null,

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -14,6 +14,7 @@ import {
   type CollectionListQuery,
   type CollectionSchema,
   type CollectionSchemaPack,
+  type CollectionFields,
   type CollectionSpec,
   type Database,
   type DbRecord,
@@ -73,7 +74,7 @@ function schemaFor(spec: CollectionSpec): CollectionSchema {
   const contentField = spec.schema.contentField ?? 'content'
   const labelField = spec.schema.labelField ?? 'title'
   const raw = withBuiltinFields(spec.schema.fields, contentField, labelField)
-  const fields: Record<string, FieldSpec> = {}
+  const fields: CollectionFields = { ...raw }
   for (const [key, field] of Object.entries(raw)) {
     fields[key] = field.computed ? { ...field, writable: false } : field
   }

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -1,4 +1,5 @@
 import type { CollectionInfo, CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { builtinAllView, isReadOnlyViewId } from '../catalog-views.ts'
 import type { SavedView } from '../web/saved-view.ts'
 import { isViewModeId } from '../web/fields.ts'
@@ -125,6 +126,7 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
       labelField: 'title',
       columns: ['title', 'table', 'mode', 'sortField', 'sortDir', 'query', 'groupBy', 'pageSize'],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '视图', writable: true },
         table: { type: 'string', label: '来源表' },
         tablePath: { type: 'string', label: '表路径' },

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -1,5 +1,5 @@
 import type { CollectionInfo, CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { builtinAllView, isReadOnlyViewId } from '../catalog-views.ts'
 import type { SavedView } from '../web/saved-view.ts'
 import { isViewModeId } from '../web/fields.ts'
@@ -67,6 +67,10 @@ export class SavedViewsStore {
         ...(patch.sortDir === 'asc' || patch.sortDir === 'desc' ? { sortDir: patch.sortDir } : {}),
         ...(typeof patch.query === 'string' ? { query: patch.query } : {}),
         ...(typeof patch.groupBy === 'string' ? { groupBy: patch.groupBy } : {}),
+        ...('emoji' in patch ? { emoji: String(patch.emoji ?? '') } : {}),
+        ...('schema' in patch ? { schema: normalizeSchemaValue(patch.schema) } : {}),
+        updatedAt: Date.now(),
+        createdAt: Number((cur as { createdAt?: number }).createdAt) || Date.now(),
       }
       views[idx] = next
       return asRecord(path, path, next)
@@ -103,6 +107,7 @@ function asRecord(path: string, tableName: string, view: StoredView): DbRecord {
     pageSize: Number(view.pageSize) || 50,
     columns: Array.isArray(view.columns) ? view.columns.map(String) : [],
     filters: JSON.stringify(filters),
+    ...recordBuiltinValues(view as Record<string, unknown>),
   }
 }
 

--- a/packages/core-file-system/src/host/super-tags-collection.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.ts
@@ -1,5 +1,5 @@
 import type { CollectionInfo, CollectionListQuery, CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { SchemaTagsStore, slugSuperTagId } from './schema-tags.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
@@ -40,6 +40,7 @@ export function superTagsCollection(
     title: label,
     fieldCount: fields.length,
     stampCount,
+    ...recordBuiltinValues(),
   })
 
   const tableLabel = (path: string) => {
@@ -62,6 +63,7 @@ export function superTagsCollection(
       tablePath: item.collection,
       sourceId: item.id,
       tag: id,
+      ...recordBuiltinValues(),
     }))
   }
 

--- a/packages/core-file-system/src/host/super-tags-collection.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.ts
@@ -1,4 +1,5 @@
 import type { CollectionInfo, CollectionListQuery, CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { SchemaTagsStore, slugSuperTagId } from './schema-tags.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
@@ -83,6 +84,7 @@ export function superTagsCollection(
       contentField: 'none',
       columns: ['title', 'fieldCount', 'stampCount'],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标签', writable: true },
         fieldCount: { type: 'number', label: '字段', computed: true },
         stampCount: { type: 'number', label: '收集', computed: true, sortable: true },

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -1,6 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { defaultColumnKeys, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, isViewModeId, matchActionWhen, matchesFilters, parentFieldKey, resolveFieldType, sortRows } from './fields'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -12,6 +13,7 @@ test('isViewModeId accepts builtin and custom slugs', () => {
 const schema: CollectionSchema = {
   labelField: 'title',
   fields: {
+    ...REQUIRED_RECORD_FIELDS,
     title: { type: 'string' },
     status: { type: 'select', enum: ['todo', 'doing', 'done'] },
     tags: { type: 'multi-select' },
@@ -88,7 +90,7 @@ test('contentFieldKey prefers content then contentField then notes', () => {
   assert.equal(
     contentFieldKey({
       labelField: 'title',
-      fields: { title: { type: 'string' }, content: { type: 'file' } },
+      fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, content: { type: 'file' } },
     }),
     'content',
   )
@@ -96,7 +98,7 @@ test('contentFieldKey prefers content then contentField then notes', () => {
     contentFieldKey({
       labelField: 'title',
       contentField: 'notes',
-      fields: { title: { type: 'string' }, notes: { type: 'string' } },
+      fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, notes: { type: 'string' } },
     }),
     'notes',
   )
@@ -126,7 +128,7 @@ test('groupRecords puts multi-select rows in every matching column', () => {
     rows,
     {
       labelField: 'title',
-      fields: { title: { type: 'string' }, tags: { type: 'multi-select', enum: ['game', 'web'] } },
+      fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, tags: { type: 'multi-select', enum: ['game', 'web'] } },
     },
     'tags',
   )
@@ -146,20 +148,20 @@ test('parentFieldKey reads schema then parentId then data links', () => {
     parentFieldKey({
       labelField: 'title',
       parentField: 'owner',
-      fields: { title: { type: 'string' }, owner: { type: 'string' } },
+      fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, owner: { type: 'string' } },
     }),
     'owner',
   )
   assert.equal(
     parentFieldKey({
       labelField: 'title',
-      fields: { title: { type: 'string' }, parentId: { type: 'string' } },
+      fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, parentId: { type: 'string' } },
     }),
     'parentId',
   )
   assert.equal(
     parentFieldKey(
-      { labelField: 'title', fields: { title: { type: 'string' }, folder: { type: 'string' } } },
+      { labelField: 'title', fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, folder: { type: 'string' } } },
       [
         { id: 'a', title: 'root', folder: '' },
         { id: 'b', title: 'child', folder: 'a' },
@@ -194,7 +196,7 @@ test('flattenTree keeps sibling order, indents children, and hides collapsed sub
 test('defaultColumnKeys omits parentId', () => {
   const treeSchema: CollectionSchema = {
     labelField: 'title',
-    fields: { title: { type: 'string' }, parentId: { type: 'string' }, status: { type: 'select' } },
+    fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' }, parentId: { type: 'string' }, status: { type: 'select' } },
   }
   assert.deepEqual(defaultColumnKeys(treeSchema, ['title', 'parentId', 'status', 'createdAt']), ['title', 'status'])
 })

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -1,4 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import {
   createArgs,
   PLUGIN_CREATE_DESCRIPTION,
@@ -129,6 +130,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         'headless',
       ],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         name: { type: 'string', label: '名称' },
         blurb: { type: 'string', label: '简介' },
         installed: { type: 'boolean', label: '已安装' },

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -1,5 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import {
   createArgs,
   PLUGIN_CREATE_DESCRIPTION,
@@ -20,7 +20,7 @@ function omitEmpty(row: DbRecord): DbRecord {
     if (Array.isArray(value) && value.length === 0) continue
     next[key] = value
   }
-  return next
+  return { ...next, ...recordBuiltinValues(row) }
 }
 
 function asInstalledRecord(row: StoreListing): DbRecord {

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -1,5 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 
 type Actor = {
   name?: string
@@ -129,6 +129,7 @@ function taskRecord(row: TaskRow, lookup: (id: string) => TaskRow | undefined, u
     nextTriggerAt: row.nextTriggerAt ?? null,
     createdAt: row.createdAt ?? 0,
     updatedAt: row.updatedAt ?? 0,
+    ...recordBuiltinValues(row),
   }
 }
 

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -1,4 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 
 type Actor = {
   name?: string
@@ -175,6 +176,7 @@ export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActi
       parentField: 'parentId',
       columns: ['title', 'status', 'priority', 'difficulty', 'usage', 'creator', 'assignee', 'project', 'tags', 'dueAt'],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题', writable: true },
         status: { type: 'select', label: '状态', writable: true, enum: ['todo', 'doing', 'done'] },
         priority: { type: 'select', label: '优先级', writable: true, enum: ['low', 'med', 'high'] },

--- a/packages/core-task-system/src/host/index.ts
+++ b/packages/core-task-system/src/host/index.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import { Service, type Context } from 'cordis'
 import { currentSessionId } from '@biu/host-sessions/scope'
+import { emptySchemaValue, normalizeSchemaValue, type SchemaFieldValue } from '@biu/type-file-system'
 import { startTaskClock } from './clock.ts'
 import { tasksCollection } from './collection.ts'
 
@@ -121,6 +122,8 @@ export type TaskRow = {
   /** report 中 done 的次数（派生） */
   doneCount?: number
   sort: number
+  emoji: string
+  schema: SchemaFieldValue
   createdAt: number
   updatedAt: number
   creator: TaskActor
@@ -237,6 +240,8 @@ export type TaskCreateInput = {
   trigger?: Partial<TaskTrigger>
   /** 进度汇报提醒间隔（秒），默认 60。 */
   reportIntervalSec?: number
+  emoji?: string
+  schema?: SchemaFieldValue
 }
 
 export type TaskUpdateInput = Partial<{
@@ -261,6 +266,8 @@ export type TaskUpdateInput = Partial<{
   reportIntervalSec: number
   /** 上次进度追问时间戳（ms），仅供内部监测更新。 */
   lastReportPromptAt: number | null
+  emoji: string
+  schema: SchemaFieldValue
 }>
 
 export type TaskListFilter = {
@@ -883,6 +890,15 @@ function mapRow(row: Record<string, unknown>): TaskRow {
     }
   }
 
+  let schema = emptySchemaValue()
+  if (typeof row.schema_json === 'string' && row.schema_json) {
+    try {
+      schema = normalizeSchemaValue(JSON.parse(row.schema_json))
+    } catch {
+      schema = emptySchemaValue()
+    }
+  }
+
   return {
     id: String(row.id),
     title: String(row.title ?? ''),
@@ -898,6 +914,8 @@ function mapRow(row: Record<string, unknown>): TaskRow {
     dependsOn,
     depth: typeof row.depth === 'number' ? Number(row.depth) : 0,
     sort: Number(row.sort ?? 0),
+    emoji: String(row.emoji ?? ''),
+    schema,
     createdAt: Number(row.created_at ?? 0),
     updatedAt: Number(row.updated_at ?? 0),
     creator,
@@ -1131,6 +1149,8 @@ export class TasksService extends Service {
       "ALTER TABLE tasks ADD COLUMN trigger_json TEXT NOT NULL DEFAULT '{}'",
       'ALTER TABLE tasks ADD COLUMN report_interval_sec INTEGER NOT NULL DEFAULT 60',
       'ALTER TABLE tasks ADD COLUMN last_report_prompt_at INTEGER',
+      "ALTER TABLE tasks ADD COLUMN schema_json TEXT NOT NULL DEFAULT '{}'",
+      "ALTER TABLE tasks ADD COLUMN emoji TEXT NOT NULL DEFAULT ''",
     ]) {
       try {
         this.db.exec(sql)
@@ -1260,8 +1280,8 @@ export class TasksService extends Service {
           id, title, status, priority, difficulty, assignee, due_at, description, notes, sort,
           created_at, updated_at, creator_json, assignee_json, assigned_at,
           project, tags_json, parent_id, depends_on, depth, trigger_json,
-          report_interval_sec
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          report_interval_sec, schema_json, emoji
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         id,
@@ -1286,6 +1306,8 @@ export class TasksService extends Service {
         depth,
         JSON.stringify(trigger),
         reportIntervalSec,
+        JSON.stringify(normalizeSchemaValue(input.schema)),
+        typeof input.emoji === 'string' ? input.emoji : '',
       )
     this.emitChange()
     return this.get(id)!
@@ -1379,6 +1401,8 @@ export class TasksService extends Service {
         : patch.lastReportPromptAt == null
           ? null
           : Number(patch.lastReportPromptAt)
+    const emoji = patch.emoji !== undefined ? String(patch.emoji ?? '') : current.emoji
+    const schema = patch.schema !== undefined ? normalizeSchemaValue(patch.schema) : current.schema
 
     const ts = now()
     this.db
@@ -1387,7 +1411,7 @@ export class TasksService extends Service {
           title = ?, status = ?, priority = ?, difficulty = ?, assignee = ?, due_at = ?, description = ?, notes = ?, sort = ?,
           updated_at = ?, creator_json = ?, assignee_json = ?, assigned_at = ?, project = ?, tags_json = ?,
           parent_id = ?, depends_on = ?, depth = ?, trigger_json = ?,
-          report_interval_sec = ?, last_report_prompt_at = ?
+          report_interval_sec = ?, last_report_prompt_at = ?, schema_json = ?, emoji = ?
          WHERE id = ?`,
       )
       .run(
@@ -1412,6 +1436,8 @@ export class TasksService extends Service {
         JSON.stringify(trigger),
         reportIntervalSec,
         lastReportPromptAt,
+        JSON.stringify(schema),
+        emoji,
         id,
       )
     this.emitChange()

--- a/packages/host-hub/src/host/events-collection.ts
+++ b/packages/host-hub/src/host/events-collection.ts
@@ -1,4 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 
 export type HubEventRow = {
   id: string
@@ -48,6 +49,7 @@ export function eventsCollection(hub: HubLike): CollectionSpec {
       labelField: 'title',
       columns: ['title', 'mode', 'ts', 'args'],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '事件' },
         mode: { type: 'string', label: '模式' },
         name: { type: 'string', label: '名称' },

--- a/packages/host-hub/src/host/events-collection.ts
+++ b/packages/host-hub/src/host/events-collection.ts
@@ -1,5 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 
 export type HubEventRow = {
   id: string
@@ -29,6 +29,7 @@ export function eventsCollection(hub: HubLike): CollectionSpec {
     mode: row.mode,
     name: row.name,
     args: stringifyArgs(row.args),
+    ...recordBuiltinValues({ createdAt: row.ts, updatedAt: row.ts }),
   })
   const list = () => hub.listEvents().map(asRecord)
   return {

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -1,5 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS, normalizeSchemaValue } from '@biu/type-file-system'
 import {
   isSessionCompactPoint,
   nameFromSessionMascot,
@@ -42,12 +42,17 @@ function asRecord(row: SessionSummary): DbRecord {
     tags: Array.isArray(row.config?.tags) ? row.config.tags.map(String) : [],
     eventCount: row.eventCount,
     project: row.project?.name ?? '',
-    updatedAt: row.updatedAt,
     mascot,
     mascotName: nameFromSessionMascot(mascot),
     mascotShape: mascot.shape,
     mascotColor: mascot.color,
     mascotEye: mascot.eye,
+    ...recordBuiltinValues({
+      createdAt: row.config?.createdAt,
+      updatedAt: row.updatedAt,
+      emoji: row.config?.emoji,
+      schema: row.config?.schema,
+    }),
   }
 }
 
@@ -155,6 +160,9 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
       const config: SessionConfig = {}
       if (typeof patch.pinned === 'boolean') config.pinned = patch.pinned
       if (Array.isArray(patch.tags)) config.tags = patch.tags.map((item) => String(item))
+      if ('emoji' in patch) config.emoji = String(patch.emoji ?? '')
+      if ('schema' in patch) config.schema = normalizeSchemaValue(patch.schema)
+      if (typeof patch.createdAt === 'number') config.createdAt = patch.createdAt
       if (Object.keys(config).length) await sessions.patchConfig(id, config)
       const next = (await list()).find((row) => row.id === id)
       if (!next) throw new Error(`unknown session: ${id}`)

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -1,4 +1,5 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import {
   isSessionCompactPoint,
   nameFromSessionMascot,
@@ -133,6 +134,7 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
       labelField: 'title',
       columns: ['title', 'type', 'pinned', 'tags', 'eventCount', 'project', 'updatedAt'],
       fields: {
+        ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题', writable: true },
         type: { type: 'select', label: '类型', enum: ['chat', 'live'] },
         pinned: { type: 'boolean', label: '置顶', writable: true },

--- a/packages/type-file-system/src/index.test.ts
+++ b/packages/type-file-system/src/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { asImageSrc, emptySchemaValue, normalizeSchemaPack, normalizeSchemaValue, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, schemaSearchHaystack, withBuiltinFields } from './index.ts'
+import { asImageSrc, emptySchemaValue, normalizeSchemaPack, normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, schemaSearchHaystack, withBuiltinFields } from './index.ts'
 
 test('asImageSrc keeps http, data:image, and same-origin image paths', () => {
   assert.equal(asImageSrc('https://example.com/a.png'), 'https://example.com/a.png')
@@ -44,6 +44,16 @@ test('withBuiltinFields always includes writable SuperTag schema', () => {
   assert.equal(fields.schema?.type, 'schema')
   assert.equal(fields.schema?.writable, true)
   assert.equal(fields.schema?.label, 'SuperTag')
+})
+
+test('recordBuiltinValues fills required record columns', () => {
+  assert.deepEqual(recordBuiltinValues({}), {
+    createdAt: 0,
+    updatedAt: 0,
+    emoji: '',
+    schema: { tags: [], values: {} },
+  })
+  assert.equal(recordBuiltinValues({ createdAt: 10, emoji: '📄' }).emoji, '📄')
 })
 
 test('required record fields are icon, timestamps, and SuperTag', () => {

--- a/packages/type-file-system/src/index.test.ts
+++ b/packages/type-file-system/src/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { asImageSrc, emptySchemaValue, normalizeSchemaPack, normalizeSchemaValue, schemaSearchHaystack, withBuiltinFields } from './index.ts'
+import { asImageSrc, emptySchemaValue, normalizeSchemaPack, normalizeSchemaValue, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, schemaSearchHaystack, withBuiltinFields } from './index.ts'
 
 test('asImageSrc keeps http, data:image, and same-origin image paths', () => {
   assert.equal(asImageSrc('https://example.com/a.png'), 'https://example.com/a.png')
@@ -44,4 +44,12 @@ test('withBuiltinFields always includes writable SuperTag schema', () => {
   assert.equal(fields.schema?.type, 'schema')
   assert.equal(fields.schema?.writable, true)
   assert.equal(fields.schema?.label, 'SuperTag')
+})
+
+test('required record fields are icon, timestamps, and SuperTag', () => {
+  assert.deepEqual([...REQUIRED_RECORD_FIELD_KEYS].sort(), ['createdAt', 'emoji', 'schema', 'updatedAt'])
+  assert.equal(REQUIRED_RECORD_FIELDS.emoji.type, 'string')
+  assert.equal(REQUIRED_RECORD_FIELDS.schema.type, 'schema')
+  assert.equal(REQUIRED_RECORD_FIELDS.createdAt.type, 'datetime')
+  assert.equal(REQUIRED_RECORD_FIELDS.updatedAt.type, 'datetime')
 })

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -198,6 +198,19 @@ export function normalizeSchemaValue(raw: unknown): SchemaFieldValue {
   return { tags, values }
 }
 
+export function recordBuiltinValues(row: Record<string, unknown> = {}) {
+  const createdAt = Number(row.createdAt)
+  const updatedAt = Number(row.updatedAt)
+  const created = Number.isFinite(createdAt) && createdAt > 0 ? createdAt : 0
+  const updated = Number.isFinite(updatedAt) && updatedAt > 0 ? updatedAt : created
+  return {
+    createdAt: created,
+    updatedAt: updated,
+    emoji: String(row.emoji ?? ''),
+    schema: normalizeSchemaValue(row.schema),
+  }
+}
+
 /** 全文检索：Tag id、显示名、以及包内已填的值。 */
 export function schemaSearchHaystack(raw: unknown, packs: CollectionSchemaPack[] = []): string {
   const parsed = normalizeSchemaValue(raw)

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -73,7 +73,7 @@ export function asAttachment(value: unknown): AttachmentValue | null {
   return { name: href.split('/').filter(Boolean).pop() || href, href }
 }
 
-/** 每张表都有：登记方不必再写。可覆盖 label；id / 时间列默认不可写，表格默认不展开 id 与时间列。标题列始终存在。 */
+/** 每张表都有。id / 时间列默认不可写，表格默认不展开 id 与时间列。标题列始终存在。 */
 export const BUILTIN_FIELDS = {
   id: { type: 'string', label: 'ID' },
   title: { type: 'string', label: '标题', writable: true },
@@ -83,6 +83,22 @@ export const BUILTIN_FIELDS = {
   emoji: { type: 'string', label: '图标', writable: true },
   schema: { type: 'schema', label: 'SuperTag', writable: true },
 } as const satisfies Record<string, FieldSpec>
+
+/** 登记 CollectionSpec.schema.fields 必须声明：图标、创建/更新时间、SuperTag。由登记方自己存。 */
+export const REQUIRED_RECORD_FIELD_KEYS = ['createdAt', 'updatedAt', 'emoji', 'schema'] as const
+
+export type RequiredRecordFieldKey = (typeof REQUIRED_RECORD_FIELD_KEYS)[number]
+
+export type RequiredRecordFields = { [K in RequiredRecordFieldKey]: FieldSpec }
+
+export type CollectionFields = RequiredRecordFields & Record<string, FieldSpec>
+
+export const REQUIRED_RECORD_FIELDS: RequiredRecordFields = {
+  createdAt: BUILTIN_FIELDS.createdAt,
+  updatedAt: BUILTIN_FIELDS.updatedAt,
+  emoji: BUILTIN_FIELDS.emoji,
+  schema: BUILTIN_FIELDS.schema,
+}
 
 /** 表格默认不展开这些内置列（标题除外）。SuperTag 作为默认业务列留下。 */
 export const BUILTIN_FIELD_KEYS = ['id', 'createdAt', 'updatedAt', 'content', 'emoji'] as const
@@ -207,7 +223,7 @@ export function withBuiltinFields(
   fields: Record<string, FieldSpec>,
   contentField = 'content',
   labelField = 'title',
-): Record<string, FieldSpec> {
+): CollectionFields {
   const next = { ...fields }
   next.id = { ...BUILTIN_FIELDS.id, ...next.id, writable: false }
   if (!next[labelField]) next[labelField] = { ...BUILTIN_FIELDS.title, label: labelField === 'title' ? '标题' : labelField }
@@ -224,7 +240,7 @@ export function withBuiltinFields(
     if (key === 'id' || key === labelField) continue
     ordered[key] = field
   }
-  return ordered
+  return ordered as CollectionFields
 }
 
 /** 登记方可序列化的动作声明。图标与按钮长什么样由前端 decorate，不进这份契约。 */
@@ -247,7 +263,8 @@ export type CollectionSchema = {
   labelField?: string
   /** 记录正文：真正存的文件内容。默认 `content`。结构由登记方自定。 */
   contentField?: string
-  fields: Record<string, FieldSpec>
+  /** 必须包含图标、创建/更新时间、SuperTag；登记方自己持久化。 */
+  fields: CollectionFields
   /** 表格默认可见列（须为 fields 的键）。不写则列出全部列表列。详情仍显示全部字段。 */
   columns?: string[]
   /** 指向本表另一条记录 id 的字段。有则表格可按树展示；不写则按 parentId / parent 或数据里的父子引用推断。 */

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -84,6 +84,11 @@ export interface SessionConfig {
   tags?: string[]
   /** 侧栏置顶 */
   pinned?: boolean
+  /** 记录图标 */
+  emoji?: string
+  /** SuperTag */
+  schema?: { tags: string[]; values: Record<string, Record<string, unknown>> }
+  createdAt?: number
 }
 
 export function normalizeSessionConfig(value: unknown): SessionConfig | undefined {
@@ -102,6 +107,19 @@ export function normalizeSessionConfig(value: unknown): SessionConfig | undefine
     next.tags = [...new Set(raw.tags.map((name) => String(name).trim()).filter(Boolean))].slice(0, 24)
   }
   if (typeof raw.pinned === 'boolean') next.pinned = raw.pinned
+  if (typeof raw.emoji === 'string') next.emoji = raw.emoji
+  if (typeof raw.createdAt === 'number' && Number.isFinite(raw.createdAt) && raw.createdAt > 0) next.createdAt = raw.createdAt
+  if (raw.schema && typeof raw.schema === 'object' && !Array.isArray(raw.schema)) {
+    const rec = raw.schema as Record<string, unknown>
+    const tags = Array.isArray(rec.tags) ? [...new Set(rec.tags.map((item) => String(item).trim()).filter(Boolean))] : []
+    const values: Record<string, Record<string, unknown>> = {}
+    if (rec.values && typeof rec.values === 'object' && !Array.isArray(rec.values)) {
+      for (const [key, bag] of Object.entries(rec.values as Record<string, unknown>)) {
+        if (bag && typeof bag === 'object' && !Array.isArray(bag)) values[key] = { ...bag }
+      }
+    }
+    next.schema = { tags, values }
+  }
   return Object.keys(next).length ? next : undefined
 }
 
@@ -135,6 +153,17 @@ export function mergeSessionConfig(
   if (typeof patch.pinned === 'boolean') {
     if (patch.pinned) next.pinned = true
     else delete next.pinned
+  }
+  if ('emoji' in patch) {
+    if (patch.emoji == null || !String(patch.emoji)) delete next.emoji
+    else next.emoji = String(patch.emoji)
+  }
+  if ('schema' in patch) {
+    if (patch.schema == null) delete next.schema
+    else next.schema = patch.schema
+  }
+  if (typeof patch.createdAt === 'number' && Number.isFinite(patch.createdAt) && patch.createdAt > 0) {
+    next.createdAt = patch.createdAt
   }
   return Object.keys(next).length ? next : undefined
 }

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -61,6 +61,8 @@ test('plus menu can add another database tab', () => {
 test('inspector header tabs sit on the same vertical center as the main header', () => {
   assert.match(css, /\.app-side-bar-head\s*\{[^}]*align-items:\s*center/s)
   assert.match(css, /\.inspector-tabs\s*\{[^}]*align-items:\s*center/s)
+  assert.match(css, /\.session-inspector\s*\{[^}]*background:\s*#191919/s)
+  assert.match(css, /\.session-inspector \.app-side-bar-head\s*\{[^}]*background:\s*#191919/s)
   assert.match(css, /\.inspector-tabs\s*\{[^}]*padding:\s*0/s)
   assert.doesNotMatch(css, /\.inspector-tabs\s*\{[^}]*padding-bottom:\s*8px/s)
   assert.match(css, /\.inspector-tab\s*\{[^}]*padding:\s*0 8px/s)

--- a/web/style.css
+++ b/web/style.css
@@ -1100,7 +1100,11 @@ body {
   overflow: visible;
   box-sizing: border-box;
   padding-bottom: var(--brand-corner-clearance);
-  background: #202020;
+  background: #191919;
+}
+
+.session-inspector .app-side-bar-head {
+  background: #191919;
 }
 
 .app-shell-agent.is-chat-overlay .session-inspector {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器导航栏不再用 `#202020`，与画布一样是 **#191919**。

登记契约仍要求 `emoji`、`createdAt`、`updatedAt`、`schema`。各表已补上这些列：

- 页面：frontmatter 增加 `emoji`（`schema`/时间原本就有）
- 任务：sqlite `schema_json` / `emoji`
- 会话：写进 session config
- 视图 / 插件 / 事件 / 标签：行上带上默认值；视图 update 会落盘

数据由登记方自己存。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

