### PR TITLE
清掉会话 type 列和界面 Live 字样

### DIFF
--- a/packages/cap-chat/src/host/inspector.test.ts
+++ b/packages/cap-chat/src/host/inspector.test.ts
@@ -2,11 +2,11 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 import { buildInspectorTools, isToolActiveForSession, toolSourceOf } from './inspector.ts'
 
-test('toolSourceOf tags minimal / live / plugin / store', () => {
+test('toolSourceOf tags minimal / db / plugin / store', () => {
   assert.equal(toolSourceOf('bash'), 'minimal')
   assert.equal(toolSourceOf('str_replace_editor'), 'minimal')
-  assert.equal(toolSourceOf('db_action'), 'live')
-  assert.equal(toolSourceOf('db_list'), 'live')
+  assert.equal(toolSourceOf('db_action'), 'db')
+  assert.equal(toolSourceOf('db_list'), 'db')
   assert.equal(toolSourceOf('fs_read'), 'plugin')
   assert.equal(toolSourceOf('gomoku_move', 'store'), 'store')
 })
@@ -81,4 +81,15 @@ test('buildInspectorTools marks configurable plugin tools in minimal mode', () =
   assert.equal(rows.find((row) => row.name === 'fs_read')?.configurable, true)
   assert.equal(rows.find((row) => row.name === 'gomoku_move')?.active, false)
   assert.equal(rows.find((row) => row.name === 'gomoku_move')?.configurable, false)
+})
+
+test('inspector tool sources do not use a live type', async () => {
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  const src = readFileSync(resolve(import.meta.dirname, './inspector.ts'), 'utf8')
+  const dialog = readFileSync(resolve(import.meta.dirname, '../../../web-session-view/src/web/session-config-dialog.tsx'), 'utf8')
+  assert.doesNotMatch(src, /Live 调度/)
+  assert.doesNotMatch(src, /id: 'live'/)
+  assert.match(src, /id: 'db'/)
+  assert.doesNotMatch(dialog, /'live'/)
 })

--- a/packages/cap-chat/src/host/inspector.ts
+++ b/packages/cap-chat/src/host/inspector.ts
@@ -8,7 +8,7 @@ import {
 } from '@biu/host-live-sessions/usage'
 import type { SessionEvent } from '@biu/type-session'
 
-export type ToolSourceId = 'minimal' | 'live' | 'plugin' | 'store'
+export type ToolSourceId = 'minimal' | 'db' | 'plugin' | 'store'
 
 export interface InspectorToolRow {
   name: string
@@ -31,8 +31,8 @@ const SOURCE_INFO: InspectorSourceInfo[] = [
     description: 'agentMode=minimal 时的底座工具（bash、str_replace_editor）。',
   },
   {
-    id: 'live',
-    label: 'Live 调度',
+    id: 'db',
+    label: '数据库',
     description: '数据库读写与动作工具。',
   },
   {
@@ -49,7 +49,7 @@ const SOURCE_INFO: InspectorSourceInfo[] = [
 
 export function toolSourceOf(name: string, origin?: 'core' | 'store'): ToolSourceId {
   if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return 'minimal'
-  if ((LIVE_TOOL_NAMES as readonly string[]).includes(name)) return 'live'
+  if ((LIVE_TOOL_NAMES as readonly string[]).includes(name)) return 'db'
   if (origin === 'store') return 'store'
   return 'plugin'
 }
@@ -87,7 +87,7 @@ export function buildInspectorTools(
       }
     })
     .sort((a, b) => {
-      const order = { minimal: 0, live: 1, plugin: 2, store: 3 } as const
+      const order = { minimal: 0, db: 1, plugin: 2, store: 3 } as const
       const diff = order[a.source] - order[b.source]
       return diff !== 0 ? diff : a.name.localeCompare(b.name)
     })

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -510,7 +510,7 @@ function UserSenderAvatar({
     return (
       <span
         className="grid size-[18px] shrink-0 place-items-center text-(--dsw-label-3)"
-        title={hit?.title || 'Live session'}
+        title={hit?.title || '会话'}
         data-testid="user-sender-mascot"
       >
         <StaticMascotMark identity={identity} size={16} title={hit?.title || identity.shape} />

--- a/packages/cap-chat/src/web/trajectory.tsx
+++ b/packages/cap-chat/src/web/trajectory.tsx
@@ -204,7 +204,7 @@ export const TrajectoryView = memo(function TrajectoryView(props: SlotProps) {
             <span className="traj-meta-sep">·</span>
             {groups.length} turns
           </span>
-          <span className="traj-meta-usage" title="本会话 + Live 派工到其它 session 的 turn usage">
+          <span className="traj-meta-usage" title="本会话 + 派工到其它会话的用量">
             <span className="traj-meta-usage-label">usage</span>
             <UsageInline usage={cumulative} />
           </span>

--- a/packages/host-session-store/src/host/sqlite-session-store.ts
+++ b/packages/host-session-store/src/host/sqlite-session-store.ts
@@ -26,10 +26,13 @@ type SessionRow = {
   project_json: string | null
   mascot_json: string | null
   config_json: string | null
-  type: string | null
   event_count: number
   title: string
   updated_at: number
+}
+
+function tableColumns(db: DatabaseSync, table: string) {
+  return (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name)
 }
 
 function parseProject(raw: string | null): SessionProject | undefined {
@@ -93,24 +96,24 @@ export class SqliteSessionStore implements SessionStore {
       /* column already exists */
     }
     try {
-      this.db.exec(`ALTER TABLE sessions ADD COLUMN type TEXT NOT NULL DEFAULT 'chat'`)
-    } catch {
-      /* column already exists */
-    }
-    try {
       this.db.exec('ALTER TABLE sessions ADD COLUMN config_json TEXT')
     } catch {
       /* column already exists */
+    }
+    if (tableColumns(this.db, 'sessions').includes('type')) {
+      try {
+        this.db.exec('ALTER TABLE sessions DROP COLUMN type')
+      } catch {
+        /* older sqlite without DROP COLUMN */
+      }
     }
     return this
   }
 
   async load(id: string): Promise<SessionRecord | undefined> {
     const row = this.db
-      .prepare('SELECT id, version, project_json, mascot_json, config_json, type FROM sessions WHERE id = ?')
-      .get(id) as
-      | Pick<SessionRow, 'id' | 'version' | 'project_json' | 'mascot_json' | 'config_json' | 'type'>
-      | undefined
+      .prepare('SELECT id, version, project_json, mascot_json, config_json FROM sessions WHERE id = ?')
+      .get(id) as Pick<SessionRow, 'id' | 'version' | 'project_json' | 'mascot_json' | 'config_json'> | undefined
     if (!row) return undefined
     if (row.version !== SESSION_FORMAT_VERSION) {
       throw new Error(`unsupported session version ${row.version}`)
@@ -147,14 +150,13 @@ export class SqliteSessionStore implements SessionStore {
       'INSERT INTO events (session_id, seq, ts, type, event_json) VALUES (?, ?, ?, ?, ?)',
     )
     const upsertSession = this.db.prepare(`
-      INSERT INTO sessions (id, version, project_json, mascot_json, config_json, type, event_count, title, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (id, version, project_json, mascot_json, config_json, event_count, title, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         version = excluded.version,
         project_json = excluded.project_json,
         mascot_json = excluded.mascot_json,
         config_json = excluded.config_json,
-        type = excluded.type,
         event_count = excluded.event_count,
         title = excluded.title,
         updated_at = excluded.updated_at
@@ -187,7 +189,6 @@ export class SqliteSessionStore implements SessionStore {
         projectJson,
         mascotJson,
         configJson,
-        'chat',
         eventCount,
         title,
         updatedAt,
@@ -233,7 +234,7 @@ export class SqliteSessionStore implements SessionStore {
   async listSummaries(): Promise<SessionSummary[]> {
     const rows = this.db
       .prepare(
-        'SELECT id, version, project_json, mascot_json, config_json, type, event_count, title, updated_at FROM sessions ORDER BY updated_at DESC',
+        'SELECT id, version, project_json, mascot_json, config_json, event_count, title, updated_at FROM sessions ORDER BY updated_at DESC',
       )
       .all() as SessionRow[]
     return rows.map((row) => {

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -238,14 +238,54 @@ test('sqlite persists session records across reopen', async () => {
   const ctx = new Context()
   await ctx.plugin(sessionStore, { driver: 'sqlite', path })
   await ctx.plugin(sessions)
-  await ctx.sessions.create('live-sql', { title: 'saved' })
+  await ctx.sessions.create('persist-sql', { title: 'saved' })
   const ctx2 = new Context()
   await ctx2.plugin(sessionStore, { driver: 'sqlite', path })
   await ctx2.plugin(sessions)
-  const loaded = await ctx2.sessions.get('live-sql')
-  assert.equal(loaded?.id, 'live-sql')
+  const loaded = await ctx2.sessions.get('persist-sql')
+  assert.equal(loaded?.id, 'persist-sql')
   assert.equal('type' in (loaded ?? {}), false)
-  assert.equal((await ctx2.sessions.listSummaries())[0]?.id, 'live-sql')
+  assert.equal((await ctx2.sessions.listSummaries())[0]?.id, 'persist-sql')
+})
+
+test('sqlite drops leftover sessions.type column', async () => {
+  const { createRequire } = await import('node:module')
+  const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite')
+  const dir = await mkdtemp(join(tmpdir(), 'cordis-drop-type-'))
+  const path = join(dir, 'sessions.sqlite')
+  const db = new DatabaseSync(path)
+  db.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      version INTEGER NOT NULL,
+      project_json TEXT,
+      event_count INTEGER NOT NULL DEFAULT 0,
+      title TEXT NOT NULL DEFAULT '',
+      updated_at INTEGER NOT NULL DEFAULT 0,
+      type TEXT NOT NULL DEFAULT 'live'
+    );
+    CREATE TABLE events (
+      session_id TEXT NOT NULL,
+      seq INTEGER NOT NULL,
+      ts INTEGER NOT NULL,
+      type TEXT NOT NULL,
+      event_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, seq)
+    );
+  `)
+  db.prepare(
+    'INSERT INTO sessions (id, version, title, type, event_count, updated_at) VALUES (?, 1, ?, ?, 0, 1)',
+  ).run('legacy', 'old', 'live')
+  db.close()
+
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'sqlite', path })
+  await ctx.plugin(sessions)
+  const opened = new DatabaseSync(path)
+  const cols = (opened.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>).map((row) => row.name)
+  opened.close()
+  assert.equal(cols.includes('type'), false)
+  assert.equal('type' in ((await ctx.sessions.get('legacy')) ?? {}), false)
 })
 
 

--- a/packages/host-tools/src/host/index.ts
+++ b/packages/host-tools/src/host/index.ts
@@ -103,7 +103,7 @@ export class ToolsService extends Service {
   }
 
   setPinnedExtras(names: readonly string[]) {
-    const liveSet = new Set<string>([
+    const dbTools = new Set<string>([
       'db_list',
       'db_read',
       'db_update',
@@ -119,7 +119,7 @@ export class ToolsService extends Service {
           .map((name) => name.trim())
           .filter(Boolean)
           .filter((name) => !(MINIMAL_TOOL_NAMES as readonly string[]).includes(name))
-          .filter((name) => !liveSet.has(name)),
+          .filter((name) => !dbTools.has(name)),
       ),
     ]
     const same =

--- a/packages/web-session-view/src/web/session-config-dialog.tsx
+++ b/packages/web-session-view/src/web/session-config-dialog.tsx
@@ -6,7 +6,7 @@ import {
 } from './index.ts'
 import { ChatOutlineFilterFields } from './chat-outline-fields.tsx'
 
-type ToolSourceId = 'minimal' | 'live' | 'plugin' | 'store'
+type ToolSourceId = 'minimal' | 'db' | 'plugin' | 'store'
 type AgentMode = 'standard' | 'minimal'
 type ChatProvider = 'deepseek' | 'openai'
 
@@ -305,8 +305,8 @@ export const SessionConfigDialog = memo(function SessionConfigDialog({
                       </span>
                     )}
                     <span className="min-w-0 flex-1 truncate font-mono text-[11px] font-medium">{tool.name}</span>
-                    <span className="shrink-0 text-[10px] font-medium lowercase text-(--dsw-label-3)">
-                      {tool.source}
+                    <span className="shrink-0 text-[10px] font-medium text-(--dsw-label-3)">
+                      {sources.find((item) => item.id === tool.source)?.label ?? tool.source}
                     </span>
                     <span
                       className={`ml-auto shrink-0 text-[10px] font-semibold ${


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一轮只去掉了会话记录上的 chat/live 类型字段，SQLite 还留着 `sessions.type`，配置页工具来源也还写着 live / Live 调度。

这次打开库会丢掉 `sessions.type` 列；配置里数据库工具改称「数据库」，行尾显示来源中文名而不是 live。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

