### PR TITLE
去掉视图「⋯」，点当前视图打开菜单

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -422,11 +422,9 @@ export function CollectionBrowser({
       const right = toolbarRightRef.current
       const row = viewMeasureRef.current
       if (!toolbar || !right || !row) return
-      const more = row.querySelector('[data-view-measure-more]')
       const tabs = [...row.querySelectorAll('[data-view-measure]')] as HTMLElement[]
       const available = Math.max(0, toolbar.clientWidth - right.offsetWidth - 12)
-      const moreWidth = more instanceof HTMLElement ? more.offsetWidth : 32
-      setViewTabFit(countFittingViewTabs(tabs.map((el) => el.offsetWidth), moreWidth, available, 2))
+      setViewTabFit(countFittingViewTabs(tabs.map((el) => el.offsetWidth), available, 2))
     }
     measure()
     const ro = new ResizeObserver(measure)
@@ -1876,42 +1874,40 @@ export function CollectionBrowser({
                     <span className="tasks-viewdd-name">{view.name}</span>
                   </button>
                 ))}
-                <button type="button" className="tasks-viewdd-btn tasks-viewdd-more" tabIndex={-1} data-view-measure-more>
-                  <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
-                </button>
               </div>
               <div className="tasks-viewtabs">
                 {(views.length ? splitVisibleViews(views, viewTabFit, activeViewId).shown : []).map((view) => (
                   <button
                     key={view.id}
                     type="button"
-                    className={`tasks-viewdd-btn tasks-viewtab${view.id === activeViewId ? ' is-active' : ''}`}
+                    className={`tasks-viewdd-btn tasks-viewtab${view.id === activeViewId ? ' is-active' : ''}${view.id === activeViewId && viewMenuOpen ? ' is-menu' : ''}`}
                     data-testid="fsdb-view-tab"
                     aria-pressed={view.id === activeViewId}
-                    onClick={() => selectView(view)}
+                    aria-haspopup={view.id === activeViewId ? 'menu' : undefined}
+                    aria-expanded={view.id === activeViewId ? viewMenuOpen : undefined}
+                    onClick={() => {
+                      if (view.id === activeViewId) toggleMenu('view')
+                      else selectView(view)
+                    }}
                   >
                     <ViewModeGlyph mode={view.mode} className="size-[14px]" />
                     <span className="tasks-viewdd-name">{view.name}</span>
                   </button>
                 ))}
                 {!views.length ? (
-                  <button type="button" className="tasks-viewdd-btn tasks-viewtab is-active" disabled>
+                  <button
+                    type="button"
+                    className={`tasks-viewdd-btn tasks-viewtab is-active${viewMenuOpen ? ' is-menu' : ''}`}
+                    aria-haspopup="menu"
+                    aria-expanded={viewMenuOpen}
+                    data-testid="fsdb-view-tab"
+                    onClick={() => toggleMenu('view')}
+                  >
                     <Squares2X2Icon aria-hidden className="size-[14px]" />
                     <span className="tasks-viewdd-name">未保存</span>
                   </button>
                 ) : null}
               </div>
-              <button
-                type="button"
-                className={`tasks-viewdd-btn tasks-viewdd-more${viewMenuOpen ? ' is-active' : ''}`}
-                aria-label="视图菜单"
-                aria-haspopup="menu"
-                aria-expanded={viewMenuOpen}
-                data-testid="fsdb-view-more"
-                onClick={() => toggleMenu('view')}
-              >
-                <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
-              </button>
               {viewMenuOpen ? (
                 <div className="tasks-viewdd-menu" role="menu">
                   <div className="tasks-viewdd-head">视图</div>

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -83,7 +83,6 @@ const CSS = `
 .fsdb-page .tasks-viewtabs-measure{position:absolute;left:0;top:0;visibility:hidden;pointer-events:none;display:flex;align-items:center;gap:2px;white-space:nowrap}
 .fsdb-page .tasks-viewdd-btn{display:inline-flex;align-items:center;gap:6px;border:0;border-radius:8px;padding:5px 9px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:650;cursor:pointer;flex:none}
 .fsdb-page .tasks-viewtab.is-active{background:var(--dsw-hover)}
-.fsdb-page .tasks-viewdd-more{padding:5px 6px}
 .fsdb-page .tasks-viewdd-btn:hover,.fsdb-page .tasks-viewdd-btn.is-active{background:var(--dsw-hover)}
 .fsdb-page .tasks-viewdd-name{max-width:160px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-page .tasks-viewdd-menu,.fsdb-page .tasks-sort-menu,.fsdb-page .tasks-filter-menu{position:absolute;top:calc(100% + 6px);z-index:40;min-width:180px;padding:8px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:4px}

--- a/packages/core-file-system/src/web/view-tabs.test.ts
+++ b/packages/core-file-system/src/web/view-tabs.test.ts
@@ -1,17 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { countFittingViewTabs, splitVisibleViews } from './view-tabs.ts'
 
 test('fits every tab when the strip is wide enough', () => {
-  assert.equal(countFittingViewTabs([80, 80, 80], 36, 400, 2), 3)
+  assert.equal(countFittingViewTabs([80, 80, 80], 400, 2), 3)
 })
 
-test('stops before colliding with the reserved more control', () => {
-  assert.equal(countFittingViewTabs([80, 80, 80, 80], 36, 220, 2), 2)
+test('stops before overflowing the toolbar', () => {
+  assert.equal(countFittingViewTabs([80, 80, 80, 80], 220, 2), 2)
 })
 
 test('keeps at least one tab even when space is tight', () => {
-  assert.equal(countFittingViewTabs([120, 120], 36, 80, 2), 1)
+  assert.equal(countFittingViewTabs([120, 120], 80, 2), 1)
+})
+
+test('active view tab opens the view menu; the more button is gone', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+  assert.match(src, /if \(view\.id === activeViewId\) toggleMenu\('view'\)/)
+  assert.doesNotMatch(src, /data-testid="fsdb-view-more"/)
+  assert.doesNotMatch(src, /tasks-viewdd-more/)
 })
 
 test('pins the active view into the last visible slot when it would overflow', () => {

--- a/packages/core-file-system/src/web/view-tabs.ts
+++ b/packages/core-file-system/src/web/view-tabs.ts
@@ -1,13 +1,12 @@
 export function countFittingViewTabs(
   tabWidths: number[],
-  moreWidth: number,
   available: number,
   gap: number,
 ): number {
   const n = tabWidths.length
   if (n === 0) return 0
   const widthOf = (count: number) => {
-    let w = moreWidth
+    let w = 0
     for (let i = 0; i < count; i++) w += tabWidths[i] + gap
     return w
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
工具栏不再单独放省略号按钮。点**当前选中的视图标签**弹出原来的视图菜单（列表、添加、拷贝）；点其它标签仍是切换视图。溢出时仍会收起标签，藏起来的视图从菜单里选。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

