### PR TITLE
聊天主列左右也统一 100px

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -21,7 +21,9 @@ describe('composer dock stacking above sticky user', () => {
     expect(thread).not.toMatch(/Running/)
     expect(thread).not.toMatch(/StatusRow/)
     expect(shell).toContain('chat-composer-dock')
+    expect(shell).toContain('px-[100px]')
     expect(shell).toContain('pb-[calc(1rem+25px)]')
+    expect(shell).not.toMatch(/md:px-8|lg:px-10/)
     expect(shell).not.toMatch(/bottom-0 z-\[2\]/)
   })
 

--- a/packages/public-ui/src/chat-pane.test.ts
+++ b/packages/public-ui/src/chat-pane.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { CHAT_DOCK_STACK, CHAT_STAGE_PANE } from './chat-pane.tsx'
+import { CHAT_DOCK_STACK, CHAT_STAGE_CENTER, CHAT_STAGE_PANE } from './chat-pane.tsx'
 
 test('ChatPane is the overlay interior: thread, optional composer dock', () => {
   const src = readFileSync(resolve(import.meta.dirname, './chat-pane.tsx'), 'utf8')
@@ -13,6 +13,8 @@ test('ChatPane is the overlay interior: thread, optional composer dock', () => {
   assert.match(src, /aside/)
   assert.match(src, /export function ChatStage/)
   assert.match(src, /export function ChatDockStack/)
+  assert.match(CHAT_STAGE_CENTER, /px-\[100px\]/)
+  assert.doesNotMatch(CHAT_STAGE_CENTER, /px-6|md:px-8|lg:px-10/)
   assert.match(CHAT_STAGE_PANE, /px-1 py-1/)
   assert.match(CHAT_DOCK_STACK, /space-y-2/)
 })

--- a/packages/public-ui/src/chat-pane.tsx
+++ b/packages/public-ui/src/chat-pane.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, type Ref } from 'react'
 
 export const CHAT_STAGE_CENTER =
-  'chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-6 py-3 pb-44 md:px-8 lg:px-10'
+  'chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-[100px] py-3 pb-44'
 export const CHAT_STAGE_PANE =
   'chat-stage flex min-h-0 flex-1 flex-col overflow-y-auto overscroll-contain px-1 py-1'
 export const CHAT_DOCK_STACK = 'pointer-events-auto w-full space-y-2 bg-transparent'

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -165,7 +165,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
         <div className="absolute inset-0 z-1 flex min-h-0 overflow-hidden">
           <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {centerStage}
-            <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-6 pb-[calc(1rem+25px)] md:px-8 lg:px-10">
+            <div className="chat-composer-dock pointer-events-none absolute inset-x-0 bottom-0 bg-transparent px-[100px] pb-[calc(1rem+25px)]">
               {centerDock}
             </div>
             {renderSlot('stage-aside')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天区内页（对话列表 + 底部输入栏）左右改为固定 100px，与数据库列表/详情一致，不再用 `px-6 / md:px-8 / lg:px-10` 随宽度变窄。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

