### PR TITLE
fix: 表格会话详情聊天不再撑破右侧 padding

### DIFF
--- a/packages/cap-chat/src/web/sessions-chrome.test.ts
+++ b/packages/cap-chat/src/web/sessions-chrome.test.ts
@@ -34,6 +34,7 @@ test('session table uses mascot as the standalone icon property, title is just t
   assert.match(src, /background:#191919/)
   assert.match(src, /\.fsdb-detail-main:has\(\.chat-pane-embed\) \.chat-stage\{[^}]*overflow:visible/)
   assert.match(src, /\.fsdb-detail-main:has\(\.chat-pane-embed\) \.chat-stage\{[^}]*overscroll-behavior:auto/)
+  assert.match(src, /\.fsdb-detail-main:has\(\.chat-pane-embed\) \.chat-stage>\*\{[^}]*max-width:100%/)
   assert.match(src, /\.fsdb-fileview:has\(\.chat-pane-embed\)\{[^}]*flex:none/)
   assert.doesNotMatch(src, /sessionView\.load/)
   assert.doesNotMatch(src, /SlotOutlet/)

--- a/packages/cap-chat/src/web/sessions-chrome.tsx
+++ b/packages/cap-chat/src/web/sessions-chrome.tsx
@@ -132,12 +132,12 @@ if (typeof document !== 'undefined') {
   style.id = id
   style.textContent = `
 .sessions-title-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
-.fsdb-fileview:has(.chat-pane-embed){display:flex;flex-direction:column;flex:none;min-height:0;height:auto;width:100%;background:#191919}
+.fsdb-fileview:has(.chat-pane-embed){display:flex;flex-direction:column;flex:none;min-width:0;min-height:0;height:auto;width:100%;max-width:100%;background:#191919}
 .inspector-database-page .fsdb-fileview:has(.chat-pane-embed){min-height:0;flex:1}
 .fsdb-detail-main:has(.chat-pane-embed),.fsdb-detail-screen:has(.chat-pane-embed){background:#191919}
-.fsdb-detail-main:has(.chat-pane-embed) .chat-pane-embed{padding-inline:0;min-height:0;width:100%}
-.fsdb-detail-main:has(.chat-pane-embed) .chat-pane-embed,.fsdb-detail-main:has(.chat-pane-embed) .chat-overlay-thread,.fsdb-detail-main:has(.chat-pane-embed) .chat-stage{overflow:visible;flex:none;min-height:0;height:auto;overscroll-behavior:auto;align-items:stretch}
-.fsdb-detail-main:has(.chat-pane-embed) .chat-stage>*{max-width:none;width:100%}
+.fsdb-detail-main:has(.chat-pane-embed) .chat-pane-embed{padding-inline:0;min-width:0;min-height:0;width:100%;max-width:100%;box-sizing:border-box}
+.fsdb-detail-main:has(.chat-pane-embed) .chat-pane-embed,.fsdb-detail-main:has(.chat-pane-embed) .chat-overlay-thread,.fsdb-detail-main:has(.chat-pane-embed) .chat-stage{overflow:visible;flex:none;min-width:0;min-height:0;height:auto;max-width:100%;overscroll-behavior:auto;align-items:stretch;scrollbar-gutter:auto}
+.fsdb-detail-main:has(.chat-pane-embed) .chat-stage>*{max-width:100%;width:100%;min-width:0;box-sizing:border-box}
 .session-outline-host{position:absolute;inset:0;z-index:20;pointer-events:none}
 .fsdb-right:has(.session-outline-host),.fsdb-right-body:has(.session-outline-host),.fsdb-detail-stage:has(.session-outline-host){position:relative}
 .session-outline-host .chat-outline{left:8px;top:50%}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
取消表格详情内层滚动后，`.chat-stage > *` 仍按 `--dsw-chat-max-width`（768px）作为最小内容宽度撑开，详情列本身已是 768px 再加 100px padding，聊天会从右边顶出去。

嵌入链改为 `min-width:0`、`max-width:100%`，气泡跟标题属性落在同一条 padding 里。整页仍由 `.fsdb-right-body` 滚动。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

