### PR TITLE
去掉聊天窗 Running step 状态行

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -18,6 +18,8 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
     expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)
     expect(thread).toMatch(/sticky top-0 z-1 bg-transparent/)
+    expect(thread).not.toMatch(/Running/)
+    expect(thread).not.toMatch(/StatusRow/)
     expect(shell).toContain('chat-composer-dock')
     expect(shell).not.toMatch(/bottom-0 z-\[2\]/)
   })

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -724,22 +724,6 @@ export const ChatNodeList = memo(function ChatNodeList({
   )
 })
 
-function StatusRow({
-  agentStatus,
-  agentStep,
-}: {
-  agentStatus: 'idle' | 'running'
-  agentStep?: number
-}) {
-  if (agentStatus !== 'running') return null
-  return (
-    <div className="mb-4 flex items-center gap-2 text-xs text-(--dsw-label-3)">
-      <span className="inline-block size-1.5 animate-pulse rounded-full bg-(--dsw-ok)" />
-      Running{agentStep != null ? ` · step ${agentStep + 1}` : ''}
-    </div>
-  )
-}
-
 export const ChatThread = memo(function ChatThread(props: SlotProps) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const sessionView = props.sessionView as SessionViewService
@@ -765,8 +749,6 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
   }
   const mountedNodes = useMemo(() => sliceTurnsFrom(nodes, revealStart), [nodes, revealStart])
   const pending = useSessionView((state) => state.pending)
-  const agentStatus = useSessionView((state) => state.agentStatus)
-  const agentStep = useSessionView((state) => state.agentStep)
   const sessions = useSessionView((state) => state.sessions)
   const error = useSessionView((state) => state.error)
   const switchingSession = useSessionView((state) => state.switchingSession)
@@ -971,7 +953,6 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       data-switching={switchingSession ? '1' : undefined}
       style={switchingSession ? { opacity: 0.72, transition: 'opacity 120ms ease' } : undefined}
     >
-      <StatusRow agentStatus={agentStatus} agentStep={agentStep} />
       {loadingOlder ? (
         <div className="mb-3 text-center text-(length:--dsw-chat-ui-font-size) text-(--dsw-label-3)">加载更早消息…</div>
       ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天线程顶部不再显示 `Running · step N`。运行中的工具行本身仍保留转圈状态。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

