### PR TITLE
去掉 /pages 标签上的演示 enum

### DIFF
--- a/packages/cap-page/src/host/index.test.ts
+++ b/packages/cap-page/src/host/index.test.ts
@@ -59,6 +59,7 @@ test('page plugin stores markdown under .page and assets for images', async () =
   assert.equal(registered[0]?.view?.icon, 'document')
   const types = new Set(Object.values(registered[0]!.schema.fields).map((field) => field.type))
   for (const type of FIELD_TYPES) assert.equal(types.has(type), true, type)
+  assert.equal(registered[0]?.schema.fields.tags?.enum, undefined)
   assert.deepEqual(registered[0]?.records, { update: true, create: true, delete: true })
 
   const spec = registered[0]!
@@ -71,8 +72,9 @@ test('page plugin stores markdown under .page and assets for images', async () =
     title: '新页面',
     notes: '# 标题\n内容',
     cover: 'assets/hero.png',
-    tags: ['blue'],
+    tags: ['docs', 'wip'],
   }])
+  assert.deepEqual(created[0]?.tags, ['docs', 'wip'])
   assert.equal(created[0]?.title, '新页面')
   assert.equal(created[0]?.notes, '# 标题\n内容')
   assert.equal(created[0]?.cover, '/api/page/file/hero.png')

--- a/packages/cap-page/src/host/index.ts
+++ b/packages/cap-page/src/host/index.ts
@@ -5,8 +5,6 @@ import { PagesStore, STATUS, type WorkspaceFs } from './store.ts'
 
 export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
 
-const COLORS = ['red', 'orange', 'yellow', 'green', 'blue'] as const
-
 export function pagesCollection(store: PagesStore): CollectionSpec {
   return {
     id: 'pages',
@@ -46,7 +44,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
         count: { type: 'number', label: '计数', writable: true },
         enabled: { type: 'boolean', label: '启用', writable: true },
         status: { type: 'select', label: '状态', writable: true, enum: [...STATUS] },
-        tags: { type: 'multi-select', label: '标签', writable: true, enum: [...COLORS, 'prod', 'lab'] },
+        tags: { type: 'multi-select', label: '标签', writable: true },
         aliases: { type: 'string[]', label: '别名', writable: true },
         publishedAt: { type: 'datetime', label: '发布时间', writable: true },
         size: { type: 'number', label: '体积', writable: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/pages` 的 `tags` 被写成 `enum: red/orange/yellow/green/blue/prod/lab`，只是当年用来展示 multi-select 的演示选项，不是真的产品约束。UI 会把 `enum` 当成仅有可选项。

已去掉这段 enum，和 `/sessions`、`/tasks` 的标签一样自由填写。`status`（draft/live/archived）仍然是固定 select。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

