### PR TITLE
fix: 空搜索时各类展示最近更新记录

### DIFF
--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -807,7 +807,12 @@ function Shell(props: SlotProps) {
       {searchOpen
         ? createPortal(
           <ShellSearchPanel
-            sessions={danceSessions.map((item) => ({ id: item.id, title: item.title, tags: item.tags }))}
+            sessions={danceSessions.map((item) => ({
+              id: item.id,
+              title: item.title,
+              tags: item.tags,
+              updatedAt: item.updatedAt,
+            }))}
             onClose={() => setSearchOpen(false)}
             focusSeq={searchFocusSeq}
           />,

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -2,7 +2,15 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { SEARCH_SCOPES, openSearchHit, searchCollection, searchHref, tagsFromRecord } from './shell-search.tsx'
+import {
+  SEARCH_SCOPES,
+  openSearchHit,
+  pickRecentHits,
+  recordUpdatedAt,
+  searchCollection,
+  searchHref,
+  tagsFromRecord,
+} from './shell-search.tsx'
 
 test('search opens inspector collections, not chat or database routes', () => {
   assert.equal(searchCollection('session'), '/sessions')
@@ -45,6 +53,34 @@ test('search hits collect tags from tags, facet.tags, and config.tags', () => {
   assert.deepEqual(tagsFromRecord({ facet: { tags: ['dp'] } }), ['dp'])
   assert.deepEqual(tagsFromRecord({ config: { tags: ['host-ui'] } }), ['host-ui'])
   assert.deepEqual(tagsFromRecord({ tags: ['a'], facet: { tags: ['a', 'b'] } }), ['a', 'b'])
+})
+
+test('recordUpdatedAt prefers updatedAt then createdAt', () => {
+  assert.equal(recordUpdatedAt({ updatedAt: 9, createdAt: 1 }), 9)
+  assert.equal(recordUpdatedAt({ createdAt: 4 }), 4)
+  assert.equal(recordUpdatedAt({}), 0)
+})
+
+test('pickRecentHits takes the newest records per kind', () => {
+  assert.deepEqual(
+    pickRecentHits(
+      [
+        { id: 'old', updatedAt: 1 },
+        { id: 'new', updatedAt: 9 },
+        { id: 'mid', updatedAt: 5 },
+      ],
+      2,
+    ).map((item) => item.id),
+    ['new', 'mid'],
+  )
+})
+
+test('empty search lists every kind by updatedAt instead of skipping remotes', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
+  assert.doesNotMatch(src, /if \(!needle && scope === 'all'\) \{\s*setHits\(\[\]\)/)
+  assert.match(src, /sort: 'updatedAt'/)
+  assert.match(src, /item.id === 'session' \? '\/sessions'/)
+  assert.match(src, /空着时会话、任务、页面、插件、类型各按更新时间列最近/)
 })
 
 test('session task page plugin hits render record tags on the right, not kind chips', () => {

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -34,9 +34,10 @@ export type SearchHit = {
   id: string
   title: string
   tags?: string[]
+  updatedAt?: number
 }
 
-export type SessionHint = { id: string; title: string; tags?: string[] }
+export type SessionHint = { id: string; title: string; tags?: string[]; updatedAt?: number }
 
 function recordTitle(row: Record<string, unknown>) {
   const title = row.title ?? row.name ?? row.label
@@ -65,6 +66,19 @@ export function tagsFromRecord(row: Record<string, unknown>) {
     pushTags(tags, (config as { tags?: unknown }).tags)
   }
   return [...new Set(tags)]
+}
+
+export function recordUpdatedAt(row: Record<string, unknown>) {
+  const updated = Number(row.updatedAt)
+  if (Number.isFinite(updated) && updated) return updated
+  const created = Number(row.createdAt)
+  return Number.isFinite(created) ? created : 0
+}
+
+export function pickRecentHits<T extends { id: string; updatedAt?: number }>(items: T[], limit = PER_KIND) {
+  return [...items]
+    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0) || left.id.localeCompare(right.id))
+    .slice(0, limit)
 }
 
 export function searchCollection(kind: SearchKind) {
@@ -160,27 +174,27 @@ export function ShellSearchPanel({
   const needle = query.trim().toLowerCase()
 
   const localSessions = useMemo(() => {
-    return sessions
+    const matched = sessions
       .filter((item) => matchLocal(item.title, item.id, needle))
-      .slice(0, PER_KIND)
       .map((item) => ({
         kind: 'session' as const,
         id: item.id,
         title: item.title || item.id,
         tags: (item.tags ?? []).map((tag) => tag.trim()).filter(Boolean),
+        updatedAt: item.updatedAt ?? 0,
       }))
+    return pickRecentHits(matched)
   }, [needle, sessions])
 
   useEffect(() => {
     const keyOf = (kind: SearchKind) => `${kind}\0${needle}`
-    const remote = SEARCH_SCOPES.filter((item) => item.path && (scope === 'all' || item.id === scope))
-    const allRemote = SEARCH_SCOPES.filter((item) => item.path)
+    const listed = SEARCH_SCOPES.map((item) => ({
+      id: item.id,
+      path: item.id === 'session' ? '/sessions' : item.path,
+    })).filter((item): item is { id: SearchKind; path: string } => Boolean(item.path))
+    const remote = listed.filter((item) => scope === 'all' || item.id === scope)
+    const allRemote = listed
     const fromCache = allRemote.flatMap((item) => cacheRef.current.get(keyOf(item.id)) ?? [])
-    if (!needle && scope === 'all') {
-      setHits([])
-      setBusy(false)
-      return
-    }
     if (fromCache.length) setHits(fromCache)
     if (!remote.length) {
       setBusy(false)
@@ -206,6 +220,7 @@ export function ShellSearchPanel({
                 id,
                 title: recordTitle(row),
                 tags: tagsFromRecord(row),
+                updatedAt: recordUpdatedAt(row),
               } satisfies SearchHit
             })
           } catch {
@@ -229,15 +244,20 @@ export function ShellSearchPanel({
   }, [needle, scope])
 
   const grouped = useMemo(() => {
-    const sessionHits = scope === 'all' || scope === 'session' ? localSessions : []
     const remote = hits.filter((item) => scope === 'all' || item.kind === scope)
     const order: SearchKind[] = ['session', 'task', 'page', 'plugin', 'facet']
     return order
-      .map((kind) => ({
-        kind,
-        label: SEARCH_SCOPES.find((item) => item.id === kind)?.label ?? kind,
-        items: kind === 'session' ? sessionHits : remote.filter((item) => item.kind === kind),
-      }))
+      .map((kind) => {
+        const fromRemote = remote.filter((item) => item.kind === kind)
+        const fromLocal = kind === 'session' && (scope === 'all' || scope === 'session') ? localSessions : []
+        const seen = new Set(fromRemote.map((item) => item.id))
+        const merged = [...fromRemote, ...fromLocal.filter((item) => !seen.has(item.id))]
+        return {
+          kind,
+          label: SEARCH_SCOPES.find((item) => item.id === kind)?.label ?? kind,
+          items: pickRecentHits(merged),
+        }
+      })
       .filter((group) => group.items.length)
   }, [hits, localSessions, scope])
 
@@ -337,9 +357,9 @@ export function ShellSearchPanel({
           </TagChips>
         </div>
         <div className="shell-search-body" aria-busy={busy}>
-          {!needle && scope === 'all' && !flat.length ? (
+          {!needle && scope === 'all' && !flat.length && !busy ? (
             <p className="shell-search-hint">
-              会话用已加载的列表即时筛；其它类型并行各取最多 {PER_KIND} 条，输入后再请求。
+              空着时会话、任务、页面、插件、类型各按更新时间列最近 {PER_KIND} 条。
             </p>
           ) : null}
           {grouped.map((group) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
空着打开搜索时，不再只列出已加载的会话、也不再跳过其它表。

- 会话 / 任务 / 页面 / 插件 / 类型各自按 `updatedAt`（没有则用 `createdAt`）取最近最多 8 条
- 去掉「全部 + 空 query 直接不请求远程」的 early return
- 会话同时用已加载列表和 `/sessions` 列表，去重后再按时间取最近

输入关键词后的筛选行为不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

