### PR TITLE
fix(chat): 输入框改成实色 #202020

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -62,10 +62,9 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.chat-pane-embed\s*\{[^}]*background:\s*#191919/s)
     expect(css).not.toMatch(/\.chat-overlay-panel\.is-autohide/)
     expect(css).toMatch(/\.composer-pill/)
-    expect(css).toMatch(
-      /\.composer-pill\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s,
-    )
-    expect(css).toMatch(/\.composer-pill\s*\{[^}]*backdrop-filter:\s*blur\(16px\) saturate\(1\.2\)/s)
+    expect(css).toMatch(/\.composer-pill\s*\{[^}]*background:\s*#202020/s)
+    expect(css).not.toMatch(/\.composer-pill\s*\{[^}]*backdrop-filter:\s*blur/s)
+    expect(css).not.toMatch(/\.composer-pill\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s)
     expect(css).not.toMatch(/\.composer-pill\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s)
   })
 

--- a/web/style.css
+++ b/web/style.css
@@ -4453,10 +4453,8 @@ body {
   width: 100%;
   border: 0;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
+  background: #202020;
   box-shadow: 0 1px 2px rgba(15, 15, 15, 0.04), 0 10px 32px rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(16px) saturate(1.2);
-  -webkit-backdrop-filter: blur(16px) saturate(1.2);
   transition: border-radius 0.12s ease;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天主界面和悬浮窗共用 `.composer-pill`。输入框改成实色 `#202020`，去掉毛玻璃透明底。覆盖窗本身仍是 `#191919`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

