### PR TITLE
采集芯片走 SuperTag 色系，输入框左侧加号用玫红底

### DIFF
--- a/packages/cap-chat/src/web/composer-pick-node.tsx
+++ b/packages/cap-chat/src/web/composer-pick-node.tsx
@@ -1,6 +1,6 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 import { createRoot, type Root } from 'react-dom/client'
-import { PickChipLabel, chipLabel, type PickRef } from '@biu/cap-pick/web'
+import { PickChip, type PickRef } from '@biu/cap-pick/web'
 
 function refFromAttrs(attrs: Record<string, unknown>): PickRef {
   const kind = String(attrs.kind ?? '')
@@ -12,16 +12,7 @@ function refFromAttrs(attrs: Record<string, unknown>): PickRef {
 }
 
 function PickChipView({ attrs }: { attrs: Record<string, unknown> }) {
-  const pick = refFromAttrs(attrs)
-  return (
-    <span
-      className="composer-tool-chip is-pick"
-      data-testid="user-pick-chip"
-      title={`${pick.kind} · ${chipLabel(pick)}`}
-    >
-      <PickChipLabel pick={pick} />
-    </span>
-  )
+  return <PickChip pick={refFromAttrs(attrs)} />
 }
 
 export const PickChipNode = Node.create({

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -70,6 +70,18 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.composer-pill\.has-chips[\s\S]*border-radius:\s*var\(--dsw-radius-bubble\)/)
   })
 
+  it('uses SuperTag tones for pick chips and the composer plus', () => {
+    const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
+    const chip = readFileSync(resolve(root, 'packages/cap-pick/src/web/chip.tsx'), 'utf8')
+    const node = readFileSync(resolve(root, 'packages/cap-chat/src/web/composer-pick-node.tsx'), 'utf8')
+    expect(css).toMatch(/\.composer-plus\s*\{[^}]*background:\s*color-mix\(in srgb, #e255a1 22%, transparent\)/s)
+    expect(css).toMatch(/\.composer-plus\s*\{[^}]*color:\s*#e255a1/s)
+    expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*--biu-tag/s)
+    expect(chip).toMatch(/pickKindTone/)
+    expect(chip).toMatch(/tagTone\(kind\)/)
+    expect(node).toMatch(/<PickChip pick=/)
+  })
+
   it('uses the specified chrome palette and pick highlight', () => {
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     expect(css).toMatch(/--dsw-bg:\s*#191919/)
@@ -115,7 +127,7 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*align-items:\s*center/s)
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*vertical-align:\s*middle/s)
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*line-height:\s*1/s)
-    expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*line-height:\s*1/s)
+    expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*line-height:\s*20px/s)
     expect(css).toMatch(/\.pick-kind-icon\s*\{[^}]*display:\s*block/s)
     expect(css).toMatch(
       /\.composer-pill\.has-chips \.composer-tiptap p,\s*\n\.composer-tiptap\.is-readonly p \{\s*line-height:\s*1\.45/,

--- a/packages/cap-chat/src/web/user-bubble-editor.tsx
+++ b/packages/cap-chat/src/web/user-bubble-editor.tsx
@@ -1,5 +1,5 @@
 import { Fragment, memo, useMemo } from 'react'
-import { PickChipLabel, chipLabel, splitPickStream } from '@biu/cap-pick/web'
+import { PickChip, splitPickStream } from '@biu/cap-pick/web'
 
 /** 已发送用户消息：静态渲染，不挂 Tiptap，避免切回聊天时每条消息都新建编辑器。 */
 export const UserBubbleEditor = memo(function UserBubbleEditor({ text }: { text: string }) {
@@ -11,13 +11,7 @@ export const UserBubbleEditor = memo(function UserBubbleEditor({ text }: { text:
           const pick = part.ref
           return (
             <span key={`p${index}`} className="composer-inline-chip">
-              <span
-                className="composer-tool-chip is-pick"
-                data-testid="user-pick-chip"
-                title={`${pick.kind} · ${chipLabel(pick)}`}
-              >
-                <PickChipLabel pick={pick} />
-              </span>
+              <PickChip pick={pick} />
             </span>
           )
         }

--- a/packages/cap-pick/package.json
+++ b/packages/cap-pick/package.json
@@ -8,6 +8,9 @@
     "./host": "./src/host/index.ts",
     "./web": "./src/web/index.tsx"
   },
+  "dependencies": {
+    "@biu/public-ui": "0.1.0"
+  },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",
     "react": "^19.1.1"

--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -1,7 +1,8 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import * as lu from '@heroicons/react/16/solid'
-import { pickKindIcon } from './chip.tsx'
+import { tagTone } from '@biu/public-ui'
+import { pickKindIcon, pickKindTone } from './chip.tsx'
 
 test('kind maps to distinct heroicons', () => {
   const needed = [
@@ -29,4 +30,10 @@ test('kind maps to distinct heroicons', () => {
   assert.notEqual(pickKindIcon('collection'), pickKindIcon('usage'))
   assert.equal(pickKindIcon('plugin'), lu.PuzzlePieceIcon)
   assert.equal(pickKindIcon('unknown'), lu.TagIcon)
+})
+
+test('pick kind maps to the SuperTag palette by string', () => {
+  assert.equal(pickKindTone('session'), tagTone('session'))
+  assert.equal(pickKindTone('task'), tagTone('task'))
+  assert.notEqual(pickKindTone('session'), pickKindTone('task'))
 })

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -13,8 +13,14 @@ import {
   WrenchScrewdriverIcon,
 } from '@heroicons/react/16/solid'
 import type { ComponentType } from 'react'
+import { ensureTagChipStyle, tagTone } from '@biu/public-ui'
 import type { PickRef } from './types.ts'
 import { chipLabel } from './types.ts'
+
+/** 采集点 kind 字符串映射到 SuperTag 色板。 */
+export function pickKindTone(kind: string) {
+  return tagTone(kind)
+}
 
 type Glyph = ComponentType<{ className?: string }>
 
@@ -49,5 +55,20 @@ export function PickChipLabel({ pick }: { pick: PickRef }) {
       <PickKindGlyph kind={pick.kind} />
       <span>{chipLabel(pick)}</span>
     </>
+  )
+}
+
+export function PickChip({ pick }: { pick: PickRef }) {
+  ensureTagChipStyle()
+  return (
+    <span
+      className="biu-tag composer-tool-chip is-pick"
+      data-testid="user-pick-chip"
+      data-pick-kind={pick.kind}
+      title={`${pick.kind} · ${chipLabel(pick)}`}
+      style={{ ['--biu-tag' as string]: pickKindTone(pick.kind) }}
+    >
+      <PickChipLabel pick={pick} />
+    </span>
   )
 }

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -6,7 +6,7 @@ import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
 export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, pickDomAttrs, type PickRef } from './types.ts'
-export { PickChipLabel, PickKindGlyph, pickKindIcon } from './chip.tsx'
+export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 
 export const name = 'pick-ui'

--- a/packages/public-ui/src/index.ts
+++ b/packages/public-ui/src/index.ts
@@ -3,7 +3,7 @@ export { ChatCount } from './chat-count.tsx'
 export { BoolBox } from './bool-box.tsx'
 export { AnchorMenu } from './anchor-menu.tsx'
 export { RecordEmojiBoard } from './emoji-board.tsx'
-export { TagChip, TagChips, tagTone, TAG_TONES, ensureTagChipStyle } from './tag-chip.tsx'
+export { TagChip, TagChips, tagTone, TAG_TONES, TAG_TONE_ROSE, ensureTagChipStyle } from './tag-chip.tsx'
 export {
   ChatPane,
   ChatStage,

--- a/packages/public-ui/src/tag-chip.test.ts
+++ b/packages/public-ui/src/tag-chip.test.ts
@@ -16,4 +16,6 @@ test('TagChip ships the tinted chip markup', () => {
   assert.match(src, /className=\{\`biu-tag/)
   assert.match(src, /color-mix\(in srgb,var\(--biu-tag/)
   assert.match(src, /function TagChips/)
+  assert.match(src, /TAG_TONE_ROSE/)
+  assert.equal(TAG_TONES.includes('#e255a1' as (typeof TAG_TONES)[number]), true)
 })

--- a/packages/public-ui/src/tag-chip.tsx
+++ b/packages/public-ui/src/tag-chip.tsx
@@ -13,6 +13,8 @@ const CSS = `
 `
 
 export const TAG_TONES = ['#5b9fd6', '#9a6dd7', '#d9730d', '#448361', '#c4554d', '#e255a1', '#c2920a', '#787774'] as const
+/** SuperTag 色板里的玫红，给输入框左侧加号等固定控件用。 */
+export const TAG_TONE_ROSE = '#e255a1' as const
 
 export function tagTone(id: string) {
   let hash = 0

--- a/web/style.css
+++ b/web/style.css
@@ -4452,16 +4452,16 @@ body {
   width: 28px;
   height: 28px;
   margin: 0;
-  border: 1px solid var(--dsw-border);
+  border: 0;
   border-radius: 999px;
-  background: transparent;
-  color: var(--dsw-sidebar-fg);
+  background: color-mix(in srgb, #e255a1 22%, transparent);
+  color: #e255a1;
   cursor: pointer;
 }
 
 .composer-plus:hover {
-  color: var(--dsw-sidebar-fg-active);
-  background: var(--dsw-hover);
+  color: #e255a1;
+  background: color-mix(in srgb, #e255a1 34%, transparent);
 }
 
 .composer-editor {
@@ -4966,20 +4966,21 @@ body {
 .user-pick-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   box-sizing: border-box;
   max-width: 100%;
   overflow: hidden;
+  height: 20px;
   border: 0;
-  border-radius: 6px;
-  background: var(--dsw-pick-fill);
-  padding: 3px 6px;
-  color: #b8c0de;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--biu-tag, #5b9fd6) 22%, transparent);
+  padding: 0 6px;
+  color: var(--biu-tag, #5b9fd6);
   font-family: var(--font-sans);
-  font-size: var(--dsw-chat-chip-font-size);
-  font-weight: 400;
-  letter-spacing: 0.01em;
-  line-height: 1;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: 20px;
   white-space: nowrap;
   vertical-align: middle;
 }
@@ -4998,8 +4999,7 @@ body {
 }
 
 .composer-tool-chip.is-pick:hover {
-  background: color-mix(in srgb, var(--dsw-pick) 28%, transparent);
-  color: #c5cee8;
+  background: color-mix(in srgb, var(--biu-tag, #5b9fd6) 34%, transparent);
 }
 
 .pick-kind-icon-wrap {
@@ -5022,7 +5022,7 @@ body {
 .user-pick-chip .pick-kind-icon {
   width: 12px;
   height: 12px;
-  color: color-mix(in srgb, #3bc9d9 48%, var(--dsw-label-3));
+  color: inherit;
 }
 
 .tool-artifacts {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
输入框里 CAP 采集芯片用 SuperTag 色板：`kind` 字符串走 `tagTone()`，样式与 SuperTag 标签一致（22% 底、同色字）。

光标左边的加号（composer-plus）用 SuperTag 玫红 `#e255a1` 做同样的半透明底。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

