### PR TITLE
fix(pick): 会话聊天图标，划中正文用 text

### DIFF
--- a/packages/cap-pick/src/web/chip.test.ts
+++ b/packages/cap-pick/src/web/chip.test.ts
@@ -8,7 +8,6 @@ import { pickKindIcon, pickKindTone } from './chip.tsx'
 
 test('kind maps to distinct heroicons', () => {
   const needed = [
-    'CpuChipIcon',
     'CircleStackIcon',
     'StopCircleIcon',
     'HashtagIcon',
@@ -16,6 +15,7 @@ test('kind maps to distinct heroicons', () => {
     'RectangleStackIcon',
     'ClipboardDocumentCheckIcon',
     'CheckCircleIcon',
+    'DocumentTextIcon',
     'ChatBubbleLeftIcon',
     'PuzzlePieceIcon',
     'TagIcon',
@@ -25,9 +25,10 @@ test('kind maps to distinct heroicons', () => {
   for (const name of needed) {
     assert.ok(name in lu, `${name} missing`)
   }
-  assert.equal(pickKindIcon('session'), lu.CpuChipIcon)
+  assert.equal(pickKindIcon('session'), lu.ChatBubbleLeftIcon)
   assert.equal(pickKindIcon('message'), lu.ChatBubbleLeftIcon)
-  assert.notEqual(pickKindIcon('session'), pickKindIcon('message'))
+  assert.equal(pickKindIcon('text'), lu.DocumentTextIcon)
+  assert.notEqual(pickKindIcon('text'), pickKindIcon('session'))
   assert.equal(pickKindIcon('task'), lu.CheckCircleIcon)
   assert.equal(pickKindIcon('tasks'), lu.CheckCircleIcon)
   assert.equal(pickKindIcon('page'), lu.DocumentIcon)

--- a/packages/cap-pick/src/web/chip.tsx
+++ b/packages/cap-pick/src/web/chip.tsx
@@ -1,11 +1,11 @@
 import {
-  CpuChipIcon,
   CircleStackIcon,
   StopCircleIcon,
   HashtagIcon,
   Square3Stack3DIcon,
   RectangleStackIcon,
   DocumentIcon,
+  DocumentTextIcon,
   ClipboardDocumentCheckIcon,
   CheckCircleIcon,
   ChatBubbleLeftIcon,
@@ -47,7 +47,8 @@ export function pickKindTone(kind: string) {
 type Glyph = ComponentType<{ className?: string }>
 
 const KIND_ICONS: Record<string, Glyph> = {
-  session: CpuChipIcon,
+  session: ChatBubbleLeftIcon,
+  text: DocumentTextIcon,
   task: CheckCircleIcon,
   page: DocumentIcon,
   collection: RectangleStackIcon,

--- a/packages/cap-pick/src/web/index.tsx
+++ b/packages/cap-pick/src/web/index.tsx
@@ -5,7 +5,7 @@ import { PickService, getPick, usePickState } from './service.ts'
 import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
-export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, pickDomAttrs, type PickRef } from './types.ts'
+export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, type PickRef } from './types.ts'
 export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
 

--- a/packages/cap-pick/src/web/overlay.test.ts
+++ b/packages/cap-pick/src/web/overlay.test.ts
@@ -35,6 +35,12 @@ test('Escape blurs the focused control so the UA focus ring does not linger', ()
   assert.match(overlay, /active.blur\(\)/)
 })
 
+test('pointerup prefers a text selection over object picks', () => {
+  assert.match(overlay, /textPickFromSelection/)
+  assert.match(overlay, /inReadable/)
+  assert.match(overlay, /\.chat-stage/)
+})
+
 test('pointerup does not attach picks after pick mode has exited', () => {
   assert.match(overlay, /if \(!pick.picking\) return/)
 })

--- a/packages/cap-pick/src/web/overlay.tsx
+++ b/packages/cap-pick/src/web/overlay.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import type { SlotProps } from '@biu/type-slots'
 import { getPick, usePickState } from './service.ts'
 import { boxFromPoints, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
+import { textPickFromSelection } from './types.ts'
 
 const DRAG_PX = 6
 
@@ -57,7 +58,9 @@ export function PickOverlay(_props: SlotProps) {
     const onDown = (event: PointerEvent) => {
       if (event.button !== 0) return
       if (ignorePickCapture(event.target, event)) return
-      event.preventDefault()
+      const inReadable =
+        event.target instanceof Element && Boolean(event.target.closest('.chat-stage'))
+      if (!inReadable) event.preventDefault()
       drag = { x: event.clientX, y: event.clientY, boxed: false }
     }
 
@@ -66,6 +69,12 @@ export function PickOverlay(_props: SlotProps) {
       const started = drag
       drag = null
       if (!pick.picking) return
+      const snippet = textPickFromSelection(route())
+      if (snippet) {
+        pick.add(snippet)
+        window.getSelection()?.removeAllRanges()
+        return
+      }
       if (started.boxed) {
         const box = boxFromPoints(started.x, started.y, event.clientX, event.clientY)
         pick.addMany(resolvePicksInRect(box, route()).map((hit) => hit.ref))

--- a/packages/cap-pick/src/web/resolve.test.ts
+++ b/packages/cap-pick/src/web/resolve.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
-import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks } from './types.ts'
+import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks, textPickFromSelection } from './types.ts'
 
 test('splitPickStream keeps text and chips in order', () => {
   const parts = splitPickStream('看 <pick kind="task" id="t1" label="写需求" /> 和 <pick kind="plugin" id="p1" label="Hello" /> 吧')
@@ -66,6 +66,20 @@ test('formatPicks emits data handles only', () => {
   ])
   assert.equal(text, '<pick kind="session" id="abc" route="/s/abc" label="聊天" />')
   assert.doesNotMatch(text, /class=|svg|html/i)
+})
+
+test('selected body text becomes a text pick', () => {
+  const fake = {
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => '  这段正文  ',
+  }
+  const ref = textPickFromSelection('/s/abc', fake)
+  assert.ok(ref)
+  assert.equal(ref.kind, 'text')
+  assert.equal(ref.label, '这段正文')
+  assert.equal(ref.route, '/s/abc')
+  assert.equal(textPickFromSelection('/', { isCollapsed: true, rangeCount: 1, toString: () => 'x' }), null)
 })
 
 test('parsePicks recovers chips that markdown would strip', () => {

--- a/packages/cap-pick/src/web/types.ts
+++ b/packages/cap-pick/src/web/types.ts
@@ -122,6 +122,21 @@ export function pickPreview(text: string, max = 48) {
   return value.length > max ? `${value.slice(0, max)}…` : value
 }
 
+/** 选取态下划到的一段正文；空选区返回 null。 */
+export function textPickFromSelection(
+  route: string,
+  selection: Pick<Selection, 'isCollapsed' | 'toString' | 'rangeCount'> | null = typeof window === 'undefined' ? null : window.getSelection(),
+): PickRef | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return null
+  const raw = selection.toString()
+  const label = pickPreview(raw, 80)
+  if (!label) return null
+  let hash = 0
+  const key = raw.replace(/\s+/g, ' ').trim()
+  for (let i = 0; i < key.length; i += 1) hash = (hash * 33 + key.charCodeAt(i)) >>> 0
+  return { kind: 'text', id: hash.toString(16), label, route }
+}
+
 export function pickDomAttrs(kind: string, id: string, label?: string) {
   return {
     'data-biu-kind': kind,

--- a/web/style.css
+++ b/web/style.css
@@ -5184,6 +5184,11 @@ html.pick-mode * {
   user-select: none !important;
 }
 
+html.pick-mode .chat-stage,
+html.pick-mode .chat-stage * {
+  user-select: text !important;
+}
+
 html.pick-mode .chat-overlay-panel,
 html.pick-mode .chat-overlay-panel * {
   cursor: auto !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话记录芯片改回聊天气泡图标。选取态下在对话里划中的正文不再当成 session/message，而是写入 `kind=text`，芯片用 DocumentText 图标。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

