### PR TITLE
修复打开插件 README 详情卡死

### DIFF
--- a/packages/core-file-system/src/web/heading-outline.test.ts
+++ b/packages/core-file-system/src/web/heading-outline.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { headingsFromHtml, headingsFromRoot } from './heading-outline.ts'
+import { headingElById, headingsFromHtml, headingsFromRoot } from './heading-outline.ts'
 
 test('headingsFromHtml extracts h1–h3 and skips chrome titles', () => {
   const html = `
@@ -22,17 +22,26 @@ test('headingsFromHtml extracts h1–h3 and skips chrome titles', () => {
   ])
 })
 
-test('headingsFromRoot stamps data-heading-outline on live nodes', () => {
+test('headingsFromRoot is read-only so TipTap headings do not trip MutationObserver', () => {
   const root = document.createElement('div')
-  root.innerHTML = '<h1>A</h1><h2>B</h2><h3>C</h3>'
+  root.innerHTML = '<div class="tiptap"><h1>A</h1><h2>B</h2><h3>C</h3></div>'
+  let fires = 0
+  const mo = new MutationObserver(() => {
+    fires += 1
+    headingsFromRoot(root)
+  })
+  mo.observe(root, { subtree: true, childList: true, characterData: true, attributes: true })
   const items = headingsFromRoot(root)
   assert.deepEqual(
-    items.map((item) => [item.text, item.level]),
+    items.map((item) => [item.id, item.text, item.level]),
     [
-      ['A', 1],
-      ['B', 2],
-      ['C', 3],
+      ['heading-0', 'A', 1],
+      ['heading-1', 'B', 2],
+      ['heading-2', 'C', 3],
     ],
   )
-  assert.equal(root.querySelector('[data-heading-outline="heading-2"]')?.textContent, 'C')
+  assert.equal(root.querySelector('[data-heading-outline]'), null)
+  assert.equal(fires, 0)
+  mo.disconnect()
+  assert.equal(headingElById(root, 'heading-2')?.textContent, 'C')
 })

--- a/packages/core-file-system/src/web/heading-outline.ts
+++ b/packages/core-file-system/src/web/heading-outline.ts
@@ -16,6 +16,18 @@ function asLevel(n: number): 1 | 2 | 3 {
   return 3
 }
 
+function headingElements(root: ParentNode): HTMLElement[] {
+  return [...root.querySelectorAll('h1, h2, h3')].filter(
+    (el) => el instanceof HTMLElement && !SKIP.some((sel) => el.closest(sel)),
+  ) as HTMLElement[]
+}
+
+function itemFromEl(el: HTMLElement, index: number): HeadingOutlineItem | null {
+  const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+  if (!text) return null
+  return { id: `heading-${index}`, text, level: asLevel(Number(el.tagName.slice(1))) }
+}
+
 /** 从 HTML 抽出 h1–h3，忽略详情页标题和附加栏标题。 */
 export function headingsFromHtml(html: string): HeadingOutlineItem[] {
   const items: HeadingOutlineItem[] = []
@@ -33,15 +45,33 @@ export function headingsFromHtml(html: string): HeadingOutlineItem[] {
   return items
 }
 
+/** 只读扫描。禁止给标题写 data-*：PageEditor / TipTap 拥有这些节点，写属性会触发 MutationObserver 死循环。 */
 export function headingsFromRoot(root: ParentNode): HeadingOutlineItem[] {
-  const nodes = [...root.querySelectorAll('h1, h2, h3')].filter(
-    (el) => !SKIP.some((sel) => el.closest(sel)),
+  const items: HeadingOutlineItem[] = []
+  for (const el of headingElements(root)) {
+    const item = itemFromEl(el, items.length)
+    if (item) items.push(item)
+  }
+  return items
+}
+
+export function headingElById(root: ParentNode, id: string): HTMLElement | null {
+  const items: HeadingOutlineItem[] = []
+  for (const el of headingElements(root)) {
+    const item = itemFromEl(el, items.length)
+    if (!item) continue
+    if (item.id === id) return el
+    items.push(item)
+  }
+  return null
+}
+
+export function sameOutlineItems(a: HeadingOutlineItem[], b: HeadingOutlineItem[]) {
+  return (
+    a.length === b.length &&
+    a.every((item, index) => {
+      const other = b[index]
+      return other && item.id === other.id && item.text === other.text && item.level === other.level
+    })
   )
-  return nodes.flatMap((el, index) => {
-    const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim()
-    if (!text) return []
-    const id = el.getAttribute('data-heading-outline') || `heading-${index}`
-    el.setAttribute('data-heading-outline', id)
-    return [{ id, text, level: asLevel(Number(el.tagName.slice(1))) }]
-  })
 }

--- a/packages/core-file-system/src/web/heading-outline.tsx
+++ b/packages/core-file-system/src/web/heading-outline.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { OutlineNav } from '@biu/public-ui'
-import { headingsFromRoot } from './heading-outline.ts'
-
-function escapeId(id: string) {
-  return typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(id) : id
-}
+import { headingElById, headingsFromRoot, sameOutlineItems } from './heading-outline.ts'
 
 export function HeadingOutline({ enabled }: { enabled: boolean }) {
   const [host, setHost] = useState<HTMLElement | null>(null)
@@ -15,17 +11,19 @@ export function HeadingOutline({ enabled }: { enabled: boolean }) {
     const stage = document.querySelector('.fsdb-detail-stage')
     const main = document.querySelector('.fsdb-detail-main')
     if (!(main instanceof HTMLElement)) {
-      setItems([])
+      setItems((prev) => (prev.length ? [] : prev))
       return
     }
     const root = main.closest('.fsdb-right') ?? main.closest('.fsdb-right-body') ?? stage
-    setHost(root instanceof HTMLElement ? root : main)
-    setItems(headingsFromRoot(main))
+    const nextHost = root instanceof HTMLElement ? root : main
+    setHost((prev) => (prev === nextHost ? prev : nextHost))
+    const next = headingsFromRoot(main)
+    setItems((prev) => (sameOutlineItems(prev, next) ? prev : next))
   }, [])
 
   useLayoutEffect(() => {
     if (!enabled) {
-      setItems([])
+      setItems((prev) => (prev.length ? [] : prev))
       setHost(null)
       return
     }
@@ -38,8 +36,9 @@ export function HeadingOutline({ enabled }: { enabled: boolean }) {
   }, [enabled, scan])
 
   const go = useCallback((id: string) => {
-    const el = document.querySelector<HTMLElement>(`[data-heading-outline="${escapeId(id)}"]`)
-    el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+    const main = document.querySelector('.fsdb-detail-main')
+    if (!(main instanceof HTMLElement)) return
+    headingElById(main, id)?.scrollIntoView({ block: 'start', behavior: 'smooth' })
   }, [])
 
   if (!enabled || !host || !items.length) return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开插件介绍详情会挂上 PageEditor。正文里的 `#` 变成 `h1` 后，标题大纲的 MutationObserver 扫描会给这些节点写 `data-heading-outline`。TipTap 拥有这些 DOM，属性一改就回写，观察器再扫，形成死循环，页面卡死。

这不是改了 `readme` 字段类型本身直接导致的，而是 `contentField: readme` + `/plugins` 上的 PageEditor + 大纲写 DOM 叠在一起。

改动：大纲只读扫描标题，点击跳转按序号找节点，不再改编辑器 DOM。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

