### PR TITLE
搜索 action 对齐系统 icon 按钮间距

### DIFF
--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -97,8 +97,8 @@ test('session task page plugin hits render tags left of actions', () => {
   assert.match(css, /\.shell-search-hit-aside\s*\{[^}]*margin-left:\s*auto/s)
   assert.match(css, /\.shell-search-hit-icon\s*\{[^}]*color:\s*var\(--dsw-label-2\)/s)
   assert.match(css, /\.shell-search-hit-action\s*\{[^}]*color:\s*var\(--dsw-label-2\)/s)
-  assert.match(css, /\.shell-search-hit-action\s*\{[^}]*width:\s*16px/s)
-  assert.match(css, /\.shell-search-hit-action\s*\{[^}]*height:\s*16px/s)
+  assert.match(css, /\.shell-search-hit-action\s*\{[^}]*padding:\s*3px/s)
+  assert.match(css, /\.shell-search-hit-action:hover\s*\{[^}]*background:\s*var\(--dsw-hover\)/s)
 })
 
 test('search hit icons follow record mark: emoji, else session mascot', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -363,13 +363,11 @@ body {
 
 .shell-search-hit-action {
   display: inline-flex;
-  width: 16px;
-  height: 16px;
   align-items: center;
   justify-content: center;
   border: 0;
   border-radius: 5px;
-  padding: 0;
+  padding: 3px;
   background: transparent;
   color: var(--dsw-label-2);
   cursor: pointer;
@@ -378,7 +376,7 @@ body {
 }
 
 .shell-search-hit-action:hover {
-  background: var(--dsw-input);
+  background: var(--dsw-hover);
   color: var(--dsw-label-2);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索结果行内 action 图标保持 16px，按钮不再锁死 16×16。内边距、圆角和悬停底与表格 `tasks-icon-btn` 一致（padding 3px、`--dsw-hover`），避免背景贴着图标、按钮挤在一起。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

