### PR TITLE
fix: 数据库打开按钮不再带 pick action

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1473,7 +1473,6 @@ export function CollectionBrowser({
             type="button"
             className="tasks-title-open"
             data-testid="record-title-open"
-            data-biu-action="open"
             aria-label="查看详情"
             title="查看详情"
             onClick={(event) => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -222,6 +222,7 @@ test('card and queue rows expose split and expand like the table', () => {
   assert.match(browser, /className="fsdb-title-host"/)
   assert.doesNotMatch(browser, /fsdb-row-check-cell/)
   assert.doesNotMatch(browser, /<th>操作<\/th>/)
+  assert.doesNotMatch(browser, /data-biu-action="open"/)
   assert.doesNotMatch(browser, /tasks-queue-item-main" data-biu-action="open"/)
   assert.doesNotMatch(browser, /tasks-minicard-open" data-biu-action="open"/)
   const style = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据库标题旁的放大打开按钮不再带 `data-biu-action="open"`。点选记录时不会再附上唤起 action（pick 里的 `action="open"`）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

