### PR TITLE
feat(fs): 创建改为批量，删除改为条件删除

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -67,34 +67,34 @@ test('page plugin stores markdown under .page and assets for images', async () =
   await mkdir(join(root, PAGE_ASSETS), { recursive: true })
   await writeFile(join(root, PAGE_ASSETS, 'hero.png'), 'fake-png', 'utf8')
 
-  const created = await spec.create!({
+  const created = await spec.create!([{
     title: '新页面',
     notes: '# 标题\n内容',
     cover: 'assets/hero.png',
     tags: ['blue'],
-  })
-  assert.equal(created.title, '新页面')
-  assert.equal(created.notes, '# 标题\n内容')
-  assert.equal(created.cover, '/api/page/file/hero.png')
-  assert.equal(asImageSrc(created.cover), '/api/page/file/hero.png')
+  }])
+  assert.equal(created[0]?.title, '新页面')
+  assert.equal(created[0]?.notes, '# 标题\n内容')
+  assert.equal(created[0]?.cover, '/api/page/file/hero.png')
+  assert.equal(asImageSrc(created[0]?.cover), '/api/page/file/hero.png')
 
-  const disk = await readFile(join(root, PAGE_ROOT, `${created.id}.md`), 'utf8')
+  const disk = await readFile(join(root, PAGE_ROOT, `${created[0]!.id}.md`), 'utf8')
   assert.match(disk, /^---\n/)
   assert.match(disk, /title: 新页面/)
   assert.match(disk, /cover: assets\/hero.png/)
   assert.match(disk, /# 标题\n内容/)
 
-  const written = await spec.update!(created.id, {
+  const written = await spec.update!(created[0]!.id, {
     enabled: false,
     schema: { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } },
   })
   assert.equal(written.enabled, false)
   assert.deepEqual(written.schema, { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } })
-  const again = await readFile(join(root, PAGE_ROOT, `${created.id}.md`), 'utf8')
+  const again = await readFile(join(root, PAGE_ROOT, `${created[0]!.id}.md`), 'utf8')
   assert.match(again, /enabled: false/)
   assert.match(again, /complexity: O\(n\)/)
 
-  await spec.remove!(created.id)
+  await spec.remove!({ ids: [created[0]!.id] })
   assert.equal((await spec.list()).length, 0)
 
   const store = new PagesStore(ctx.fs.workspace as never)

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -62,8 +62,16 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
     list: (query) => store.list(query?.ids),
     get: (id) => store.get(id),
     update: (id, patch) => store.update(id, patch),
-    create: (fields = {}) => store.create(fields),
-    remove: (id) => store.remove(id),
+    create: async (rows) => {
+      const out = []
+      for (const fields of rows) out.push(await store.create(fields))
+      return out
+    },
+    remove: async (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) await store.remove(id)
+      return ids
+    },
   }
 }
 

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -348,14 +348,19 @@ test('create and delete follow records caps declared at register', async () => {
     records: { create: true, delete: true },
     list: () => [...rows.values()],
     get: (id) => rows.get(id) ?? null,
-    create: (fields = {}) => {
-      const id = `n${rows.size + 1}`
-      const row = { id, title: typeof fields.title === 'string' ? fields.title : '未命名' }
-      rows.set(id, row)
-      return row
-    },
-    remove: (id) => {
-      if (!rows.delete(id)) throw new Error('unknown')
+    create: (incoming) =>
+      incoming.map((fields) => {
+        const id = `n${rows.size + 1}`
+        const row = { id, title: typeof fields.title === 'string' ? fields.title : '未命名' }
+        rows.set(id, row)
+        return row
+      }),
+    remove: (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) {
+        if (!rows.delete(id)) throw new Error('unknown')
+      }
+      return ids
     },
   })
   const stat = await db.stat('/notes')
@@ -365,15 +370,21 @@ test('create and delete follow records caps declared at register', async () => {
   assert.equal(stat.schema.records?.delete, true)
   assert.equal((stat.caps as string[]).includes('create'), true)
   assert.equal((stat.caps as string[]).includes('delete'), true)
-  const created = await db.create('/notes', { title: '新笔记' })
-  assert.equal(created.value.title, '新笔记')
+  const created = await db.create('/notes', [{ title: '新笔记' }, { title: '第二篇' }])
+  assert.equal(created.items.length, 2)
+  assert.equal(created.items[0]?.value.title, '新笔记')
   const listed = await db.list('/notes')
   if (listed.kind !== 'collection') return
-  assert.equal(listed.items.length, 2)
-  await db.remove(`${created.path}`)
+  assert.equal(listed.items.length, 3)
+  await db.remove('/notes', { ids: [String(created.items[0]?.value.id)] })
+  const afterOne = await db.list('/notes')
+  if (afterOne.kind !== 'collection') return
+  assert.equal(afterOne.items.length, 2)
+  await db.remove('/notes', { q: '第二篇' })
   const after = await db.list('/notes')
   if (after.kind !== 'collection') return
   assert.equal(after.items.length, 1)
+  await assert.rejects(() => db.remove('/notes', {}), /delete requires/)
 })
 
 test('SuperTag catalog is workspace-wide and collect uses sqlite stamps', async () => {
@@ -469,7 +480,7 @@ test('tables without records.create/delete reject create and delete', async () =
   assert.equal(stat.schema.records?.create, false)
   assert.equal(stat.schema.records?.delete, false)
   await assert.rejects(() => db.create('/notes'), /cannot create/)
-  await assert.rejects(() => db.remove('/notes/n1'), /cannot delete/)
+  await assert.rejects(() => db.remove('/notes', { ids: ['n1'] }), /cannot delete/)
   assert.throws(
     () =>
       db.register({

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -8,6 +8,7 @@ import {
   normalizeSchemaValue,
   schemaSearchHaystack,
   withBuiltinFields,
+  hasCollectionDeleteQuery,
   type CollectionAction,
   type CollectionActionInfo,
   type CollectionInfo,
@@ -390,6 +391,24 @@ export class DatabaseService extends Service implements Database {
     return rows.filter((row) => allow.has(row.id))
   }
 
+  private async matchCollectionRows(
+    spec: CollectionSpec,
+    query: CollectionListQuery,
+    filter: Record<string, unknown> | undefined,
+    q: string,
+  ) {
+    let schema = schemaFor(spec)
+    const packs = this.schemaTags.list()
+    const rows = await this.loadCollectionRows(spec, query)
+    const tagFilter = spec.path === '/supertags' ? String(filter?.tag ?? '').trim() : ''
+    const tagPack = tagFilter ? this.schemaTags.get(tagFilter) : null
+    if (tagFilter) {
+      schema = schemaWithTagPack(schema, tagPack)
+      await this.hydrateSuperTagStamps(rows, tagPack)
+    }
+    return rows.filter((row) => matchListFilter(row, filter, schema, packs) && matchQuery(row, q, packs))
+  }
+
   private async hydrateSuperTagStamps(rows: DbRecord[], pack: CollectionSchemaPack | null) {
     if (!pack?.fields.length) return
     const wanted = pack.fields.filter((field) => !STAMP_FIELD_BLOCKLIST.has(field.key))
@@ -467,7 +486,6 @@ export class DatabaseService extends Service implements Database {
     const q = page?.q ?? ''
     const sortField = page?.sortField ?? ''
     const sortDir = page?.sortDir === 'desc' ? 'desc' : 'asc'
-    const packs = this.schemaTags.list()
     const schemaFilter = filter?.schema != null && filter.schema !== '' ? String(filter.schema) : ''
     const query: CollectionListQuery = { q, filter }
     if (schemaFilter && schema.fields.schema && spec.path !== '/supertags') {
@@ -487,14 +505,9 @@ export class DatabaseService extends Service implements Database {
       }
       query.ids = [...stamped]
     }
-    const rows = await this.loadCollectionRows(spec, query)
+    const matched = await this.matchCollectionRows(spec, query, filter, q)
     const tagFilter = spec.path === '/supertags' ? String(filter?.tag ?? '').trim() : ''
-    const tagPack = tagFilter ? this.schemaTags.get(tagFilter) : null
-    if (tagFilter) {
-      schema = schemaWithTagPack(schema, tagPack)
-      await this.hydrateSuperTagStamps(rows, tagPack)
-    }
-    const matched = rows.filter((row) => matchListFilter(row, filter, schema, packs) && matchQuery(row, q, packs))
+    if (tagFilter) schema = schemaWithTagPack(schema, this.schemaTags.get(tagFilter))
     const sorted = sortRecords(matched, sortField, sortDir)
     const total = sorted.length
     const slice = sorted.slice(offset, offset + limit)
@@ -569,25 +582,46 @@ export class DatabaseService extends Service implements Database {
     const spec = this.collection(`/${parts[0]}`)
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     if (!spec.records?.create || !spec.create) throw new Error(`collection cannot create: ${spec.path}`)
-    const fields = content == null || content === '' ? {} : pickWritablePatch(schemaFor(spec), parseContent(content))
-    const record = await spec.create(fields)
-    this.indexSuperTagRecord(spec, record)
+    const schema = schemaFor(spec)
+    const records = parseRecords(content).map((row) => pickWritablePatch(schema, row))
+    const created = await spec.create(records)
+    for (const record of created) this.indexSuperTagRecord(spec, record)
     this.bump()
-    return { kind: 'record' as const, path: `${spec.path}/${record.id}`, value: withoutContent(spec, record) }
+    return {
+      kind: 'created' as const,
+      path: spec.path,
+      items: created.map((record) => ({
+        kind: 'record' as const,
+        path: `${spec.path}/${record.id}`,
+        value: withoutContent(spec, record),
+      })),
+    }
   }
 
-  async remove(path: string) {
+  async remove(path: string, query: CollectionListQuery = {}) {
     const parts = splitPath(path)
-    if (parts.length !== 2) throw new Error(`cannot delete: ${normalizeCollectionPath(path)}`)
+    if (parts.length !== 1) throw new Error(`cannot delete: ${normalizeCollectionPath(path)}`)
     const spec = this.collection(`/${parts[0]}`)
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     if (!spec.records?.delete || !spec.remove) throw new Error(`collection cannot delete: ${spec.path}`)
-    const record = await spec.get(parts[1]!)
-    if (!record) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
-    await spec.remove(parts[1]!)
-    this.schemaTags.removeRecord(spec.path, parts[1]!)
+    if (!hasCollectionDeleteQuery(query)) throw new Error('delete requires ids, q, or filter')
+    const schema = schemaFor(spec)
+    const q = query.q ?? ''
+    const filter = query.filter
+    const listQuery: CollectionListQuery = { q, filter, ids: query.ids }
+    const schemaFilter = filter?.schema != null && filter.schema !== '' ? String(filter.schema) : ''
+    if (schemaFilter && schema.fields.schema && spec.path !== '/supertags') {
+      const stamped = this.schemaTags.stampedIds(spec.path, schemaFilter)
+      if (!stamped.size) return { kind: 'deleted' as const, path: spec.path, ids: [] as string[] }
+      listQuery.ids = query.ids?.length ? query.ids.filter((id) => stamped.has(id)) : [...stamped]
+    }
+    const matched = await this.matchCollectionRows(spec, listQuery, filter, q)
+    const ids = [...new Set(matched.map((row) => row.id))]
+    if (!ids.length) return { kind: 'deleted' as const, path: spec.path, ids }
+    await spec.remove({ ids })
+    for (const id of ids) this.schemaTags.removeRecord(spec.path, id)
     this.bump()
-    return { kind: 'deleted' as const, path: `${spec.path}/${parts[1]}`, id: parts[1] }
+    return { kind: 'deleted' as const, path: spec.path, ids }
   }
 
   async action(path: string, actionId: string, args?: Record<string, unknown>) {
@@ -663,11 +697,37 @@ function parseContent(content: unknown): Record<string, unknown> {
   return content as Record<string, unknown>
 }
 
+function parseRecords(content: unknown): Record<string, unknown>[] {
+  const raw = typeof content === 'string' ? JSON.parse(content.trim() || 'null') : content
+  if (!Array.isArray(raw) || !raw.length) throw new Error('records must be a non-empty array')
+  return raw.map((item, index) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) throw new Error(`records[${index}] must be an object`)
+    return item as Record<string, unknown>
+  })
+}
+
 const PATH_PARAM = { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } as const
 
 function asFilter(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
   return value as Record<string, unknown>
+}
+
+function asIds(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.map((item) => String(item).trim()).filter(Boolean)
+}
+
+function asDeleteQuery(args: Record<string, unknown>): CollectionListQuery {
+  return {
+    ids: asIds(args.ids),
+    q: args.q != null ? String(args.q) : undefined,
+    filter: asFilter(args.filter),
+  }
+}
+
+function asCreateRecords(args: Record<string, unknown>) {
+  return args.records !== undefined ? args.records : args.content
 }
 
 export const name = 'core-file-system'
@@ -736,22 +796,31 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_create',
-    description: '在已登记且允许新建的表中新增一条记录。路径为 /<表>。能否新建看 db_stat 的 caps 与 schema.records。',
+    description: '在已登记且允许新建的表中批量新增记录。路径为 /<表>，records 为对象数组。能否新建看 db_stat 的 caps 与 schema.records。',
     parameters: {
       type: 'object',
       properties: {
         path: { type: 'string' },
-        content: { description: '可选，按 schema 可写字段给出初值（对象或 JSON 字符串）' },
+        records: { type: 'array', description: '要创建的记录（对象数组），按 schema 可写字段给初值' },
       },
-      required: ['path'],
+      required: ['path', 'records'],
     },
-    execute: (args) => db.create(String(args.path), args.content),
+    execute: (args) => db.create(String(args.path), asCreateRecords(args)),
   })
   ctx.tools.register({
     name: 'db_delete',
-    description: '删除一条记录，路径为 /<表>/<id>。能否删除看 db_stat 的 caps 与 schema.records；未声明 delete 的表会失败。',
-    parameters: PATH_PARAM,
-    execute: (args) => db.remove(String(args.path)),
+    description: '按条件删除记录。路径为 /<表>，必须带 ids、q 或 filter 之一，禁止无条件清空全表。能否删除看 db_stat 的 caps 与 schema.records。',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        ids: { type: 'array', items: { type: 'string' }, description: '要删除的 id 列表' },
+        q: { type: 'string', description: '全文搜索条件' },
+        filter: { type: 'object', description: '按列等值过滤' },
+      },
+      required: ['path'],
+    },
+    execute: (args) => db.remove(String(args.path), asDeleteQuery(args)),
   })
   ctx.tools.register({
     name: 'db_action',
@@ -845,16 +914,16 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/db/create', async (route) => {
     try {
-      const body = (await route.json()) as { path?: string; content?: unknown }
-      route.send(200, await db.create(String(body?.path ?? ''), body?.content))
+      const body = (await route.json()) as { path?: string; records?: unknown; content?: unknown }
+      route.send(200, await db.create(String(body?.path ?? ''), body?.records ?? body?.content))
     } catch (error) {
       route.send(400, { error: String(error) })
     }
   })
   ctx.http.route('POST', '/api/db/delete', async (route) => {
     try {
-      const body = (await route.json()) as { path?: string }
-      route.send(200, await db.remove(String(body?.path ?? '')))
+      const body = (await route.json()) as { path?: string; ids?: unknown; q?: unknown; filter?: unknown }
+      route.send(200, await db.remove(String(body?.path ?? ''), asDeleteQuery((body ?? {}) as Record<string, unknown>)))
     } catch (error) {
       route.send(400, { error: String(error) })
     }

--- a/packages/core-file-system/src/host/super-tags-collection.test.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.test.ts
@@ -15,16 +15,16 @@ test('superTagsCollection lists tags with stamp counts and supports create/updat
   assert.equal(listed[0]?.fieldCount, 1)
   assert.equal(listed[0]?.stampCount, 1)
 
-  const created = await spec.create!({ title: 'IO' })
-  assert.equal(created.id, 'io')
+  const created = await spec.create!([{ title: 'IO' }])
+  assert.equal(created[0]?.id, 'io')
   assert.equal(store.get('io')?.label, 'IO')
 
-  const updated = await spec.update!(created.id, { title: 'I/O', fields: [{ key: 'format', type: 'string', label: '格式' }] })
+  const updated = await spec.update!(created[0]!.id, { title: 'I/O', fields: [{ key: 'format', type: 'string', label: '格式' }] })
   assert.equal(updated.title, 'I/O')
   assert.equal(updated.fieldCount, 1)
   assert.equal(store.get('io')?.fields[0]?.key, 'format')
 
-  await spec.remove!(created.id)
+  await spec.remove!({ ids: [created[0]!.id] })
   assert.equal(store.get('io'), null)
   assert.equal((await spec.list()).length, 1)
 

--- a/packages/core-file-system/src/host/super-tags-collection.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.ts
@@ -121,12 +121,13 @@ export function superTagsCollection(
       }
       return tagRows().find((row) => row.id === id) ?? null
     },
-    create: (fields = {}) => {
-      const title = String(fields.title ?? '').trim() || '未命名标签'
-      const id = slugSuperTagId(title, new Set(store.list().map((tag) => tag.id)))
-      const pack = store.upsert({ id, label: title, fields: parseFields(fields.fields) })
-      return asTag(pack.id, pack.label, pack.fields, 0)
-    },
+    create: (rows) =>
+      rows.map((fields = {}) => {
+        const title = String(fields.title ?? '').trim() || '未命名标签'
+        const id = slugSuperTagId(title, new Set(store.list().map((tag) => tag.id)))
+        const pack = store.upsert({ id, label: title, fields: parseFields(fields.fields) })
+        return asTag(pack.id, pack.label, pack.fields, 0)
+      }),
     update: (id, patch) => {
       if (parseStampRecordId(id)) throw new Error(`cannot update collected row: ${id}`)
       const current = store.get(id)
@@ -136,9 +137,13 @@ export function superTagsCollection(
       const pack = store.upsert({ id: current.id, label, fields })
       return asTag(pack.id, pack.label, pack.fields, store.stampCounts()[pack.id] ?? 0)
     },
-    remove: (id) => {
-      if (parseStampRecordId(id)) throw new Error(`cannot delete collected row: ${id}`)
-      if (!store.removeTag(id)) throw new Error(`unknown tag: ${id}`)
+    remove: (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) {
+        if (parseStampRecordId(id)) throw new Error(`cannot delete collected row: ${id}`)
+        if (!store.removeTag(id)) throw new Error(`unknown tag: ${id}`)
+      }
+      return ids
     },
   }
 }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1126,17 +1126,17 @@ export function CollectionBrowser({
   async function createRecord() {
     if (!canCreate) return
     try {
-      const data = await readJson<{ value?: DbRecord }>('/api/db/create', {
+      const data = await readJson<{ items?: Array<{ value?: DbRecord }> }>('/api/db/create', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path: dataPath, content: {} }),
+        body: JSON.stringify({ path: dataPath, records: [{}] }),
       })
       quietUntil.current = 0
       await reload()
-      const id = data.value?.id
+      const id = data.items?.[0]?.value?.id
       if (id) {
         setOpenDetailId(id)
-        if (data.value) setDetailRow(data.value)
+        if (data.items?.[0]?.value) setDetailRow(data.items[0]!.value)
         onOpenRecord?.(id, activeViewId, dataPath)
       }
     } catch (err) {
@@ -1149,7 +1149,7 @@ export function CollectionBrowser({
       await readJson('/api/db/delete', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ path: `${dataPath}/${row.id}` }),
+        body: JSON.stringify({ path: dataPath, ids: [row.id] }),
       })
       onCloseRecord?.()
       quietUntil.current = 0
@@ -1161,13 +1161,11 @@ export function CollectionBrowser({
 
   async function executeDeleteRecords(ids: string[]) {
     try {
-      for (const id of ids) {
-        await readJson('/api/db/delete', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ path: `${dataPath}/${id}` }),
-        })
-      }
+      await readJson('/api/db/delete', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: dataPath, ids }),
+      })
       if (detailId && ids.includes(detailId)) onCloseRecord?.()
       setPickedIds([])
       quietUntil.current = 0

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -156,8 +156,10 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
     },
     list,
     get: find,
-    remove: async (id) => {
-      await store.uninstall(id)
+    remove: async (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) await store.uninstall(id)
+      return ids
     },
     actions: [
       {

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -208,13 +208,18 @@ export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActi
       const rows = tasks.list().map((row) => (row.id === id ? { ...row, ...next, id } : row))
       return recordsWithUsage(rows).find((row) => row.id === id) ?? taskRecord(next, (pid) => tasks.get(pid), ZERO_USAGE, false)
     },
-    create: (fields = {}) => {
-      const title = typeof fields.title === 'string' && fields.title.trim() ? fields.title.trim() : '未命名任务'
-      const row = tasks.create({ ...fields, title, creator: { kind: 'user', name: '用户' } })
-      return recordsWithUsage(tasks.list()).find((item) => item.id === row.id) ?? taskRecord(row, (pid) => tasks.get(pid), ZERO_USAGE, false)
-    },
-    remove: (id) => {
-      if (!tasks.delete(id)) throw new Error(`unknown task: ${id}`)
+    create: (rows) =>
+      rows.map((fields = {}) => {
+        const title = typeof fields.title === 'string' && fields.title.trim() ? fields.title.trim() : '未命名任务'
+        const row = tasks.create({ ...fields, title, creator: { kind: 'user', name: '用户' } })
+        return recordsWithUsage(tasks.list()).find((item) => item.id === row.id) ?? taskRecord(row, (pid) => tasks.get(pid), ZERO_USAGE, false)
+      }),
+    remove: (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) {
+        if (!tasks.delete(id)) throw new Error(`unknown task: ${id}`)
+      }
+      return ids
     },
     actions: recordActions
       ? [

--- a/packages/core-task-system/src/host/index.ts
+++ b/packages/core-task-system/src/host/index.ts
@@ -727,7 +727,7 @@ function actorsEqual(a: TaskActor | null, b: TaskActor | null): boolean {
 export const DELIVER_COLLABORATION_NOTE = [
   '',
   '【协作规范】请优先使用本系统的任务体系进行后续任务派发与协作：',
-  '新需求请用 db_create 在 /tasks 建记录、用 db_action path=/tasks/<id> action=deliver 派工、action=report 上报进度。',
+  '新需求请用 db_create 在 /tasks 批量建记录（records 数组）、用 db_action path=/tasks/<id> action=deliver 派工、action=report 上报进度。',
   '这样需求可被跟踪、进度可回传、派发人会收到回执。避免绕过任务系统直接 dispatch 子 session。',
 ].join('\n')
 

--- a/packages/host-live-sessions/src/host/index.ts
+++ b/packages/host-live-sessions/src/host/index.ts
@@ -14,7 +14,7 @@ export const LIVE_TOOL_NAMES = [
 ] as const
 
 const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
-工作流：用 db_list /sessions 和 db_action action=inspect / progress 了解现场；新建用 db_create /sessions，改元数据用 db_update 或 db_action configure/tag/star。上下文压缩用 db_action action=compact / clear / retrieve / status。派工必须走任务体系：db_create /tasks、db_update 指派 assigneeSessionId、db_action action=deliver 派发、action=report 上报；不要直接 dispatch。废弃会话用 db_delete /sessions/<id>。
+工作流：用 db_list /sessions 和 db_action action=inspect / progress 了解现场；新建用 db_create /sessions（records 数组），改元数据用 db_update 或 db_action configure/tag/star。上下文压缩用 db_action action=compact / clear / retrieve / status。派工必须走任务体系：db_create /tasks（records 数组）、db_update 指派 assigneeSessionId、db_action action=deliver 派发、action=report 上报；不要直接 dispatch。废弃会话用 db_delete path=/sessions ids=[id]。
 异步派工后不要等待对方完成：完成态在目标 session 自己的 turn 里，需要时再 inspect / progress。
 向用户汇报要克制：只在关键节点、明显卡住、或用户追问时说明，不要刷屏。
 回答简洁：说明调度了谁、当前状态、下一步。`

--- a/packages/host-sessions/src/host/sessions-collection.test.ts
+++ b/packages/host-sessions/src/host/sessions-collection.test.ts
@@ -41,7 +41,7 @@ test('sessionsCollection maps summaries and writes title/pinned/tags', async () 
   assert.equal(rows[0]?.mascotName, '橙石美')
   assert.deepEqual(rows[0]?.tags, ['a'])
   await spec.update?.('s1', { title: 'renamed', pinned: true, tags: ['b', 'c'] })
-  await spec.remove?.('s1')
+  await spec.remove?.({ ids: ['s1'] })
   assert.deepEqual(calls, [
     ['rename', 's1', 'renamed'],
     ['patch', 's1', { pinned: true, tags: ['b', 'c'] }],

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -169,18 +169,26 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
       return next
     },
     create: sessions.create
-      ? async (fields = {}) => {
-          const rec = await sessions.create!({
-            ...(typeof fields.title === 'string' ? { title: fields.title } : {}),
-            ...(fields.type === 'live' || fields.type === 'chat' ? { type: String(fields.type) } : {}),
-          })
-          const next = (await list()).find((row) => row.id === rec.id)
-          if (!next) throw new Error(`unknown session: ${rec.id}`)
-          return next
+      ? async (rows) => {
+          const out = []
+          for (const fields of rows) {
+            const rec = await sessions.create!({
+              ...(typeof fields.title === 'string' ? { title: fields.title } : {}),
+              ...(fields.type === 'live' || fields.type === 'chat' ? { type: String(fields.type) } : {}),
+            })
+            const next = (await list()).find((row) => row.id === rec.id)
+            if (!next) throw new Error(`unknown session: ${rec.id}`)
+            out.push(next)
+          }
+          return out
         }
       : undefined,
-    remove: async (id) => {
-      if (!(await sessions.delete(id))) throw new Error(`unknown session: ${id}`)
+    remove: async (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) {
+        if (!(await sessions.delete(id))) throw new Error(`unknown session: ${id}`)
+      }
+      return ids
     },
     actions: [
       {

--- a/packages/type-file-system/src/index.test.ts
+++ b/packages/type-file-system/src/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { asImageSrc, emptySchemaValue, normalizeSchemaPack, normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, schemaSearchHaystack, withBuiltinFields } from './index.ts'
+import { asImageSrc, emptySchemaValue, hasCollectionDeleteQuery, normalizeSchemaPack, normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, schemaSearchHaystack, withBuiltinFields } from './index.ts'
 
 test('asImageSrc keeps http, data:image, and same-origin image paths', () => {
   assert.equal(asImageSrc('https://example.com/a.png'), 'https://example.com/a.png')
@@ -62,4 +62,13 @@ test('required record fields are icon, timestamps, and SuperTag', () => {
   assert.equal(REQUIRED_RECORD_FIELDS.schema.type, 'schema')
   assert.equal(REQUIRED_RECORD_FIELDS.createdAt.type, 'datetime')
   assert.equal(REQUIRED_RECORD_FIELDS.updatedAt.type, 'datetime')
+})
+
+test('hasCollectionDeleteQuery requires ids, q, or a non-empty filter', () => {
+  assert.equal(hasCollectionDeleteQuery({}), false)
+  assert.equal(hasCollectionDeleteQuery({ ids: [] }), false)
+  assert.equal(hasCollectionDeleteQuery({ ids: ['a'] }), true)
+  assert.equal(hasCollectionDeleteQuery({ q: '  x ' }), true)
+  assert.equal(hasCollectionDeleteQuery({ filter: { status: 'open' } }), true)
+  assert.equal(hasCollectionDeleteQuery({ filter: { status: '' } }), false)
 })

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -321,6 +321,16 @@ export type CollectionListQuery = {
   filter?: Record<string, unknown>
 }
 
+export function hasCollectionDeleteQuery(query?: CollectionListQuery | null): boolean {
+  if (!query) return false
+  if (Array.isArray(query.ids) && query.ids.some((id) => String(id).trim())) return true
+  if (String(query.q ?? '').trim()) return true
+  if (query.filter && Object.keys(query.filter).some((key) => query.filter?.[key] != null && query.filter[key] !== '')) {
+    return true
+  }
+  return false
+}
+
 export type CollectionSpec = {
   id: string
   path: string
@@ -337,8 +347,8 @@ export type CollectionSpec = {
   get: (id: string) => DbRecord | null | undefined | Promise<DbRecord | null | undefined>
   /** 更新已有记录的可写字段。不要叫 write。 */
   update?: (id: string, patch: Record<string, unknown>) => DbRecord | Promise<DbRecord>
-  create?: (fields?: Record<string, unknown>) => DbRecord | Promise<DbRecord>
-  remove?: (id: string) => void | boolean | Promise<void | boolean>
+  create?: (rows: Record<string, unknown>[]) => DbRecord[] | Promise<DbRecord[]>
+  remove?: (query: CollectionListQuery) => string[] | void | boolean | Promise<string[] | void | boolean>
   actions?: CollectionAction[]
 }
 
@@ -367,8 +377,8 @@ export interface Database {
   list(path: string, filter?: Record<string, unknown>, page?: ListPage): Promise<unknown>
   read(path: string): Promise<unknown>
   update(path: string, content: unknown): Promise<unknown>
-  create(path: string, content?: unknown): Promise<unknown>
-  remove(path: string): Promise<unknown>
+  create(path: string, records: unknown): Promise<unknown>
+  remove(path: string, query: CollectionListQuery): Promise<unknown>
   action(path: string, actionId: string, args?: Record<string, unknown>): Promise<unknown>
   stat(path: string): Promise<unknown>
   /** 单独读写记录正文（content 字段），不走 list/read。 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
文件系统不再提供单条创建/单条按路径删除。

**创建**
- `create(path, records)`，`records` 必须是非空对象数组
- `db_create`：`path=/tasks`，`records: [{ title: '...' }, ...]`
- UI 新建一条也走 `records: [{}]`

**删除**
- `remove(path, query)`，路径是表（`/tasks`），必须带 `ids`、`q` 或 `filter` 之一
- 无条件删除会报错，不会清空全表
- `db_delete`：`path=/sessions`，`ids=['...']` 或搜索/过滤
- 表格里删一行/多行都走 `ids`

中间主界面的 HTTP 与各表登记实现（任务、页面、会话、标签、插件）已一起改完。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

