### PR TITLE
style: 聊天用量数字对齐 12px 侧栏色

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -129,7 +129,8 @@ const CSS = `
 .fsdb-page .tasks-table.is-wrap td{white-space:normal;vertical-align:top;max-width:28rem}
 .fsdb-page .tasks-table th,.fsdb-page .tasks-table.is-wrap th{white-space:nowrap}
 .fsdb-cell{display:flex;align-items:center;min-width:0;max-width:100%;min-height:18px}
-.fsdb-page .traj-usage,.fsdb-page .traj-usage-empty{font-size:14px;line-height:inherit}
+.fsdb-page .fsdb-cell .traj-usage,.fsdb-page .fsdb-cell .traj-usage-empty,.fsdb-page .tasks-table .traj-usage,.fsdb-page .tasks-table .traj-usage-empty,.fsdb-page .tasks-queue-item-main .traj-usage,.fsdb-page .tasks-queue-item-main .traj-usage-empty{font-size:14px;line-height:inherit}
+.fsdb-page .chat-pane .traj-usage,.fsdb-page .chat-pane .traj-usage-empty{font-size:var(--dsw-chat-ui-font-size);line-height:1;font-weight:400;color:var(--dsw-sidebar-fg)}
 .fsdb-link{color:inherit;text-underline-offset:2px;overflow-wrap:anywhere}
 .fsdb-link:hover{text-decoration:underline}
 .fsdb-thumb-link,.fsdb-thumb-btn{display:inline-flex;align-items:center;justify-content:center;line-height:0;border:0;padding:0;background:transparent;cursor:zoom-in;vertical-align:middle}

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -59,7 +59,8 @@ test('list and detail properties share key and value colors', () => {
 })
 
 test('usage figures in collection cells match the table font size', () => {
-  assert.match(css, /\.fsdb-page \.traj-usage,\.fsdb-page \.traj-usage-empty\{[^}]*font-size:14px/)
+  assert.match(css, /\.fsdb-page \.fsdb-cell \.traj-usage,\.fsdb-page \.fsdb-cell \.traj-usage-empty,\.fsdb-page \.tasks-table \.traj-usage,\.fsdb-page \.tasks-table \.traj-usage-empty,\.fsdb-page \.tasks-queue-item-main \.traj-usage,\.fsdb-page \.tasks-queue-item-main \.traj-usage-empty\{[^}]*font-size:14px/)
+  assert.match(css, /\.fsdb-page \.chat-pane \.traj-usage,\.fsdb-page \.chat-pane \.traj-usage-empty\{[^}]*font-size:var\(--dsw-chat-ui-font-size\)/)
 })
 
 test('visible column menu scrolls inside a max height', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -3287,8 +3287,10 @@ body {
   justify-content: flex-end;
   gap: 4px;
   max-width: 100%;
-  font-size: 10px;
+  font-size: var(--dsw-chat-ui-font-size);
   line-height: 1;
+  font-weight: 400;
+  color: var(--dsw-sidebar-fg);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -3304,8 +3306,8 @@ body {
 }
 
 .traj-usage-in {
-  color: var(--dsw-label);
-  font-weight: 600;
+  color: var(--dsw-sidebar-fg);
+  font-weight: 400;
 }
 
 .traj-usage-arrow {
@@ -3314,8 +3316,8 @@ body {
 }
 
 .traj-usage-out {
-  color: var(--dsw-label);
-  font-weight: 600;
+  color: var(--dsw-sidebar-fg);
+  font-weight: 400;
 }
 
 /* 绿色 cache / 橙色历史：SVG 描边圆环，不用 mask，取色能落到实色 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天回合统计栏里的 token 用量跟 `--dsw-chat-ui-font-size`（12px）和 `--dsw-sidebar-fg` 对齐，去掉 10px 加粗。

`.fsdb-page` 里 14px 只作用在表格/单元格，不再把会话详情聊天里的用量撑成 14px。HUD 仍保持 11px。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-763dbec6-b960-4b00-9a46-0331c32acbc2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763dbec6-b960-4b00-9a46-0331c32acbc2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

