### PR TITLE
style(chat): 输入框文字 16px，已发送消息仍为 14px

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -16,7 +16,8 @@ describe('composer dock stacking above sticky user', () => {
     const thread = readFileSync(resolve(root, 'packages/cap-chat/src/web/thread.tsx'), 'utf8')
 
     expect(css).toMatch(/--dsw-chat-font-size:\s*14px/)
-    expect(css).toMatch(/--dsw-chat-composer-font-size:\s*14px/)
+    expect(css).toMatch(/--dsw-chat-composer-font-size:\s*16px/)
+    expect(css).toMatch(/\.composer-tiptap\.is-readonly\s*\{[^}]*font-size:\s*var\(--dsw-chat-font-size\)/s)
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
     expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)
     expect(thread).toMatch(/sticky top-0 z-1 bg-transparent/)

--- a/web/style.css
+++ b/web/style.css
@@ -37,7 +37,7 @@
   /* 右侧对话正文字号 */
   --dsw-chat-font-size: 14px;
   --dsw-chat-line-height: 1.6;
-  --dsw-chat-composer-font-size: 14px;
+  --dsw-chat-composer-font-size: 16px;
   /* 聊天窗内控件：工具条、回合栏、排队、slash、模型、工具卡 */
   --dsw-chat-ui-font-size: 12px;
   --dsw-chat-chip-font-size: 12px;
@@ -5010,6 +5010,7 @@ body {
 
 .composer-tiptap.is-readonly {
   cursor: default;
+  font-size: var(--dsw-chat-font-size);
 }
 
 .composer-tiptap.is-readonly .composer-tool-chip.is-pick {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
只改底部输入框里正在输入的文字大小为 16px。

已发送的用户气泡使用 `.composer-tiptap.is-readonly`，显式继续用 `--dsw-chat-font-size`（14px），不会跟着变大。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

