### PR TITLE
Agent 用 db_create /views 新建并切到表视图

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -313,6 +313,48 @@ test('db_list on a table broadcasts inspector working then done', async () => {
   assert.equal(extra.length, 0)
 })
 
+test('db_create /views reveals the source table and view', async () => {
+  const seen: Array<{ type: string; payload: unknown }> = []
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  class HttpStub extends Service {
+    constructor(c: Context) {
+      super(c, 'http')
+    }
+    route() {}
+    broadcast(type: string, payload: unknown) {
+      seen.push({ type, payload })
+    }
+  }
+  new HttpStub(ctx)
+  await ctx.plugin({ inject: ['tools', 'http'], apply: applyFileSystem })
+  const db = ctx.get('database') as DatabaseService
+  db.register(notesCollection())
+  const created = await runWithSession('s1', () =>
+    ctx.tools.invoke('db_create', {
+      path: '/views',
+      records: [{ tablePath: '/notes', title: '看板', mode: 'board' }],
+    }),
+  )
+  const row = (created as { items: Array<{ value: { tablePath?: string; viewId?: string; title?: string } }> }).items[0]?.value
+  assert.equal(row?.tablePath, '/notes')
+  assert.equal(row?.title, '看板')
+  assert.equal(typeof row?.viewId, 'string')
+  const done = [...seen].reverse().find((item) => {
+    const payload = item.payload as { phase?: string; reveal?: { collection?: string; viewId?: string } }
+    return item.type === 'database' && payload?.phase === 'done' && payload.reveal?.collection === '/notes'
+  })
+  const payload = done?.payload as {
+    sessionId?: string
+    reveal?: { collection?: string; viewId?: string }
+    savedView?: { name?: string; mode?: string }
+  }
+  assert.equal(payload.sessionId, 's1')
+  assert.equal(payload.reveal?.viewId, row?.viewId)
+  assert.equal(payload.savedView?.name, '看板')
+  assert.equal(payload.savedView?.mode, 'board')
+})
+
 test('register rejects duplicate view route and nav title', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -746,7 +746,46 @@ function broadcastInspectorReveal(
     reveal,
     phase,
     sessionId: currentSessionId(),
+    ...(savedViewFromCreated(result) ? { savedView: savedViewFromCreated(result) } : {}),
   })
+}
+
+function savedViewFromCreated(result: unknown) {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return undefined
+  if ((result as { kind?: unknown }).kind !== 'created') return undefined
+  const items = (result as { items?: unknown }).items
+  if (!Array.isArray(items) || !items[0] || typeof items[0] !== 'object') return undefined
+  const value = (items[0] as { value?: unknown }).value
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const row = value as Record<string, unknown>
+  const id = String(row.viewId ?? '').trim()
+  if (!id) return undefined
+  let filters: Record<string, string> = {}
+  if (typeof row.filters === 'string' && row.filters.trim()) {
+    try {
+      const parsed = JSON.parse(row.filters)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        filters = Object.fromEntries(Object.entries(parsed).map(([key, item]) => [key, String(item)]))
+      }
+    } catch {
+      filters = {}
+    }
+  }
+  return {
+    id,
+    name: String(row.title ?? '新视图'),
+    mode: String(row.mode ?? 'table'),
+    sortField: String(row.sortField ?? 'id'),
+    sortDir: row.sortDir === 'desc' ? 'desc' : 'asc',
+    query: String(row.query ?? ''),
+    groupBy: String(row.groupBy ?? ''),
+    columns: Array.isArray(row.columns) ? row.columns.map((item) => String(item)) : [],
+    filters,
+    tree: row.tree !== false,
+    wrap: Boolean(row.wrap),
+    truncate: row.truncate !== false,
+    pageSize: Number(row.pageSize) || 50,
+  }
 }
 
 async function withInspectorReveal<T>(

--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -36,6 +36,27 @@ test('viewsCollection lists saved views with source table', async () => {
   assert.equal(graphed.mode, 'graph')
 })
 
+test('viewsCollection creates and deletes user views on a registered table', async () => {
+  const store = new SavedViewsStore()
+  const spec = viewsCollection(store, () => [
+    { path: '/tasks', id: 'tasks', kind: 'collection', label: 'Task', view: { moduleId: 'tasks', route: '/tasks', title: 'Task' } },
+  ])
+  assert.equal(spec.records?.create, true)
+  assert.equal(spec.records?.delete, true)
+  const [row] = await spec.create!([{ tablePath: '/tasks', title: '看板', mode: 'board', filters: '{"status":"doing"}' }])
+  assert.equal(row?.tablePath, '/tasks')
+  assert.equal(row?.title, '看板')
+  assert.equal(row?.mode, 'board')
+  assert.equal(row?.filters, '{"status":"doing"}')
+  assert.equal(typeof row?.viewId, 'string')
+  assert.throws(() => spec.create!([{ tablePath: '/nope', title: 'x' }]), /unknown collection/)
+  assert.throws(() => spec.create!([{ title: '无表' }]), /tablePath required/)
+  const ids = await spec.remove!({ ids: [String(row?.id)] })
+  assert.deepEqual(ids, [String(row?.id)])
+  const listed = await spec.list()
+  assert.equal(listed.some((item) => item.id === row?.id), false)
+})
+
 test('every registered table gets a builtin all-view even before the client syncs', async () => {
   const store = new SavedViewsStore()
   const spec = viewsCollection(store, () => [

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -51,6 +51,51 @@ export class SavedViewsStore {
     return out.sort((a, b) => String(a.table).localeCompare(String(b.table)) || String(a.title).localeCompare(String(b.title)))
   }
 
+  create(fields: Record<string, unknown>, tables: CollectionInfo[]): DbRecord {
+    const tablePath = tablePathOf(fields)
+    if (!tablePath || tablePath === '/' || tablePath === '/views') throw new Error('tablePath required')
+    if (!tables.some((item) => normalizeCollectionPath(item.path) === tablePath)) {
+      throw new Error(`unknown collection: ${tablePath}`)
+    }
+    const table = tables.find((item) => normalizeCollectionPath(item.path) === tablePath)
+    const label = table?.view?.title ?? table?.label ?? tablePath
+    const id = String(fields.viewId ?? '').trim() || `${Date.now()}`
+    if (isReadOnlyViewId(id)) throw new Error('builtin view is read-only')
+    const views = this.byPath.get(tablePath) ?? []
+    if (views.some((view) => view.id === id)) throw new Error(`view exists: ${id}`)
+    const name = uniqueViewName(String(fields.title ?? fields.name ?? '新视图').trim() || '新视图', views)
+    const view: StoredView = {
+      id,
+      name,
+      mode: typeof fields.mode === 'string' && isViewModeId(fields.mode) ? fields.mode : 'table',
+      sortField: typeof fields.sortField === 'string' && fields.sortField.trim() ? fields.sortField : 'id',
+      sortDir: fields.sortDir === 'desc' ? 'desc' : 'asc',
+      query: typeof fields.query === 'string' ? fields.query : '',
+      groupBy: typeof fields.groupBy === 'string' ? fields.groupBy : '',
+      columns: Array.isArray(fields.columns) ? fields.columns.map((item) => String(item)) : [],
+      filters: asFilters(fields.filters),
+      tree: fields.tree !== false,
+      wrap: Boolean(fields.wrap),
+      truncate: fields.truncate !== false,
+      pageSize: Number(fields.pageSize) || 50,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    }
+    this.byPath.set(tablePath, [...views, view])
+    return asRecord(tablePath, label, view)
+  }
+
+  remove(id: string): boolean {
+    if (isReadOnlyViewId(viewIdOfRow(id))) throw new Error('builtin view is read-only')
+    for (const [path, views] of this.byPath) {
+      const next = views.filter((view) => rowId(path, view.id) !== id)
+      if (next.length === views.length) continue
+      this.byPath.set(path, next)
+      return true
+    }
+    throw new Error(`unknown view: ${id}`)
+  }
+
   write(id: string, patch: Record<string, unknown>): DbRecord {
     if (isReadOnlyViewId(viewIdOfRow(id))) throw new Error('builtin view is read-only')
     for (const [path, views] of this.byPath) {
@@ -67,6 +112,12 @@ export class SavedViewsStore {
         ...(patch.sortDir === 'asc' || patch.sortDir === 'desc' ? { sortDir: patch.sortDir } : {}),
         ...(typeof patch.query === 'string' ? { query: patch.query } : {}),
         ...(typeof patch.groupBy === 'string' ? { groupBy: patch.groupBy } : {}),
+        ...('filters' in patch ? { filters: asFilters(patch.filters) } : {}),
+        ...(Array.isArray(patch.columns) ? { columns: patch.columns.map((item) => String(item)) } : {}),
+        ...(typeof patch.pageSize === 'number' ? { pageSize: patch.pageSize } : {}),
+        ...(typeof patch.tree === 'boolean' ? { tree: patch.tree } : {}),
+        ...(typeof patch.wrap === 'boolean' ? { wrap: patch.wrap } : {}),
+        ...(typeof patch.truncate === 'boolean' ? { truncate: patch.truncate } : {}),
         ...('emoji' in patch ? { emoji: String(patch.emoji ?? '') } : {}),
         ...('schema' in patch ? { schema: normalizeSchemaValue(patch.schema) } : {}),
         updatedAt: Date.now(),
@@ -86,6 +137,35 @@ function rowId(path: string, viewId: string) {
 function viewIdOfRow(id: string) {
   const cut = id.indexOf('::')
   return cut >= 0 ? id.slice(cut + 2) : id
+}
+
+function tablePathOf(fields: Record<string, unknown>) {
+  const raw = fields.tablePath ?? (typeof fields.table === 'string' && String(fields.table).startsWith('/') ? fields.table : '')
+  return normalizeCollectionPath(String(raw ?? ''))
+}
+
+function uniqueViewName(base: string, views: StoredView[]) {
+  const names = new Set(views.map((view) => view.name))
+  if (!names.has(base)) return base
+  let n = 2
+  while (names.has(`${base} ${n}`)) n += 1
+  return `${base} ${n}`
+}
+
+function asFilters(value: unknown): Record<string, string> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const out: Record<string, string> = {}
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) out[key] = String(item)
+    return out
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return asFilters(JSON.parse(value))
+    } catch {
+      return {}
+    }
+  }
+  return {}
 }
 
 function asRecord(path: string, tableName: string, view: StoredView): DbRecord {
@@ -122,11 +202,11 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
       route: '/db-views',
       title: '视图',
       inspector: true,
-      blurb: '各表已保存的视图：来源表、排序、筛选、列与呈现方式。',
+      blurb: '各表已保存的视图。新建用 db_create，records 里写 tablePath 和 mode（table / board / cards / queue），检查器会切到该表该视图。',
       order: 17,
       icon: 'eye',
     },
-    records: { update: true, create: false, delete: false },
+    records: { update: true, create: true, delete: true },
     schema: {
       labelField: 'title',
       columns: ['title', 'table', 'mode', 'sortField', 'sortDir', 'query', 'groupBy', 'pageSize'],
@@ -134,9 +214,9 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
         ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '视图', writable: true },
         table: { type: 'string', label: '来源表' },
-        tablePath: { type: 'string', label: '表路径' },
+        tablePath: { type: 'string', label: '表路径', writable: true },
         viewId: { type: 'string', label: '视图 ID' },
-        mode: { type: 'select', label: '呈现', writable: true },
+        mode: { type: 'select', label: '呈现', writable: true, enum: ['queue', 'table', 'cards', 'board'] },
         sortField: { type: 'string', label: '排序字段', writable: true },
         sortDir: { type: 'select', label: '升降序', writable: true, enum: ['asc', 'desc'] },
         query: { type: 'string', label: '搜索', writable: true },
@@ -144,13 +224,19 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
         tree: { type: 'boolean', label: '树形' },
         wrap: { type: 'boolean', label: '换行' },
         truncate: { type: 'boolean', label: '截断' },
-        pageSize: { type: 'number', label: '每页' },
-        columns: { type: 'multi-select', label: '列' },
-        filters: { type: 'string', label: '筛选' },
+        pageSize: { type: 'number', label: '每页', writable: true },
+        columns: { type: 'multi-select', label: '列', writable: true },
+        filters: { type: 'string', label: '筛选', writable: true },
       },
     },
     list,
     get: (id) => list().find((row) => row.id === id) ?? null,
     update: (id, patch) => store.write(id, patch),
+    create: (rows) => rows.map((fields) => store.create(fields, tables())),
+    remove: async (query) => {
+      const ids = query.ids ?? []
+      for (const id of ids) store.remove(id)
+      return ids
+    },
   }
 }

--- a/packages/core-file-system/src/paths.test.ts
+++ b/packages/core-file-system/src/paths.test.ts
@@ -26,3 +26,23 @@ test('databaseRevealForTool follows result path and drops deleted records', () =
   )
   assert.equal(databaseRevealForTool({ path: '/' }), null)
 })
+
+test('databaseRevealForTool opens the source table view after creating a saved view', () => {
+  assert.deepEqual(
+    databaseRevealForTool({
+      path: '/views',
+      result: {
+        kind: 'created',
+        items: [{ value: { tablePath: '/tasks', viewId: 'board-1', title: '看板' } }],
+      },
+    }),
+    { collection: '/tasks', viewId: 'board-1' },
+  )
+  assert.deepEqual(
+    databaseRevealForTool({
+      path: '/views',
+      result: { kind: 'created', items: [{ value: { title: '普通行' } }] },
+    }),
+    { collection: '/views' },
+  )
+})

--- a/packages/core-file-system/src/paths.ts
+++ b/packages/core-file-system/src/paths.ts
@@ -9,6 +9,7 @@ export function normalizeCollectionPath(path: string) {
 export type DatabaseReveal = {
   collection: string
   recordId?: string
+  viewId?: string
 }
 
 function resultPathOf(result: unknown): string {
@@ -28,7 +29,7 @@ export function databaseRevealFromPath(path: string): DatabaseReveal | null {
   return recordId ? { collection, recordId } : { collection }
 }
 
-/** 删除后记录没了只切表；创建/读取可跟结果 path。 */
+/** 删除后记录没了只切表；创建/读取可跟结果 path。新建视图切到来源表的该视图。 */
 export function databaseRevealForTool(opts: {
   path: string
   result?: unknown
@@ -38,5 +39,23 @@ export function databaseRevealForTool(opts: {
     const fromPath = databaseRevealFromPath(opts.path)
     return fromPath ? { collection: fromPath.collection } : null
   }
+  const created = revealFromCreatedView(opts.result)
+  if (created) return created
   return databaseRevealFromPath(resultPathOf(opts.result) || opts.path)
+}
+
+function revealFromCreatedView(result: unknown): DatabaseReveal | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null
+  if ((result as { kind?: unknown }).kind !== 'created') return null
+  const items = (result as { items?: unknown }).items
+  if (!Array.isArray(items) || !items.length) return null
+  const first = items[0]
+  if (!first || typeof first !== 'object' || Array.isArray(first)) return null
+  const value = (first as { value?: unknown }).value
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const row = value as { tablePath?: unknown; viewId?: unknown }
+  const collection = normalizeCollectionPath(String(row.tablePath ?? ''))
+  const viewId = String(row.viewId ?? '').trim()
+  if (!collection || collection === '/' || !viewId) return null
+  return { collection, viewId }
 }

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -116,3 +116,43 @@ test('applyDatabaseChannelPayload ignores other sessions and unsigned broadcasts
   assert.equal(isInspectorAgentWorking('/tasks'), false)
   assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks')
 })
+
+test('applyDatabaseReveal opens a saved view when viewId is present', () => {
+  applyDatabaseReveal({ collection: '/tasks', viewId: 'board-1' })
+  assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/view/board-1')
+})
+
+test('applyDatabaseChannelPayload upserts a created view then opens it', () => {
+  const mem: Record<string, string> = {}
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => mem[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mem[key] = value
+      },
+      removeItem: (key: string) => {
+        delete mem[key]
+      },
+      key: (index: number) => Object.keys(mem)[index] ?? null,
+      get length() {
+        return Object.keys(mem).length
+      },
+    },
+  })
+  applyDatabaseChannelPayload(
+    {
+      phase: 'done',
+      sessionId: 'main',
+      reveal: { collection: '/tasks', viewId: 'board-1' },
+      savedView: { id: 'board-1', name: '看板', mode: 'board', filters: { status: 'doing' } },
+    },
+    'main',
+  )
+  assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/view/board-1')
+  assert.equal(isInspectorAgentWorking('/tasks'), false)
+  const stored = JSON.parse(mem['fsdb.views:/tasks'] ?? '[]') as Array<{ id: string; name: string; mode: string }>
+  assert.equal(stored[0]?.id, 'board-1')
+  assert.equal(stored[0]?.name, '看板')
+  assert.equal(stored[0]?.mode, 'board')
+})

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,7 +1,9 @@
 /** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
 
 import { normalizeCollectionPath } from '../paths.ts'
-import { DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath } from './database-path.ts'
+import { DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath, databaseViewPath } from './database-path.ts'
+import { upsertSavedView } from './view-storage.ts'
+import { normalizeSavedView, type SavedView } from './saved-view.ts'
 
 const DEFAULT_PANE = 'database'
 const listeners = new Set<() => void>()
@@ -101,6 +103,11 @@ export function applyDatabaseReveal(reveal: unknown) {
     showRecordInInspector(collection, recordId)
     return
   }
+  const viewId = String((reveal as { viewId?: unknown }).viewId ?? '').trim()
+  if (viewId) {
+    showInInspector(collection, databaseViewPath(collection, viewId))
+    return
+  }
   showInInspector(collection, databaseAllViewPath(collection))
 }
 
@@ -113,9 +120,38 @@ export function applyDatabaseChannelPayload(payload: unknown, currentSessionId?:
   if (!reveal || typeof reveal !== 'object' || Array.isArray(reveal)) return
   const collection = normalizeCollectionPath(String((reveal as { collection?: unknown }).collection ?? ''))
   if (!collection || collection === '/') return
+  const savedView = savedViewFromPayload((payload as { savedView?: unknown }).savedView, (reveal as { viewId?: unknown }).viewId)
+  if (savedView) upsertSavedView(collection, savedView)
   const phase = String((payload as { phase?: unknown }).phase ?? '')
   applyDatabaseReveal(reveal)
   setInspectorAgentWorking(collection, phase !== 'done')
+}
+
+function savedViewFromPayload(raw: unknown, revealViewId: unknown): SavedView | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const rec = raw as Record<string, unknown>
+  const id = String(rec.id ?? revealViewId ?? '').trim()
+  if (!id) return null
+  let filters: Record<string, string> = {}
+  if (rec.filters && typeof rec.filters === 'object' && !Array.isArray(rec.filters)) {
+    filters = Object.fromEntries(Object.entries(rec.filters).map(([key, item]) => [key, String(item)]))
+  }
+  return normalizeSavedView({
+    id,
+    name: String(rec.name ?? rec.title ?? '新视图'),
+    mode: rec.mode as SavedView['mode'],
+    sortField: String(rec.sortField ?? 'id'),
+    sortDir: rec.sortDir === 'desc' ? 'desc' : 'asc',
+    filters,
+    columns: Array.isArray(rec.columns) ? rec.columns.map((item) => String(item)) : [],
+    groupBy: String(rec.groupBy ?? ''),
+    tree: rec.tree !== false,
+    wrap: Boolean(rec.wrap),
+    truncate: rec.truncate !== false,
+    query: String(rec.query ?? ''),
+    pageSize: Number(rec.pageSize) || 50,
+    builtin: false,
+  })
 }
 
 export function seedInspectorDbPath(paneId: string, pathname?: string) {

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -125,6 +125,19 @@ export function pushSavedViews(collectionPath: string, views: SavedView[]) {
   }).catch(() => undefined)
 }
 
+export function upsertSavedView(collectionPath: string, view: SavedView) {
+  const next = normalizeSavedView({ ...view, builtin: false })
+  const stored = loadViews(collectionPath).filter((item) => item.id !== next.id && !item.builtin)
+  stored.push(next)
+  rememberViews(collectionPath, stored)
+  try {
+    localStorage.setItem(viewsKey(collectionPath), JSON.stringify(stored))
+  } catch {
+    /* ignore */
+  }
+  pushSavedViews(collectionPath, stored)
+}
+
 export function pushAllSavedViews() {
   try {
     for (let i = 0; i < localStorage.length; i++) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 做什么

Agent 不再需要单独的 view 工具。对 `/views` 走现有 `db_create`：

```
db_create path=/views records:[{ tablePath: '/tasks', mode: 'board', title: '看板' }]
```

`tablePath` 必须是已登记表。随后可用 `db_update` 改 `/views/<table>::<viewId>` 的筛选和呈现。

## 检查器

创建成功后广播会揭示**来源表 + viewId**（不是 `/views` 目录），并把 `savedView` 写进前端同一套 localStorage / saved-views API。主 Session 闸门不变。

## 测试

`saved-views`、`paths`、`inspector-db-route`、host `db_create /views`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

