### PR TITLE
chore: 删除已被 saved-views 替代的 /api/task-views

### DIFF
--- a/packages/core-task-system/src/host/index.test.ts
+++ b/packages/core-task-system/src/host/index.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Context } from 'cordis'
-import { buildDeliverText, coerceAssigneeArg, computeBlocked, computeBlockedBy, computeNextTriggerAt, computeTurnUsage, defaultTrigger, depsSatisfied, deriveExecution, deriveExecutionFromReports, MAX_REPORT_PROMPTS, normalizeTrigger, normalizeViewConfig, parseCron, reportBackToCreator, shouldPromptProgress, sumReportUsage, TasksService } from './index.ts'
+import { buildDeliverText, coerceAssigneeArg, computeBlocked, computeBlockedBy, computeNextTriggerAt, computeTurnUsage, defaultTrigger, depsSatisfied, deriveExecution, deriveExecutionFromReports, MAX_REPORT_PROMPTS, normalizeTrigger, parseCron, reportBackToCreator, shouldPromptProgress, sumReportUsage, TasksService } from './index.ts'
 
 test('tasks sqlite crud and status move', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'tasks-'))
@@ -735,78 +735,6 @@ test('trigger default state is idle and enabled=false (no auto-trigger for plain
     // source=null（未给 trigger）→ 自动触发不开启
     assert.equal(plain.trigger?.enabled, false)
     assert.equal(plain.trigger?.state, 'idle')
-  } finally {
-    await rm(dir, { recursive: true, force: true })
-  }
-})
-
-// ==================== 视图系统（Notion 风格）测试 ====================
-
-test('task_views: no builtin layout views; create / update / delete', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'tasks-views-'))
-  const path = join(dir, 'tasks.sqlite')
-  try {
-    const ctx = new Context()
-    const tasks = new TasksService(ctx, path).open()
-    assert.equal(tasks.listTaskViews().length, 0)
-
-    const v = tasks.createTaskView({
-      name: '  我的视图  ',
-      config: {
-        mode: 'gantt' as never,
-        filter: { project: 'biu', tags: ['a', 'a', ' '], time: '99d' },
-        sort: { field: 'bogus' as never, dir: 'side' as never },
-      },
-    })
-    assert.equal(v.name, '我的视图')
-    assert.equal(v.isBuiltin, false)
-    assert.deepEqual(v.config, {
-      mode: 'table',
-      filter: { project: 'biu', tags: ['a'], time: '' },
-      sort: { field: 'status', dir: 'asc' },
-    })
-
-    const tasks2 = new TasksService(new Context(), path).open()
-    assert.equal(tasks2.listTaskViews().length, 1)
-
-    const updated = tasks.updateTaskView(v.id, {
-      name: '高优看板',
-      config: { mode: 'board', filter: { project: 'biu-harness', tags: ['前端'], time: '7d' }, sort: { field: 'due', dir: 'asc' } },
-    })
-    assert.equal(updated.name, '高优看板')
-    assert.deepEqual(updated.config.filter, { project: 'biu-harness', tags: ['前端'], time: '7d' })
-    assert.deepEqual(updated.config.sort, { field: 'due', dir: 'asc' })
-
-    assert.throws(() => tasks.updateTaskView('nope', { name: 'x' }), /unknown view/)
-    assert.equal(tasks.deleteTaskView('nope'), false)
-    assert.equal(tasks.deleteTaskView(v.id), true)
-    assert.equal(tasks.getTaskView(v.id), undefined)
-    assert.equal(tasks.listTaskViews().length, 0)
-  } finally {
-    await rm(dir, { recursive: true, force: true })
-  }
-})
-
-test('task_views: open drops leftover builtin layout rows', async () => {
-  const dir = await mkdtemp(join(tmpdir(), 'tasks-views-drop-'))
-  const path = join(dir, 'tasks.sqlite')
-  try {
-    new TasksService(new Context(), path).open()
-    const { DatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
-    const db = new DatabaseSync(path)
-    const ts = Date.now()
-    db.prepare(
-      'INSERT INTO task_views (id, name, config_json, is_builtin, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)',
-    ).run(
-      'builtin-table',
-      '表格',
-      JSON.stringify({ mode: 'table', filter: { project: '', tags: [], time: '' }, sort: { field: 'status', dir: 'asc' } }),
-      ts,
-      ts,
-    )
-    db.close()
-    const again = new TasksService(new Context(), path).open()
-    assert.equal(again.listTaskViews().length, 0)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/core-task-system/src/host/index.ts
+++ b/packages/core-task-system/src/host/index.ts
@@ -147,84 +147,7 @@ export type TaskRow = {
   lastReportPromptAt: number | null
   /** 自上次汇报以来已追问次数。达到 MAX_REPORT_PROMPTS 后停止，避免把执行会话问死。 */
   reportPromptCount: number
-}
-
-
-// ==================== 视图系统（Notion 风格）：task_views 表 + 配置归一化 ====================
-export type TaskViewMode = 'queue' | 'table' | 'cards' | 'board' | 'graph'
-export type TaskViewSortField = 'priority' | 'due' | 'updated' | 'created' | 'status'
-export type TaskViewSortDir = 'asc' | 'desc'
-
-/** 视图筛选（与工具栏筛选对应；time：''=全部 | '1h' | '24h' | '7d' | '30d'） */
-export type TaskViewFilter = {
-  project: string
-  tags: string[]
-  time: string
-}
-
-/** 视图排序：字段 + 升降序。字段为 status 时按「状态 → 优先级 → 截止」复合排序。 */
-export type TaskViewSort = {
-  field: TaskViewSortField
-  dir: TaskViewSortDir
-}
-
-/** 视图 = 一套完整配置：呈现方式 + 筛选 + 排序 */
-export type TaskViewConfig = {
-  mode: TaskViewMode
-  filter: TaskViewFilter
-  sort: TaskViewSort
-}
-
-export type TaskView = {
-  id: string
-  name: string
-  config: TaskViewConfig
-  isBuiltin: boolean
-  createdAt: number
-  updatedAt: number
-}
-
-const VIEW_MODES = new Set<TaskViewMode>(['queue', 'table', 'cards', 'board', 'graph'])
-const VIEW_SORT_FIELDS = new Set<TaskViewSortField>(['priority', 'due', 'updated', 'created', 'status'])
-const VIEW_SORT_DIRS = new Set<TaskViewSortDir>(['asc', 'desc'])
-const VIEW_TIME_FILTERS = new Set<string>(['', '1h', '24h', '7d', '30d'])
-
-export function defaultViewConfig(): TaskViewConfig {
-  return {
-    mode: 'table',
-    filter: { project: '', tags: [], time: '' },
-    // 默认排序：状态 → 优先级 → 截止（status 为复合排序）
-    sort: { field: 'status', dir: 'asc' },
-  }
-}
-
-/** 归一化视图配置：非法字段回退默认，保证写入 task_views.config_json 的数据结构稳定。 */
-export function normalizeViewConfig(value: unknown): TaskViewConfig {
-  const d = defaultViewConfig()
-  if (!value || typeof value !== 'object') return d
-  const raw = value as Record<string, unknown>
-  const mode = VIEW_MODES.has(raw.mode as TaskViewMode) ? (raw.mode as TaskViewMode) : d.mode
-  const filterRaw = (raw.filter && typeof raw.filter === 'object' ? raw.filter : {}) as Record<string, unknown>
-  const tags = Array.isArray(filterRaw.tags) ? [...new Set(filterRaw.tags.map((t) => String(t).trim()).filter(Boolean))] : []
-  const filter: TaskViewFilter = {
-    project: typeof filterRaw.project === 'string' ? filterRaw.project : '',
-    tags,
-    time: VIEW_TIME_FILTERS.has(String(filterRaw.time ?? '')) ? String(filterRaw.time) : '',
-  }
-  const sortRaw = (raw.sort && typeof raw.sort === 'object' ? raw.sort : {}) as Record<string, unknown>
-  const sort: TaskViewSort = {
-    field: VIEW_SORT_FIELDS.has(sortRaw.field as TaskViewSortField) ? (sortRaw.field as TaskViewSortField) : d.sort.field,
-    dir: VIEW_SORT_DIRS.has(sortRaw.dir as TaskViewSortDir) ? (sortRaw.dir as TaskViewSortDir) : d.sort.dir,
-  }
-  return { mode, filter, sort }
-}
-
-export function normalizeViewName(value: unknown): string {
-  const s = typeof value === 'string' ? value.trim() : ''
-  return s ? s.slice(0, 80) : '未命名视图'
-}
-
-export type TaskCreateInput = {
+}export type TaskCreateInput = {
   title: string
   status?: TaskStatus
   priority?: TaskPriority
@@ -1177,20 +1100,8 @@ export class TasksService extends Service {
         /* already exists */
       }
     }
-    // ---- 视图持久化：task_views 表。呈现方式（列表/表格/看板/依赖）不是视图，不 seed 内置行。 ----
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS task_views (
-        id TEXT PRIMARY KEY,
-        name TEXT NOT NULL,
-        config_json TEXT NOT NULL,
-        is_builtin INTEGER NOT NULL DEFAULT 0,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL
-      );
-    `)
-    this.db.exec(
-      `DELETE FROM task_views WHERE is_builtin = 1 OR id IN ('builtin-queue','builtin-table','builtin-board','builtin-graph')`,
-    )
+    // 视图已迁到 File System `/api/db/saved-views`，丢掉旧的 task_views 表。
+    this.db.exec('DROP TABLE IF EXISTS task_views')
     return this
   }
 
@@ -1198,16 +1109,6 @@ export class TasksService extends Service {
     try {
       const host = this.ctx as HostCtx
       host.http?.broadcast?.('tasks', { ts: now(), ...extra })
-    } catch {
-      /* host http 未就绪（单测） */
-    }
-  }
-
-  /** 广播「切换到指定视图」事件（Agent 工具触发，前端 WS 收到后自动切换看板）。 */
-  emitViewSwitch(viewId: string) {
-    try {
-      const host = this.ctx as HostCtx
-      host.http?.broadcast?.('tasks', { ts: now(), type: 'view-switch', viewId })
     } catch {
       /* host http 未就绪（单测） */
     }
@@ -1474,69 +1375,6 @@ export class TasksService extends Service {
     return result.changes > 0
   }
 
-  // ---- 视图（task_views）----
-  private rowToView(row: Record<string, unknown>): TaskView {
-    let config = defaultViewConfig()
-    try {
-      config = normalizeViewConfig(JSON.parse(String(row.config_json ?? '{}')))
-    } catch {
-      /* 脏数据回退默认 */
-    }
-    return {
-      id: String(row.id),
-      name: String(row.name),
-      config,
-      isBuiltin: Number(row.is_builtin) === 1,
-      createdAt: Number(row.created_at ?? 0),
-      updatedAt: Number(row.updated_at ?? 0),
-    }
-  }
-
-  listTaskViews(): TaskView[] {
-    const rows = this.db
-      .prepare('SELECT * FROM task_views ORDER BY is_builtin DESC, created_at ASC, id ASC')
-      .all() as Array<Record<string, unknown>>
-    return rows.map((r) => this.rowToView(r))
-  }
-
-  getTaskView(id: string): TaskView | undefined {
-    const row = this.db.prepare('SELECT * FROM task_views WHERE id = ?').get(id) as Record<string, unknown> | undefined
-    return row ? this.rowToView(row) : undefined
-  }
-
-  createTaskView(input: { name: string; config: TaskViewConfig }): TaskView {
-    const name = normalizeViewName(input.name)
-    const config = normalizeViewConfig(input.config)
-    const id = `view_${now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
-    const ts = now()
-    this.db
-      .prepare('INSERT INTO task_views (id, name, config_json, is_builtin, created_at, updated_at) VALUES (?, ?, ?, 0, ?, ?)')
-      .run(id, name, JSON.stringify(config), ts, ts)
-    this.emitChange({ type: 'view-changed', viewId: id })
-    return this.getTaskView(id)!
-  }
-
-  updateTaskView(id: string, patch: { name?: string; config?: TaskViewConfig }): TaskView {
-    const current = this.getTaskView(id)
-    if (!current) throw new Error('unknown view')
-    const name = patch.name !== undefined ? normalizeViewName(patch.name) : current.name
-    const config = patch.config !== undefined ? normalizeViewConfig(patch.config) : current.config
-    this.db
-      .prepare('UPDATE task_views SET name = ?, config_json = ?, updated_at = ? WHERE id = ?')
-      .run(name, JSON.stringify(config), now(), id)
-    this.emitChange({ type: 'view-changed', viewId: id })
-    return this.getTaskView(id)!
-  }
-
-  /** 返回是否删除成功。 */
-  deleteTaskView(id: string): boolean {
-    const current = this.getTaskView(id)
-    if (!current) return false
-    const result = this.db.prepare('DELETE FROM task_views WHERE id = ?').run(id) as { changes: number }
-    if (result.changes > 0) this.emitChange({ type: 'view-changed', viewId: id })
-    return result.changes > 0
-  }
-
   /** DAG 环检测：从每个依赖任务沿其依赖链 DFS，若回溯到本任务则成环 */
   private assertNoCycle(id: string, dependsOn: string[]): void {
     const visited = new Set<string>()
@@ -1679,49 +1517,6 @@ export function apply(ctx: Context) {
       steps: turn.steps.length,
     }
   }
-
-  // ==================== 视图（task_views）REST：Notion 风格视图持久化 ====================
-  // GET    /api/task-views      —— 视图列表
-  // POST   /api/task-views      —— 新建/另存为（body: { name, config }）
-  // PATCH  /api/task-views/:id  —— 重命名/更新配置（body: { name?, config? }）
-  // DELETE /api/task-views/:id  —— 删除已保存视图
-  host.http.route('GET', '/api/task-views', async (route) => {
-    route.send(200, { views: tasks.listTaskViews() })
-  })
-
-  host.http.route('POST', '/api/task-views', async (route) => {
-    try {
-      const body = (await route.json()) as { name?: string; config?: TaskViewConfig }
-      const view = tasks.createTaskView({ name: normalizeViewName(body.name), config: normalizeViewConfig(body.config) })
-      route.send(201, { view })
-    } catch (error) {
-      route.send(400, { error: String(error) })
-    }
-  })
-
-  host.http.route('PATCH', '/api/task-views/:id', async (route) => {
-    try {
-      const body = (await route.json()) as { name?: string; config?: TaskViewConfig }
-      const view = tasks.updateTaskView(route.params.id, {
-        ...(body.name !== undefined ? { name: body.name } : {}),
-        ...(body.config !== undefined ? { config: body.config } : {}),
-      })
-      route.send(200, { view })
-    } catch (error) {
-      const message = String(error)
-      route.send(message.includes('unknown') ? 404 : 400, { error: message })
-    }
-  })
-
-  host.http.route('DELETE', '/api/task-views/:id', async (route) => {
-    try {
-      const ok = tasks.deleteTaskView(route.params.id)
-      if (!ok) return route.send(404, { error: 'unknown view' })
-      route.send(200, { ok: true })
-    } catch (error) {
-      route.send(400, { error: String(error) })
-    }
-  })
 
   // ==================== Trigger 统一调度 driver（自包含，事件驱动） ====================
   // 触发语义：cron(定时) / at(特定时间) / on(自动事件 dep:done·turn:end) 三源统一。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
任务看板视图已走 File System 的 `/api/db/saved-views`。本 PR 删除无人调用的 `/api/task-views` REST、`task_views` SQLite 表及相关归一化/测试。启动时 `DROP TABLE IF EXISTS task_views` 清掉旧库残留。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

