### PR TITLE
fix: 搜索结果去掉类型芯片

### DIFF
--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -47,11 +47,11 @@ test('search hits collect tags from tags, facet.tags, and config.tags', () => {
   assert.deepEqual(tagsFromRecord({ tags: ['a'], facet: { tags: ['a', 'b'] } }), ['a', 'b'])
 })
 
-test('session task page plugin hits render a kind tag on the right', () => {
+test('session task page plugin hits render record tags on the right, not kind chips', () => {
   const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
-  assert.match(src, /HitKindTag/)
+  assert.doesNotMatch(src, /HitKindTag/)
   assert.match(src, /HitRecordTags/)
-  assert.match(src, /item\.kind === 'session' \|\| item\.kind === 'task' \|\| item\.kind === 'page' \|\| item\.kind === 'plugin'/)
+  assert.match(src, /item\.tags\?\.length/)
   assert.match(src, /shell-search-hit-tags/)
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(css, /\.shell-search-hit-tags\s*\{[^}]*margin-left:\s*auto/s)

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -108,12 +108,6 @@ async function listKind(path: string, query: string, signal: AbortSignal) {
   return Array.isArray(body.items) ? body.items : []
 }
 
-function HitKindTag({ kind }: { kind: SearchKind }) {
-  const scope = SEARCH_SCOPES.find((item) => item.id === kind)
-  if (!scope) return null
-  return <TagChip id={kind} label={scope.label} icon={<KindGlyph kind={kind} compact />} />
-}
-
 function HitRecordTags({ tags }: { tags?: string[] }) {
   const list = (tags ?? []).map((tag) => tag.trim()).filter(Boolean)
   if (!list.length) return null
@@ -366,10 +360,9 @@ export function ShellSearchPanel({
                       <KindGlyph kind={item.kind} />
                     </span>
                     <span className="shell-search-hit-title">{item.title}</span>
-                    {item.kind === 'session' || item.kind === 'task' || item.kind === 'page' || item.kind === 'plugin' ? (
+                    {(item.kind === 'session' || item.kind === 'task' || item.kind === 'page' || item.kind === 'plugin') && item.tags?.length ? (
                       <span className="shell-search-hit-tags">
                         <HitRecordTags tags={item.tags} />
-                        <HitKindTag kind={item.kind} />
                       </span>
                     ) : null}
                   </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索结果右侧去掉会话/任务/页面/插件的类型芯片，避免占位。有记录标签时仍显示在右侧。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

