### PR TITLE
修复改窗口宽度时整页卡顿

### DIFF
--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -47,6 +47,8 @@ test('table and view rows only expand from the fold column', () => {
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(css, /\.sidebar-fold\s*\{[^}]*grid-template-rows:\s*0fr/s)
   assert.match(css, /\.sidebar-fold\.is-open\s*\{[^}]*grid-template-rows:\s*1fr/)
+  assert.match(css, /\.sidebar-fold\.is-animating\s*\{[^}]*transition:\s*grid-template-rows/)
+  assert.doesNotMatch(css, /\.sidebar-fold\s*\{[^}]*transition:\s*grid-template-rows/s)
   assert.match(sidebar, /const listed = path === collectionPath \? views : loadViews\(path\)/)
   assert.match(sidebar, /viewsForRegisteredCollection\(path, tables, listed\)/)
   assert.doesNotMatch(sidebar, /catalog: true/)

--- a/packages/public-ui/src/sidebar-fold.test.ts
+++ b/packages/public-ui/src/sidebar-fold.test.ts
@@ -7,4 +7,5 @@ test('public-ui fold uses grid 0fr to 1fr', () => {
   const src = readFileSync(resolve(import.meta.dirname, './sidebar-fold.tsx'), 'utf8')
   assert.match(src, /function SidebarFold/)
   assert.match(src, /className=\{\`sidebar-fold\$\{open \? ' is-open' : ''\}/)
+  assert.match(src, /is-animating/)
 })

--- a/packages/public-ui/src/sidebar-fold.tsx
+++ b/packages/public-ui/src/sidebar-fold.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type ReactNode, type TransitionEvent } from 'react'
 
 export function SidebarFold({
   open,
@@ -9,8 +9,26 @@ export function SidebarFold({
   children: ReactNode
   className?: string
 }) {
+  const [animating, setAnimating] = useState(false)
+  const openRef = useRef(open)
+  useLayoutEffect(() => {
+    if (openRef.current === open) return
+    openRef.current = open
+    setAnimating(true)
+  }, [open])
+
+  function onTransitionEnd(event: TransitionEvent<HTMLDivElement>) {
+    if (event.target !== event.currentTarget) return
+    if (event.propertyName !== 'grid-template-rows') return
+    setAnimating(false)
+  }
+
   return (
-    <div className={`sidebar-fold${open ? ' is-open' : ''}${className ? ` ${className}` : ''}`} aria-hidden={!open}>
+    <div
+      className={`sidebar-fold${open ? ' is-open' : ''}${animating ? ' is-animating' : ''}${className ? ` ${className}` : ''}`}
+      aria-hidden={!open}
+      onTransitionEnd={onTransitionEnd}
+    >
       <div className="sidebar-fold-inner" inert={!open || undefined}>
         {children}
       </div>

--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -90,6 +90,8 @@ test('shell columns keep three tracks so sidebar and inspector can animate', () 
     css,
     /\.app-shell-agent\s*\{[^}]*grid-template-columns:\s*var\(--sidebar-col, 0px\) minmax\(0, 1fr\) var\(--inspector-width, 0px\)/s,
   )
+  assert.match(css, /\.app-shell-agent\.is-window-resizing\s*\{[^}]*transition:\s*none/s)
+  assert.match(css, /\.app-shell-module\.is-window-resizing\s*\{[^}]*transition:\s*none/s)
   assert.doesNotMatch(css, /\.app-shell-agent\.is-sidebar-collapsed\s*\{/)
   assert.match(frame, /is-closed flex/)
   assert.match(css, /\.app-side-bar\s*\{[^}]*min-width:\s*0/s)

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -58,8 +58,10 @@ test('center stage keeps modules mounted and crossfades', () => {
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(shell, /className="app-stage"/)
   assert.match(shell, /app-stage-pane/)
+  assert.match(shell, /is-window-resizing/)
   assert.doesNotMatch(shell, /if \(moduleId !== activeId\) return null/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
+  assert.match(css, /\.app-stage-pane[\s\S]*?content-visibility:\s*hidden/)
   assert.match(css, /\.app-pane-in\s*\{[^}]*animation:\s*app-pane-in/s)
 })
 

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -335,6 +335,7 @@ function Shell(props: SlotProps) {
     return 320
   })
   const [columnResizing, setColumnResizing] = useState(false)
+  const [windowResizing, setWindowResizing] = useState(false)
   useEffect(() => {
     const onDown = (event: PointerEvent) => {
       const target = event.target
@@ -427,10 +428,19 @@ function Shell(props: SlotProps) {
     typeof window === 'undefined' ? 1440 : window.innerWidth,
   )
   useEffect(() => {
-    const sync = () => setViewportWidth(window.innerWidth)
+    let timer = 0
+    const sync = () => {
+      setViewportWidth(window.innerWidth)
+      setWindowResizing(true)
+      window.clearTimeout(timer)
+      timer = window.setTimeout(() => setWindowResizing(false), 120)
+    }
     sync()
     window.addEventListener('resize', sync)
-    return () => window.removeEventListener('resize', sync)
+    return () => {
+      window.clearTimeout(timer)
+      window.removeEventListener('resize', sync)
+    }
   }, [])
   const leftPane =
     showChatSidebar ||
@@ -605,8 +615,8 @@ function Shell(props: SlotProps) {
     <div
       className={`app-shell${leftPane
           ? ` app-shell-agent${leftHidden ? ' is-sidebar-collapsed' : ''}${sidebarNarrow && !leftHidden ? ' is-sidebar-narrow' : ''}${inspectorVisible ? ' is-inspector-open' : ''
-          }${columnResizing ? ' is-resizing' : ''}`
-          : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}${columnResizing ? ' is-resizing' : ''}`
+          }${columnResizing ? ' is-resizing' : ''}${windowResizing ? ' is-window-resizing' : ''}`
+          : ` app-shell-module${inspectorVisible ? ' is-inspector-open' : ''}${columnResizing ? ' is-resizing' : ''}${windowResizing ? ' is-window-resizing' : ''}`
         }${leftHidden ? ' is-left-hidden' : ''}`}
       data-testid="app-shell"
       style={

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -70,5 +70,6 @@ test('inspector header tabs sit on the same vertical center as the main header',
   assert.doesNotMatch(css, /\.inspector-crumb-tab\s*\{[^}]*padding-right:\s*4px/s)
   assert.match(css, /\.inspector-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
   assert.match(css, /\.inspector-stage-pane[\s\S]*?transition:/)
+  assert.match(css, /\.inspector-stage-pane[\s\S]*?content-visibility:\s*hidden/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -898,23 +898,21 @@ body {
   flex-direction: column;
   overflow: hidden;
   opacity: 0;
-  transform: translateY(8px);
   pointer-events: none;
   visibility: hidden;
+  content-visibility: hidden;
   transition:
     opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    visibility 0s linear 220ms;
+    visibility 0s linear 0s;
 }
 
 .inspector-stage-pane.is-active,
 .app-stage-pane.is-active {
   opacity: 1;
-  transform: none;
   pointer-events: auto;
   visibility: visible;
+  content-visibility: visible;
   z-index: 1;
-  transition-delay: 0s;
 }
 
 @keyframes app-pane-in {
@@ -1153,7 +1151,8 @@ body {
   transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.app-shell-agent.is-resizing {
+.app-shell-agent.is-resizing,
+.app-shell-agent.is-window-resizing {
   transition: none;
 }
 
@@ -1504,7 +1503,8 @@ body {
   transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.app-shell-module.is-resizing {
+.app-shell-module.is-resizing,
+.app-shell-module.is-window-resizing {
   transition: none;
 }
 
@@ -2011,11 +2011,14 @@ body {
 .sidebar-fold {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .sidebar-fold.is-open {
   grid-template-rows: 1fr;
+}
+
+.sidebar-fold.is-animating {
+  transition: grid-template-rows 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .sidebar-fold-inner {
@@ -2024,7 +2027,7 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .sidebar-fold {
+  .sidebar-fold.is-animating {
     transition: none;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

上次给侧栏折叠加了 `grid-template-rows: 0fr → 1fr` 的常驻过渡。打开数据库（搜索浏览器）后侧栏里有很多折叠层；一改窗口宽度，浏览器会把每个 `1fr` 的实际高度再插值 220ms。同时整页 `grid-template-columns` 也在跟 `--sidebar-col` / `--inspector-width` 缓动，底下还叠着未激活的聊天/数据库面板，resize 就会整页卡。

## 改动

- 折叠动画只在 `open` 切换时加 `is-animating`，resize 不再播
- 拖窗口时给 shell 加 `is-window-resizing`，关掉列宽过渡（开关侧栏/检查器仍有动画）
- 未激活的 `app-stage-pane` / `inspector-stage-pane` 用 `content-visibility: hidden`，并去掉整页 `translateY` 合成层

切换模块仍有透明度淡入。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

