### PR TITLE
任务承担者可写，agent 创建人记为当前会话

### DIFF
--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -213,6 +213,10 @@ function coerce(field: FieldSpec, value: unknown) {
   }
   if (kind === 'action') return value == null ? '' : value
   if (isFacetFieldType(kind)) return normalizeSchemaValue(value)
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const rec = value as Record<string, unknown>
+    if (typeof rec.sessionId === 'string' || rec.kind === 'agent' || rec.kind === 'user') return value
+  }
   return String(value ?? '')
 }
 

--- a/packages/core-task-system/src/host/collection.test.ts
+++ b/packages/core-task-system/src/host/collection.test.ts
@@ -43,6 +43,9 @@ test('tasksCollection maps /tasks rows with rolled-up usage', async () => {
   assert.equal(spec.view?.icon, 'check-circle')
   assert.deepEqual(spec.schema.columns, ['title', 'status', 'priority', 'difficulty', 'usage', 'creator', 'assignee', 'project', 'tags', 'dueAt'])
   assert.equal(spec.schema.fields.usage?.computed, true)
+  assert.equal(spec.schema.fields.assignee?.writable, true)
+  assert.equal(spec.schema.fields.assigneeSessionId?.writable, true)
+  assert.equal(spec.schema.fields.creator?.writable, undefined)
   const listed = await spec.list()
   const child = listed.find((row) => row.id === 't1')
   const parent = listed.find((row) => row.id === 'p')
@@ -56,4 +59,38 @@ test('tasksCollection maps /tasks rows with rolled-up usage', async () => {
   assert.deepEqual(spec.records, { update: true, create: true, delete: true })
   assert.equal(spec.actions?.some((item) => item.id === 'report'), true)
   assert.equal(spec.actions?.some((item) => item.id === 'deliver'), true)
+})
+
+test('tasksCollection lets agents write assignee and stamps the creating session', async () => {
+  const created: Array<Record<string, unknown>> = []
+  const updated: Array<Record<string, unknown>> = []
+  const tasks: TasksLike = {
+    list: () => [],
+    get: () => undefined,
+    update(_id, patch) {
+      updated.push(patch)
+      return { id: 't1', title: '写方案', ...patch }
+    },
+    create(input) {
+      created.push(input)
+      return { id: 'new', title: input.title, creator: input.creator, assignee: input.assignee ?? null }
+    },
+    delete: () => true,
+  }
+  const spec = tasksCollection(tasks, undefined, {
+    resolveCreator: async () => ({ kind: 'agent', sessionId: 'boss', name: '指挥' }),
+    resolveAssignee: async (input) => {
+      const sid = String(input.assigneeSessionId ?? input.assignee ?? '').trim()
+      if (!sid) return null
+      return { kind: 'agent', sessionId: sid, name: sid }
+    },
+  })
+  const [row] = await spec.create!([{ title: '派工', assigneeSessionId: 'worker-1' }])
+  assert.deepEqual(created[0]?.creator, { kind: 'agent', sessionId: 'boss', name: '指挥' })
+  assert.deepEqual(created[0]?.assignee, { kind: 'agent', sessionId: 'worker-1', name: 'worker-1' })
+  assert.equal(row?.creatorSessionId, 'boss')
+  const written = await spec.update!('t1', { assignee: 'worker-2' })
+  assert.deepEqual(updated[0]?.assignee, { kind: 'agent', sessionId: 'worker-2', name: 'worker-2' })
+  assert.equal('assigneeSessionId' in (updated[0] ?? {}), false)
+  assert.equal(written.assigneeSessionId, 'worker-2')
 })

--- a/packages/core-task-system/src/host/collection.ts
+++ b/packages/core-task-system/src/host/collection.ts
@@ -47,6 +47,14 @@ export type TaskRecordActions = {
   deliver: (id: string, record: DbRecord, args?: Record<string, unknown>) => unknown | Promise<unknown>
 }
 
+export type TaskPeople = {
+  resolveCreator?: () => Actor | Promise<Actor>
+  resolveAssignee?: (input: {
+    assignee?: unknown
+    assigneeSessionId?: string | null
+  }) => Actor | null | Promise<Actor | null>
+}
+
 const ZERO_USAGE: Usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, totalTokens: 0 }
 
 function asUsage(value: unknown): Usage | null {
@@ -157,7 +165,19 @@ function recordsWithUsage(rows: TaskRow[]): DbRecord[] {
   )
 }
 
-export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActions): CollectionSpec {
+async function resolvedAssignee(
+  people: TaskPeople | undefined,
+  fields: Record<string, unknown>,
+): Promise<Actor | null | undefined> {
+  if (!people?.resolveAssignee) return undefined
+  if (!('assignee' in fields) && !('assigneeSessionId' in fields)) return undefined
+  return people.resolveAssignee({
+    ...('assigneeSessionId' in fields ? { assigneeSessionId: fields.assigneeSessionId == null ? '' : String(fields.assigneeSessionId) } : {}),
+    ...('assignee' in fields ? { assignee: fields.assignee } : {}),
+  })
+}
+
+export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActions, people?: TaskPeople): CollectionSpec {
   return {
     id: 'tasks',
     path: '/tasks',
@@ -189,7 +209,8 @@ export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActi
         description: { type: 'file', label: '描述', writable: true },
         notes: { type: 'string', label: '备忘', writable: true },
         creator: { type: 'string', label: '创建人' },
-        assignee: { type: 'string', label: '承担者' },
+        assignee: { type: 'string', label: '承担者', writable: true },
+        assigneeSessionId: { type: 'string', label: '承担会话', writable: true },
         parentId: { type: 'string', label: '父任务', writable: true },
         dependsOn: { type: 'multi-select', label: '依赖' },
       },
@@ -203,17 +224,32 @@ export function tasksCollection(tasks: TasksLike, recordActions?: TaskRecordActi
       return recordsWithUsage(tasks.list(query?.q ? { q: query.q } : {}))
     },
     get: (id) => recordsWithUsage(tasks.list()).find((row) => row.id === id) ?? null,
-    update: (id, patch) => {
-      const next = tasks.update(id, patch) as TaskRow
+    update: async (id, patch) => {
+      const nextPatch = { ...patch }
+      const assignee = await resolvedAssignee(people, patch)
+      if (assignee !== undefined) {
+        nextPatch.assignee = assignee
+        delete nextPatch.assigneeSessionId
+      }
+      const next = tasks.update(id, nextPatch) as TaskRow
       const rows = tasks.list().map((row) => (row.id === id ? { ...row, ...next, id } : row))
       return recordsWithUsage(rows).find((row) => row.id === id) ?? taskRecord(next, (pid) => tasks.get(pid), ZERO_USAGE, false)
     },
-    create: (rows) =>
-      rows.map((fields = {}) => {
-        const title = typeof fields.title === 'string' && fields.title.trim() ? fields.title.trim() : '未命名任务'
-        const row = tasks.create({ ...fields, title, creator: { kind: 'user', name: '用户' } })
-        return recordsWithUsage(tasks.list()).find((item) => item.id === row.id) ?? taskRecord(row, (pid) => tasks.get(pid), ZERO_USAGE, false)
-      }),
+    create: async (rows) =>
+      Promise.all(
+        rows.map(async (fields = {}) => {
+          const title = typeof fields.title === 'string' && fields.title.trim() ? fields.title.trim() : '未命名任务'
+          const creator = people?.resolveCreator ? await people.resolveCreator() : { kind: 'user', name: '用户' }
+          const assignee = await resolvedAssignee(people, fields)
+          const row = tasks.create({
+            ...fields,
+            title,
+            creator,
+            ...(assignee !== undefined ? { assignee } : {}),
+          })
+          return recordsWithUsage(tasks.list()).find((item) => item.id === row.id) ?? taskRecord(row, (pid) => tasks.get(pid), ZERO_USAGE, false)
+        }),
+      ),
     remove: (query) => {
       const ids = query.ids ?? []
       for (const id of ids) {

--- a/packages/core-task-system/src/host/index.ts
+++ b/packages/core-task-system/src/host/index.ts
@@ -2006,10 +2006,20 @@ export function apply(ctx: Context) {
 
   ctx.inject(['database'], (inner) => {
     inner.database.register(
-      tasksCollection(tasks, {
-        report: (id, _record, args) => runTaskReport(id, args),
-        deliver: (id, _record, args) => runTaskDeliver(id, args),
-      }),
+      tasksCollection(
+        tasks,
+        {
+          report: (id, _record, args) => runTaskReport(id, args),
+          deliver: (id, _record, args) => runTaskDeliver(id, args),
+        },
+        {
+          resolveCreator: () => resolveCreator(host),
+          resolveAssignee: async (input) => {
+            const resolved = await resolveAssignee(host, input)
+            return resolved.touchAssignedAt ? resolved.assignee : null
+          },
+        },
+      ),
     )
   })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`db_update` 之前会因承担者字段不可写而拒绝。现在 assignee / assigneeSessionId 可写；agent 用 `db_create` 建任务时，创建人记为当前会话，不再一律写成「用户」。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

