### PR TITLE
模型配置窗置顶，不被右侧边栏挡住

### DIFF
--- a/packages/cap-chat/src/web/model-config-dialog.test.ts
+++ b/packages/cap-chat/src/web/model-config-dialog.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('model config dialog stacking', () => {
+  it('portals above the inspector and composer dock', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './model-config-dialog.tsx'), 'utf8')
+    expect(src).toMatch(/createPortal/)
+    expect(src).toMatch(/document\.body/)
+    expect(src).toMatch(/z-\[240\]/)
+    expect(src).not.toMatch(/z-30/)
+  })
+})

--- a/packages/cap-chat/src/web/model-config-dialog.tsx
+++ b/packages/cap-chat/src/web/model-config-dialog.tsx
@@ -1,17 +1,20 @@
+import { createPortal } from 'react-dom'
 import { ChatConfig } from './config.tsx'
 
 /**
  * 遮罩 + 直接弹出主从面板（不再外套一层标题白盒）。
+ * 挂到 document.body，避免被 .chat-composer-dock（z-index:20）和右侧检查器（z-index:90）盖住。
  */
 export function ModelConfigDialog(props: { open: boolean; onClose: () => void }) {
   if (!props.open) return null
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-30 flex items-center justify-center bg-(--dsw-overlay) p-4"
+      className="fixed inset-0 z-[240] flex items-center justify-center bg-(--dsw-overlay) p-4"
       data-testid="model-config-dialog"
       onClick={props.onClose}
     >
       <ChatConfig onClose={props.onClose} />
-    </div>
+    </div>,
+    document.body,
   )
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
模型配置对话框原先挂在输入栏 `.chat-composer-dock` 里（`z-index: 20`），`fixed` 出不去这个层叠上下文，会被右侧检查器（约 `z-index: 90`）盖住。

改成 `createPortal` 到 `document.body`，遮罩用 `z-[240]`（高于检查器和品牌角 `200`，低于商店/slash）。

测试：`packages/cap-chat/src/web/model-config-dialog.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

