### PR TITLE
SuperTag 谁都可以改，不跟插件能不能 update 绑死

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -547,6 +547,48 @@ test('SuperTag list filter asks the collection only for stamped ids', async () =
   assert.equal(filtered.items[0]?.id, 'a')
 })
 
+test('SuperTag schema can be written on tables that cannot update other fields', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  const rows = new Map<string, Record<string, unknown>>([['p1', { id: 'p1', title: 'Demo' }]])
+  db.register({
+    id: 'plugins',
+    path: '/plugins',
+    label: '插件',
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string' } } },
+    records: { update: false, delete: true },
+    list: () => [...rows.values()] as { id: string }[],
+    get: (id) => (rows.get(id) as { id: string } | undefined) ?? null,
+    remove: (query) => query.ids ?? [],
+  })
+  db.schemaTags.replace([{ id: 'dp', label: '动态规划', fields: [{ key: 'complexity', type: 'string', label: '复杂度' }] }])
+  await assert.rejects(() => db.update('/plugins/p1', { title: '改名' }), /cannot update/)
+  const written = await db.update('/plugins/p1', { schema: { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } } })
+  assert.deepEqual((written.value as { schema?: { tags?: string[] } }).schema?.tags, ['dp'])
+  const read = await db.read('/plugins/p1')
+  if (read.kind !== 'record') return
+  assert.equal((read.value.schema as { values?: { dp?: { complexity?: string } } }).values?.dp?.complexity, 'O(n)')
+  const listed = await db.list('/plugins')
+  if (listed.kind !== 'collection') return
+  assert.deepEqual((listed.items[0]?.schema as { tags?: string[] })?.tags, ['dp'])
+  const collected = await db.collectSuperTag('dp')
+  assert.equal(collected.items.length, 1)
+  assert.equal(collected.items[0]?.path, '/plugins/p1')
+})
+
+test('db_update /supertags writes SuperTag field packs', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  db.register(superTagsCollection(db.schemaTags))
+  const created = await db.create('/supertags', [{ title: '动态规划' }])
+  const id = String(created.items[0]?.value.id)
+  const updated = await db.update(`/supertags/${id}`, {
+    fields: JSON.stringify([{ key: 'complexity', type: 'string', label: '复杂度' }]),
+  })
+  assert.equal(updated.value.fieldCount, 1)
+  assert.equal(db.schemaTags.get(id)?.fields[0]?.key, 'complexity')
+})
+
 test('tables without records.create/delete reject create and delete', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -387,9 +387,8 @@ export class DatabaseService extends Service implements Database {
 
   private async loadCollectionRows(spec: CollectionSpec, query: CollectionListQuery) {
     const rows = await spec.list(query)
-    if (!query.ids?.length) return rows
-    const allow = new Set(query.ids)
-    return rows.filter((row) => allow.has(row.id))
+    const listed = !query.ids?.length ? rows : rows.filter((row) => query.ids!.includes(row.id))
+    return listed.map((row) => this.applySchemaOverlay(spec, row))
   }
 
   private async matchCollectionRows(
@@ -419,8 +418,9 @@ export class DatabaseService extends Service implements Database {
       const id = String(row.sourceId ?? '')
       const spec = collection ? this.collection(collection) : undefined
       if (!spec || !id) continue
-      const record = await spec.get(id)
-      if (!record) continue
+      const found = await spec.get(id)
+      if (!found) continue
+      const record = this.applySchemaOverlay(spec, found)
       const bag = normalizeSchemaValue(record.schema).values[pack.id] ?? {}
       for (const field of wanted) {
         if (bag[field.key] !== undefined) row[field.key] = bag[field.key]
@@ -464,7 +464,7 @@ export class DatabaseService extends Service implements Database {
         label: spec.label ?? spec.id,
         schema: schemaFor(spec),
         caps,
-        value: withoutContent(spec, record),
+        value: withoutContent(spec, this.applySchemaOverlay(spec, record)),
       }
     }
     throw new Error(`path too deep: ${normalizeCollectionPath(path)}`)
@@ -541,6 +541,17 @@ export class DatabaseService extends Service implements Database {
     }
   }
 
+  private applySchemaOverlay(spec: CollectionSpec, row: DbRecord): DbRecord {
+    if (spec.path === '/supertags' || !schemaFor(spec).fields.schema) return row
+    const overlay = this.schemaTags.recordSchema(spec.path, row.id)
+    if (!overlay) return row
+    return { ...row, schema: overlay }
+  }
+
+  private collectionCanUpdate(spec: CollectionSpec) {
+    return Boolean(spec.records?.update && spec.update)
+  }
+
   private indexSuperTagRecord(spec: CollectionSpec, record: DbRecord) {
     if (spec.path === '/supertags' || !schemaFor(spec).fields.schema) return
     const labelKey = schemaFor(spec).labelField ?? 'title'
@@ -561,7 +572,7 @@ export class DatabaseService extends Service implements Database {
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     const record = await spec.get(parts[1]!)
     if (!record) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
-    return { kind: 'record' as const, path: `${spec.path}/${record.id}`, schema: schemaFor(spec), value: withoutContent(spec, record) }
+    return { kind: 'record' as const, path: `${spec.path}/${record.id}`, schema: schemaFor(spec), value: withoutContent(spec, this.applySchemaOverlay(spec, record)) }
   }
 
   async update(path: string, content: unknown) {
@@ -569,8 +580,26 @@ export class DatabaseService extends Service implements Database {
     if (parts.length !== 2) throw new Error(`cannot update: ${normalizeCollectionPath(path)}`)
     const spec = this.collection(`/${parts[0]}`)
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
-    if (!spec.records?.update || !spec.update) throw new Error(`collection cannot update: ${spec.path}`)
-    const patch = pickWritablePatch(schemaFor(spec), parseContent(content))
+    const schema = schemaFor(spec)
+    const raw = parseContent(content)
+    if (!this.collectionCanUpdate(spec)) {
+      const keys = Object.keys(raw)
+      if (keys.length !== 1 || keys[0] !== 'schema' || !schema.fields.schema?.writable || schema.fields.schema.computed) {
+        throw new Error(`collection cannot update: ${spec.path}`)
+      }
+      const current = await spec.get(parts[1]!)
+      if (!current) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
+      const nextSchema = coerce(schema.fields.schema, raw.schema)
+      const labelKey = schema.labelField ?? 'title'
+      this.schemaTags.writeRecordSchema(spec.path, current.id, nextSchema, String(current[labelKey] ?? current.id))
+      this.bump()
+      return {
+        kind: 'record' as const,
+        path: `${spec.path}/${current.id}`,
+        value: withoutContent(spec, { ...current, schema: nextSchema }),
+      }
+    }
+    const patch = pickWritablePatch(schema, raw)
     const record = await spec.update(parts[1]!, patch)
     this.indexSuperTagRecord(spec, record)
     this.bump()
@@ -861,7 +890,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_update',
-    description: '按 schema 可写字段更新一条已有记录，路径为 /<表>/<id>。新建用 db_create，正文用 db_content。',
+    description: '按 schema 可写字段更新一条已有记录，路径为 /<表>/<id>。SuperTag（schema 字段）在所有表都可写，包括 records.update 为 false 的表（如 /plugins）；其它字段仍看 caps。新建用 db_create，正文用 db_content。改标签属性用 db_update path=/supertags/<id> content.fields。',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/core-file-system/src/host/schema-tags.test.ts
+++ b/packages/core-file-system/src/host/schema-tags.test.ts
@@ -48,3 +48,13 @@ test('sqlite file round-trips SuperTag catalog and stamp index', async () => {
   assert.equal(again.removeTag('dp'), true)
   assert.equal(again.list().length, 0)
 })
+
+test('sqlite stores SuperTag schema overlay for records that cannot update', async () => {
+  const store = new SchemaTagsStore()
+  store.writeRecordSchema('/plugins', 'demo', { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } }, 'Demo')
+  assert.deepEqual(store.recordSchema('/plugins', 'demo')?.tags, ['dp'])
+  assert.equal(store.stampedIds('/plugins', 'dp').has('demo'), true)
+  store.removeRecord('/plugins', 'demo')
+  assert.equal(store.recordSchema('/plugins', 'demo'), null)
+  assert.equal(store.stampedIds('/plugins', 'dp').has('demo'), false)
+})

--- a/packages/core-file-system/src/host/schema-tags.ts
+++ b/packages/core-file-system/src/host/schema-tags.ts
@@ -1,7 +1,12 @@
 import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { createRequire } from 'node:module'
-import { normalizeSchemaPack, type CollectionSchemaPack } from '@biu/type-file-system'
+import {
+  normalizeSchemaPack,
+  normalizeSchemaValue,
+  type CollectionSchemaPack,
+  type SchemaFieldValue,
+} from '@biu/type-file-system'
 
 type DatabaseSync = import('node:sqlite').DatabaseSync
 
@@ -75,6 +80,12 @@ export class SchemaTagsStore {
       );
       CREATE INDEX IF NOT EXISTS super_tag_stamps_tag ON super_tag_stamps(tag_id);
       CREATE INDEX IF NOT EXISTS super_tag_stamps_record ON super_tag_stamps(collection, record_id);
+      CREATE TABLE IF NOT EXISTS super_tag_record_schema (
+        collection TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        schema_json TEXT NOT NULL,
+        PRIMARY KEY (collection, record_id)
+      );
     `)
     return this
   }
@@ -194,10 +205,31 @@ export class SchemaTagsStore {
     }
   }
 
-  removeRecord(collection: string, recordId: string) {
+  recordSchema(collection: string, recordId: string): SchemaFieldValue | null {
+    const row = this.ensure()
+      .prepare('SELECT schema_json FROM super_tag_record_schema WHERE collection = ? AND record_id = ?')
+      .get(collection, recordId) as { schema_json: string } | undefined
+    if (!row) return null
+    return normalizeSchemaValue(row.schema_json)
+  }
+
+  writeRecordSchema(collection: string, recordId: string, schema: unknown, title: string) {
+    const value = normalizeSchemaValue(schema)
     this.ensure()
-      .prepare('DELETE FROM super_tag_stamps WHERE collection = ? AND record_id = ?')
-      .run(collection, recordId)
+      .prepare(
+        `INSERT INTO super_tag_record_schema (collection, record_id, schema_json)
+         VALUES (?, ?, ?)
+         ON CONFLICT(collection, record_id) DO UPDATE SET schema_json = excluded.schema_json`,
+      )
+      .run(collection, recordId, JSON.stringify(value))
+    this.indexRecord(collection, recordId, title, value.tags)
+    return value
+  }
+
+  removeRecord(collection: string, recordId: string) {
+    const db = this.ensure()
+    db.prepare('DELETE FROM super_tag_stamps WHERE collection = ? AND record_id = ?').run(collection, recordId)
+    db.prepare('DELETE FROM super_tag_record_schema WHERE collection = ? AND record_id = ?').run(collection, recordId)
   }
 
   stampedIds(collection: string, tagIdOrLabel: string): Set<string> {

--- a/packages/core-file-system/src/host/super-tags-collection.test.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.test.ts
@@ -23,6 +23,8 @@ test('superTagsCollection lists tags with stamp counts and supports create/updat
   assert.equal(updated.title, 'I/O')
   assert.equal(updated.fieldCount, 1)
   assert.equal(store.get('io')?.fields[0]?.key, 'format')
+  assert.equal(spec.schema.fields.fields?.writable, true)
+  assert.match(String(updated.fields), /format/)
 
   await spec.remove!({ ids: [created[0]!.id] })
   assert.equal(store.get('io'), null)

--- a/packages/core-file-system/src/host/super-tags-collection.ts
+++ b/packages/core-file-system/src/host/super-tags-collection.ts
@@ -40,6 +40,7 @@ export function superTagsCollection(
     title: label,
     fieldCount: fields.length,
     stampCount,
+    fields: JSON.stringify(fields),
     ...recordBuiltinValues(),
   })
 
@@ -76,7 +77,7 @@ export function superTagsCollection(
       route: '/db-supertags',
       title: '标签',
       inspector: true,
-      blurb: '工作区全局标签。',
+      blurb: '工作区全局标签，谁都可以改属性和贴到任意表的记录上（含插件）。新建用 db_create，改名/属性用 db_update（fields 为属性 JSON 数组）。',
       order: 31,
       icon: 'tag',
     },
@@ -90,6 +91,7 @@ export function superTagsCollection(
         title: { type: 'string', label: '标签', writable: true },
         fieldCount: { type: 'number', label: '字段', computed: true },
         stampCount: { type: 'number', label: '收集', computed: true, sortable: true },
+        fields: { type: 'string', label: '属性', writable: true },
         table: { type: 'string', label: '来源表', computed: true },
         tablePath: { type: 'string', label: '表路径', computed: true },
         sourceId: { type: 'string', label: '记录', computed: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
SuperTag 是工作区全局的，不跟表的 `records.update` 绑死。

- `/plugins` 这类不能改行内容的表，仍可用 `db_update` 只写 `schema`（贴标签和属性值），存在 File System 的 overlay 里。改插件名等其它字段照旧拒绝。
- 改标签自己的属性：`db_update path=/supertags/<id> content.fields`（JSON 数组），和前端加属性同一套目录。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

