### PR TITLE
fix(chat): 输入框毛玻璃与清空上下文玫红

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -295,7 +295,7 @@ export function ApprovalsRail(props: SlotProps) {
             type="button"
             disabled={!sessionId || clearBusy}
             aria-label="清空上下文"
-            className="project-chip project-chip-icon-only relative"
+            className="project-chip project-chip-icon-only project-chip-clear-ctx relative"
             data-dock-tip={
               histRatio != null
                 ? `清空上下文 · 上下文占输入文字 ${Math.round(histRatio * 100)}%`

--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -61,6 +61,11 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.chat-pane-embed\s*\{[^}]*background:\s*#191919/s)
     expect(css).not.toMatch(/\.chat-overlay-panel\.is-autohide/)
     expect(css).toMatch(/\.composer-pill/)
+    expect(css).toMatch(
+      /\.composer-pill\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s,
+    )
+    expect(css).toMatch(/\.composer-pill\s*\{[^}]*backdrop-filter:\s*blur\(16px\) saturate\(1\.2\)/s)
+    expect(css).not.toMatch(/\.composer-pill\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)
   })
 
   it('squares the composer when pick chips are present', () => {
@@ -70,12 +75,17 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.composer-pill\.has-chips[\s\S]*border-radius:\s*var\(--dsw-radius-bubble\)/)
   })
 
-  it('uses SuperTag tones for pick chips and the composer plus', () => {
+  it('uses SuperTag tones for pick chips and the clear-context control, not the plus', () => {
     const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
     const chip = readFileSync(resolve(root, 'packages/cap-pick/src/web/chip.tsx'), 'utf8')
     const node = readFileSync(resolve(root, 'packages/cap-chat/src/web/composer-pick-node.tsx'), 'utf8')
-    expect(css).toMatch(/\.composer-plus\s*\{[^}]*background:\s*color-mix\(in srgb, #e255a1 22%, transparent\)/s)
-    expect(css).toMatch(/\.composer-plus\s*\{[^}]*color:\s*#e255a1/s)
+    const approvals = readFileSync(resolve(root, 'packages/cap-chat/src/web/approvals.tsx'), 'utf8')
+    expect(css).toMatch(/\.project-chip\.project-chip-clear-ctx\s*\{[^}]*background:\s*color-mix\(in srgb, #e255a1 22%, transparent\)/s)
+    expect(css).toMatch(/\.project-chip\.project-chip-clear-ctx\s*\{[^}]*color:\s*#e255a1/s)
+    expect(css).toMatch(/\.composer-plus\s*\{[^}]*background:\s*transparent/s)
+    expect(css).toMatch(/\.composer-plus\s*\{[^}]*color:\s*var\(--dsw-sidebar-fg\)/s)
+    expect(css).not.toMatch(/\.composer-plus\s*\{[^}]*color:\s*#e255a1/s)
+    expect(approvals).toMatch(/project-chip-clear-ctx/)
     expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*--biu-tag/s)
     expect(chip).toMatch(/pickKindTone/)
     expect(chip).toMatch(/tagTone\(kind\)/)

--- a/packages/public-ui/src/tag-chip.tsx
+++ b/packages/public-ui/src/tag-chip.tsx
@@ -13,7 +13,7 @@ const CSS = `
 `
 
 export const TAG_TONES = ['#5b9fd6', '#9a6dd7', '#d9730d', '#448361', '#c4554d', '#e255a1', '#c2920a', '#787774'] as const
-/** SuperTag 色板里的玫红，给输入框左侧加号等固定控件用。 */
+/** SuperTag 色板里的玫红，给清空上下文等固定控件用。 */
 export const TAG_TONE_ROSE = '#e255a1' as const
 export const TAG_TONE_GREEN = '#448361' as const
 export const TAG_TONE_RED = '#c4554d' as const

--- a/web/style.css
+++ b/web/style.css
@@ -2288,6 +2288,17 @@ body {
   color: var(--dsw-sidebar-fg-active);
 }
 
+.project-chip.project-chip-clear-ctx {
+  border: 0;
+  background: color-mix(in srgb, #e255a1 22%, transparent);
+  color: #e255a1;
+}
+
+.project-chip.project-chip-clear-ctx:hover:not(:disabled) {
+  color: #e255a1;
+  background: color-mix(in srgb, #e255a1 34%, transparent);
+}
+
 .project-chip:disabled,
 .project-chip.is-busy {
   opacity: 0.55;
@@ -4415,10 +4426,12 @@ body {
 .composer-pill {
   position: relative;
   width: 100%;
-  border: 1px solid var(--dsw-bubble);
+  border: 0;
   border-radius: 999px;
-  background: var(--dsw-sidebar);
-  box-shadow: none;
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 1px 2px rgba(15, 15, 15, 0.04), 0 10px 32px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(16px) saturate(1.2);
+  -webkit-backdrop-filter: blur(16px) saturate(1.2);
   transition: border-radius 0.12s ease;
 }
 
@@ -4458,16 +4471,16 @@ body {
   width: 28px;
   height: 28px;
   margin: 0;
-  border: 0;
+  border: 1px solid var(--dsw-border);
   border-radius: 999px;
-  background: color-mix(in srgb, #e255a1 22%, transparent);
-  color: #e255a1;
+  background: transparent;
+  color: var(--dsw-sidebar-fg);
   cursor: pointer;
 }
 
 .composer-plus:hover {
-  color: #e255a1;
-  background: color-mix(in srgb, #e255a1 34%, transparent);
+  color: var(--dsw-sidebar-fg-active);
+  background: var(--dsw-hover);
 }
 
 .composer-editor {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
纠正两处控件：

- 毛玻璃只加在输入胶囊 `.composer-pill`（与 dock 货架同一套 blur / saturate / 半透明白），悬浮聊天窗背景仍透明，不加毛玻璃。
- SuperTag 玫红改到输入栏上方「清空上下文」画笔按钮；输入框里的加号恢复原来的描边透明样式。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

