### PR TITLE
搜索左侧打开会话后焦点回到输入框

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -36,6 +36,7 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.chat-overlay-panel \{/)
     expect(css).not.toMatch(/\.chat-overlay-panel\.is-compose-only \.chat-overlay-thread/)
     expect(composer).toContain('revealOverlayThread')
+    expect(composer).toContain('isComposerFocusPending')
     expect(composer).toContain('biu:composer-focus')
   })
 

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -18,7 +18,7 @@ import {
 import { ModelConfigDialog } from './model-config-dialog.tsx'
 import { ImageThumbs } from './image-thumbs.tsx'
 import { collectClipboardImages, collectImageFiles } from './clipboard-images.ts'
-import { revealOverlayThread } from '@biu/web-app-shell/chat-overlay'
+import { revealOverlayThread, isComposerFocusPending } from '@biu/web-app-shell/chat-overlay'
 import { shouldNavigateToSession } from './composer-nav.ts'
 
 /** 按键不驱动受控 value；仅防抖更新发送按钮可用态，避免每个字符打穿 React 渲染。 */
@@ -569,6 +569,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
     }
     if (keep.length && !pick?.picking) pick?.addMany(keep)
     pickKeysRef.current = collectPickKeys(editor)
+    if (isComposerFocusPending()) editor.commands.focus('end')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, editor])
 

--- a/packages/web-app-shell/src/web/chat-overlay.ts
+++ b/packages/web-app-shell/src/web/chat-overlay.ts
@@ -159,11 +159,22 @@ export function setOverlayThread(next: boolean) {
   emitThread()
 }
 
+let composerFocusPending = false
+
 export function requestComposerFocus() {
+  composerFocusPending = true
   const fire = () => window.dispatchEvent(new Event('biu:composer-focus'))
   fire()
   requestAnimationFrame(fire)
   window.setTimeout(fire, 40)
+  window.setTimeout(() => {
+    fire()
+    composerFocusPending = false
+  }, 160)
+}
+
+export function isComposerFocusPending() {
+  return composerFocusPending
 }
 
 /** 聊天页中间已有输入框，选取不要再弹悬浮窗。 */

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -7,7 +7,6 @@ import {
   openSearchHit,
   pickRecentHits,
   recordUpdatedAt,
-  refocusSearchField,
   searchCollection,
   searchHref,
   tagsFromRecord,
@@ -155,15 +154,8 @@ test('search hits never show report even if placement is row', () => {
   )
 })
 
-test('opening a session on the left keeps search and refocuses the field', () => {
+test('opening a session on the left closes search and focuses the composer', () => {
   const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
-  assert.match(src, /refocusSearchField\(inputRef\.current\)/)
-  assert.match(src, /window\.setTimeout\(go, 60\)/)
-  assert.match(src, /navigate\(href\)\s*refocusSearchField/)
-  assert.doesNotMatch(src, /navigate\(href\)\s*\} else \{\s*openSearchHit/)
-  const calls: number[] = []
-  const node = { focus: () => calls.push(1) } as unknown as HTMLInputElement
-  refocusSearchField(node)
-  assert.equal(calls.length, 1)
-  refocusSearchField(null)
+  assert.match(src, /onClose\(\)\s*if \(side === 'left' && hit\.kind === 'session'\) requestComposerFocus\(\)/)
+  assert.doesNotMatch(src, /refocusSearchField/)
 })

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -7,6 +7,7 @@ import {
   openSearchHit,
   pickRecentHits,
   recordUpdatedAt,
+  refocusSearchField,
   searchCollection,
   searchHref,
   tagsFromRecord,
@@ -152,4 +153,17 @@ test('search hits never show report even if placement is row', () => {
     ).map((item) => item.id),
     ['deliver'],
   )
+})
+
+test('opening a session on the left keeps search and refocuses the field', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
+  assert.match(src, /refocusSearchField\(inputRef\.current\)/)
+  assert.match(src, /window\.setTimeout\(go, 60\)/)
+  assert.match(src, /navigate\(href\)\s*refocusSearchField/)
+  assert.doesNotMatch(src, /navigate\(href\)\s*\} else \{\s*openSearchHit/)
+  const calls: number[] = []
+  const node = { focus: () => calls.push(1) } as unknown as HTMLInputElement
+  refocusSearchField(node)
+  assert.equal(calls.length, 1)
+  refocusSearchField(null)
 })

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -19,7 +19,7 @@ import { TagChip, TagChips } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { actionVisibleToUser } from '@biu/type-file-system'
-import { setChatOverlay } from './chat-overlay.ts'
+import { setChatOverlay, requestComposerFocus } from './chat-overlay.ts'
 
 export type SearchKind = 'session' | 'task' | 'page' | 'plugin' | 'facet'
 
@@ -187,14 +187,6 @@ export function searchHref(hit: { kind: SearchKind; id: string }) {
   if (hit.kind === 'session') return `/s/${encodeURIComponent(hit.id)}`
   const collection = searchCollection(hit.kind)
   return `/database${collection}/record/${encodeURIComponent(hit.id)}`
-}
-
-/** 左侧打开会抢走焦点（会话切主栏、composer 抢焦）；搜索层保持打开并把光标拉回输入框。 */
-export function refocusSearchField(node: HTMLInputElement | null) {
-  const go = () => node?.focus()
-  go()
-  requestAnimationFrame(go)
-  window.setTimeout(go, 60)
 }
 
 function matchLocal(title: string, id: string, needle: string) {
@@ -482,11 +474,11 @@ export function ShellSearchPanel({
       const href = searchHref(hit)
       if (hit.kind === 'session') setChatOverlay(false)
       navigate(href)
-      refocusSearchField(inputRef.current)
-      return
+    } else {
+      openSearchHit(hit)
     }
-    openSearchHit(hit)
     onClose()
+    if (side === 'left' && hit.kind === 'session') requestComposerFocus()
   }
 
   let cursor = -1

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -189,6 +189,14 @@ export function searchHref(hit: { kind: SearchKind; id: string }) {
   return `/database${collection}/record/${encodeURIComponent(hit.id)}`
 }
 
+/** 左侧打开会抢走焦点（会话切主栏、composer 抢焦）；搜索层保持打开并把光标拉回输入框。 */
+export function refocusSearchField(node: HTMLInputElement | null) {
+  const go = () => node?.focus()
+  go()
+  requestAnimationFrame(go)
+  window.setTimeout(go, 60)
+}
+
 function matchLocal(title: string, id: string, needle: string) {
   if (!needle) return true
   return title.toLowerCase().includes(needle) || id.toLowerCase().includes(needle)
@@ -474,9 +482,10 @@ export function ShellSearchPanel({
       const href = searchHref(hit)
       if (hit.kind === 'session') setChatOverlay(false)
       navigate(href)
-    } else {
-      openSearchHit(hit)
+      refocusSearchField(inputRef.current)
+      return
     }
+    openSearchHit(hit)
     onClose()
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
从搜索用 ⇧↵（或 Shift+点击）在左侧打开会话时，主栏/composer 会抢走焦点。

现在搜索层保持打开，并把光标重新放到搜索输入框，方便继续搜。右侧 ↵ 仍会关闭搜索。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

