### PR TITLE
聊天输入框改为 14px

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -16,6 +16,7 @@ describe('composer dock stacking above sticky user', () => {
     const thread = readFileSync(resolve(root, 'packages/cap-chat/src/web/thread.tsx'), 'utf8')
 
     expect(css).toMatch(/--dsw-chat-font-size:\s*14px/)
+    expect(css).toMatch(/--dsw-chat-composer-font-size:\s*14px/)
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
     expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)
     expect(thread).toMatch(/sticky top-0 z-1 bg-transparent/)

--- a/web/style.css
+++ b/web/style.css
@@ -37,7 +37,7 @@
   /* 右侧对话正文字号 */
   --dsw-chat-font-size: 14px;
   --dsw-chat-line-height: 1.6;
-  --dsw-chat-composer-font-size: 16px;
+  --dsw-chat-composer-font-size: 14px;
   /* 聊天窗内控件：工具条、回合栏、排队、slash、模型、工具卡 */
   --dsw-chat-ui-font-size: 12px;
   --dsw-chat-chip-font-size: 12px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
底部聊天输入框（`.composer-tiptap`）字号改为 14px，与对话正文一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

