### PR TITLE
行悬停显示左侧选择框

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -173,8 +173,10 @@ const CSS = `
 .fsdb-page .tasks-table th{padding:6px 6px;color:var(--dsw-label-2);font-size:14px;font-weight:600;position:sticky;top:0;background:var(--dsw-surface);z-index:1;white-space:nowrap}
 .fsdb-row-check{position:absolute;top:50%;left:0;z-index:3;display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;margin:0;transform:translate(-100%,-50%);opacity:0;pointer-events:none}
 .fsdb-page .tasks-table td:first-child{position:relative}
+.fsdb-page .tasks-table td:first-child::before,.fsdb-page .tasks-table th:first-child::before{content:"";position:absolute;left:-26px;top:0;bottom:0;width:26px}
 .fsdb-page .tasks-table td:first-child > .fsdb-row-check,.fsdb-page .tasks-table th:first-child > .fsdb-row-check{left:0;margin-left:-4px}
 .tasks-table tbody tr:hover .fsdb-row-check,.tasks-queue-item:hover .fsdb-row-check,.tasks-minicard:hover .fsdb-row-check,.fsdb-row-check.is-on,.fsdb-row-check:focus-visible{opacity:1;pointer-events:auto}
+.fsdb-page .tasks-table:has(.fsdb-row-check.is-on) tbody .fsdb-row-check{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-table thead .fsdb-row-check{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-th{display:inline-flex;align-items:center;gap:5px;font-weight:600;white-space:nowrap;flex-wrap:nowrap}
 .fsdb-page .tasks-th svg{color:inherit}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -183,6 +183,8 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.doesNotMatch(browser, /tasks-title-cell/)
   assert.doesNotMatch(css, /tasks-title-cell/)
   assert.match(css, /tbody tr:hover \.fsdb-row-check/)
+  assert.match(css, /td:first-child::before,[\s\S]*th:first-child::before\{[^}]*left:-26px/)
+  assert.match(css, /\.tasks-table:has\(\.fsdb-row-check\.is-on\) tbody \.fsdb-row-check/)
   assert.match(browser, /index === 0 \? <RowCheck id=\{row\.id\} \/> : null/)
   assert.match(browser, /index === 0 \? <RowCheck ids=\{pickableIds\} \/> : null/)
   const titleFn = browser.slice(browser.indexOf('function RecordTitle'), browser.indexOf('function RecordOpenControls'))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
鼠标悬停表格行时，行左侧外侧出现选择框。第一格向左延伸热区，移到勾选上不会丢掉悬停。勾选任意一行后，其余行的选择框保持可见，方便多选。表头全选一直显示。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

