### PR TITLE
fix(chat): 对齐详情页输入框位置并补全 dock 工具栏

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -134,10 +134,11 @@ function activeWorkerAgents(
   }
   return [...latest.values()].sort((a, b) => workerRecency(b) - workerRecency(a))
 }
-export function ApprovalsRail(props: SlotProps) {
+export function ApprovalsRail(props: SlotProps & { boundSessionId?: string; boundNodes?: ChatNode[]; onSessionRefresh?: () => void }) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
   const sessionView = props.sessionView as SessionViewService
-  const sessionId = useSessionView((state) => state.sessionId)
+  const liveSessionId = useSessionView((state) => state.sessionId)
+  const sessionId = props.boundSessionId ?? liveSessionId
   const sessions = useSessionView((state) => state.sessions)
   const dispatchedTasksByTurn = useSessionView((state) => state.dispatchedTasksByTurn)
   const workerAgents = useMemo(
@@ -148,7 +149,8 @@ export function ApprovalsRail(props: SlotProps) {
   const hiddenWorkerCount = Math.max(0, workerAgents.length - visibleWorkers.length)
   const approvals = useSessionView((state) => state.approvals)
   const approvalMode = useSessionView((state) => state.approvalMode)
-  const nodes = useSessionView((state) => state.nodes)
+  const liveNodes = useSessionView((state) => state.nodes)
+  const nodes = props.boundNodes ?? liveNodes
   const histRatio = useMemo(() => latestHistRatio(nodes), [nodes])
   const [agentMode, setAgentMode] = useState<AgentMode>('standard')
   const [modeBusy, setModeBusy] = useState(false)
@@ -244,8 +246,11 @@ export function ApprovalsRail(props: SlotProps) {
     try {
       const res = await fetch(`/api/sessions/${sessionId}/clear-context`, { method: 'POST' })
       if (!res.ok) return
-      // 后台校对拉取最新事件，使新插入的日志记录立即出现在会话视图中。
-      await sessionView.load(sessionId, { view: 'chat', wait: false })
+      if (props.onSessionRefresh) {
+        props.onSessionRefresh()
+      } else {
+        await sessionView.load(sessionId, { view: 'chat', wait: false })
+      }
     } finally {
       setClearBusy(false)
     }
@@ -349,7 +354,7 @@ export function ApprovalsRail(props: SlotProps) {
           ) : null}
         </div>
         <div className="chat-dock-toolbar-end flex shrink-0 items-center justify-end gap-1">
-          <SessionProjectPanel {...props} />
+          <SessionProjectPanel {...props} boundSessionId={props.boundSessionId} />
           <DockIconMenu
             label="Agent 模式"
             value={agentMode}

--- a/packages/cap-chat/src/web/index.ts
+++ b/packages/cap-chat/src/web/index.ts
@@ -89,6 +89,12 @@ export function apply(ctx: Context) {
   ctx.inject(['databaseUi', 'snapshot'], (inner) => {
     const ui = inner.get('databaseUi') as DatabaseUi
     const snap = inner.get('snapshot') as SnapshotService
-    return ui.decorate('/sessions', sessionsChrome(snap)).dispose
+    let pick: PickService | undefined
+    try {
+      pick = inner.get('pick') as PickService
+    } catch {
+      pick = undefined
+    }
+    return ui.decorate('/sessions', sessionsChrome({ snapshot: snap, slotProps: props(), pick })).dispose
   })
 }

--- a/packages/cap-chat/src/web/live-hud.tsx
+++ b/packages/cap-chat/src/web/live-hud.tsx
@@ -6,7 +6,7 @@ import {
   WrenchScrewdriverIcon,
 } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/web-slots'
-import { bindSessionView } from '@biu/web-session-view'
+import { bindSessionView, type ChatNode } from '@biu/web-session-view'
 import { UsageInline } from './usage-inline.tsx'
 import { MarkdownBody } from './markdown.tsx'
 import { splitReplyForDisplay } from './thread.tsx'
@@ -71,9 +71,10 @@ export function ChatLiveMetrics(props: { useSessionView: ReturnType<typeof bindS
   )
 }
 
-export const ChatLiveHud = memo(function ChatLiveHud(props: SlotProps) {
+export const ChatLiveHud = memo(function ChatLiveHud(props: SlotProps & { boundNodes?: ChatNode[] }) {
   const useSessionView = props.useSessionView as ReturnType<typeof bindSessionView>
-  const nodes = useSessionView((state) => state.nodes)
+  const liveNodes = useSessionView((state) => state.nodes)
+  const nodes = props.boundNodes ?? liveNodes
   const agentStep = useSessionView((state) => state.agentStep)
   const replyId = useSyncExternalStore(subscribeHudReplyId, getHudReplyId, () => null)
   const hud = extractLiveHud(nodes, agentStep, replyId)

--- a/packages/cap-chat/src/web/project-panel.tsx
+++ b/packages/cap-chat/src/web/project-panel.tsx
@@ -3,10 +3,11 @@ import { bindProjectView, type ProjectViewService } from '@biu/web-project-view'
 import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 
 /** 紧凑项目绑定：始终仅文件夹图标；未绑定虚线框，绑定后实线，无文字/高亮。 */
-export function SessionProjectPanel(props: SlotProps) {
+export function SessionProjectPanel(props: SlotProps & { boundSessionId?: string }) {
   const useProjectView = props.useProjectView as ReturnType<typeof bindProjectView>
   const projectView = props.projectView as ProjectViewService
-  const sessionId = useProjectView((state) => state.sessionId)
+  const liveSessionId = useProjectView((state) => state.sessionId)
+  const sessionId = props.boundSessionId ?? liveSessionId
   const project = useProjectView((state) => state.project)
   const busy = useProjectView((state) => state.busy)
   const error = useProjectView((state) => state.error)

--- a/packages/cap-chat/src/web/sessions-chrome.test.ts
+++ b/packages/cap-chat/src/web/sessions-chrome.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { sessionsChrome } from './sessions-chrome.tsx'
 
-const chrome = sessionsChrome()
+const chrome = sessionsChrome({ slotProps: {} })
 
 test('session table uses mascot as the standalone icon property, title is just the label', () => {
   assert.equal(typeof chrome.Title, 'function')
@@ -43,7 +43,11 @@ test('session table uses mascot as the standalone icon property, title is just t
   assert.doesNotMatch(src, /sessionView\.load/)
   assert.doesNotMatch(src, /SlotOutlet/)
   assert.doesNotMatch(src, /name="composer"/)
-  assert.doesNotMatch(src, /ApprovalsRail/)
+  assert.match(src, /ApprovalsRail/)
+  assert.match(src, /ChatConfigBanner/)
+  assert.match(src, /ChatLiveHud/)
+  assert.match(src, /boundSessionId={sessionId}/)
+  assert.match(src, /bottom:0;z-index:20;padding:0 60px calc\(1rem \+ 25px\)/)
   const composer = readFileSync(resolve(import.meta.dirname, './composer.tsx'), 'utf8')
   assert.match(composer, /boundSessionId/)
   assert.match(composer, /\/api\/sessions\/\$\{boundSessionId\}\/messages/)

--- a/packages/cap-chat/src/web/sessions-chrome.tsx
+++ b/packages/cap-chat/src/web/sessions-chrome.tsx
@@ -5,6 +5,8 @@ import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import { MASCOT_COLOR_NAME, MASCOT_EYE_NAME, MASCOT_SHAPE_NAME } from '@biu/type-session'
 import type { CollectionChrome, FsCellProps, FsContentProps } from '@biu/type-file-system/ui'
 import type { DbRecord } from '@biu/type-file-system'
+import type { SlotProps } from '@biu/web-slots'
+import type { PickService } from '@biu/cap-pick/web'
 import {
   deriveChatOutline,
   getChatOutlineFilter,
@@ -18,6 +20,9 @@ import {
   type TrajectoryUsage,
   upsertSessionEvent,
 } from '@biu/web-session-view'
+import { ApprovalsRail } from './approvals.tsx'
+import { ChatConfigBanner } from './config-banner.tsx'
+import { ChatLiveHud } from './live-hud.tsx'
 import { ChatNodeList } from './thread.tsx'
 import { ChatComposer } from './composer.tsx'
 import type { SnapshotService } from '@biu/web-snapshot'
@@ -75,10 +80,18 @@ const idleSessionView = {
   get: () => ({ sessionId: '' }),
 } as never
 
+type SessionChromeDeps = {
+  snapshot?: SnapshotService
+  slotProps: Record<string, unknown>
+  pick?: PickService
+}
+
 function SessionRecordChat({
   record,
   snapshot,
-}: FsContentProps & { snapshot?: SnapshotService }) {
+  slotProps,
+  pick,
+}: FsContentProps & SessionChromeDeps) {
   const sessionId = String(record.id)
   const [events, setEvents] = useState<SessionEvent[]>([])
   const [nodes, setNodes] = useState<ChatNode[]>([])
@@ -89,22 +102,9 @@ function SessionRecordChat({
   const stageRef = useRef<HTMLDivElement>(null)
   const filter = useSyncExternalStore(subscribeChatOutline, getChatOutlineFilter, (): ChatOutlineFilter => 'user')
   const items = useMemo(() => deriveChatOutline(nodes, filter), [nodes, filter])
-  const go = useCallback((id: string) => {
-    const el = document.querySelector<HTMLElement>(
-      `[data-testid="session-record-chat"] [data-node-id="${escapeId(id)}"]`,
-    )
-    el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
-  }, [])
-  useLayoutEffect(() => {
-    const el = anchorRef.current
-    const right = el?.closest('.fsdb-right')
-    const root = right instanceof HTMLElement ? right : null
-    setOutlineHost(root)
-    setComposerHost(root)
-  }, [])
-  useEffect(() => {
-    const ac = new AbortController()
-    void fetch(`/api/sessions/${sessionId}?turns=${SESSION_LOAD_TURNS}`, { signal: ac.signal })
+  const dockSlotProps = slotProps as SlotProps
+  const reloadSession = useCallback(() => {
+    void fetch(`/api/sessions/${sessionId}?turns=${SESSION_LOAD_TURNS}`)
       .then((res) => (res.ok ? res.json() : null))
       .then((body) => {
         if (!body || !Array.isArray(body.events)) return
@@ -118,8 +118,24 @@ function SessionRecordChat({
         )
       })
       .catch(() => undefined)
-    return () => ac.abort()
   }, [sessionId])
+  const go = useCallback((id: string) => {
+    const el = document.querySelector<HTMLElement>(
+      `[data-testid="session-record-chat"] [data-node-id="${escapeId(id)}"]`,
+    )
+    el?.scrollIntoView({ block: 'start', behavior: 'smooth' })
+  }, [])
+  useLayoutEffect(() => {
+    const el = anchorRef.current
+    const main = el?.closest('main')
+    const right = el?.closest('.fsdb-right')
+    const root = (main instanceof HTMLElement ? main : right instanceof HTMLElement ? right : null)
+    setOutlineHost(right instanceof HTMLElement ? right : root)
+    setComposerHost(root)
+  }, [])
+  useEffect(() => {
+    reloadSession()
+  }, [reloadSession])
   useEffect(() => {
     if (!snapshot) return
     const offSession = snapshot.onMessage('session', (payload) => {
@@ -148,7 +164,17 @@ function SessionRecordChat({
   const outline = <OutlineNav items={items} testId="session-outline" onSelect={go} />
   const dock = (
     <ChatDockStack>
+      <ChatLiveHud {...dockSlotProps} boundNodes={nodes} />
+      <ChatConfigBanner {...dockSlotProps} />
+      <ApprovalsRail
+        {...dockSlotProps}
+        boundSessionId={sessionId}
+        boundNodes={nodes}
+        onSessionRefresh={reloadSession}
+      />
       <ChatComposer
+        {...dockSlotProps}
+        pick={pick}
         boundSessionId={sessionId}
         boundPending={boundPending}
         useSessionView={useIdleSessionView}
@@ -161,7 +187,7 @@ function SessionRecordChat({
       {outlineHost ? createPortal(<div className="session-outline-host">{outline}</div>, outlineHost) : null}
       {composerHost ? createPortal(
         <div className="session-composer-host">
-          <div className="chat-composer-dock">{dock}</div>
+          <div className="chat-composer-dock pointer-events-none bg-transparent">{dock}</div>
         </div>,
         composerHost,
       ) : null}
@@ -179,11 +205,11 @@ function SessionRecordChat({
   )
 }
 
-export function sessionsChrome(snapshot?: SnapshotService): CollectionChrome {
+export function sessionsChrome(deps: SessionChromeDeps): CollectionChrome {
   return {
     Title: SessionTitle,
     Icon: SessionIcon,
-    Content: (props) => <SessionRecordChat {...props} snapshot={snapshot} />,
+    Content: (props) => <SessionRecordChat {...props} {...deps} />,
     cells: {
       mascotShape: MascotShapeCell,
       mascotColor: MascotColorCell,
@@ -210,10 +236,11 @@ if (typeof document !== 'undefined') {
 }
 .inspector-database-page .fsdb-detail-main:has(.chat-pane-embed){padding-bottom:12px}
 .session-outline-host{position:absolute;inset:0;z-index:20;pointer-events:none}
-.session-composer-host{position:absolute;inset-inline:0;bottom:calc(1rem + 25px);z-index:20;padding:0 60px;pointer-events:none}
-.session-composer-host .chat-composer-dock{position:static;padding:0;background:transparent;pointer-events:none}
-.session-composer-host .chat-composer-dock>*{pointer-events:auto;width:100%;max-width:var(--dsw-chat-max-width);margin-inline:auto}
-.fsdb-right:has(.session-outline-host),.fsdb-right:has(.session-composer-host){position:relative}
+main:has(.session-composer-host){position:relative}
+.session-composer-host{position:absolute;inset-inline:0;bottom:0;z-index:20;padding:0 60px calc(1rem + 25px);pointer-events:none}
+.session-composer-host .chat-composer-dock{position:static;padding:0;background:transparent}
+.session-composer-host .chat-composer-dock>*{width:100%;max-width:var(--dsw-chat-max-width);margin-inline:auto}
+.fsdb-right:has(.session-outline-host){position:relative}
 .session-outline-host .chat-outline{left:8px;top:50%}
 `
   document.head.appendChild(style)

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -30,7 +30,7 @@ const CSS = `
 .fsdb-right-body:has(.fsdb-pager){overflow:hidden}
 .fsdb-right-body:has(.fsdb-pager)>*,.fsdb-right-body:has(.fsdb-pager) .fsdb-main{display:flex;flex-direction:column;min-height:0;flex:1;height:100%;overflow:hidden}
 .fsdb-detail-main:has(.chat-pane-embed),.fsdb-detail-screen:has(.chat-pane-embed){background:#191919}
-.fsdb-detail-main:has(.chat-pane-embed){padding-bottom:calc(5.5rem + 1rem + 25px)}
+.fsdb-detail-main:has(.chat-pane-embed){padding-bottom:calc(5.5rem + 2rem + 1rem + 25px)}
 .fsdb-views{display:flex;width:100%;max-width:none;min-width:0;flex:1;flex-direction:column;min-height:0;overflow:hidden;box-sizing:border-box}
 .fsdb-page>.fsdb-views{width:var(--sidebar-col,var(--dsw-sidebar-min,160px));max-width:var(--dsw-sidebar-max,360px);flex:none}
 .fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -39,7 +39,7 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.tasks-viewdd-item-actions\{[^}]*visibility:hidden/)
   assert.match(css, /\.tasks-viewdd-act\{[^}]*width:26px/)
   assert.match(css, /\.fsdb-right-body:has\(\.fsdb-pager\)\{[^}]*overflow:hidden/)
-  assert.match(css, /\.fsdb-detail-main:has\(\.chat-pane-embed\)\{[^}]*padding-bottom:calc\(5\.5rem \+ 1rem \+ 25px\)/)
+  assert.match(css, /\.fsdb-detail-main:has\(\.chat-pane-embed\)\{[^}]*padding-bottom:calc\(5\.5rem \+ 2rem \+ 1rem \+ 25px\)/)
   assert.doesNotMatch(css, /\.fsdb-right-body:has\(\.chat-pane-embed\)/)
   assert.match(css, /\.fsdb-pager\{[^}]*margin-top:auto/)
   assert.match(css, /\.fsdb-page\{[^}]*--fsdb-pager-lift:calc\(1rem \+ 44px \+ 25px \+ 25px - 30px\)/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

### 输入框位置对齐
- 将会话详情 composer portal 到 `main`（与主聊天同一容器）
- 使用与主聊天相同的 `bottom: 0` + `padding-bottom: calc(1rem + 25px)` + 左右 60px
- 增加详情页底部留白，为工具栏 + 输入框留出空间

### 补全悬浮工具栏
详情页 dock 现在与主聊天一致，包含：
- ChatLiveHud
- ChatConfigBanner
- ApprovalsRail（清空上下文、Agent 模式、工具审批、项目绑定等）
- ChatComposer

绑定会话上下文（`boundSessionId` / `boundNodes`）已接入 ApprovalsRail 和 ProjectPanel。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

