### PR TITLE
工具调用行：轨迹在左，状态在右

### DIFF
--- a/packages/cap-chat/src/web/tool-card.test.ts
+++ b/packages/cap-chat/src/web/tool-card.test.ts
@@ -16,4 +16,5 @@ test('tool panels match the step bar: sidebar fill, no border', () => {
     css,
     /\.tool-call-head:hover::before,\s*\.tool-call-head\.is-open::before\s*\{[^}]*background:\s*var\(--dsw-sidebar\)/s,
   )
+  assert.match(source, /tool-call-inspect[\s\S]*status\.className/)
 })

--- a/packages/cap-chat/src/web/tool-card.tsx
+++ b/packages/cap-chat/src/web/tool-card.tsx
@@ -265,9 +265,6 @@ export function ToolCard({
           <span className="tool-call-title">{title}</span>
           {open ? null : <span className="tool-call-summary">{summary}</span>}
         </button>
-        <span className={status.className} title={status.label} aria-label={status.label}>
-          {status.icon}
-        </span>
         <button
           type="button"
           className="tool-call-inspect"
@@ -277,6 +274,9 @@ export function ToolCard({
         >
           <MapIcon className="size-3.5" aria-hidden />
         </button>
+        <span className={status.className} title={status.label} aria-label={status.label}>
+          {status.icon}
+        </span>
       </div>
       {!open && previewLines && previewLines.length > 0 ? (
         <div className="tool-call-body">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
工具卡片 `tool-call-head` 右侧操作对调：先「在轨迹中查看」，再绿勾/红叉状态，与点选的布局一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

