### PR TITLE
fix(pick): 选中记录的 kind 与图标对齐

### DIFF
--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -15,6 +15,7 @@ test('kind maps to distinct heroicons', () => {
     'Square3Stack3DIcon',
     'RectangleStackIcon',
     'ClipboardDocumentCheckIcon',
+    'CheckCircleIcon',
     'ChatBubbleLeftIcon',
     'PuzzlePieceIcon',
     'TagIcon',
@@ -27,16 +28,19 @@ test('kind maps to distinct heroicons', () => {
   assert.equal(pickKindIcon('session'), lu.CpuChipIcon)
   assert.equal(pickKindIcon('message'), lu.ChatBubbleLeftIcon)
   assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
-  assert.equal(pickKindIcon('task'), lu.ClipboardDocumentCheckIcon)
+  assert.equal(pickKindIcon('task'), lu.CheckCircleIcon)
+  assert.equal(pickKindIcon('tasks'), lu.CheckCircleIcon)
   assert.equal(pickKindIcon('page'), lu.DocumentIcon)
   assert.notEqual(pickKindIcon('collection'), pickKindIcon('usage'))
   assert.equal(pickKindIcon('plugin'), lu.PuzzlePieceIcon)
+  assert.equal(pickKindIcon('plugins'), lu.PuzzlePieceIcon)
   assert.equal(pickKindIcon('unknown'), lu.TagIcon)
 })
 
 test('pick kind maps to the SuperTag palette by string', () => {
   assert.equal(pickKindTone('session'), tagTone('session'))
   assert.equal(pickKindTone('task'), tagTone('task'))
+  assert.equal(pickKindTone('tasks'), tagTone('task'))
   assert.notEqual(pickKindTone('session'), pickKindTone('task'))
 })
 

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -7,6 +7,7 @@ import {
   RectangleStackIcon,
   DocumentIcon,
   ClipboardDocumentCheckIcon,
+  CheckCircleIcon,
   ChatBubbleLeftIcon,
   PuzzlePieceIcon,
   TagIcon,
@@ -17,16 +18,37 @@ import { ensureTagChipStyle, TagChipCloseMark, tagTone } from '@biu/public-ui'
 import type { PickRef } from './types.ts'
 import { chipLabel } from './types.ts'
 
+/** 注入侧可能写 tasks / sessions-db，芯片按规范 kind 取色和图标。 */
+const PICK_KIND_ALIAS: Record<string, string> = {
+  tasks: 'task',
+  pages: 'page',
+  plugins: 'plugin',
+  sessions: 'session',
+  'sessions-db': 'session',
+  events: 'event',
+  'events-db': 'event',
+  views: 'view',
+  'views-db': 'view',
+  tags: 'tag',
+  supertags: 'tag',
+  'supertags-db': 'tag',
+}
+
+export function canonicalPickKind(kind: string) {
+  const key = String(kind ?? '').trim()
+  return PICK_KIND_ALIAS[key] ?? key.replace(/-db$/, '')
+}
+
 /** 采集点 kind 字符串映射到 SuperTag 色板。 */
 export function pickKindTone(kind: string) {
-  return tagTone(kind)
+  return tagTone(canonicalPickKind(kind))
 }
 
 type Glyph = ComponentType<{ className?: string }>
 
 const KIND_ICONS: Record<string, Glyph> = {
   session: CpuChipIcon,
-  task: ClipboardDocumentCheckIcon,
+  task: CheckCircleIcon,
   page: DocumentIcon,
   collection: RectangleStackIcon,
   view: Square3Stack3DIcon,
@@ -38,10 +60,12 @@ const KIND_ICONS: Record<string, Glyph> = {
   event: StopCircleIcon,
   turn: HashtagIcon,
   usage: CircleStackIcon,
+  tag: TagIcon,
+  record: ClipboardDocumentCheckIcon,
 }
 
 export function pickKindIcon(kind: string): Glyph {
-  return KIND_ICONS[kind] ?? TagIcon
+  return KIND_ICONS[canonicalPickKind(kind)] ?? TagIcon
 }
 
 export function PickKindGlyph({ kind }: { kind: string }) {

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -6,7 +6,7 @@ import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
 export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, pickDomAttrs, type PickRef } from './types.ts'
-export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone } from './chip.tsx'
+export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 
 export const name = 'pick-ui'

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1209,7 +1209,7 @@ export function CollectionBrowser({
     [activeView?.name, activeViewId, collectionPath, items, routeViewId, schema?.labelField, selected, tables, title, views],
   )
   const currentTable = tables.find((item) => item.path === collectionPath)
-  const recordKind = recordPickKind(currentTable?.view?.moduleId)
+  const recordKind = recordPickKind(currentTable?.view?.moduleId || currentTable?.id)
   const recordPick = (row: DbRecord) => pickDomAttrs(recordKind, row.id, labelOf(row))
 
   function renderCell(row: DbRecord, key: string, field: FieldSpec) {

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -564,7 +564,7 @@ export const DataSidebar = memo(function DataSidebar({
                     path={table.path}
                     view={view}
                     open={expanded}
-                    recordKind={recordPickKind(table.view?.moduleId)}
+                    recordKind={recordPickKind(table.view?.moduleId || table.id)}
                     tableIcon={table.view?.icon}
                     onOpenRecord={(id, row) => openRecord(table.path, view, id, row)}
                   />
@@ -688,7 +688,7 @@ export const DataSidebar = memo(function DataSidebar({
                           path={table.path}
                           view={view}
                           open={expanded}
-                          recordKind={recordPickKind(table.view?.moduleId)}
+                          recordKind={recordPickKind(table.view?.moduleId || table.id)}
                           tableIcon={table.view?.icon}
                           onOpenRecord={(id, row) => openRecord(table.path, view, id, row)}
                         />

--- a/packages/core-file-system/src/web/pick-dom.test.ts
+++ b/packages/core-file-system/src/web/pick-dom.test.ts
@@ -9,6 +9,9 @@ test('pickDomAttrs writes the same handles cap-pick reads', () => {
     'data-biu-label': '页面 1',
   })
   assert.equal(recordPickKind('page'), 'page')
+  assert.equal(recordPickKind('tasks'), 'task')
+  assert.equal(recordPickKind('plugins'), 'plugin')
+  assert.equal(recordPickKind('sessions-db'), 'session')
   assert.equal(recordPickKind(''), 'record')
   assert.equal(viewPickId('/pages', 'v1'), '/pages::v1')
 })

--- a/packages/core-file-system/src/web/pick-dom.ts
+++ b/packages/core-file-system/src/web/pick-dom.ts
@@ -7,9 +7,32 @@ export function pickDomAttrs(kind: string, id: string, label?: string) {
   }
 }
 
+/** 登记 moduleId / 表 id 对到 CAP 芯片用的 kind（单数、和 icon 表一致）。 */
+const RECORD_PICK_KIND: Record<string, string> = {
+  tasks: 'task',
+  task: 'task',
+  page: 'page',
+  pages: 'page',
+  plugins: 'plugin',
+  plugin: 'plugin',
+  sessions: 'session',
+  session: 'session',
+  'sessions-db': 'session',
+  events: 'event',
+  event: 'event',
+  'events-db': 'event',
+  views: 'view',
+  view: 'view',
+  'views-db': 'view',
+  supertags: 'tag',
+  tag: 'tag',
+  'supertags-db': 'tag',
+}
+
 export function recordPickKind(moduleId?: string | null) {
   const kind = String(moduleId ?? '').trim()
-  return kind || 'record'
+  if (!kind) return 'record'
+  return RECORD_PICK_KIND[kind] ?? kind.replace(/-db$/, '')
 }
 
 export function viewPickId(path: string, viewId: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取任务等记录时，注入的 `data-biu-kind` 原先直接用 `moduleId`（如 `tasks`），芯片只认识 `task`，于是落到默认 Tag 图标。

现在把 tasks / plugins / sessions-db 等归一成 task / plugin / session 再写入；芯片侧也对旧 kind 做别名。任务芯片用与表登记一致的 check-circle。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

