### PR TITLE
关闭检查器轨迹面板后不再被 inspect 焦点立刻打开

### DIFF
--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -41,6 +41,8 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /XMarkIcon/)
   assert.match(inspector, /onClose=\{\(\) => closeOpenedTab\(item.id\)\}/)
   assert.match(inspector, /closeOpenedTab/)
+  assert.match(inspector, /slotTabId\(id\) === focusTabId\) sessionView.clearInspectCall/)
+  assert.match(inspector, /if \(!focusCallId \|\| !focusTabId\) return/)
   assert.match(inspector, /inspector-tab-remove-\$\{item.id\}/)
   assert.doesNotMatch(inspector, /item\.repeatable \? \(/)
   assert.match(inspector, /getInspectorCaption/)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -190,11 +190,23 @@ export const SessionInspector = memo(function SessionInspector({
 
   const focusTabId = extraTabs.find((item) => item.focusOnCall)?.id
   useEffect(() => {
-    if (focusCallId && focusTabId) {
-      persistOpened(opened.includes(focusTabId) ? opened : [...opened, focusTabId])
-      setTab(focusTabId)
-      return
-    }
+    if (!focusCallId || !focusTabId) return
+    setOpened((prev) => {
+      if (prev.includes(focusTabId)) return prev
+      const next = [...prev, focusTabId]
+      try {
+        localStorage.setItem(inspectorOpenedKey(sessionId), JSON.stringify(next))
+      } catch {
+        /* ignore */
+      }
+      window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
+      return next
+    })
+    setTab(focusTabId)
+  }, [focusCallId, focusTabId, sessionId, setTab])
+
+  useEffect(() => {
+    if (focusCallId && focusTabId) return
     setTabState((current) => {
       const next = resolveInspectorTab(current, allowedTabs, opened)
       if (next !== current) {
@@ -206,7 +218,7 @@ export const SessionInspector = memo(function SessionInspector({
       }
       return next
     })
-  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened, setTab])
+  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened])
 
   useEffect(() => {
     const onTab = (event: Event) => {
@@ -300,6 +312,7 @@ export const SessionInspector = memo(function SessionInspector({
   }
 
   function closeOpenedTab(id: string) {
+    if (slotTabId(id) === focusTabId) sessionView.clearInspectCall()
     const next = opened.filter((item) => item !== id)
     persistOpened(next)
     if (tab === id) setTab(next.at(-1) ?? '')

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -352,6 +352,11 @@ export class SessionViewService extends Service {
     void this.ensureTrajectory()
   }
 
+  clearInspectCall() {
+    if (this.value.focusCallId == null) return
+    this.replace({ focusCallId: undefined })
+  }
+
   /** URL → 状态：只由路由层调用，不回写 URL。
    * `/s/:id` 打开该会话；其它页面打开最近一条对话，供全局悬浮窗使用。
    * 会话表记录详情不切换主 session，详情自己 peek 该行日志。 */

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -208,6 +208,8 @@ test('inspectCall switches to trajectory with focus', async () => {
   view.inspectCall('c1')
   assert.equal(view.get().view, 'chat')
   assert.equal(view.get().focusCallId, 'c1')
+  view.clearInspectCall()
+  assert.equal(view.get().focusCallId, undefined)
 })
 
 test('ingest coalesces consecutive chunks and skips trajectory on chat view', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
从聊天轨迹图标打开右侧轨迹后，关掉该面板会因 `focusCallId` 仍在而马上加回。关闭时清掉 inspect 焦点，且打开逻辑不再跟着 `opened` 回写。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

