### PR TITLE
去掉数据库详情里的删除按钮

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2600,7 +2600,6 @@ export function CollectionBrowser({
           writePatch={writePatch}
           tableIcon={currentTable?.view?.icon}
           onOpenRecord={(recordId, collection) => onOpenRecord?.(recordId, activeViewId, collection)}
-          onDelete={canDelete && selected ? () => setDlg({ kind: 'delete-record', row: selected }) : undefined}
           onPrev={total > 1 ? () => void stepViewRecord(-1) : undefined}
           onNext={total > 1 ? () => void stepViewRecord(1) : undefined}
           canPrev={viewIndex == null ? total > 1 : viewIndex > 0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -258,6 +258,8 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(style, /\.fsdb-detail-float-btn svg\{[^}]*width:16px/)
   assert.doesNotMatch(style, /border-radius:999px/)
   assert.match(detail, /<h1 className="fsdb-detail-title">/)
+  assert.doesNotMatch(detail, /aria-label="删除记录"/)
+  assert.doesNotMatch(browser, /onDelete=\{canDelete/)
   assert.match(detail, /<HeadingOutline enabled=\{headingOutline\} \/>/)
   assert.match(browser, /headingOutline=\{collectionPath !== '\/sessions'\}/)
   assert.match(style, /\.heading-outline-host\{[^}]*z-index:20/)

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, type ReactNode, type Dispatch, type SetStateAction
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import type { CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
 import { ChevronDownIcon, ChevronUpIcon, HashtagIcon } from '@heroicons/react/16/solid'
-import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { contentFieldKey, formatField, resolveFieldType } from './fields.ts'
 import { LocalText } from './controls.tsx'
 import { FilePreview } from './fsdb-cells.tsx'
@@ -99,7 +98,6 @@ export function RecordDetail({
   writePatch,
   tableIcon,
   onOpenRecord,
-  onDelete,
   onPrev,
   onNext,
   canPrev,
@@ -118,7 +116,6 @@ export function RecordDetail({
   writePatch: (row: DbRecord, patch: Record<string, unknown>) => Promise<unknown> | void
   tableIcon?: string
   onOpenRecord?: (recordId: string, collection?: string) => void
-  onDelete?: () => void
   onPrev?: () => void
   onNext?: () => void
   canPrev?: boolean
@@ -182,11 +179,6 @@ export function RecordDetail({
                 ) : (
                   <h1 className="fsdb-detail-title">{labelOf(selected)}</h1>
                 )}
-                {onDelete ? (
-                  <button type="button" className="tasks-icon-btn is-danger" title="删除" aria-label="删除记录" onClick={onDelete}>
-                    <TrashGlyph aria-hidden className="size-[14px]" />
-                  </button>
-                ) : null}
                 </div>
                 {chrome?.Board ? <chrome.Board record={selected} openRecord={onOpenRecord} /> : null}
                 {chrome?.Board ? null : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
记录详情标题旁的垃圾桶已删除。列表勾选后的批量删除还在。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

