### PR TITLE
前端新建的视图持久化到后端

### DIFF
--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -841,6 +841,7 @@ export function apply(ctx: Context) {
   const db = new DatabaseService(ctx)
   db.schemaTags.open(join(process.cwd(), SUPER_TAGS_SQLITE))
   const savedViews = new SavedViewsStore()
+  savedViews.open(process.env.VITEST ? ':memory:' : join(process.cwd(), SUPER_TAGS_SQLITE))
   const schemaTags = db.schemaTags
   db.register(viewsCollection(savedViews, () => db.collectionsList().map((item) => ({
     id: item.id,

--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { builtinAllViewId } from '../catalog-views.ts'
 import { SavedViewsStore, viewsCollection } from './saved-views.ts'
 
@@ -67,4 +70,39 @@ test('every registered table gets a builtin all-view even before the client sync
   assert.equal(rows.length, 2)
   assert.equal(rows.find((row) => row.tablePath === '/sessions')?.title, '全部会话')
   assert.equal(rows.find((row) => row.tablePath === '/events')?.title, '全部事件')
+})
+
+test('saved views persist created fields and updates across reopen', async () => {
+  const file = join(mkdtempSync(join(tmpdir(), 'fsdb-views-')), 'file-system.sqlite')
+  const tables = [
+    { path: '/tasks', id: 'tasks', kind: 'collection' as const, label: 'Task', view: { moduleId: 'tasks', route: '/tasks', title: 'Task' } },
+  ]
+  const first = new SavedViewsStore()
+  first.open(file)
+  const spec = viewsCollection(first, () => tables)
+  const [row] = await spec.create!([{ tablePath: '/tasks', title: '看板', mode: 'board', sortField: 'dueAt' }])
+  await spec.update!(String(row?.id), { query: 'foo', groupBy: 'status' })
+  first.replace('/tasks', [
+    {
+      id: String(row?.viewId),
+      name: '看板',
+      mode: 'board',
+      sortField: 'dueAt',
+      sortDir: 'asc',
+      query: 'foo',
+      groupBy: 'status',
+      filters: { status: 'doing' },
+      columns: ['title', 'status'],
+    },
+  ])
+  const second = new SavedViewsStore()
+  second.open(file)
+  const listed = await viewsCollection(second, () => tables).list()
+  const hit = listed.find((item) => item.id === row?.id)
+  assert.equal(hit?.title, '看板')
+  assert.equal(hit?.mode, 'board')
+  assert.equal(hit?.query, 'foo')
+  assert.equal(hit?.groupBy, 'status')
+  assert.equal(hit?.sortField, 'dueAt')
+  assert.equal(hit?.filters, '{"status":"doing"}')
 })

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -1,3 +1,6 @@
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { createRequire } from 'node:module'
 import type { CollectionInfo, CollectionSpec, DbRecord } from '@biu/type-file-system'
 import { normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { builtinAllView, isReadOnlyViewId } from '../catalog-views.ts'
@@ -5,10 +8,82 @@ import type { SavedView } from '../web/saved-view.ts'
 import { isViewModeId } from '../web/fields.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
+type DatabaseSync = import('node:sqlite').DatabaseSync
+
+const require = createRequire(import.meta.url)
+
 export type StoredView = Partial<SavedView> & Pick<SavedView, 'id' | 'name'>
+
+type ViewRow = { collection: string; payload_json: string }
 
 export class SavedViewsStore {
   private byPath = new Map<string, StoredView[]>()
+  private db: DatabaseSync | null = null
+
+  open(path = ':memory:') {
+    if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true })
+    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
+    this.db = new DatabaseSync(path)
+    this.db.exec('PRAGMA journal_mode = WAL')
+    this.db.exec('PRAGMA synchronous = NORMAL')
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS saved_views (
+        collection TEXT NOT NULL,
+        view_id TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (collection, view_id)
+      );
+    `)
+    this.hydrate()
+    return this
+  }
+
+  private hydrate() {
+    if (!this.db) return
+    this.byPath.clear()
+    const rows = this.db.prepare('SELECT collection, payload_json FROM saved_views').all() as ViewRow[]
+    for (const row of rows) {
+      const collection = normalizeCollectionPath(row.collection)
+      if (!collection || collection === '/' || collection === '/views') continue
+      let parsed: StoredView | null = null
+      try {
+        parsed = JSON.parse(row.payload_json) as StoredView
+      } catch {
+        continue
+      }
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+      const id = String(parsed.id ?? '').trim()
+      const name = String(parsed.name ?? id).trim()
+      if (!id || isReadOnlyViewId(id) || parsed.builtin) continue
+      const list = this.byPath.get(collection) ?? []
+      list.push({ ...parsed, id, name })
+      this.byPath.set(collection, list)
+    }
+  }
+
+  private persistPath(collectionPath: string) {
+    if (!this.db) return
+    const path = normalizeCollectionPath(collectionPath)
+    const views = this.byPath.get(path) ?? []
+    const upsert = this.db.prepare(
+      `INSERT INTO saved_views (collection, view_id, payload_json, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(collection, view_id) DO UPDATE SET payload_json = excluded.payload_json, updated_at = excluded.updated_at`,
+    )
+    this.db.exec('BEGIN IMMEDIATE')
+    try {
+      this.db.prepare('DELETE FROM saved_views WHERE collection = ?').run(path)
+      for (const view of views) {
+        if (view.builtin || isReadOnlyViewId(String(view.id))) continue
+        upsert.run(path, String(view.id), JSON.stringify(view), Date.now())
+      }
+      this.db.exec('COMMIT')
+    } catch (error) {
+      this.db.exec('ROLLBACK')
+      throw error
+    }
+  }
 
   replace(collectionPath: string, views: StoredView[]) {
     const path = normalizeCollectionPath(collectionPath)
@@ -18,6 +93,7 @@ export class SavedViewsStore {
         .filter((view) => !view.builtin && !isReadOnlyViewId(String(view.id)))
         .map((view) => ({ ...view, id: String(view.id), name: String(view.name || view.id) })),
     )
+    this.persistPath(path)
   }
 
   rows(tables: CollectionInfo[]): DbRecord[] {
@@ -82,6 +158,7 @@ export class SavedViewsStore {
       updatedAt: Date.now(),
     }
     this.byPath.set(tablePath, [...views, view])
+    this.persistPath(tablePath)
     return asRecord(tablePath, label, view)
   }
 
@@ -91,6 +168,7 @@ export class SavedViewsStore {
       const next = views.filter((view) => rowId(path, view.id) !== id)
       if (next.length === views.length) continue
       this.byPath.set(path, next)
+      this.persistPath(path)
       return true
     }
     throw new Error(`unknown view: ${id}`)
@@ -124,6 +202,7 @@ export class SavedViewsStore {
         createdAt: Number((cur as { createdAt?: number }).createdAt) || Date.now(),
       }
       views[idx] = next
+      this.persistPath(path)
       return asRecord(path, path, next)
     }
     throw new Error(`unknown view: ${id}`)

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -853,9 +853,9 @@ export function CollectionBrowser({
     const listed = listedViews(path, next).map((view) => withViewDisplay(path, view))
     const stored = listed.filter((view) => !view.builtin)
     rememberViews(path, listed)
+    pushSavedViews(path, stored)
     if (!nested) {
       localStorage.setItem(viewsKey(path), JSON.stringify(stored))
-      pushSavedViews(path, stored)
     }
     if (path === collectionPath) {
       viewsRef.current = listed

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -15,7 +15,7 @@ import {
   bootLoadCollections,
   collectionNavKey,
 } from './nav-boot.ts'
-import { defaultViewId, pushAllSavedViews } from './view-storage.ts'
+import { defaultViewId, pullSavedViews, pushAllSavedViews } from './view-storage.ts'
 import { DATA_MODULE, DATA_MODULE_ID, DATA_MODULE_PATH, SUPERTAGS_COLLECTION_PATH, VIEWS_COLLECTION_PATH, sortDataCollections } from './database-path.ts'
 import { superTagsChrome } from './super-tags-chrome.tsx'
 import { viewsChrome } from './views-chrome.ts'
@@ -102,7 +102,7 @@ function CollectionPage(props: SlotProps) {
   }
 
   useEffect(() => {
-    pushAllSavedViews()
+    void pullSavedViews().then(() => pushAllSavedViews())
   }, [])
 
   useEffect(() => {

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -5,6 +5,7 @@ import { VIEWS_COLLECTION_PATH } from './database-path.ts'
 import {
   defaultViewId,
   persistViewDisplay,
+  savedViewFromRecord,
   viewDisplayKey,
   viewForPath,
   withViewDisplay,
@@ -67,4 +68,19 @@ test('builtin view columns overlay survives withViewDisplay', () => {
     'title',
     'project',
   ])
+})
+
+test('savedViewFromRecord skips builtin rows and keeps filters', () => {
+  assert.equal(savedViewFromRecord({ viewId: builtinAllViewId('/tasks'), title: '全部' }), null)
+  const view = savedViewFromRecord({
+    viewId: 'v1',
+    title: '看板',
+    mode: 'board',
+    sortField: 'dueAt',
+    filters: '{"status":"doing"}',
+    columns: ['title'],
+  })
+  assert.equal(view?.id, 'v1')
+  assert.equal(view?.mode, 'board')
+  assert.equal(view?.filters.status, 'doing')
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -1,4 +1,5 @@
-import { builtinAllViewId, stubBuiltinAllView, stubBuiltinCatalogView, stubBuiltinTagView } from '../catalog-views.ts'
+import { builtinAllViewId, stubBuiltinAllView, stubBuiltinCatalogView, stubBuiltinTagView, isReadOnlyViewId } from '../catalog-views.ts'
+import { listCollection } from './db-client.ts'
 import { normalizeSavedView, type SavedView } from './saved-view.ts'
 
 export function viewsKey(collectionPath: string) {
@@ -118,11 +119,73 @@ export function persistStarredViews(items: StarredView[]) {
 }
 
 export function pushSavedViews(collectionPath: string, views: SavedView[]) {
-  void fetch('/api/db/saved-views', {
+  return fetch('/api/db/saved-views', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ path: collectionPath, views }),
   }).catch(() => undefined)
+}
+
+function parseViewFilters(value: unknown): Record<string, string> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const out: Record<string, string> = {}
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) out[key] = String(item)
+    return out
+  }
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parseViewFilters(JSON.parse(value))
+    } catch {
+      return {}
+    }
+  }
+  return {}
+}
+
+export function savedViewFromRecord(row: { viewId?: unknown; title?: unknown; mode?: unknown; sortField?: unknown; sortDir?: unknown; query?: unknown; groupBy?: unknown; columns?: unknown; filters?: unknown; tree?: unknown; wrap?: unknown; truncate?: unknown; pageSize?: unknown }): SavedView | null {
+  const id = String(row.viewId ?? '').trim()
+  if (!id || isReadOnlyViewId(id)) return null
+  return normalizeSavedView({
+    id,
+    name: String(row.title ?? id),
+    mode: String(row.mode ?? 'table') as SavedView['mode'],
+    sortField: String(row.sortField ?? 'id'),
+    sortDir: row.sortDir === 'desc' ? 'desc' : 'asc',
+    query: String(row.query ?? ''),
+    groupBy: String(row.groupBy ?? ''),
+    columns: Array.isArray(row.columns) ? row.columns.map((item) => String(item)) : [],
+    filters: parseViewFilters(row.filters),
+    tree: row.tree !== false,
+    wrap: Boolean(row.wrap),
+    truncate: row.truncate !== false,
+    pageSize: Number(row.pageSize) || 50,
+    builtin: false,
+  })
+}
+
+export async function pullSavedViews() {
+  try {
+    const page = await listCollection({ path: '/views', limit: 200, offset: 0 })
+    const byPath = new Map<string, SavedView[]>()
+    for (const row of page.items) {
+      const tablePath = String(row.tablePath ?? '').trim()
+      const view = savedViewFromRecord(row)
+      if (!tablePath || !view) continue
+      const list = byPath.get(tablePath) ?? []
+      list.push(view)
+      byPath.set(tablePath, list)
+    }
+    for (const [path, views] of byPath) {
+      rememberViews(path, views)
+      try {
+        localStorage.setItem(viewsKey(path), JSON.stringify(views))
+      } catch {
+        /* ignore */
+      }
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 export function upsertSavedView(collectionPath: string, view: SavedView) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
前端在表里新建/改视图以前只写内存（`POST /api/db/saved-views`）和 localStorage，刷新或重启后 `/views` 里的记录和属性就没了。

现在用户视图落到 `.cordis/file-system.sqlite` 的 `saved_views` 表：创建、改模式/筛选/列、以及前端同步都会写盘。页面启动先从 `/views` 拉回，再把本地缓存补上去。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

