### PR TITLE
去掉会话 live/chat，模式只留标准和极简

### DIFF
--- a/packages/cap-chat/src/host/index.ts
+++ b/packages/cap-chat/src/host/index.ts
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { Service, type Context } from 'cordis'
 import type { ChatMessage } from './chat-types.ts'
-import { isAgentToolMode, type AgentToolMode } from '@biu/host-tools'
+import { isAgentToolMode, normalizeAgentMode, type AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
 import { probeLlmConnection } from '@biu/host-llm'
 import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl } from './model-catalog.ts'
@@ -22,7 +22,6 @@ import {
 import { estimateTokens } from '@biu/host-sessions'
 import { readArtifactFile } from '@biu/host-sessions/artifacts'
 import { collectLiveDispatchedTasks } from '@biu/host-live-sessions/usage'
-import { normalizeSessionType } from '@biu/type-session'
 import { loadLiveDispatchTasks, registerChatInspectorRoutes } from './inspector.ts'
 
 export type { ChatMessage }
@@ -136,7 +135,7 @@ function writePersisted(config: ChatConfig) {
 }
 
 function parseAgentMode(value: unknown, fallback: AgentToolMode): AgentToolMode {
-  return isAgentToolMode(value) ? value : fallback
+  return normalizeAgentMode(value, fallback)
 }
 
 function parseProvider(value: unknown): ChatProvider | null {
@@ -908,18 +907,14 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/sessions', async (route) => {
     const payload = ((await route.json().catch(() => null)) ?? {}) as {
-      type?: string
       title?: string
     }
-    const type = payload?.type === 'live' ? 'live' : 'chat'
     const record = await ctx.sessions.create(undefined, {
-      type,
       ...(typeof payload.title === 'string' ? { title: payload.title } : {}),
     })
     route.send(201, {
       id: record.id,
       version: record.version,
-      type: record.type ?? type,
       title: record.config?.title,
       ...(record.mascot ? { mascot: record.mascot } : {}),
       ...(record.config ? { config: record.config } : {}),
@@ -974,7 +969,6 @@ export function apply(ctx: Context) {
         eventCount: item.eventCount,
         title: item.title,
         updatedAt: item.updatedAt,
-        type: item.type ?? 'chat',
         busy: ctx.agents.isBusy(item.id),
         ...(item.project ? { project: item.project } : {}),
         ...(item.mascot ? { mascot: item.mascot } : {}),
@@ -997,7 +991,6 @@ export function apply(ctx: Context) {
     const payload: Record<string, unknown> = {
       id: record.id,
       version: record.version,
-      type: record.type ?? 'chat',
       events: window.events,
       hasMore: window.hasMore,
       totalTurns: window.totalTurns,
@@ -1007,44 +1000,41 @@ export function apply(ctx: Context) {
       ...(record.project ? { project: record.project } : {}),
       ...(record.mascot ? { mascot: record.mascot } : {}),
     }
-    if ((record.type ?? 'chat') === 'live') {
-      const summaries = await ctx.sessions.listSummaries()
-      const workers = []
-      const titles = new Map<string, string>()
-      const mascots = new Map<string, NonNullable<(typeof summaries)[number]['mascot']>>()
-      const projects = new Map<string, { name: string; path?: string }>()
-      for (const item of summaries) {
-        titles.set(item.id, item.title)
-        if (item.mascot) mascots.set(item.id, item.mascot)
-        if (item.project?.name) {
-          projects.set(item.id, {
-            name: item.project.name,
-            ...(item.project.path ? { path: item.project.path } : {}),
-          })
-        }
-        if (item.id === record.id) continue
-        if (normalizeSessionType(item.type) === 'live') continue
-        const worker = await ctx.sessions.require(item.id)
-        workers.push({ id: item.id, events: worker.events })
+    const summaries = await ctx.sessions.listSummaries()
+    const workers = []
+    const titles = new Map<string, string>()
+    const mascots = new Map<string, NonNullable<(typeof summaries)[number]['mascot']>>()
+    const projects = new Map<string, { name: string; path?: string }>()
+    for (const item of summaries) {
+      titles.set(item.id, item.title)
+      if (item.mascot) mascots.set(item.id, item.mascot)
+      if (item.project?.name) {
+        projects.set(item.id, {
+          name: item.project.name,
+          ...(item.project.path ? { path: item.project.path } : {}),
+        })
       }
-      const liveTasks = await loadLiveDispatchTasks(ctx, record.id)
-      const dispatched = collectLiveDispatchedTasks(record.id, record.events, workers, liveTasks)
-      payload.dispatchedUsage = dispatched.total
-      payload.dispatchedUsageByTurn = Object.fromEntries(
-        Object.entries(dispatched.byLiveTurn).map(([key, value]) => [key, value.usage]),
-      )
-      payload.dispatchedTasksByTurn = Object.fromEntries(
-        Object.entries(dispatched.byLiveTurn).map(([key, value]) => [
-          key,
-          value.tasks.map((task) => ({
-            ...task,
-            title: titles.get(task.sessionId) ?? task.sessionId.slice(0, 8),
-            ...(mascots.get(task.sessionId) ? { mascot: mascots.get(task.sessionId) } : {}),
-            ...(projects.get(task.sessionId) ? { project: projects.get(task.sessionId) } : {}),
-          })),
-        ]),
-      )
+      if (item.id === record.id) continue
+      const worker = await ctx.sessions.require(item.id)
+      workers.push({ id: item.id, events: worker.events })
     }
+    const liveTasks = await loadLiveDispatchTasks(ctx, record.id)
+    const dispatched = collectLiveDispatchedTasks(record.id, record.events, workers, liveTasks)
+    payload.dispatchedUsage = dispatched.total
+    payload.dispatchedUsageByTurn = Object.fromEntries(
+      Object.entries(dispatched.byLiveTurn).map(([key, value]) => [key, value.usage]),
+    )
+    payload.dispatchedTasksByTurn = Object.fromEntries(
+      Object.entries(dispatched.byLiveTurn).map(([key, value]) => [
+        key,
+        value.tasks.map((task) => ({
+          ...task,
+          title: titles.get(task.sessionId) ?? task.sessionId.slice(0, 8),
+          ...(mascots.get(task.sessionId) ? { mascot: mascots.get(task.sessionId) } : {}),
+          ...(projects.get(task.sessionId) ? { project: projects.get(task.sessionId) } : {}),
+        })),
+      ]),
+    )
     route.send(200, payload)
   })
   ctx.http.route('GET', '/api/sessions/:id/events', async (route) => {
@@ -1211,7 +1201,6 @@ export function apply(ctx: Context) {
         id: child.id,
         version: child.version,
         parentId: route.params.id,
-        type: child.type ?? 'chat',
         ...(child.mascot ? { mascot: child.mascot } : {}),
       })
     } catch (error) {

--- a/packages/cap-chat/src/host/inspector.test.ts
+++ b/packages/cap-chat/src/host/inspector.test.ts
@@ -11,12 +11,11 @@ test('toolSourceOf tags minimal / live / plugin / store', () => {
   assert.equal(toolSourceOf('gomoku_move', 'store'), 'store')
 })
 
-test('minimal live session unlocks live tools; pinned extras unlock built-in plugins', () => {
+test('minimal unlocks extras; standard includes store tools', () => {
   assert.equal(
     isToolActiveForSession({
       name: 'bash',
       mode: 'minimal',
-      sessionType: 'chat',
       pinnedExtras: [],
     }),
     true,
@@ -25,7 +24,6 @@ test('minimal live session unlocks live tools; pinned extras unlock built-in plu
     isToolActiveForSession({
       name: 'db_action',
       mode: 'minimal',
-      sessionType: 'chat',
       pinnedExtras: [],
     }),
     false,
@@ -34,8 +32,7 @@ test('minimal live session unlocks live tools; pinned extras unlock built-in plu
     isToolActiveForSession({
       name: 'db_action',
       mode: 'minimal',
-      sessionType: 'live',
-      pinnedExtras: [],
+      pinnedExtras: ['db_action'],
     }),
     true,
   )
@@ -43,7 +40,6 @@ test('minimal live session unlocks live tools; pinned extras unlock built-in plu
     isToolActiveForSession({
       name: 'fs_read',
       mode: 'minimal',
-      sessionType: 'chat',
       pinnedExtras: ['fs_read'],
     }),
     true,
@@ -52,21 +48,19 @@ test('minimal live session unlocks live tools; pinned extras unlock built-in plu
     isToolActiveForSession({
       name: 'gomoku_move',
       mode: 'standard',
-      sessionType: 'chat',
-      pinnedExtras: ['gomoku_move'],
-      origin: 'store',
-    }),
-    false,
-  )
-  assert.equal(
-    isToolActiveForSession({
-      name: 'gomoku_move',
-      mode: 'create',
-      sessionType: 'chat',
       pinnedExtras: [],
       origin: 'store',
     }),
     true,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'gomoku_move',
+      mode: 'minimal',
+      pinnedExtras: [],
+      origin: 'store',
+    }),
+    false,
   )
 })
 
@@ -78,12 +72,11 @@ test('buildInspectorTools marks configurable plugin tools in minimal mode', () =
       { name: 'fs_read', description: 'read file' },
       { name: 'gomoku_move', description: 'play', origin: 'store' },
     ],
-    { mode: 'minimal', sessionType: 'live', pinnedExtras: [] },
+    { mode: 'minimal', pinnedExtras: [] },
   )
   assert.equal(rows.find((row) => row.name === 'bash')?.active, true)
   assert.equal(rows.find((row) => row.name === 'bash')?.configurable, false)
-  assert.equal(rows.find((row) => row.name === 'db_action')?.active, true)
-  assert.equal(rows.find((row) => row.name === 'db_action')?.configurable, false)
+  assert.equal(rows.find((row) => row.name === 'db_action')?.active, false)
   assert.equal(rows.find((row) => row.name === 'fs_read')?.active, false)
   assert.equal(rows.find((row) => row.name === 'fs_read')?.configurable, true)
   assert.equal(rows.find((row) => row.name === 'gomoku_move')?.active, false)

--- a/packages/cap-chat/src/host/inspector.ts
+++ b/packages/cap-chat/src/host/inspector.ts
@@ -6,7 +6,7 @@ import {
   type DispatchedTask,
   type TaskDispatchSource,
 } from '@biu/host-live-sessions/usage'
-import { normalizeSessionType, type SessionEvent, type SessionType } from '@biu/type-session'
+import type { SessionEvent } from '@biu/type-session'
 
 export type ToolSourceId = 'minimal' | 'live' | 'plugin' | 'store'
 
@@ -33,17 +33,17 @@ const SOURCE_INFO: InspectorSourceInfo[] = [
   {
     id: 'live',
     label: 'Live 调度',
-    description: '仅 live session 回合自动解锁的指挥工具。',
+    description: '数据库读写与动作工具。',
   },
   {
     id: 'plugin',
     label: '插件注册',
-    description: '内置 seams 工具；标准与创造模式全开，极简需勾选常驻或 slash 临时放开。',
+    description: '内置 seams 工具；标准模式全开，极简需勾选常驻或 slash 临时放开。',
   },
   {
     id: 'store',
     label: '商店插件',
-    description: '已安装商店插件注册的工具，仅创造模式可调用。',
+    description: '已安装商店插件注册的工具，标准模式可调用。',
   },
 ]
 
@@ -57,23 +57,18 @@ export function toolSourceOf(name: string, origin?: 'core' | 'store'): ToolSourc
 export function isToolActiveForSession(opts: {
   name: string
   mode: AgentToolMode
-  sessionType: SessionType
   pinnedExtras: readonly string[]
   origin?: 'core' | 'store'
 }): boolean {
-  if (opts.mode === 'create') return true
-  if (opts.origin === 'store' || toolSourceOf(opts.name, opts.origin) === 'store') return false
   if (opts.mode === 'standard') return true
+  if (opts.origin === 'store' || toolSourceOf(opts.name, opts.origin) === 'store') return false
   if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(opts.name)) return true
-  if (opts.sessionType === 'live' && (LIVE_TOOL_NAMES as readonly string[]).includes(opts.name)) {
-    return true
-  }
   return opts.pinnedExtras.includes(opts.name)
 }
 
 export function buildInspectorTools(
   catalog: Array<{ name: string; description: string; origin?: 'core' | 'store' }>,
-  opts: { mode: AgentToolMode; sessionType: SessionType; pinnedExtras: readonly string[] },
+  opts: { mode: AgentToolMode; pinnedExtras: readonly string[] },
 ): InspectorToolRow[] {
   return catalog
     .map((item) => {
@@ -85,7 +80,6 @@ export function buildInspectorTools(
         active: isToolActiveForSession({
           name: item.name,
           mode: opts.mode,
-          sessionType: opts.sessionType,
           pinnedExtras: opts.pinnedExtras,
           origin: item.origin,
         }),
@@ -104,20 +98,17 @@ export function registerChatInspectorRoutes(ctx: Context) {
     const id = route.params.id
     const record = await ctx.sessions.get(id)
     if (!record) return route.send(404, { error: 'unknown session' })
-    const sessionType = normalizeSessionType(record.type)
     const resolved = ctx.chat.resolveEffective(id)
     const rawMode = resolved.effective.agentMode
-    const mode: AgentToolMode =
-      rawMode === 'minimal' || rawMode === 'create' ? rawMode : 'standard'
+    const mode: AgentToolMode = rawMode === 'minimal' ? 'minimal' : 'standard'
     const pinnedExtras = Array.isArray(resolved.effective.extraTools) ? resolved.effective.extraTools : []
-    const tools = buildInspectorTools(ctx.tools.catalog(), { mode, sessionType, pinnedExtras })
+    const tools = buildInspectorTools(ctx.tools.catalog(), { mode, pinnedExtras })
     const title =
       'title' in resolved.effective && typeof resolved.effective.title === 'string'
         ? resolved.effective.title
         : record.config?.title ?? null
     const body: Record<string, unknown> = {
       sessionId: id,
-      type: sessionType,
       title,
       agentMode: mode,
       extraTools: pinnedExtras,
@@ -127,20 +118,18 @@ export function registerChatInspectorRoutes(ctx: Context) {
       sources: SOURCE_INFO,
       tools,
     }
-    if (sessionType === 'live') {
-      const dispatched = await loadDispatchedUsage(ctx, id, record.events)
-      const { titles, mascots, projects } = await sessionDecorations(ctx)
-      body.dispatchedUsage = dispatched.total
-      body.dispatchedUsageByTurn = Object.fromEntries(
-        Object.entries(dispatched.byLiveTurn).map(([key, value]) => [key, value.usage]),
-      )
-      body.dispatchedTasksByTurn = Object.fromEntries(
-        Object.entries(dispatched.byLiveTurn).map(([key, value]) => [
-          key,
-          value.tasks.map((task) => decorateTask(task, titles, mascots, projects)),
-        ]),
-      )
-    }
+    const dispatched = await loadDispatchedUsage(ctx, id, record.events)
+    const { titles, mascots, projects } = await sessionDecorations(ctx)
+    body.dispatchedUsage = dispatched.total
+    body.dispatchedUsageByTurn = Object.fromEntries(
+      Object.entries(dispatched.byLiveTurn).map(([key, value]) => [key, value.usage]),
+    )
+    body.dispatchedTasksByTurn = Object.fromEntries(
+      Object.entries(dispatched.byLiveTurn).map(([key, value]) => [
+        key,
+        value.tasks.map((task) => decorateTask(task, titles, mascots, projects)),
+      ]),
+    )
     route.send(200, body)
   })
 
@@ -148,14 +137,6 @@ export function registerChatInspectorRoutes(ctx: Context) {
     const id = route.params.id
     const record = await ctx.sessions.get(id)
     if (!record) return route.send(404, { error: 'unknown session' })
-    if (normalizeSessionType(record.type) !== 'live') {
-      return route.send(200, {
-        sessionId: id,
-        dispatchedUsage: null,
-        dispatchedUsageByTurn: {},
-        dispatchedTasksByTurn: {},
-      })
-    }
     const dispatched = await loadDispatchedUsage(ctx, id, record.events)
     const { titles, mascots, projects } = await sessionDecorations(ctx)
     const tasksByTurn: Record<string, Array<Record<string, unknown>>> = {}
@@ -231,7 +212,6 @@ async function loadDispatchedUsage(
   const workers: Array<{ id: string; events: SessionEvent[] }> = []
   for (const item of summaries) {
     if (item.id === liveId) continue
-    if (normalizeSessionType(item.type) === 'live') continue
     const worker = await ctx.sessions.require(item.id)
     workers.push({ id: item.id, events: worker.events })
   }

--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -6,7 +6,6 @@ import {
   ExclamationCircleIcon,
   PaintBrushIcon,
   PauseIcon,
-  SparklesIcon,
   Squares2X2Icon,
 } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/web-slots'
@@ -14,10 +13,10 @@ import { bindSessionView, type ChatNode, type DispatchedTaskRow, type SessionVie
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import { SessionProjectPanel } from './project-panel.tsx'
 
-type AgentMode = 'minimal' | 'standard' | 'create'
+type AgentMode = 'minimal' | 'standard'
 
 function parseAgentMode(value: unknown): AgentMode {
-  return value === 'minimal' || value === 'create' ? value : 'standard'
+  return value === 'minimal' ? 'minimal' : 'standard'
 }
 
 /** 最新一条回复里，上下文（更早 turn）占发给模型的输入文字的比例（0..1）。 */
@@ -373,13 +372,7 @@ export function ApprovalsRail(props: SlotProps) {
                 id: 'standard',
                 label: '标准',
                 icon: <Squares2X2Icon className="size-4" aria-hidden />,
-                hint: '内置 Agent 工具全开（读文件、任务、MCP 等），不含商店插件。',
-              },
-              {
-                id: 'create',
-                label: '创造',
-                icon: <SparklesIcon className="size-4" aria-hidden />,
-                hint: '在标准之上，允许调用已安装的商店插件工具。',
+                hint: '内置 Agent 工具和已安装商店插件全开。',
               },
             ]}
           />

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -1,10 +1,8 @@
 import { Service, type Context } from 'cordis'
 import type { AssistantReply, ChatOptions, LlmClient, LlmConfig, LlmMessage, LlmUsage } from '@biu/host-llm'
-import { normalizeSessionType } from '@biu/type-session'
 import { runWithSession } from '@biu/host-sessions/scope'
 import { applyContextBudget } from '@biu/host-sessions'
 import { runWithToolPolicy, type AgentToolMode } from '@biu/host-tools'
-import { LIVE_TOOL_NAMES } from '@biu/host-live-sessions'
 
 /** 工具结果写入事件日志( tool/result )时统一上限字符数；超长裁剪，避免上下文被单次工具输出撑爆。 */
 export const MAX_TOOL_RESULT_CHARS = 16_000
@@ -26,7 +24,6 @@ export class AgentLoop implements AgentRunner {
     let extras = [
       ...new Set(claimed.flatMap((item) => item.extraTools ?? []).map((name) => name.trim()).filter(Boolean)),
     ]
-    const peek = this.ctx.sessions.peek(this.sessionId)
     const chat = this.ctx.get('chat') as
       | {
           resolveEffective?: (id?: string | null) => {
@@ -44,13 +41,8 @@ export class AgentLoop implements AgentRunner {
         if (!extras.includes(name)) extras.push(name)
       }
     }
-    // 极简是底座；Slash / Live 增量放开。商店插件仅创造模式可见。
-    if (normalizeSessionType(peek?.type) === 'live') {
-      for (const name of LIVE_TOOL_NAMES) {
-        if (!extras.includes(name)) extras.push(name)
-      }
-    }
-    if (mode !== 'create') {
+    // 极简是底座；Slash 增量放开。商店插件跟标准模式一起可见。
+    if (mode === 'minimal') {
       extras = extras.filter((name) => this.ctx.tools.originOf(name) !== 'store')
     }
     return runWithSession(this.sessionId, () =>

--- a/packages/host-live-sessions/src/host/index.test.ts
+++ b/packages/host-live-sessions/src/host/index.test.ts
@@ -34,7 +34,7 @@ test('live plugin no longer registers session_* tools', async () => {
   ])
 })
 
-test('live session turn unlocks db_* tools on top of minimal mode', async () => {
+test('session turn follows tool mode and does not special-case a live type', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'memory' })
   await ctx.plugin(sessions)
@@ -60,7 +60,7 @@ test('live session turn unlocks db_* tools on top of minimal mode', async () => 
   ctx.tools.setMode('minimal')
   assert.deepEqual(ctx.tools.names().sort(), ['bash'])
 
-  const live = await ctx.sessions.create(undefined, { type: 'live' })
+  const session = await ctx.sessions.create()
   let seen: string[] = []
   const { AgentLoop } = await import('@biu/host-agent-loop')
   const loop = new AgentLoop(
@@ -71,7 +71,7 @@ test('live session turn unlocks db_* tools on top of minimal mode', async () => 
         return { content: 'ok', toolCalls: [], usage: { inputTokens: 1, outputTokens: 1 } }
       },
     },
-    live.id,
+    session.id,
     new AbortController().signal,
   )
   await loop.run([{ kind: 'wake', text: 'list sessions' }])

--- a/packages/host-live-sessions/src/host/index.ts
+++ b/packages/host-live-sessions/src/host/index.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'cordis'
-import { currentSessionId } from '@biu/host-sessions/scope'
-import { normalizeSessionType, type SessionEvent, type SessionType } from '@biu/type-session'
+import type { SessionEvent } from '@biu/type-session'
 
 export const LIVE_TOOL_NAMES = [
   'db_list',
@@ -13,15 +12,8 @@ export const LIVE_TOOL_NAMES = [
   'db_content',
 ] as const
 
-const LIVE_PROMPT = `你是 Live 指挥席（文字版）：调度其他 chat session，而不是亲自改代码或跑长任务。
-工作流：用 db_list /sessions 和 db_action action=inspect / progress 了解现场；新建用 db_create /sessions（records 数组），改标题/置顶/标签/模型/项目路径用 db_update。上下文压缩用 db_action action=compact / clear / retrieve / status。派工必须走任务体系：db_create /tasks（records 数组）、db_update 指派 assigneeSessionId、db_action action=deliver 派发、action=report 上报；不要直接 dispatch。废弃会话用 db_delete path=/sessions ids=[id]。
-异步派工后不要等待对方完成：完成态在目标 session 自己的 turn 里，需要时再 inspect / progress。
-向用户汇报要克制：只在关键节点、明显卡住、或用户追问时说明，不要刷屏。
-回答简洁：说明调度了谁、当前状态、下一步。`
-
 export interface SessionProgressSnapshot {
   sessionId: string
-  type: SessionType
   status: 'idle' | 'running'
   turn: number | null
   step: number | null
@@ -41,7 +33,7 @@ export interface SessionProgressSnapshot {
 export function buildSessionProgress(
   events: SessionEvent[],
   opts: { afterSeq?: number; textLimit?: number; busy?: boolean; inboxPending?: number } = {},
-): Omit<SessionProgressSnapshot, 'sessionId' | 'type'> {
+): Omit<SessionProgressSnapshot, 'sessionId'> {
   const textLimit = Math.min(2000, Math.max(80, opts.textLimit ?? 600))
   const afterSeq =
     opts.afterSeq == null || !Number.isFinite(opts.afterSeq) ? undefined : opts.afterSeq
@@ -128,12 +120,4 @@ export function buildSessionProgress(
 export const name = 'live-sessions'
 export const inject = ['tools', 'sessions', 'agents', 'systemPrompt']
 
-export function apply(ctx: Context) {
-  ctx.systemPrompt.register('live.persona', () => {
-    const sessionId = currentSessionId()
-    if (!sessionId) return ''
-    const type = normalizeSessionType(ctx.sessions.peek(sessionId)?.type)
-    return type === 'live' ? LIVE_PROMPT : ''
-  })
-
-}
+export function apply(_ctx: Context) {}

--- a/packages/host-session-store/src/host/index.ts
+++ b/packages/host-session-store/src/host/index.ts
@@ -4,7 +4,6 @@ import {
   type SessionRecord,
   type SessionStore,
   type SessionSummary,
-  normalizeSessionType,
   sessionDisplayTitle,
 } from '@biu/type-session'
 
@@ -15,7 +14,6 @@ function toSummary(record: SessionRecord, updatedAt?: number): SessionSummary {
     eventCount: record.events.length,
     title: sessionDisplayTitle(record),
     updatedAt: updatedAt ?? record.events.at(-1)?.ts ?? 0,
-    type: normalizeSessionType(record.type),
     ...(record.project ? { project: record.project } : {}),
     ...(record.mascot ? { mascot: record.mascot } : {}),
     ...(record.config ? { config: record.config } : {}),

--- a/packages/host-session-store/src/host/sqlite-session-store.ts
+++ b/packages/host-session-store/src/host/sqlite-session-store.ts
@@ -9,11 +9,9 @@ import {
   type SessionRecord,
   type SessionStore,
   type SessionSummary,
-  type SessionType,
   type SessionConfig,
   nameFromSessionMascot,
   normalizeSessionConfig,
-  normalizeSessionType,
   sessionDisplayTitle,
 } from '@biu/type-session'
 import { isSessionMascot, parseSessionMascot } from '@biu/host-sessions/mascot'
@@ -124,12 +122,10 @@ export class SqliteSessionStore implements SessionStore {
     const project = parseProject(row.project_json)
     const mascot = parseMascot(row.mascot_json)
     const config = parseConfig(row.config_json)
-    const type = normalizeSessionType(row.type) as SessionType
     return {
       id: row.id,
       version: row.version,
       events,
-      type,
       ...(project ? { project } : {}),
       ...(mascot ? { mascot } : {}),
       ...(config ? { config } : {}),
@@ -145,7 +141,6 @@ export class SqliteSessionStore implements SessionStore {
     const projectJson = record.project ? JSON.stringify(record.project) : null
     const mascotJson = record.mascot ? JSON.stringify(record.mascot) : null
     const configJson = record.config ? JSON.stringify(record.config) : null
-    const type = normalizeSessionType(record.type)
     const eventCount = record.events.length
 
     const insertEvent = this.db.prepare(
@@ -192,7 +187,7 @@ export class SqliteSessionStore implements SessionStore {
         projectJson,
         mascotJson,
         configJson,
-        type,
+        'chat',
         eventCount,
         title,
         updatedAt,
@@ -256,7 +251,6 @@ export class SqliteSessionStore implements SessionStore {
               ? nameFromSessionMascot(mascot)
               : row.title || row.id.slice(0, 8),
         updatedAt: row.updated_at,
-        type: normalizeSessionType(row.type),
         ...(project ? { project } : {}),
         ...(mascot ? { mascot } : {}),
         ...(config ? { config } : {}),

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -11,13 +11,11 @@ import {
   type SessionMascot,
   type SessionProject,
   type SessionRecord,
-  type SessionType,
   type SessionConfig,
   type MessageSender,
   nameFromSessionMascot,
   mergeSessionConfig,
   normalizeSessionConfig,
-  normalizeSessionType,
   isSessionCompactPoint,
   sessionCompactSummaryText,
 } from '@biu/type-session'
@@ -31,8 +29,8 @@ import {
 import { rebuildHealedEvents } from './session-heal.ts'
 import { sessionsCollection } from './sessions-collection.ts'
 
-export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord, SessionMascot, SessionType, SessionConfig }
-export { SESSION_FORMAT_VERSION, normalizeSessionType, normalizeSessionConfig, mergeSessionConfig }
+export type { SessionEvent, SessionEventBody, SessionProject, SessionRecord, SessionMascot, SessionConfig }
+export { SESSION_FORMAT_VERSION, normalizeSessionConfig, mergeSessionConfig }
 export {
   findOpenTurnStep,
   healInterruptedTurnBodies,
@@ -301,11 +299,10 @@ export class SessionsService extends Service {
 
   async create(
     id: string = crypto.randomUUID(),
-    opts: { type?: SessionType; title?: string; config?: SessionConfig } = {},
+    opts: { title?: string; config?: SessionConfig } = {},
   ) {
     const used = await this.collectUsedMascots()
     const mascot = pickSessionMascot(id, used)
-    const type = normalizeSessionType(opts.type)
     const title = opts.title?.trim() || nameFromSessionMascot(mascot)
     const seeded = normalizeSessionConfig({
       ...(opts.config ?? {}),
@@ -316,7 +313,6 @@ export class SessionsService extends Service {
       version: SESSION_FORMAT_VERSION,
       events: [{ type: 'session/open', version: SESSION_FORMAT_VERSION, seq: 0, ts: Date.now() }],
       mascot,
-      type,
       ...(seeded ? { config: seeded } : {}),
     }
     await this.persist(record)
@@ -447,7 +443,6 @@ export class SessionsService extends Service {
       events: source.events.map((event) => ({ ...event })),
       ...(source.project ? { project: { ...source.project } } : {}),
       mascot,
-      type: normalizeSessionType(source.type),
       config: normalizeSessionConfig({
         ...(source.config ?? {}),
         title: nameFromSessionMascot(mascot),
@@ -500,17 +495,6 @@ export class SessionsService extends Service {
           await this.persist(record)
           next = { ...next, mascot: ensured }
         }
-      }
-      const type = normalizeSessionType(next.type)
-      if (next.type !== type) {
-        const record = await this.require(item.id)
-        if (normalizeSessionType(record.type) !== type) {
-          record.type = type
-          await this.persist(record)
-        }
-        next = { ...next, type }
-      } else {
-        next = { ...next, type }
       }
       if (next.mascot && next.title === item.id.slice(0, 8)) {
         next = { ...next, title: nameFromSessionMascot(next.mascot) }

--- a/packages/host-sessions/src/host/sessions-collection.test.ts
+++ b/packages/host-sessions/src/host/sessions-collection.test.ts
@@ -12,7 +12,6 @@ test('sessionsCollection maps summaries and writes title/pinned/tags', async () 
         eventCount: 3,
         title: 'hello',
         updatedAt: 100,
-        type: 'chat',
         mascot: { shape: 'pebble', color: 'orange', eye: 1 },
         config: { pinned: false, tags: ['a'] },
       },

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -3,7 +3,6 @@ import { recordBuiltinValues, REQUIRED_RECORD_FIELDS, normalizeSchemaValue } fro
 import {
   isSessionCompactPoint,
   nameFromSessionMascot,
-  normalizeSessionType,
   type SessionConfig,
   type SessionEvent,
   type SessionSummary,
@@ -13,7 +12,6 @@ import { GROK_COLORS, GROK_SHAPES, ensureSessionMascot, isSessionMascot, mascotF
 
 type SessionRecordLike = {
   id: string
-  type?: string
   events: SessionEvent[]
   config?: SessionConfig | null
   project?: { path?: string; name?: string } | null
@@ -24,7 +22,7 @@ type SessionsLike = {
   rename: (id: string, title: string) => Promise<unknown>
   patchConfig: (id: string, patch: SessionConfig) => Promise<unknown>
   delete: (id: string) => Promise<boolean>
-  create?: (opts?: { type?: string; title?: string; config?: SessionConfig }) => Promise<{ id: string }>
+  create?: (opts?: { title?: string; config?: SessionConfig }) => Promise<{ id: string }>
   require?: (id: string) => Promise<SessionRecordLike>
   setProject?: (id: string, project: { path: string } | null) => Promise<unknown>
   isBusy?: (id: string) => boolean
@@ -37,7 +35,6 @@ function asRecord(row: SessionSummary): DbRecord {
   return {
     id: row.id,
     title: row.title,
-    type: row.type ?? 'chat',
     pinned: Boolean(row.config?.pinned),
     tags: Array.isArray(row.config?.tags) ? row.config.tags.map(String) : [],
     eventCount: row.eventCount,
@@ -143,11 +140,10 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
     records: { update: true, create: Boolean(sessions.create), delete: true },
     schema: {
       labelField: 'title',
-      columns: ['title', 'type', 'pinned', 'tags', 'eventCount', 'project', 'updatedAt'],
+      columns: ['title', 'pinned', 'tags', 'eventCount', 'project', 'updatedAt'],
       fields: {
         ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题', writable: true },
-        type: { type: 'select', label: '类型', enum: ['chat', 'live'] },
         pinned: { type: 'boolean', label: '置顶', writable: true },
         tags: { type: 'multi-select', label: '标签', writable: true },
         eventCount: { type: 'number', label: '事件数', computed: true, sortable: true },
@@ -156,7 +152,7 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
         model: { type: 'string', label: '模型', writable: true },
         provider: { type: 'select', label: '服务商', enum: ['deepseek', 'openai', 'anthropic'], writable: true },
         systemPrompt: { type: 'string', label: '系统提示', writable: true },
-        agentMode: { type: 'select', label: '模式', enum: ['standard', 'minimal', 'create'], writable: true },
+        agentMode: { type: 'select', label: '模式', enum: ['standard', 'minimal'], writable: true },
         extraTools: { type: 'multi-select', label: '额外工具', writable: true },
         updatedAt: { type: 'datetime', label: '更新时间', sortable: true },
         mascotName: { type: 'string', label: '形象', computed: true },
@@ -180,9 +176,8 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
         config.provider = patch.provider
       }
       if (typeof patch.systemPrompt === 'string') config.systemPrompt = patch.systemPrompt
-      if (patch.agentMode === 'standard' || patch.agentMode === 'minimal' || patch.agentMode === 'create') {
-        config.agentMode = patch.agentMode
-      }
+      if (patch.agentMode === 'minimal') config.agentMode = 'minimal'
+      if (patch.agentMode === 'standard' || patch.agentMode === 'create') config.agentMode = 'standard'
       if (Array.isArray(patch.extraTools)) config.extraTools = patch.extraTools.map((item) => String(item))
       if (Object.keys(config).length) await sessions.patchConfig(id, config)
       if ('projectPath' in patch && sessions.setProject) {
@@ -199,7 +194,6 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
           for (const fields of rows) {
             const rec = await sessions.create!({
               ...(typeof fields.title === 'string' ? { title: fields.title } : {}),
-              ...(fields.type === 'live' || fields.type === 'chat' ? { type: String(fields.type) } : {}),
             })
             const next = (await list()).find((row) => row.id === rec.id)
             if (!next) throw new Error(`unknown session: ${rec.id}`)
@@ -230,7 +224,6 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
           const limit = Math.min(40, Math.max(1, Number(args?.limit) || 12))
           return {
             id: record.id,
-            type: normalizeSessionType(record.type),
             status: sessions.isBusy?.(id) ? 'running' : 'idle',
             title: record.config?.title,
             config: record.config ?? null,
@@ -258,7 +251,6 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
           const record = await sessions.require(id)
           return {
             sessionId: record.id,
-            type: normalizeSessionType(record.type),
             ...sessionProgress(record, {
               afterSeq: args?.afterSeq == null ? undefined : Number(args.afterSeq),
               textLimit: args?.textLimit == null ? undefined : Number(args.textLimit),

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -218,34 +218,34 @@ test('delete removes session from store and cache', async () => {
   assert.equal(await ctx.sessions.delete(record.id), false)
 })
 
-test('create/listSummaries/fork preserve session type', async () => {
+test('create/listSummaries/fork round-trip without a session type field', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'memory' })
   await ctx.plugin(sessions)
   const chat = await ctx.sessions.create()
-  const live = await ctx.sessions.create(undefined, { type: 'live' })
-  assert.equal(chat.type, 'chat')
-  assert.equal(live.type, 'live')
+  const other = await ctx.sessions.create()
+  assert.equal('type' in chat, false)
+  assert.equal('type' in other, false)
   const summaries = await ctx.sessions.listSummaries()
-  assert.equal(summaries.find((item) => item.id === live.id)?.type, 'live')
-  assert.equal(summaries.find((item) => item.id === chat.id)?.type, 'chat')
-  const forked = await ctx.sessions.fork(live.id)
-  assert.equal(forked.type, 'live')
+  assert.equal(summaries.every((item) => !('type' in item)), true)
+  const forked = await ctx.sessions.fork(other.id)
+  assert.equal('type' in forked, false)
 })
 
-test('sqlite persists session type across reopen', async () => {
+test('sqlite persists session records across reopen', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'cordis-type-'))
   const path = join(dir, 'sessions.sqlite')
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'sqlite', path })
   await ctx.plugin(sessions)
-  await ctx.sessions.create('live-sql', { type: 'live' })
+  await ctx.sessions.create('live-sql', { title: 'saved' })
   const ctx2 = new Context()
   await ctx2.plugin(sessionStore, { driver: 'sqlite', path })
   await ctx2.plugin(sessions)
   const loaded = await ctx2.sessions.get('live-sql')
-  assert.equal(loaded?.type, 'live')
-  assert.equal((await ctx2.sessions.listSummaries())[0]?.type, 'live')
+  assert.equal(loaded?.id, 'live-sql')
+  assert.equal('type' in (loaded ?? {}), false)
+  assert.equal((await ctx2.sessions.listSummaries())[0]?.id, 'live-sql')
 })
 
 

--- a/packages/host-tools/src/host/index.test.ts
+++ b/packages/host-tools/src/host/index.test.ts
@@ -97,7 +97,7 @@ test('catalog lists all tools; extraTools temporarily unlocks minimal', async ()
   await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in minimal mode/)
 })
 
-test('store tools only appear in create mode', async () => {
+test('store tools appear in standard mode', async () => {
   const ctx = new Context()
   await ctx.plugin(tools)
   ctx.tools.register({
@@ -115,10 +115,11 @@ test('store tools only appear in create mode', async () => {
     })
   })
   assert.equal(ctx.tools.originOf('store_ping'), 'store')
+  ctx.tools.setMode('minimal')
   assert.equal(ctx.tools.names().includes('store_ping'), false)
-  ctx.tools.setMode('create')
+  ctx.tools.setMode('standard')
   assert.equal(ctx.tools.names().includes('store_ping'), true)
   assert.equal(await ctx.tools.invoke('store_ping'), 'pong')
-  ctx.tools.setMode('standard')
-  await assert.rejects(() => ctx.tools.invoke('store_ping'), /not available in standard mode/)
+  ctx.tools.setMode('minimal')
+  await assert.rejects(() => ctx.tools.invoke('store_ping'), /not available in minimal mode/)
 })

--- a/packages/host-tools/src/host/index.ts
+++ b/packages/host-tools/src/host/index.ts
@@ -24,12 +24,18 @@ export interface ToolRequest {
 
 export type ToolGuard = (req: ToolRequest) => ToolRequest | Promise<ToolRequest>
 
-/** 极简=底座；标准=内置工具；创造=内置 + 商店插件。 */
-export const AGENT_TOOL_MODES = ['minimal', 'standard', 'create'] as const
+/** 极简=底座；标准=内置 + 商店插件。旧创造配置并入标准。 */
+export const AGENT_TOOL_MODES = ['minimal', 'standard'] as const
 export type AgentToolMode = (typeof AGENT_TOOL_MODES)[number]
 
 export function isAgentToolMode(value: unknown): value is AgentToolMode {
-  return value === 'minimal' || value === 'standard' || value === 'create'
+  return value === 'minimal' || value === 'standard'
+}
+
+export function normalizeAgentMode(value: unknown, fallback: AgentToolMode = 'standard'): AgentToolMode {
+  if (value === 'minimal') return 'minimal'
+  if (value === 'standard' || value === 'create') return 'standard'
+  return fallback
 }
 
 export const MINIMAL_TOOL_NAMES = ['bash', 'str_replace_editor'] as const
@@ -45,7 +51,7 @@ const toolPolicyStorage = new AsyncLocalStorage<{
 
 const toolOriginStorage = new AsyncLocalStorage<ToolOrigin>()
 
-/** 商店插件 apply 期间注册的工具标成 store，仅创造模式可见。 */
+/** 商店插件 apply 期间注册的工具标成 store，标准模式可见。 */
 export function runWithToolOrigin<T>(origin: ToolOrigin, fn: () => T): T {
   return toolOriginStorage.run(origin, fn)
 }
@@ -126,9 +132,8 @@ export class ToolsService extends Service {
   private visible(name: string) {
     const policy = toolPolicyStorage.getStore()
     const mode = policy?.mode ?? this.mode
-    if (mode === 'create') return true
-    if (this.originOf(name) === 'store') return false
     if (mode === 'standard') return true
+    if (this.originOf(name) === 'store') return false
     if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return true
     if ((policy?.extras ?? new Set()).has(name)) return true
     if (!policy && this.pinnedExtras.includes(name)) return true

--- a/packages/public-mascot/src/web/brand-mascot.tsx
+++ b/packages/public-mascot/src/web/brand-mascot.tsx
@@ -6,7 +6,6 @@ export type CornerAgent = {
   id: string
   title: string
   updatedAt?: number
-  type?: string
   mascot?: { shape: string; color: string; eye?: number }
 }
 
@@ -85,10 +84,7 @@ export function BrandAgentMenu({
               onClick={() => onSelect(item.id)}
             >
               <SidebarMascot size={24} sessionId={item.id} identity={face} animate={false} title={item.title} />
-              <span className="min-w-0 flex-1 truncate">
-                {(item.type ?? 'chat') === 'live' ? <span className="mr-1 text-[9px] font-semibold tracking-wide uppercase">live</span> : null}
-                {item.title}
-              </span>
+              <span className="min-w-0 flex-1 truncate">{item.title}</span>
             </button>
           )
         })

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -63,13 +63,6 @@ export interface SessionMascot {
   eye?: number
 }
 
-/** Session 用途：普通对话 vs Live 指挥席。缺省按 chat 处理。 */
-export type SessionType = 'chat' | 'live'
-
-export function normalizeSessionType(value: unknown): SessionType {
-  return value === 'live' ? 'live' : 'chat'
-}
-
 /** 会话级覆盖配置；未设字段回落到全局 chat-config。 */
 export interface SessionConfig {
   /** 侧栏显示名；未设则仍用最近 user/message 推导 */
@@ -77,7 +70,7 @@ export interface SessionConfig {
   provider?: 'deepseek' | 'openai' | 'anthropic'
   model?: string
   systemPrompt?: string
-  agentMode?: 'standard' | 'minimal' | 'create'
+  agentMode?: 'standard' | 'minimal'
   /** 极简模式下常驻额外工具 */
   extraTools?: string[]
   /** 侧栏标签；一条会话可属于多个标签组 */
@@ -99,7 +92,8 @@ export function normalizeSessionConfig(value: unknown): SessionConfig | undefine
   if (raw.provider === 'deepseek' || raw.provider === 'openai' || raw.provider === 'anthropic') next.provider = raw.provider
   if (typeof raw.model === 'string' && raw.model.trim()) next.model = raw.model.trim()
   if (typeof raw.systemPrompt === 'string') next.systemPrompt = raw.systemPrompt
-  if (raw.agentMode === 'standard' || raw.agentMode === 'minimal' || raw.agentMode === 'create') next.agentMode = raw.agentMode
+  if (raw.agentMode === 'minimal') next.agentMode = 'minimal'
+  if (raw.agentMode === 'standard' || raw.agentMode === 'create') next.agentMode = 'standard'
   if (Array.isArray(raw.extraTools)) {
     next.extraTools = [...new Set(raw.extraTools.map((name) => String(name).trim()).filter(Boolean))]
   }
@@ -141,7 +135,8 @@ export function mergeSessionConfig(
     if (patch.systemPrompt == null) delete next.systemPrompt
     else next.systemPrompt = String(patch.systemPrompt)
   }
-  if (patch.agentMode === 'standard' || patch.agentMode === 'minimal' || patch.agentMode === 'create') next.agentMode = patch.agentMode
+  if (patch.agentMode === 'minimal') next.agentMode = 'minimal'
+  if (patch.agentMode === 'standard' || patch.agentMode === 'create') next.agentMode = 'standard'
   if (Array.isArray(patch.extraTools)) {
     next.extraTools = [...new Set(patch.extraTools.map((name) => String(name).trim()).filter(Boolean))]
   }
@@ -174,7 +169,6 @@ export interface SessionRecord {
   events: SessionEvent[]
   project?: SessionProject
   mascot?: SessionMascot
-  type?: SessionType
   config?: SessionConfig
 }
 
@@ -187,7 +181,6 @@ export interface SessionSummary {
   updatedAt: number
   project?: SessionProject
   mascot?: SessionMascot
-  type?: SessionType
   config?: SessionConfig
 }
 

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -27,7 +27,6 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
   PlusIcon,
-  SignalIcon,
   StarIcon,
   FolderIcon,
   TagIcon,
@@ -106,11 +105,6 @@ const SessionRow = memo(function SessionRow({
         title={dancing ? '跳舞中 🎉' : `${identity.shape} · ${identity.color}`}
       />
       <span className="sidebar-label min-w-0 flex-1 truncate font-medium">
-        {(item.type ?? 'chat') === 'live' ? (
-          <span className="mr-1 text-[9px] font-semibold tracking-wide uppercase">
-            live
-          </span>
-        ) : null}
         {item.title}
       </span>
       <SessionTagBadges tags={item.tags} />
@@ -270,7 +264,7 @@ export const ChatSidebar = memo(function ChatSidebar({
   const highlightId = variant === 'popover' ? sessionId : routeSessionId
 
   const createChat = useCallback(
-    (opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) => {
+    (opts: { projectPath?: string } = {}) => {
       void sessionView.newSession(opts).then((id) => {
         onActivate?.()
         if (isChatPagePath(window.location.pathname)) {
@@ -332,24 +326,12 @@ export const ChatSidebar = memo(function ChatSidebar({
             className="app-side-actions-item"
             title="添加聊天"
             aria-label="添加聊天"
-            onClick={() => createChat({ type: 'chat' })}
+            onClick={() => createChat()}
           >
             <span className="app-side-actions-icon" aria-hidden>
               <PlusIcon {...chromeIcon} />
             </span>
             <span className="app-side-actions-label">添加聊天</span>
-          </button>
-          <button
-            type="button"
-            className="app-side-actions-item"
-            title="新建 Live"
-            aria-label="新建 Live"
-            onClick={() => createChat({ type: 'live' })}
-          >
-            <span className="app-side-actions-icon" aria-hidden>
-              <SignalIcon {...chromeIcon} />
-            </span>
-            <span className="app-side-actions-label">新建 Live</span>
           </button>
         </div>
 
@@ -476,7 +458,6 @@ export const ChatSidebar = memo(function ChatSidebar({
                                       onClick={(e) => {
                                         e.stopPropagation()
                                         createChat({
-                                          type: 'chat',
                                           ...(group.path ? { projectPath: group.path } : {}),
                                         })
                                       }}

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -87,7 +87,6 @@ export interface SessionListItem {
   title: string
   eventCount: number
   updatedAt: number
-  type?: 'chat' | 'live'
   /** host 列表快照：该 session 的 agent 是否在跑 */
   busy?: boolean
   project?: { name: string; path?: string; boundAt: number }
@@ -204,7 +203,6 @@ const empty: SessionViewState = {
 type SessionPayload = {
   id: string
   events: SessionEvent[]
-  type?: 'chat' | 'live'
   hasMore?: boolean
   totalTurns?: number
   totalEvents?: number
@@ -252,8 +250,7 @@ function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
       left.mascot?.eye !== right.mascot?.eye ||
       Boolean(left.busy) !== Boolean(right.busy) ||
       Boolean(left.pinned) !== Boolean(right.pinned) ||
-      (left.tags ?? []).join('\0') !== (right.tags ?? []).join('\0') ||
-      (left.type ?? 'chat') !== (right.type ?? 'chat')
+      (left.tags ?? []).join('\0') !== (right.tags ?? []).join('\0')
     ) {
       return false
     }
@@ -296,8 +293,6 @@ export class SessionViewService extends Service {
     this.stopDispatchedPoll()
     const id = this.value.sessionId
     if (!id) return
-    const type = this.value.sessions.find((item) => item.id === id)?.type ?? 'chat'
-    if (type !== 'live') return
     this.dispatchedPoll = setInterval(() => {
       void this.refreshDispatchedUsage()
     }, 2000)
@@ -643,12 +638,11 @@ export class SessionViewService extends Service {
     this.replace({ approvalMode: body.mode === 'hold' ? 'hold' : 'auto' })
   }
 
-  async newSession(opts: { type?: 'chat' | 'live'; projectPath?: string } = {}) {
-    const type = opts.type === 'live' ? 'live' : 'chat'
+  async newSession(opts: { projectPath?: string } = {}) {
     const res = await fetch('/api/sessions', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ type }),
+      body: JSON.stringify({}),
     })
     const body = (await res.json()) as { id?: string }
     if (!body.id) throw new Error('无法创建 session')
@@ -1125,7 +1119,6 @@ export class SessionViewService extends Service {
     const body = (await res.json()) as {
       id?: string
       error?: string
-      type?: SessionListItem['type']
       mascot?: SessionListItem['mascot']
     }
     if (!res.ok || !body.id) throw new Error(body.error || 'fork failed')
@@ -1139,7 +1132,6 @@ export class SessionViewService extends Service {
             id: body.id,
             pinned: false,
             tags: [],
-            type: body.type ?? parent.type,
             ...(body.mascot ? { mascot: body.mascot } : {}),
             updatedAt: Date.now(),
           },

--- a/packages/web-session-view/src/web/session-config-dialog.tsx
+++ b/packages/web-session-view/src/web/session-config-dialog.tsx
@@ -7,7 +7,7 @@ import {
 import { ChatOutlineFilterFields } from './chat-outline-fields.tsx'
 
 type ToolSourceId = 'minimal' | 'live' | 'plugin' | 'store'
-type AgentMode = 'standard' | 'minimal' | 'create'
+type AgentMode = 'standard' | 'minimal'
 type ChatProvider = 'deepseek' | 'openai'
 
 interface InspectorTool {
@@ -37,7 +37,6 @@ interface SessionConfigFields {
 
 interface InspectorPayload {
   sessionId: string
-  type: 'chat' | 'live'
   title?: string | null
   agentMode: AgentMode
   extraTools: string[]

--- a/packages/web-session-view/src/web/session-groups.test.ts
+++ b/packages/web-session-view/src/web/session-groups.test.ts
@@ -180,7 +180,7 @@ test('mostRecentSessionId prefers newest chat and ignores pin', () => {
     mostRecentSessionId([
       item({ id: 'old', updatedAt: 1, pinned: true }),
       item({ id: 'new', updatedAt: 9 }),
-      item({ id: 'live', updatedAt: 99, type: 'live' }),
+      item({ id: 'older', updatedAt: 2 }),
     ]),
     'new',
   )

--- a/packages/web-session-view/src/web/session-groups.ts
+++ b/packages/web-session-view/src/web/session-groups.ts
@@ -24,10 +24,8 @@ export function compareSessionRows(a: SessionListItem, b: SessionListItem) {
 
 /** 悬浮聊天用：按更新时间取最近一条对话（忽略置顶；优先普通 chat）。 */
 export function mostRecentSessionId(sessions: SessionListItem[]): string | undefined {
-  const chats = sessions.filter((item) => (item.type ?? 'chat') !== 'live')
-  const pool = chats.length ? chats : sessions
   let best: SessionListItem | undefined
-  for (const item of pool) {
+  for (const item of sessions) {
     if (
       !best ||
       item.updatedAt > best.updatedAt ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话表不再有 chat/live「类型」列，也不再按这个字段分流：

- 侧栏去掉 live 徽章和「新建 Live」
- 不再按类型自动解锁 db 工具、不再注入 Live 指挥席提示
- 旧库里的 type 列写入时一律忽略

Agent 模式只留 **标准** / **极简**。创造从菜单拿掉，历史 `create` 配置读成标准；标准模式下商店插件可用。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

