### PR TITLE
搜索栏不展示汇报进度

### DIFF
--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -123,7 +123,7 @@ test('facet search scope is named 合集 with stack icon', () => {
 test('search does not draw agent progress as a hit action', () => {
   const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
   assert.match(src, /actionVisibleToUser\(action\)/)
-  assert.doesNotMatch(src, /id === 'progress' \|\| id === 'report'/)
+  assert.match(src, /SEARCH_SKIP_ACTION_IDS/)
   assert.match(src, /id === 'deliver'\) return <PaperAirplaneIcon/)
 })
 
@@ -138,5 +138,18 @@ test('search hits hide agent-only actions', () => {
       { id: 's1' },
     ).map((item) => item.id),
     ['start'],
+  )
+})
+
+test('search hits never show report even if placement is row', () => {
+  assert.deepEqual(
+    visibleRowActions(
+      [
+        { id: 'report', label: '汇报进度', placement: ['row', 'detail'], for: 'both' },
+        { id: 'deliver', label: '派工', placement: ['row', 'detail'], for: 'both' },
+      ],
+      { id: 't1' },
+    ).map((item) => item.id),
+    ['deliver'],
   )
 })

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -38,6 +38,16 @@ export const SEARCH_SCOPES: Array<{
 const PER_KIND = 8
 const DEBOUNCE_MS = 160
 const NAV_ACTION_IDS = new Set(['open-split', 'open-page'])
+/** Agent-only / internal actions that must never appear on search hits. */
+const SEARCH_SKIP_ACTION_IDS = new Set([
+  'report',
+  'progress',
+  'inspect',
+  'compact',
+  'clear',
+  'retrieve',
+  'status',
+])
 
 export type SearchAction = {
   id: string
@@ -152,6 +162,7 @@ export function visibleRowActions(actions: SearchAction[] | undefined, record: R
   return (actions ?? []).filter((action) => {
     if (!actionVisibleToUser(action)) return false
     if (NAV_ACTION_IDS.has(action.id)) return false
+    if (SEARCH_SKIP_ACTION_IDS.has(action.id)) return false
     const places = action.placement ?? ['row', 'detail']
     return places.includes('row') && matchActionWhen(row, action.when)
   })
@@ -262,7 +273,7 @@ function HitActions({
   hit: SearchHit
   onRan: () => void
 }) {
-  const actions = visibleRowActions(hit.actions, hit.record ?? { id: hit.id })
+  const actions = visibleRowActions(hit.actions, hit.record ?? { id: hit.id }).filter((action) => actionGlyph(action.id))
   const [busyId, setBusyId] = useState<string | null>(null)
   if (!actions.length) return null
   const run = async (action: SearchAction) => {
@@ -299,7 +310,7 @@ function HitActions({
             void run(action)
           }}
         >
-          {actionGlyph(action.id) ?? action.label}
+          {actionGlyph(action.id)}
         </button>
       ))}
     </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
任务 `report`（汇报进度）是 Agent 往账本追加报告用的，不应出现在搜索命中的行内动作里。

- 搜索对 `report` / `progress` 等 id 做硬过滤（即使误配 `for: both` + `placement: row` 也不会画）
- 搜索命中只渲染有图标的动作，避免无图标时露出「汇报进度」文字
- `deliver`（派工）仍可在搜索栏点击

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

