### PR TITLE
侧栏公共入口：去掉顶栏，聊天和数据添加按钮上方共用

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -44,7 +44,7 @@ import { SessionConfigDialog } from '@biu/web-session-view/dialog'
 import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 import { OverlayChatWindow } from './overlay-window.tsx'
 import { ShellDockNav } from './shell-dock-nav.tsx'
-import { ShellChromeBar, ShellSettingsUpdate } from './shell-chrome.tsx'
+import { ShellSettingsUpdate } from './shell-chrome.tsx'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 import { chromeIcon } from './chrome-icon.ts'
@@ -636,6 +636,9 @@ function Shell(props: SlotProps) {
           onExpand={expandSidebar}
           onWidthChange={onSidebarWidthChange}
           testId={showChatSidebar ? 'chat-sidebar' : 'module-sidebar'}
+          activeId={activeModule}
+          agentHref={agentHref}
+          onSettings={openSettings}
         >
           <div className="app-stage">
             <div
@@ -674,31 +677,24 @@ function Shell(props: SlotProps) {
         collections={collections}
       />
 
-      <main className="app-main">
-        <ShellChromeBar
-          activeId={activeModule}
-          agentHref={agentHref}
-          onSettings={openSettings}
-        />
-        <div className="app-stage">
-          <div
-            className={`app-stage-pane${activeModule === 'agent' ? ' is-active' : ''}`}
-            aria-hidden={activeModule !== 'agent'}
-            inert={activeModule !== 'agent' || undefined}
-          >
-            {chatHeader}
-            <AgentMainPanels
-              renderSlot={props.renderSlot}
-              header={overlayHeader}
-              showCenter={activeModule === 'agent'}
-            />
-          </div>
-          <PluginModuleStage
-            slots={slots}
-            activeId={activeModule === 'agent' ? '' : activeModule}
+      <main className="app-stage">
+        <div
+          className={`app-stage-pane${activeModule === 'agent' ? ' is-active' : ''}`}
+          aria-hidden={activeModule !== 'agent'}
+          inert={activeModule !== 'agent' || undefined}
+        >
+          {chatHeader}
+          <AgentMainPanels
             renderSlot={props.renderSlot}
+            header={overlayHeader}
+            showCenter={activeModule === 'agent'}
           />
         </div>
+        <PluginModuleStage
+          slots={slots}
+          activeId={activeModule === 'agent' ? '' : activeModule}
+          renderSlot={props.renderSlot}
+        />
       </main>
 
       <SessionInspector

--- a/packages/web-app-shell/src/web/rail-pin.test.ts
+++ b/packages/web-app-shell/src/web/rail-pin.test.ts
@@ -3,8 +3,9 @@ import { resolve } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 
-test('activity bar is gone; chat chrome switches agent and database', () => {
+test('activity bar is gone; shared sidebar places switch agent and database', () => {
   const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  const frame = readFileSync(resolve(import.meta.dirname, './shell-sidebar-frame.tsx'), 'utf8')
   const chrome = readFileSync(resolve(import.meta.dirname, './shell-chrome.tsx'), 'utf8')
   const nav = readFileSync(resolve(import.meta.dirname, './shell-dock-nav.tsx'), 'utf8')
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
@@ -13,7 +14,8 @@ test('activity bar is gone; chat chrome switches agent and database', () => {
   assert.doesNotMatch(shell, /cordis\.rail\.pinned/)
   assert.doesNotMatch(shell, /app-activity-bar/)
   assert.match(shell, /ShellDockNav/)
-  assert.match(shell, /ShellChromeBar/)
+  assert.doesNotMatch(shell, /ShellChromeBar/)
+  assert.match(frame, /ShellSidePlaces/)
   assert.match(chrome, /聊天面板/)
   assert.match(chrome, /数据面板/)
   assert.match(chrome, /navigate\('\/database'\)/)

--- a/packages/web-app-shell/src/web/shell-chrome.tsx
+++ b/packages/web-app-shell/src/web/shell-chrome.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   ArrowDownTrayIcon,
@@ -69,7 +69,42 @@ export function ShellSettingsUpdate() {
   )
 }
 
-export function ShellChromeBar({
+function SideAction({
+  title,
+  active,
+  testId,
+  onClick,
+  icon,
+  children,
+}: {
+  title: string
+  active?: boolean
+  testId: string
+  onClick: () => void
+  icon: ReactNode
+  children?: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      className={`app-side-actions-item${active ? ' is-active' : ''}`}
+      title={title}
+      aria-label={title}
+      aria-pressed={active}
+      data-testid={testId}
+      onClick={onClick}
+    >
+      <span className="app-side-actions-icon" aria-hidden>
+        {icon}
+      </span>
+      <span className="app-side-actions-label">{title}</span>
+      {children}
+    </button>
+  )
+}
+
+/** 公共入口：聊天与数据侧栏共用，堆在「添加聊天 / 添加视图」上方。 */
+export function ShellSidePlaces({
   activeId,
   agentHref,
   onSettings,
@@ -83,99 +118,71 @@ export function ShellChromeBar({
   const [notifyOpen, setNotifyOpen] = useState(false)
   const [query, setQuery] = useState('')
 
-  const openChat = () => {
-    setChatOverlay(false)
-    navigate(agentHref)
-  }
-  const openData = () => {
-    navigate('/database')
-  }
-
   return (
-    <div className="shell-chrome-bar" data-testid="shell-chrome-bar">
-      <div className="shell-chrome-bar-left">
-        <button
-          type="button"
-          className={`shell-chrome-btn${activeId === 'agent' ? ' is-active' : ''}`}
-          aria-pressed={activeId === 'agent'}
-          data-testid="chrome-chat-panel"
-          onClick={openChat}
-        >
-          <ChatBubbleLeftIcon {...chromeIcon} />
-          聊天面板
-        </button>
-        <button
-          type="button"
-          className={`shell-chrome-btn${activeId === 'database' ? ' is-active' : ''}`}
-          aria-pressed={activeId === 'database'}
-          data-testid="chrome-data-panel"
-          onClick={openData}
-        >
-          <CircleStackIcon {...chromeIcon} />
-          数据面板
-        </button>
+    <div className="app-side-actions shell-side-places" role="navigation" aria-label="面板" data-testid="shell-side-places">
+      <SideAction
+        title="聊天面板"
+        active={activeId === 'agent'}
+        testId="chrome-chat-panel"
+        icon={<ChatBubbleLeftIcon {...chromeIcon} />}
+        onClick={() => {
+          setChatOverlay(false)
+          navigate(agentHref)
+        }}
+      />
+      <SideAction
+        title="数据面板"
+        active={activeId === 'database'}
+        testId="chrome-data-panel"
+        icon={<CircleStackIcon {...chromeIcon} />}
+        onClick={() => navigate('/database')}
+      />
+      <SideAction
+        title="设置"
+        testId="chrome-settings"
+        icon={<Cog6ToothIcon {...chromeIcon} />}
+        onClick={onSettings}
+      />
+      <div className="shell-side-pop-wrap">
+        <SideAction
+          title="搜索"
+          active={searchOpen}
+          testId="chrome-search"
+          icon={<MagnifyingGlassIcon {...chromeIcon} />}
+          onClick={() => {
+            setNotifyOpen(false)
+            setSearchOpen((open) => !open)
+          }}
+        />
+        {searchOpen ? (
+          <div className="shell-side-pop" role="dialog" aria-label="搜索">
+            <input
+              className="shell-chrome-search-input"
+              autoFocus
+              placeholder="搜索…"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            <p className="shell-chrome-pop-empty">输入关键字以搜索会话与数据</p>
+          </div>
+        ) : null}
       </div>
-      <div className="shell-chrome-bar-right">
-        <div className="shell-chrome-pop-wrap">
-          <button
-            type="button"
-            className={`shell-chrome-btn icon-only${searchOpen ? ' is-active' : ''}`}
-            title="搜索"
-            aria-label="搜索"
-            aria-expanded={searchOpen}
-            data-testid="chrome-search"
-            onClick={() => {
-              setNotifyOpen(false)
-              setSearchOpen((open) => !open)
-            }}
-          >
-            <MagnifyingGlassIcon {...chromeIcon} />
-          </button>
-          {searchOpen ? (
-            <div className="shell-chrome-pop" role="dialog" aria-label="搜索">
-              <input
-                className="shell-chrome-search-input"
-                autoFocus
-                placeholder="搜索…"
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-              />
-              <p className="shell-chrome-pop-empty">输入关键字以搜索会话与数据</p>
-            </div>
-          ) : null}
-        </div>
-        <div className="shell-chrome-pop-wrap">
-          <button
-            type="button"
-            className={`shell-chrome-btn icon-only${notifyOpen ? ' is-active' : ''}`}
-            title="通知"
-            aria-label="通知"
-            aria-expanded={notifyOpen}
-            data-testid="chrome-notify"
-            onClick={() => {
-              setSearchOpen(false)
-              setNotifyOpen((open) => !open)
-            }}
-          >
-            <BellIcon {...chromeIcon} />
-          </button>
-          {notifyOpen ? (
-            <div className="shell-chrome-pop" role="dialog" aria-label="通知">
-              <p className="shell-chrome-pop-empty">暂无通知</p>
-            </div>
-          ) : null}
-        </div>
-        <button
-          type="button"
-          className="shell-chrome-btn"
-          title="设置"
-          aria-label="设置"
-          data-testid="chrome-settings"
-          onClick={onSettings}
-        >
-          <Cog6ToothIcon {...chromeIcon} />
-          设置
-        </button>
+      <div className="shell-side-pop-wrap">
+        <SideAction
+          title="通知"
+          active={notifyOpen}
+          testId="chrome-notify"
+          icon={<BellIcon {...chromeIcon} />}
+          onClick={() => {
+            setSearchOpen(false)
+            setNotifyOpen((open) => !open)
+          }}
+        />
+        {notifyOpen ? (
+          <div className="shell-side-pop" role="dialog" aria-label="通知">
+            <p className="shell-chrome-pop-empty">暂无通知</p>
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useRef, type ReactNode } from 'react'
 import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '@heroicons/react/16/solid'
 import { SidebarBrandLockup } from '@biu/public-mascot'
 import { chromeIcon } from './chrome-icon.ts'
+import { ShellSidePlaces } from './shell-chrome.tsx'
 
 export type ShellSidebarFrameProps = {
   visible: boolean
@@ -11,6 +12,9 @@ export type ShellSidebarFrameProps = {
   onExpand?: () => void
   onWidthChange?: (width: number) => void
   testId?: string
+  activeId?: string
+  agentHref?: string
+  onSettings?: () => void
   children: ReactNode
 }
 
@@ -23,6 +27,9 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
   onExpand,
   onWidthChange,
   testId = 'shell-sidebar',
+  activeId,
+  agentHref,
+  onSettings,
   children,
 }: ShellSidebarFrameProps) {
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
@@ -94,6 +101,11 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
           </button>
         )}
       </div>
+      {onSettings && agentHref && activeId != null ? (
+        <div className="shrink-0 px-2 pt-1">
+          <ShellSidePlaces activeId={activeId} agentHref={agentHref} onSettings={onSettings} />
+        </div>
+      ) : null}
       {children}
     </aside>
     </div>

--- a/packages/web-react-host/src/web/index.test.ts
+++ b/packages/web-react-host/src/web/index.test.ts
@@ -24,7 +24,7 @@ test('paints shell into el', async () => {
     await ctx.plugin(reactHost, { el })
     await ctx.plugin(shell)
   })
-  assert.match(el.innerHTML, /data-testid="shell-chrome-bar"/)
+  assert.match(el.innerHTML, /data-testid="shell-side-places"/)
   assert.match(el.innerHTML, /聊天面板/)
   assert.match(el.innerHTML, /设置/)
 })

--- a/web/main.test.ts
+++ b/web/main.test.ts
@@ -26,7 +26,7 @@ test('boots into #app', async () => {
     const { webBoot } = await import('./main.tsx')
     await webBoot
   })
-  assert.match(document.body.innerHTML, /data-testid="shell-chrome-bar"/)
+  assert.match(document.body.innerHTML, /data-testid="shell-side-places"/)
   assert.match(document.body.innerHTML, /聊天面板/)
   assert.match(document.body.innerHTML, /设置/)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -188,79 +188,15 @@ body {
   padding: 0 12px;
 }
 
-.app-main {
-  display: flex;
-  min-height: 0;
-  min-width: 0;
-  flex: 1;
-  flex-direction: column;
-  overflow: hidden;
-}
-
-.app-main > .app-stage {
-  flex: 1;
-}
-
-.shell-chrome-bar {
-  display: flex;
-  height: 44px;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 0 12px;
-  border-bottom: 1px solid var(--dsw-border);
-}
-
-.shell-chrome-bar-left,
-.shell-chrome-bar-right {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 4px;
-}
-
-.shell-chrome-btn {
-  display: inline-flex;
-  height: 28px;
-  align-items: center;
-  gap: 6px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  padding: 0 8px;
-  color: var(--dsw-label-2);
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1;
-  cursor: pointer;
-}
-
-.shell-chrome-btn.icon-only {
-  width: 28px;
-  justify-content: center;
-  padding: 0;
-}
-
-.shell-chrome-btn:hover {
-  background: var(--dsw-hover);
-  color: var(--dsw-label);
-}
-
-.shell-chrome-btn.is-active {
-  background: var(--dsw-business-soft);
-  color: var(--dsw-business);
-}
-
-.shell-chrome-pop-wrap {
+.shell-side-pop-wrap {
   position: relative;
 }
 
-.shell-chrome-pop {
+.shell-side-pop {
   position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  z-index: 30;
+  top: 0;
+  left: calc(100% + 8px);
+  z-index: 40;
   width: 240px;
   padding: 10px;
   border-radius: 12px;
@@ -1812,6 +1748,14 @@ body {
   margin: 2px 0 4px;
 }
 
+.shell-side-places {
+  margin-bottom: 0;
+}
+
+.app-stage .app-side-actions {
+  margin-top: 0;
+}
+
 .app-side-actions-item {
   position: relative;
   isolation: isolate;
@@ -1846,11 +1790,13 @@ body {
   z-index: 1;
 }
 
-.app-side-actions-item:hover {
+.app-side-actions-item:hover,
+.app-side-actions-item.is-active {
   color: var(--dsw-sidebar-fg-active);
 }
 
-.app-side-actions-item:hover::before {
+.app-side-actions-item:hover::before,
+.app-side-actions-item.is-active::before {
   background: var(--dsw-hover);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉误加的主栏顶栏。聊天面板、数据面板、设置、搜索、通知作为公共入口，挂在共用左侧栏外框上：聊天页叠在「添加聊天」上方，数据页叠在「添加视图 / 拷贝视图」上方。下载更新仍在设置的「更新」页。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

