### PR TITLE
拖窗口边框时栏宽不再播过渡动画

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -84,9 +84,9 @@ test('brand mascot lives at the corner; sidebar head is title plus collapse', ()
   assert.match(css, /\.inspector-tab\s*\{[^}]*color:\s*#F0EFED/s)
 })
 
-test('shell columns keep three tracks so sidebar and inspector can animate', () => {
-  assert.match(css, /\.app-shell-agent\s*\{[^}]*transition:\s*grid-template-columns/s)
-  assert.match(css, /\.app-shell-module\s*\{[^}]*transition:\s*grid-template-columns/s)
+test('shell columns stay three tracks without animating on window resize', () => {
+  assert.doesNotMatch(css, /\.app-shell-agent\s*\{[^}]*transition:\s*grid-template-columns/s)
+  assert.doesNotMatch(css, /\.app-shell-module\s*\{[^}]*transition:\s*grid-template-columns/s)
   assert.match(
     css,
     /\.app-shell-agent\s*\{[^}]*grid-template-columns:\s*var\(--sidebar-col, 0px\) minmax\(0, 1fr\) var\(--inspector-width, 0px\)/s,

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -60,6 +60,7 @@ test('center stage keeps modules mounted and crossfades', () => {
   assert.match(shell, /className="app-stage"/)
   assert.match(shell, /app-stage-pane/)
   assert.match(shell, /is-window-resizing/)
+  assert.match(shell, /classList\.add\('is-window-resizing'\)/)
   assert.doesNotMatch(shell, /if \(moduleId !== activeId\) return null/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
   assert.match(css, /\.app-stage-pane[\s\S]*?content-visibility:\s*hidden/)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -355,6 +355,7 @@ function Shell(props: SlotProps) {
   })
   const [columnResizing, setColumnResizing] = useState(false)
   const [windowResizing, setWindowResizing] = useState(false)
+  const shellRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     const onDown = (event: PointerEvent) => {
       const target = event.target
@@ -449,10 +450,14 @@ function Shell(props: SlotProps) {
   useEffect(() => {
     let timer = 0
     const sync = () => {
+      shellRef.current?.classList.add('is-window-resizing')
       setViewportWidth(window.innerWidth)
       setWindowResizing(true)
       window.clearTimeout(timer)
-      timer = window.setTimeout(() => setWindowResizing(false), 120)
+      timer = window.setTimeout(() => {
+        shellRef.current?.classList.remove('is-window-resizing')
+        setWindowResizing(false)
+      }, 160)
     }
     sync()
     window.addEventListener('resize', sync)
@@ -632,6 +637,7 @@ function Shell(props: SlotProps) {
 
   return (
     <div
+      ref={shellRef}
       className={`app-shell${leftPane
           ? ` app-shell-agent${leftHidden ? ' is-sidebar-collapsed' : ''}${sidebarNarrow && !leftHidden ? ' is-sidebar-narrow' : ''}${inspectorVisible ? ' is-inspector-open' : ''
           }${columnResizing ? ' is-resizing' : ''}${windowResizing ? ' is-window-resizing' : ''}`

--- a/web/style.css
+++ b/web/style.css
@@ -1347,7 +1347,6 @@ body {
 
 .app-shell-agent {
   grid-template-columns: var(--sidebar-col, 0px) minmax(0, 1fr) var(--inspector-width, 0px);
-  transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .app-shell-agent.is-resizing,
@@ -1757,7 +1756,6 @@ body {
 
 .app-shell-module {
   grid-template-columns: minmax(0, 1fr) var(--inspector-width, 0px);
-  transition: grid-template-columns 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .app-shell-module.is-resizing,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
拖浏览器左右边框卡顿，是因为壳层对 `grid-template-columns` 做了 240ms 过渡，窗口一变宽就整栏跟着缓动。

已去掉这条栏宽动画；resize 时立刻打上 `is-window-resizing`，布局跟手。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

