### PR TITLE
feat: 搜索结果会话/任务/页面/插件右侧显示标签

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -807,7 +807,7 @@ function Shell(props: SlotProps) {
       {searchOpen
         ? createPortal(
           <ShellSearchPanel
-            sessions={danceSessions.map((item) => ({ id: item.id, title: item.title }))}
+            sessions={danceSessions.map((item) => ({ id: item.id, title: item.title, tags: item.tags }))}
             onClose={() => setSearchOpen(false)}
             focusSeq={searchFocusSeq}
           />,

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { SEARCH_SCOPES, openSearchHit, searchCollection, searchHref } from './shell-search.tsx'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { SEARCH_SCOPES, openSearchHit, searchCollection, searchHref, tagsFromRecord } from './shell-search.tsx'
 
 test('search opens inspector collections, not chat or database routes', () => {
   assert.equal(searchCollection('session'), '/sessions')
@@ -36,4 +38,21 @@ test('searchHref opens the left main pane by changing the route', () => {
   assert.equal(searchHref({ kind: 'task', id: 't1' }), '/database/tasks/record/t1')
   assert.equal(searchHref({ kind: 'plugin', id: 'g1' }), '/database/plugins/record/g1')
   assert.equal(searchHref({ kind: 'facet', id: 'f1' }), '/database/facets/record/f1')
+})
+
+test('search hits collect tags from tags, facet.tags, and config.tags', () => {
+  assert.deepEqual(tagsFromRecord({ tags: ['a', 'b'] }), ['a', 'b'])
+  assert.deepEqual(tagsFromRecord({ facet: { tags: ['dp'] } }), ['dp'])
+  assert.deepEqual(tagsFromRecord({ config: { tags: ['host-ui'] } }), ['host-ui'])
+  assert.deepEqual(tagsFromRecord({ tags: ['a'], facet: { tags: ['a', 'b'] } }), ['a', 'b'])
+})
+
+test('session task page plugin hits render a kind tag on the right', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
+  assert.match(src, /HitKindTag/)
+  assert.match(src, /HitRecordTags/)
+  assert.match(src, /item\.kind === 'session' \|\| item\.kind === 'task' \|\| item\.kind === 'page' \|\| item\.kind === 'plugin'/)
+  assert.match(src, /shell-search-hit-tags/)
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  assert.match(css, /\.shell-search-hit-tags\s*\{[^}]*margin-left:\s*auto/s)
 })

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -33,14 +33,38 @@ export type SearchHit = {
   kind: SearchKind
   id: string
   title: string
+  tags?: string[]
 }
 
-export type SessionHint = { id: string; title: string }
+export type SessionHint = { id: string; title: string; tags?: string[] }
 
 function recordTitle(row: Record<string, unknown>) {
   const title = row.title ?? row.name ?? row.label
   const text = String(title ?? '').trim()
   return text || String(row.id ?? '')
+}
+
+function pushTags(into: string[], value: unknown) {
+  if (!Array.isArray(value)) return
+  for (const item of value) {
+    const text = String(item ?? '').trim()
+    if (text) into.push(text)
+  }
+}
+
+/** 列表行上的标签：tags、facet.tags、config.tags。 */
+export function tagsFromRecord(row: Record<string, unknown>) {
+  const tags: string[] = []
+  pushTags(tags, row.tags)
+  const facet = row.facet
+  if (facet && typeof facet === 'object' && !Array.isArray(facet)) {
+    pushTags(tags, (facet as { tags?: unknown }).tags)
+  }
+  const config = row.config
+  if (config && typeof config === 'object' && !Array.isArray(config)) {
+    pushTags(tags, (config as { tags?: unknown }).tags)
+  }
+  return [...new Set(tags)]
 }
 
 export function searchCollection(kind: SearchKind) {
@@ -82,6 +106,27 @@ async function listKind(path: string, query: string, signal: AbortSignal) {
   const res = await fetch(`/api/db/list?${params}`, { signal })
   const body = (await res.json()) as { items?: Array<Record<string, unknown>> }
   return Array.isArray(body.items) ? body.items : []
+}
+
+function HitKindTag({ kind }: { kind: SearchKind }) {
+  const scope = SEARCH_SCOPES.find((item) => item.id === kind)
+  if (!scope) return null
+  return <TagChip id={kind} label={scope.label} icon={<KindGlyph kind={kind} compact />} />
+}
+
+function HitRecordTags({ tags }: { tags?: string[] }) {
+  const list = (tags ?? []).map((tag) => tag.trim()).filter(Boolean)
+  if (!list.length) return null
+  const shown = list.slice(0, 2)
+  const extra = list.length - shown.length
+  return (
+    <TagChips>
+      {shown.map((tag) => (
+        <TagChip key={tag} id={tag} label={tag} />
+      ))}
+      {extra > 0 ? <TagChip id={`+${extra}`} label={`+${extra}`} /> : null}
+    </TagChips>
+  )
 }
 
 function KindGlyph({ kind, compact }: { kind: SearchKind | 'all'; compact?: boolean }) {
@@ -128,6 +173,7 @@ export function ShellSearchPanel({
         kind: 'session' as const,
         id: item.id,
         title: item.title || item.id,
+        tags: (item.tags ?? []).map((tag) => tag.trim()).filter(Boolean),
       }))
   }, [needle, sessions])
 
@@ -165,6 +211,7 @@ export function ShellSearchPanel({
                 kind: item.id,
                 id,
                 title: recordTitle(row),
+                tags: tagsFromRecord(row),
               } satisfies SearchHit
             })
           } catch {
@@ -319,6 +366,12 @@ export function ShellSearchPanel({
                       <KindGlyph kind={item.kind} />
                     </span>
                     <span className="shell-search-hit-title">{item.title}</span>
+                    {item.kind === 'session' || item.kind === 'task' || item.kind === 'page' || item.kind === 'plugin' ? (
+                      <span className="shell-search-hit-tags">
+                        <HitRecordTags tags={item.tags} />
+                        <HitKindTag kind={item.kind} />
+                      </span>
+                    ) : null}
                   </button>
                 )
               })}

--- a/web/style.css
+++ b/web/style.css
@@ -325,9 +325,24 @@ body {
 
 .shell-search-hit-title {
   min-width: 0;
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.shell-search-hit-tags {
+  display: inline-flex;
+  min-width: 0;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.shell-search-hit-tags .biu-tags {
+  flex-wrap: nowrap;
 }
 
 .shell-search-hint {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索结果里会话、任务、页面、插件每条右侧显示类型芯片（会话/任务/页面/插件）。若记录带标签，一并显示最多两个，其余 +N。

会话从侧栏已加载列表带 `tags`；任务/页面/插件从 `/api/db/list` 的 `tags` 或 `facet.tags` 读取。类型（facet）结果不加这枚右侧芯片。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

