### PR TITLE
feat(fs): Agent 动某张表时右侧检查器跟着干活

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -279,6 +279,37 @@ test('apply registers db_* tools', async () => {
   assert.equal(paths.includes('/supertags'), true)
 })
 
+test('db_list on a table broadcasts inspector working then done', async () => {
+  const seen: Array<{ type: string; payload: unknown }> = []
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  class HttpStub extends Service {
+    constructor(c: Context) {
+      super(c, 'http')
+    }
+    route() {}
+    broadcast(type: string, payload: unknown) {
+      seen.push({ type, payload })
+    }
+  }
+  new HttpStub(ctx)
+  await ctx.plugin({ inject: ['tools', 'http'], apply: applyFileSystem })
+  await ctx.tools.invoke('db_list', { path: '/views' })
+  const reveals = seen.filter((item) => {
+    const payload = item.payload as { reveal?: { collection?: string }; phase?: string }
+    return item.type === 'database' && payload?.reveal?.collection === '/views'
+  })
+  assert.equal((reveals[0]?.payload as { phase?: string }).phase, 'working')
+  assert.equal((reveals.at(-1)?.payload as { phase?: string }).phase, 'done')
+  const before = seen.length
+  await ctx.tools.invoke('db_list', { path: '/' })
+  const extra = seen.slice(before).filter((item) => {
+    const payload = item.payload as { reveal?: unknown }
+    return item.type === 'database' && payload?.reveal
+  })
+  assert.equal(extra.length, 0)
+})
+
 test('register rejects duplicate view route and nav title', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -24,7 +24,7 @@ import {
 import { SavedViewsStore, viewsCollection, type StoredView } from './saved-views.ts'
 import { SchemaTagsStore, SUPER_TAGS_SQLITE } from './schema-tags.ts'
 import { superTagsCollection } from './super-tags-collection.ts'
-import { normalizeCollectionPath } from '../paths.ts'
+import { databaseRevealForTool, normalizeCollectionPath } from '../paths.ts'
 
 function publicAction(action: CollectionAction): CollectionActionInfo {
   const { run: _run, ...info } = action
@@ -670,6 +670,36 @@ function asFilter(value: unknown): Record<string, unknown> | undefined {
   return value as Record<string, unknown>
 }
 
+function broadcastInspectorReveal(
+  ctx: Context,
+  path: string,
+  result: unknown,
+  dropRecord: boolean,
+  phase: 'working' | 'done',
+) {
+  const reveal = databaseRevealForTool({ path, result, dropRecord })
+  if (!reveal) return
+  const http = ctx.get('http') as { broadcast?: (type: string, payload: unknown) => void } | undefined
+  http?.broadcast?.(DATABASE_CHANNEL, { ts: Date.now(), reveal, phase })
+}
+
+async function withInspectorReveal<T>(
+  ctx: Context,
+  path: string,
+  op: () => T | Promise<T>,
+  dropRecord = false,
+) {
+  broadcastInspectorReveal(ctx, path, undefined, dropRecord, 'working')
+  try {
+    const result = await op()
+    broadcastInspectorReveal(ctx, path, result, dropRecord, 'done')
+    return result
+  } catch (error) {
+    broadcastInspectorReveal(ctx, path, undefined, dropRecord, 'done')
+    throw error
+  }
+}
+
 export const name = 'core-file-system'
 export const inject = ['tools', 'http']
 
@@ -706,20 +736,24 @@ export function apply(ctx: Context) {
       },
       required: ['path'],
     },
-    execute: (args) =>
-      db.list(String(args.path), asFilter(args.filter), {
-        q: args.q != null ? String(args.q) : '',
-        sortField: args.sortField != null ? String(args.sortField) : '',
-        sortDir: args.sortDir === 'desc' ? 'desc' : 'asc',
-        limit: args.limit != null ? Number(args.limit) : undefined,
-        offset: args.offset != null ? Number(args.offset) : undefined,
-      }),
+    execute: (args) => {
+      const path = String(args.path)
+      return withInspectorReveal(ctx, path, () =>
+        db.list(path, asFilter(args.filter), {
+          q: args.q != null ? String(args.q) : '',
+          sortField: args.sortField != null ? String(args.sortField) : '',
+          sortDir: args.sortDir === 'desc' ? 'desc' : 'asc',
+          limit: args.limit != null ? Number(args.limit) : undefined,
+          offset: args.offset != null ? Number(args.offset) : undefined,
+        }),
+      )
+    },
   })
   ctx.tools.register({
     name: 'db_read',
     description: '读取 File System 路径：表返回列表，记录返回该行 JSON（不含 content 正文，正文用 db_content）。',
     parameters: PATH_PARAM,
-    execute: (args) => db.read(String(args.path)),
+    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path))),
   })
   ctx.tools.register({
     name: 'db_update',
@@ -732,7 +766,7 @@ export function apply(ctx: Context) {
       },
       required: ['path', 'content'],
     },
-    execute: (args) => db.update(String(args.path), args.content),
+    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.update(String(args.path), args.content)),
   })
   ctx.tools.register({
     name: 'db_create',
@@ -745,13 +779,13 @@ export function apply(ctx: Context) {
       },
       required: ['path'],
     },
-    execute: (args) => db.create(String(args.path), args.content),
+    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.create(String(args.path), args.content)),
   })
   ctx.tools.register({
     name: 'db_delete',
     description: '删除一条记录，路径为 /<表>/<id>。能否删除看 db_stat 的 caps 与 schema.records；未声明 delete 的表会失败。',
     parameters: PATH_PARAM,
-    execute: (args) => db.remove(String(args.path)),
+    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.remove(String(args.path)), true),
   })
   ctx.tools.register({
     name: 'db_action',
@@ -767,12 +801,14 @@ export function apply(ctx: Context) {
       required: ['path', 'action'],
     },
     execute: (args) =>
-      db.action(
-        String(args.path),
-        String(args.action),
-        args.args && typeof args.args === 'object' && !Array.isArray(args.args)
-          ? (args.args as Record<string, unknown>)
-          : undefined,
+      withInspectorReveal(ctx, String(args.path), () =>
+        db.action(
+          String(args.path),
+          String(args.action),
+          args.args && typeof args.args === 'object' && !Array.isArray(args.args)
+            ? (args.args as Record<string, unknown>)
+            : undefined,
+        ),
       ),
   })
   ctx.tools.register({
@@ -793,7 +829,9 @@ export function apply(ctx: Context) {
       required: ['path'],
     },
     execute: (args) =>
-      args.value !== undefined ? db.writeContent(String(args.path), args.value) : db.content(String(args.path)),
+      withInspectorReveal(ctx, String(args.path), () =>
+        args.value !== undefined ? db.writeContent(String(args.path), args.value) : db.content(String(args.path)),
+      ),
   })
 
   const send = async (route: { query: URLSearchParams; send: (status: number, body: unknown) => void }, op: () => unknown) => {

--- a/packages/core-file-system/src/paths.test.ts
+++ b/packages/core-file-system/src/paths.test.ts
@@ -1,9 +1,28 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { normalizeCollectionPath } from './paths.ts'
+import { databaseRevealForTool, databaseRevealFromPath, normalizeCollectionPath } from './paths.ts'
 
 test('normalizeCollectionPath strips trailing slash and adds a leading one', () => {
   assert.equal(normalizeCollectionPath('/plugins/'), '/plugins')
   assert.equal(normalizeCollectionPath('plugins'), '/plugins')
   assert.equal(normalizeCollectionPath('/'), '/')
+})
+
+test('databaseRevealFromPath ignores root and splits table vs record', () => {
+  assert.equal(databaseRevealFromPath('/'), null)
+  assert.deepEqual(databaseRevealFromPath('/tasks'), { collection: '/tasks' })
+  assert.deepEqual(databaseRevealFromPath('/tasks/abc'), { collection: '/tasks', recordId: 'abc' })
+  assert.deepEqual(databaseRevealFromPath('pages/p1'), { collection: '/pages', recordId: 'p1' })
+})
+
+test('databaseRevealForTool follows result path and drops deleted records', () => {
+  assert.deepEqual(
+    databaseRevealForTool({ path: '/tasks', result: { path: '/tasks/t1' } }),
+    { collection: '/tasks', recordId: 't1' },
+  )
+  assert.deepEqual(
+    databaseRevealForTool({ path: '/tasks/t1', dropRecord: true }),
+    { collection: '/tasks' },
+  )
+  assert.equal(databaseRevealForTool({ path: '/' }), null)
 })

--- a/packages/core-file-system/src/paths.ts
+++ b/packages/core-file-system/src/paths.ts
@@ -5,3 +5,38 @@ export function normalizeCollectionPath(path: string) {
   if (withSlash === '/') return '/'
   return withSlash.replace(/\/+$/, '') || '/'
 }
+
+export type DatabaseReveal = {
+  collection: string
+  recordId?: string
+}
+
+function resultPathOf(result: unknown): string {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return ''
+  const path = (result as { path?: unknown }).path
+  return typeof path === 'string' ? path : ''
+}
+
+/** 工具路径：根目录不算；/<表> 切表，/<表>/<id> 切到该行。 */
+export function databaseRevealFromPath(path: string): DatabaseReveal | null {
+  const normalized = normalizeCollectionPath(path)
+  if (normalized === '/') return null
+  const parts = normalized.split('/').filter(Boolean)
+  if (!parts.length) return null
+  const collection = `/${parts[0]}`
+  const recordId = parts[1]
+  return recordId ? { collection, recordId } : { collection }
+}
+
+/** 删除后记录没了只切表；创建/读取可跟结果 path。 */
+export function databaseRevealForTool(opts: {
+  path: string
+  result?: unknown
+  dropRecord?: boolean
+}): DatabaseReveal | null {
+  if (opts.dropRecord) {
+    const fromPath = databaseRevealFromPath(opts.path)
+    return fromPath ? { collection: fromPath.collection } : null
+  }
+  return databaseRevealFromPath(resultPathOf(opts.result) || opts.path)
+}

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -40,6 +40,8 @@ const CSS = `
 .fsdb-page.is-full-width .fsdb-main,.fsdb-page.is-full-width .fsdb-detail-main{max-width:none}
 .fsdb-page:not(.inspector-database-page) .fsdb-main{padding-bottom:var(--brand-corner-clearance,60px)}
 .inspector-database-page .fsdb-main{padding-bottom:0}
+.fsdb-agent-follow{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
+.fsdb-agent-follow.is-working{box-shadow:inset 0 2px 0 #5b9fd6}
 .fsdb-main > .fsdb-detail-title-row{flex:none}
 .fsdb-page .tasks-toolbar{display:flex;gap:12px;align-items:center;justify-content:space-between;min-width:0}
 .fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:1 1 auto;min-width:0}

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -28,6 +28,7 @@ test('database page no longer registers collection shortcuts on the dock', () =>
   assert.doesNotMatch(page, /DATA_DOCK_TOOLS/)
   assert.doesNotMatch(page, /data:\$\{item\.path\}/)
   assert.doesNotMatch(page, /databaseAllViewPath\(item.path\)/)
+  assert.match(page, /applyDatabaseChannelPayload/)
   assert.match(page, /builtinAllViewId\(parsed.collection\)/)
   assert.doesNotMatch(page, /isCollectionHub/)
 })

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -9,6 +9,7 @@ import { isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
 import { pathForCenter, pathForCrumbTarget, type CrumbTarget } from './sidebar-nav.ts'
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseInspectorBrowse, DatabaseInspectorTab, bindInspectorSnapshot, collectionTabIcon } from './inspector-database.tsx'
+import { applyDatabaseChannelPayload } from './inspector-db-route.ts'
 import { DatabaseUiService, getDatabaseUi } from './database-ui.ts'
 import {
   bootLoadCollections,
@@ -364,8 +365,9 @@ export function apply(ctx: Context) {
     fromSnap()
     const offSnap = snapshot.subscribe?.(fromSnap)
     let debounce = 0
-    const off = snapshot.onMessage(DATABASE_CHANNEL, () => {
+    const off = snapshot.onMessage(DATABASE_CHANNEL, (payload) => {
       window.dispatchEvent(new Event('fsdb:change'))
+      applyDatabaseChannelPayload(payload)
       window.clearTimeout(debounce)
       debounce = window.setTimeout(() => void sync(), 40)
     })

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -12,7 +12,9 @@ import { builtinAllViewId } from '../catalog-views.ts'
 import { DATA_MODULE, DATA_MODULE_ID, databaseAllViewPath, databaseRecordPath, databaseViewPath } from './database-path.ts'
 import {
   getInspectorDbPath,
+  isInspectorAgentWorking,
   setInspectorDbPath,
+  subscribeInspectorAgentWorking,
   subscribeInspectorDbPath,
 } from './inspector-db-route.ts'
 import { getDatabaseUi } from './database-ui.ts'
@@ -110,6 +112,14 @@ function useBindInspectorDbPath(paneId: string, tables: CollectionInfo[], seedCo
   return inspectorPath || defaultInspectorDbPath(tables, seedCollection)
 }
 
+function useInspectorAgentWorking(collection: string) {
+  return useSyncExternalStore(
+    subscribeInspectorAgentWorking,
+    () => isInspectorAgentWorking(collection),
+    () => false,
+  )
+}
+
 function paneOf(props: { paneId?: unknown }) {
   return String(props.paneId || 'database')
 }
@@ -177,6 +187,8 @@ export function DatabaseInspectorTab({
     [collections],
   )
   const inspectorPath = useBindInspectorDbPath(id, tables, seedCollection)
+  const { collection: tabCollection } = crumbsForRoute(inspectorPath, tables)
+  const agentWorking = useInspectorAgentWorking(tabCollection || seedCollection || '')
   const [crumbOpen, setCrumbOpen] = useState<string | null>(null)
   const [trailOpen, setTrailOpen] = useState(false)
   const crumbRef = useRef<HTMLElement>(null)
@@ -214,7 +226,7 @@ export function DatabaseInspectorTab({
   return (
     <div
       ref={tabRef}
-      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}${trailOpen ? ' is-crumb-open' : ''}`}
+      className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}${trailOpen ? ' is-crumb-open' : ''}${agentWorking ? ' is-agent-working' : ''}`}
       role="tab"
       aria-selected={Boolean(active)}
       data-testid="inspector-tab-database"
@@ -301,6 +313,7 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
     [collections],
   )
   const inspectorPath = useBindInspectorDbPath(id, tables, seedOf(extra))
+  const agentWorking = useInspectorAgentWorking(seedOf(extra) || '')
   useViewTick()
   const { pathname, search } = splitHref(inspectorPath)
   const { collection, viewId, recordId } = crumbsForRoute(pathname, tables)
@@ -313,12 +326,18 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
   const lockedFilters = chrome.lockedFiltersFromSearch?.(search) ?? {}
   const table = tables.find((item) => item.path === currentPath)
   const title = table ? tableLabel(table) : '数据'
+  const liveWorking = useInspectorAgentWorking(currentPath)
 
   if (!currentPath) {
     return <p className="fsdb-inspector-empty">没有数据表</p>
   }
 
   return (
+    <div
+      className={`fsdb-agent-follow${liveWorking || agentWorking ? ' is-working' : ''}`}
+      data-testid="fsdb-agent-follow"
+      aria-busy={liveWorking || agentWorking}
+    >
     <CollectionBrowser
       embed
       moduleId={DATA_MODULE_ID}
@@ -346,5 +365,6 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
       }}
       onCrumbTarget={(target) => goInspector(id, target)}
     />
+    </div>
   )
 }

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { databaseAllViewPath } from './database-path.ts'
 import {
   getInspectorDbPath,
   isInspectorDatabasePath,
@@ -7,6 +8,10 @@ import {
   setInspectorDbPath,
   showRecordInInspector,
   showInInspector,
+  applyDatabaseReveal,
+  applyDatabaseChannelPayload,
+  isInspectorAgentWorking,
+  setInspectorAgentWorking,
 } from './inspector-db-route.ts'
 
 test('inspector database path does not overwrite after first seed', () => {
@@ -70,4 +75,22 @@ test('showInInspector opens a collection href in the inspector', async () => {
   assert.equal(getInspectorDbPath('database:/supertags'), '/database/supertags/view/builtin-all:/supertags?tag=dp')
   assert.deepEqual(tabs, ['database:/supertags'])
   window.removeEventListener('biu:inspector-tab', onTab)
+})
+
+test('applyDatabaseReveal opens the table, or the record when an id is present', () => {
+  applyDatabaseReveal({ collection: '/tasks' })
+  assert.equal(getInspectorDbPath('database:/tasks'), databaseAllViewPath('/tasks'))
+  applyDatabaseReveal({ collection: '/tasks', recordId: 't9' })
+  assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/record/t9')
+  applyDatabaseReveal({ collection: '/' })
+  assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/record/t9')
+})
+
+test('applyDatabaseChannelPayload marks the table as agent-working until done', () => {
+  setInspectorAgentWorking('/tasks', false)
+  applyDatabaseChannelPayload({ phase: 'working', reveal: { collection: '/tasks' } })
+  assert.equal(isInspectorAgentWorking('/tasks'), true)
+  applyDatabaseChannelPayload({ phase: 'done', reveal: { collection: '/tasks', recordId: 't1' } })
+  assert.equal(isInspectorAgentWorking('/tasks'), false)
+  assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/record/t1')
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,10 +1,43 @@
 /** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
 
-import { DATA_MODULE_PATH, databaseRecordPath } from './database-path.ts'
+import { normalizeCollectionPath } from '../paths.ts'
+import { DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath } from './database-path.ts'
 
 const DEFAULT_PANE = 'database'
 const listeners = new Set<() => void>()
 const paths = new Map<string, string>()
+const working = new Set<string>()
+const workingListeners = new Set<() => void>()
+
+export function subscribeInspectorAgentWorking(fn: () => void) {
+  workingListeners.add(fn)
+  return () => {
+    workingListeners.delete(fn)
+  }
+}
+
+function bumpWorking() {
+  for (const fn of workingListeners) fn()
+}
+
+export function isInspectorAgentWorking(collection: string) {
+  return working.has(normalizeCollectionPath(collection))
+}
+
+export function setInspectorAgentWorking(collection: string, next: boolean) {
+  const path = normalizeCollectionPath(collection)
+  if (!path || path === '/') return
+  const had = working.has(path)
+  if (next && !had) {
+    working.add(path)
+    bumpWorking()
+    return
+  }
+  if (!next && had) {
+    working.delete(path)
+    bumpWorking()
+  }
+}
 
 export function subscribeInspectorDbPath(fn: () => void) {
   listeners.add(fn)
@@ -56,6 +89,31 @@ export function showInInspector(collection: string, href: string) {
 /** 右侧检查器打开这条记录，中间主界面不动。 */
 export function showRecordInInspector(collection: string, recordId: string) {
   showInInspector(collection, databaseRecordPath(collection, recordId))
+}
+
+/** 工具查/改/删某张表后：打开右侧检查器并切到该表（中间主界面不动）。 */
+export function applyDatabaseReveal(reveal: unknown) {
+  if (!reveal || typeof reveal !== 'object' || Array.isArray(reveal)) return
+  const collection = normalizeCollectionPath(String((reveal as { collection?: unknown }).collection ?? ''))
+  if (!collection || collection === '/') return
+  const recordId = String((reveal as { recordId?: unknown }).recordId ?? '').trim()
+  if (recordId) {
+    showRecordInInspector(collection, recordId)
+    return
+  }
+  showInInspector(collection, databaseAllViewPath(collection))
+}
+
+/** Agent 工具推送：先切过去并标成干活中，完成后停 busy。中间主界面不动。 */
+export function applyDatabaseChannelPayload(payload: unknown) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return
+  const reveal = (payload as { reveal?: unknown }).reveal
+  if (!reveal || typeof reveal !== 'object' || Array.isArray(reveal)) return
+  const collection = normalizeCollectionPath(String((reveal as { collection?: unknown }).collection ?? ''))
+  if (!collection || collection === '/') return
+  const phase = String((payload as { phase?: unknown }).phase ?? '')
+  applyDatabaseReveal(reveal)
+  setInspectorAgentWorking(collection, phase !== 'done')
 }
 
 export function seedInspectorDbPath(paneId: string, pathname?: string) {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -301,6 +301,8 @@ test('database inspector tab has a close control beside crumb expand', () => {
   assert.match(tab, /XMarkIcon/)
   assert.match(tab, /inspector-crumb-actions/)
   assert.match(tab, /data-testid="inspector-crumb-toggle"/)
+  assert.match(tab, /is-agent-working/)
+  assert.match(tab, /fsdb-agent-follow/)
 })
 
 test('inspector crumbs lock the first level to an icon', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -674,6 +674,10 @@ body {
   color: #F0EFED;
 }
 
+.inspector-tab.is-agent-working {
+  background: color-mix(in srgb, #5b9fd6 22%, transparent);
+}
+
 .inspector-tab-main {
   display: inline-flex;
   min-width: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
交互目标：Agent 调文件系统工具时，右侧检查器要有「它正在这张表干活」的感觉，中间聊天/主界面不跳走。

**流程**
1. `db_list` / `db_read` / `db_create` / `db_delete` / `db_update` / `db_action` / `db_content` 一开始就推 `phase: working`：打开检查器、切到该表 Tab、Tab 浅蓝 busy。
2. 工具结束推 `phase: done`：busy 关掉；创建/读取有 id 则打开那一行，删除只留在表上。
3. 列根 `/`、`db_stat`、页面自己点的 HTTP 增删不走这套，避免把检查器乱拽。

中间主界面路由不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

