### PR TITLE
chore: 清理 File System 死代码

### DIFF
--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1111,7 +1111,7 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/db/facets', async (route) => {
     try {
-      const body = (await route.json()) as { path?: string; facets?: unknown[] }
+      const body = (await route.json()) as { facets?: unknown[] }
       facets.replace(Array.isArray(body.facets) ? body.facets : [])
       ctx.emit('database/change')
       route.send(200, { ok: true, facets: facets.list() })

--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { parseAppPath } from '@biu/web-session-view'
-import { DATA_MODULE, databaseAllViewPath, databaseRecordPath, databaseViewPath, isSystemCollection, sortDataCollections, viewsCatalogHref, viewsCatalogSource } from './database-path.ts'
+import { DATA_MODULE, databaseAllViewPath, databaseRecordPath, databaseViewPath, isSystemCollection, sortDataCollections, viewsCatalogSource } from './database-path.ts'
 
 const plugins = [DATA_MODULE]
 
@@ -52,13 +52,9 @@ test('table path without view still parses as a collection-view URL', () => {
   }
 })
 
-test('views catalog href is filtered by table source', () => {
-  assert.equal(
-    viewsCatalogHref('/events'),
-    `/database/views/view/${encodeURIComponent('builtin:/events')}?source=%2Fevents`,
-  )
+test('views catalog source is a query filter', () => {
   assert.equal(viewsCatalogSource('?source=%2Fevents'), '/events')
-  assert.equal(viewsCatalogHref('/views'), `/database/views/view/${encodeURIComponent('builtin:/views')}`)
+  assert.equal(viewsCatalogSource(''), '')
 })
 
 test('views and events are system collections; tags sort with user tables', () => {

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -1,5 +1,5 @@
 import { buildAppPath, type AppRoute } from '@biu/web-session-view'
-import { builtinAllViewId, builtinCatalogViewId } from '../catalog-views.ts'
+import { builtinAllViewId } from '../catalog-views.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 
 export const DATA_MODULE_ID = 'database'
@@ -68,14 +68,6 @@ export function sortDataCollections<T extends { path: string }>(tables: T[]): { 
     return aRank - bRank || left.localeCompare(right)
   })
   return { user, system }
-}
-
-export function viewsCatalogHref(sourcePath: string): string {
-  const source = normalizeCollectionPath(sourcePath)
-  const viewId = builtinCatalogViewId(source || VIEWS_COLLECTION_PATH)
-  const base = databaseViewPath(VIEWS_COLLECTION_PATH, viewId)
-  if (!source || source === VIEWS_COLLECTION_PATH) return base
-  return `${base}?source=${encodeURIComponent(source)}`
 }
 
 export function viewsCatalogSource(search: string): string {

--- a/packages/core-file-system/src/web/facet-catalog.ts
+++ b/packages/core-file-system/src/web/facet-catalog.ts
@@ -1,10 +1,8 @@
 import {
   BUILTIN_FIELDS,
-  isAtomicFieldType,
   isReservedSchemaFieldKey,
   isReservedSchemaFieldLabel,
   normalizeSchemaPack,
-  type AtomicFieldType,
   type CollectionSchemaPack,
 } from '@biu/type-file-system'
 
@@ -133,24 +131,4 @@ export function registerFacetFieldKey(
   const key = fieldKeyFromLabel(name, usedKeys)
   if (isReservedSchemaFieldKey(key) || usedKeys.has(key)) return null
   return key
-}
-
-export function addFacetField(facetId: string, name: string, type: AtomicFieldType) {
-  if (!isAtomicFieldType(type)) return false
-  const label = name.trim()
-  if (!label) return false
-  const catalog = loadFacets()
-  const facet = catalog.find((item) => item.id === facetId)
-  if (!facet) return false
-  const key = registerFacetFieldKey(label, {
-    keys: facet.fields.map((item) => item.key),
-    labels: facet.fields.map((item) => item.label ?? item.key),
-  })
-  if (!key) return false
-  persistFacets(
-    catalog.map((item) =>
-      item.id === facet.id ? { ...item, fields: [...item.fields, { key, type, label, writable: true }] } : item,
-    ),
-  )
-  return true
 }

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
-import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, matchesFilters, parentFieldKey, readFacetFlatValue, resolveFieldType, sortRows, uniqueValues } from './fields'
+import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, parentFieldKey, readFacetFlatValue, resolveFieldType, uniqueValues } from './fields'
 import { visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -61,22 +61,6 @@ test('formatField renders datetime tags and media', () => {
   assert.equal(formatField({ type: 'url' }, 'https://example.com/x'), 'https://example.com/x')
   assert.equal(formatField({ type: 'url' }, 'javascript:alert(1)'), '—')
   assert.equal(formatField({ type: 'attachment' }, { name: 'a.pdf', href: 'https://cdn.example/a.pdf' }), 'a.pdf')
-})
-
-test('filters and sort follow declared column types', () => {
-  const rows = [
-    { id: '2', title: 'b', status: 'todo', tags: ['x'], dueAt: 20, facet: { tags: ['dp'], values: {} } },
-    { id: '1', title: 'a', status: 'doing', tags: ['x', 'y'], dueAt: 10, facet: { tags: [], values: {} } },
-  ]
-  const withSchema = { ...schema, fields: { ...schema.fields, facet: { type: 'facet' as const } } }
-  assert.equal(matchesFilters(rows[1]!, { status: 'doing' }, schema), true)
-  assert.equal(matchesFilters(rows[0]!, { tags: 'y' }, schema), false)
-  assert.equal(matchesFilters(rows[0]!, { facet: 'dp' }, withSchema), true)
-  assert.equal(matchesFilters(rows[1]!, { facet: 'dp' }, withSchema), false)
-  assert.deepEqual(
-    sortRows(rows, schema, 'status', 'asc').map((row) => row.id),
-    ['2', '1'],
-  )
 })
 
 test('matchActionWhen uses field equality including booleans', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -1,15 +1,10 @@
 import type { CollectionSchema, CollectionSchemaPack, DbRecord, FieldSpec, FieldType, SchemaFieldValue } from '@biu/type-file-system'
-import { asAttachment, asHttpHref, asImageSrc, BUILTIN_FIELD_KEYS, isFacetFieldType, normalizeSchemaValue, schemaSearchHaystack } from '@biu/type-file-system'
-import { loadFacets } from './facet-catalog.ts'
+import { asAttachment, asHttpHref, asImageSrc, BUILTIN_FIELD_KEYS, isFacetFieldType, normalizeSchemaValue } from '@biu/type-file-system'
 
 export const BUILTIN_VIEW_MODES = ['queue', 'table', 'cards', 'board'] as const
 export type BuiltinViewMode = (typeof BUILTIN_VIEW_MODES)[number]
 /** 内置四种 + 集合自己 registerView 的 id（如 graph）。 */
 export type ViewMode = BuiltinViewMode | (string & {})
-
-export function isBuiltinViewMode(mode: string): mode is BuiltinViewMode {
-  return (BUILTIN_VIEW_MODES as readonly string[]).includes(mode)
-}
 
 export function isViewModeId(mode: unknown): mode is ViewMode {
   return typeof mode === 'string' && /^[a-z][a-z0-9-]{0,31}$/.test(mode)
@@ -278,85 +273,6 @@ export function contentFieldKey(schema: CollectionSchema | undefined) {
     if (field && (resolveFieldType(field) === 'string' || resolveFieldType(field) === 'file')) return key
   }
   return null
-}
-
-/** @deprecated 用 contentFieldKey */
-export function bodyFieldKey(schema: CollectionSchema | undefined) {
-  return contentFieldKey(schema)
-}
-
-export function detailsFieldKey(schema: CollectionSchema | undefined) {
-  return contentFieldKey(schema)
-}
-
-export function matchesQuery(row: DbRecord, query: string, schema: CollectionSchema) {
-  const q = query.trim().toLowerCase()
-  if (!q) return true
-  if (String(row.id).toLowerCase().includes(q)) return true
-  for (const [key, field] of Object.entries(schema.fields)) {
-    if (resolveFieldType(field) === 'facet') {
-      if (schemaSearchHaystack(row[key], loadFacets()).toLowerCase().includes(q)) return true
-      continue
-    }
-    const text = formatField(field, row[key]).toLowerCase()
-    if (text.includes(q)) return true
-  }
-  return false
-}
-
-export function matchesFilters(row: DbRecord, filters: Record<string, string>, schema: CollectionSchema) {
-  for (const [key, expected] of Object.entries(filters)) {
-    if (!expected) continue
-    const field = schema.fields[key]
-    if (!field) continue
-    const kind = resolveFieldType(field)
-    if (kind === 'datetime' && ['1h', '24h', '7d', '30d'].includes(expected)) {
-      const n = asTime(row[key])
-      if (!n) return false
-      const span =
-        expected === '1h' ? 3600e3 : expected === '24h' ? 86400e3 : expected === '7d' ? 7 * 86400e3 : 30 * 86400e3
-      if (Date.now() - n > span) return false
-      continue
-    }
-    if (kind === 'multi-select') {
-      if (!asStringList(row[key]).includes(expected)) return false
-      continue
-    }
-    if (kind === 'facet') {
-      const parsed = normalizeSchemaValue(row[key])
-      if (!parsed.tags.includes(expected) && !loadFacets().some((tag) => parsed.tags.includes(tag.id) && tag.label === expected)) {
-        return false
-      }
-      continue
-    }
-    if (kind === 'boolean') {
-      const actual = row[key] === true || row[key] === 'true' ? 'true' : 'false'
-      if (actual !== expected) return false
-      continue
-    }
-    if (String(row[key] ?? '') !== expected) return false
-  }
-  return true
-}
-
-function compareValues(field: FieldSpec, a: unknown, b: unknown): number {
-  const kind = resolveFieldType(field)
-  if (kind === 'number' || kind === 'datetime') return asTime(a) - asTime(b) || Number(a ?? 0) - Number(b ?? 0)
-  if (kind === 'boolean') return Number(a === true || a === 'true') - Number(b === true || b === 'true')
-  if (kind === 'select' && field.enum?.length) {
-    return field.enum.indexOf(String(a ?? '')) - field.enum.indexOf(String(b ?? ''))
-  }
-  return String(a ?? '').localeCompare(String(b ?? ''), 'zh')
-}
-
-export function sortRows(rows: DbRecord[], schema: CollectionSchema, field: string, dir: 'asc' | 'desc') {
-  const spec = schema.fields[field]
-  const sign = dir === 'desc' ? -1 : 1
-  return [...rows].sort((a, b) => {
-    const c = spec ? compareValues(spec, a[field], b[field]) : String(a[field] ?? '').localeCompare(String(b[field] ?? ''))
-    if (c !== 0) return c * sign
-    return String(a.id).localeCompare(String(b.id))
-  })
 }
 
 export function uniqueValues(rows: DbRecord[], key: string, field: FieldSpec): string[] {

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -123,10 +123,6 @@ export function FieldGlyph({ kind }: { kind: FieldType }) {
   return <Bars3BottomLeftIcon aria-hidden className={cls} />
 }
 
-export function boolOn(value: unknown) {
-  return value === true || value === 'true'
-}
-
 export function BoolCell({
   on,
   writable,

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -32,14 +32,9 @@ const CSS = `
 .fsdb-right-body:has(.fsdb-pager)>*,.fsdb-right-body:has(.fsdb-pager) .fsdb-main{display:flex;flex-direction:column;min-height:0;flex:1;height:100%;overflow:hidden}
 .fsdb-views{display:flex;width:100%;max-width:none;min-width:0;flex:1;flex-direction:column;min-height:0;overflow:hidden;box-sizing:border-box}
 .fsdb-page>.fsdb-views{width:var(--sidebar-col,var(--dsw-sidebar-min,160px));max-width:var(--dsw-sidebar-max,360px);flex:none}
-.fsdb-nav-chevron{flex:none;display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
-.fsdb-nav-chevron:hover{background:var(--dsw-hover);color:var(--dsw-label)}
-.fsdb-collection-head{flex:none;padding:4px 16px 10px;min-width:0}
 .fsdb-views .chat-session-row-main{border:0;background:transparent;color:inherit;cursor:default}
 .fsdb-views .chat-session-row-main button{cursor:default}
 .fsdb-views .chat-session-row-delete,.fsdb-views .chat-session-row-star{cursor:pointer}
-.fsdb-collection-name{font-size:14px;font-weight:650;color:var(--dsw-label);line-height:1.35;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.fsdb-collection-head .fsdb-footnote{margin:4px 0 0;font-size:14px;font-weight:400;line-height:1.45;color:var(--dsw-label-3);display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:3;overflow:hidden}
 .fsdb-main{box-sizing:border-box;width:100%;max-width:var(--dsw-chat-max-width);margin-inline:auto;display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;gap:10px;padding:80px 80px 16px;overflow:hidden}
 .fsdb-page.is-full-width .fsdb-main,.fsdb-page.is-full-width .fsdb-detail-main{max-width:none}
 .fsdb-page{--fsdb-pager-lift:calc(1rem + 44px + 25px + 25px - 30px);--fsdb-check-gutter:26px;--fsdb-row-tools-w:72px}
@@ -75,10 +70,6 @@ const CSS = `
 .fsdb-page .tasks-sort-btn.is-active,.fsdb-page .tasks-refresh.is-active{color:var(--dsw-business);background:color-mix(in srgb,var(--dsw-business) 10%,var(--dsw-input))}
 .fsdb-page .tasks-sort-btn.is-custom{color:var(--dsw-business)}
 .fsdb-page .tasks-sort-dot{position:absolute;top:4px;right:4px;width:5px;height:5px;border-radius:50%;background:var(--dsw-business)}
-.fsdb-col-item{display:flex;align-items:center;gap:8px;border-radius:7px;padding:5px 8px;color:var(--dsw-label);font-size:14px;cursor:pointer}
-.fsdb-col-item:hover{background:var(--dsw-hover)}
-.fsdb-col-item.is-active{color:var(--dsw-business)}
-.fsdb-col-item input{margin:0}
 .fsdb-page .tasks-viewdd-wrap,.fsdb-page .tasks-sort-wrap,.fsdb-page .tasks-filter-btn-wrap{position:relative;display:inline-flex}
 .fsdb-page .tasks-viewdd-wrap{flex:1;min-width:0;align-items:center;gap:2px}
 .fsdb-page .tasks-viewtabs{display:flex;align-items:center;gap:2px;min-width:0;flex:1;overflow:hidden}
@@ -134,7 +125,7 @@ const CSS = `
 .fsdb-page .chat-pane .traj-usage,.fsdb-page .chat-pane .traj-usage-empty{font-size:var(--dsw-chat-ui-font-size);line-height:1;font-weight:400;color:var(--dsw-sidebar-fg)}
 .fsdb-link{color:inherit;text-underline-offset:2px;overflow-wrap:anywhere}
 .fsdb-link:hover{text-decoration:underline}
-.fsdb-thumb-link,.fsdb-thumb-btn{display:inline-flex;align-items:center;justify-content:center;line-height:0;border:0;padding:0;background:transparent;cursor:zoom-in;vertical-align:middle}
+.fsdb-thumb-btn{display:inline-flex;align-items:center;justify-content:center;line-height:0;border:0;padding:0;background:transparent;cursor:zoom-in;vertical-align:middle}
 .fsdb-thumb{display:block;width:28px;height:18px;object-fit:cover;border-radius:3px;background:var(--dsw-hover);flex:none;box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--dsw-border) 70%, transparent)}
 .fsdb-lightbox{position:fixed;inset:0;z-index:140;display:flex;align-items:center;justify-content:center;padding:28px;background:rgba(0,0,0,.72);cursor:zoom-out}
 .fsdb-lightbox img{max-width:min(92vw,1100px);max-height:88vh;object-fit:contain;border-radius:10px;box-shadow:0 16px 48px rgba(0,0,0,.45);cursor:default}
@@ -243,7 +234,6 @@ const CSS = `
 .fsdb-page .tasks-minicard .fsdb-proplist .fsdb-proprow{min-height:18px}
 .fsdb-page .fsdb-proplist .fsdb-proprow-v{min-width:0;overflow:hidden}
 .fsdb-page .fsdb-proplist .fsdb-proprow-v:has(.fsdb-boolbox){overflow:visible;flex:none}
-.fsdb-page .fsdb-proplist .fsdb-pill,.fsdb-page .fsdb-proplist .fsdb-tag{padding:0;background:transparent;max-width:none}
 .fsdb-workspace{display:flex;flex-direction:column;min-width:0;min-height:0;flex:1;overflow:hidden}
 .fsdb-pager{display:flex;align-items:center;gap:8px;flex:none;margin-top:auto;min-height:28px;padding:4px 0 0;color:var(--dsw-label-3);font-size:13px;font-weight:500}
 /* 检查器分页与中间页、输入胶囊对齐。胶囊距底 = dock pb + 行高 44；检查器已有 --brand-corner-clearance */
@@ -283,17 +273,6 @@ const CSS = `
 .fsdb-detail-float-btn svg{width:16px;height:16px}
 .fsdb-detail-float-btn:hover:not(:disabled){background:rgba(255,255,255,.08);color:#F0EFED}
 .fsdb-detail-float-btn:disabled{opacity:.3;cursor:default}
-.fsdb-detail-rail{height:100%;flex:none;border-right:0;border-left:1px solid var(--dsw-border)}
-.fsdb-detail-rail .app-activity-indicator{left:auto;right:0;border-radius:2px 0 0 2px}
-.fsdb-detail-rail .app-activity-item:disabled{opacity:.35;cursor:default}
-.fsdb-detail-head{display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px 8px 12px;flex:none}
-.fsdb-detail-pager{display:inline-flex;align-items:center;gap:1px;justify-self:start}
-.fsdb-detail-pager .tasks-icon-btn:disabled{opacity:.35;cursor:default}
-.fsdb-detail-tabs{display:inline-flex;align-items:center;gap:2px;padding:2px;border-radius:8px;background:var(--dsw-muted-fill);justify-self:center}
-.fsdb-detail-tabs button{border:0;background:transparent;color:var(--dsw-label-3);padding:5px 10px;border-radius:6px;font:inherit;font-size:14px;font-weight:600;cursor:pointer}
-.fsdb-detail-tabs button.is-active{background:var(--dsw-surface);color:var(--dsw-label)}
-.fsdb-detail-tab-count{margin-left:6px;font-size:11px;font-weight:700;color:var(--dsw-label-3)}
-.fsdb-detail-head-actions{display:inline-flex;align-items:center;gap:2px;justify-self:end}
 .fsdb-detail-split{display:flex;flex-direction:column;flex:none;width:100%;min-height:min-content;overflow:visible}
 .fsdb-detail-main{box-sizing:border-box;width:100%;max-width:var(--dsw-chat-max-width);margin-inline:auto;display:flex;flex-direction:column;gap:8px;padding:80px 80px 24px;min-width:0}
 .fsdb-tag-collect{display:flex;flex:1;min-width:0;min-height:320px}
@@ -310,14 +289,6 @@ const CSS = `
 .fsdb-proprow.is-stack .fsdb-proprow-k,.fsdb-prop.is-stack>span:first-child{padding-top:6px}
 .fsdb-prop-val.is-schema{overflow:visible;white-space:normal;max-width:none}
 .fsdb-schema{display:flex;flex-direction:column;gap:2px;min-width:0;width:100%}
-.fsdb-schema-tokens{position:relative;min-width:0}
-.fsdb-schema-tokens-box{display:flex;flex-wrap:wrap;align-items:center;gap:4px;min-height:28px;border-radius:6px;padding:2px 4px;cursor:text}
-.fsdb-schema-tokens-box:hover,.fsdb-schema-tokens-box:focus-within{background:var(--dsw-hover)}
-.fsdb-schema-tokens-input{flex:1;min-width:72px;border:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;outline:none;padding:2px 0}
-.fsdb-schema-tokens-menu{position:absolute;top:calc(100% + 4px);left:0;right:0;z-index:60;max-height:240px;overflow:auto;padding:4px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
-.fsdb-schema-tokens-option{display:flex;width:100%;min-width:0;align-items:center;justify-content:space-between;gap:8px;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;text-align:left;cursor:pointer}
-.fsdb-schema-tokens-option:hover,.fsdb-schema-tokens-option.is-create{background:var(--dsw-hover)}
-.fsdb-schema-tokens-hint,.fsdb-schema-tokens-empty{color:var(--dsw-label-3);font-size:12px}
 .fsdb-schema-pack{display:flex;flex-direction:column;gap:0;min-width:0;padding:4px 0 8px}
 .fsdb-schema-pack-head{display:flex;align-items:center;min-height:24px;padding:0 4px 4px}
 .fsdb-schema-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;border-radius:6px;padding:0 4px}
@@ -341,25 +312,11 @@ const CSS = `
 .fsdb-schema-type-menu{position:absolute;right:0;top:calc(100% + 4px);z-index:70;display:flex;flex-direction:column;min-width:160px;max-height:240px;overflow:auto;padding:4px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .fsdb-schema-type-option{display:flex;align-items:center;gap:6px;width:100%;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;text-align:left;cursor:pointer}
 .fsdb-schema-type-option:hover,.fsdb-schema-type-option.is-on{background:var(--dsw-hover)}
-.fsdb-schema-chips{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
-.fsdb-schema-chip{gap:4px;max-width:none;cursor:pointer;border:0;font:inherit}
-.fsdb-schema-chip.is-on{background:color-mix(in srgb,var(--dsw-business) 22%,transparent);color:var(--dsw-business)}
-.fsdb-schema-add{display:inline-flex;align-items:center;gap:4px;height:22px;padding:0 8px;border:1px dashed var(--dsw-border);border-radius:4px;background:transparent;color:var(--dsw-label-2);font:inherit;font-size:13px;cursor:pointer}
-.fsdb-schema-add:hover{color:var(--dsw-label);border-color:var(--dsw-label-3)}
-.fsdb-schema-new,.fsdb-schema-newfield{display:inline-flex;align-items:center;gap:6px;min-width:0}
-.fsdb-schema-body{display:flex;flex-direction:column;gap:6px;padding:8px;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-input)}
-.fsdb-schema-head{font-size:13px;font-weight:650;color:var(--dsw-label-2)}
-.fsdb-schema-row{display:flex;align-items:center;justify-content:space-between;gap:8px;min-width:0}
-.fsdb-schema-row>span{display:inline-flex;align-items:center;gap:6px;min-width:0;color:var(--dsw-label-2)}
-.fsdb-schema-row-val{display:flex;align-items:center;gap:6px;min-width:0;flex:1;justify-content:flex-end}
-.fsdb-schema-del{display:grid;place-items:center;width:22px;height:22px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-3);cursor:pointer}
-.fsdb-schema-del:hover{background:var(--dsw-hover);color:var(--dsw-danger)}
 .fsdb-prop-val{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7C7A76}
-.fsdb-prop-val .fsdb-plain-input,.fsdb-prop-val .fsdb-link,.fsdb-prop-val .fsdb-meta,.fsdb-prop-val .fsdb-file,.fsdb-prop-val .fsdb-file-name,.fsdb-prop-val .fsdb-pill,.fsdb-prop-val .fsdb-tags{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.fsdb-prop-val .fsdb-plain-input,.fsdb-prop-val .fsdb-link,.fsdb-prop-val .fsdb-meta,.fsdb-prop-val .fsdb-file,.fsdb-prop-val .fsdb-file-name{max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-prop-val .fsdb-plain-input{text-overflow:ellipsis}
 .fsdb-prop-val .fsdb-plain-input:focus{text-overflow:clip}
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
-.fsdb-prop-val .fsdb-tags{display:flex;flex-wrap:nowrap}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
 .fsdb-detail-title-icon-wrap{position:relative;flex:none;margin-top:2px}
 .fsdb-detail-title-icon{display:grid;place-items:center;width:36px;height:36px;margin:0;border:0;border-radius:10px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:28px;line-height:1;overflow:visible}
@@ -380,13 +337,6 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-detail-extras{display:flex;flex-direction:column;gap:20px;margin-top:8px;padding-top:16px;border-top:1px solid var(--dsw-border)}
 .fsdb-detail-extra-title{display:flex;align-items:center;gap:8px;margin:0 0 8px;font-size:14px;font-weight:700;color:var(--dsw-label)}
 .fsdb-detail-extra-count{font-size:11px;font-weight:700;color:var(--dsw-label-3)}
-.fsdb-facet-collect{margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:2px}
-.fsdb-facet-collect-link{display:flex;align-items:baseline;justify-content:space-between;gap:12px;min-height:32px;padding:4px 8px;border-radius:6px;color:inherit;text-decoration:none}
-.fsdb-facet-collect-link:hover{background:var(--dsw-hover)}
-.fsdb-facet-collect-title{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:600}
-.fsdb-fields{display:flex;flex-direction:column;gap:8px}
-.fsdb-field{display:flex;flex-direction:column;gap:4px;color:var(--dsw-label-3);font-size:14px}
-.fsdb-field em{font-style:normal;color:var(--dsw-label);font-size:14px}
 .fsdb-plain-input{width:100%;border:0;border-radius:6px;padding:4px 6px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;outline:none}
 .fsdb-plain-input::placeholder{color:var(--dsw-placeholder)}
 .fsdb-plain-input:hover,.fsdb-plain-input:focus{background:var(--dsw-hover)}
@@ -440,17 +390,9 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-dlg-ok{border:1px solid var(--dsw-business);background:var(--dsw-business);color:var(--dsw-bg)}
 .fsdb-dlg-ok.is-danger{border-color:var(--dsw-danger);background:var(--dsw-danger);color:var(--dsw-bg)}
 .fsdb-dlg-ok:disabled,.fsdb-dlg-cancel:disabled{opacity:.6;cursor:default}
-.fsdb-save{border:0;border-radius:8px;padding:8px 10px;background:var(--dsw-business);color:#fff;font:inherit;font-size:14px;cursor:pointer}
-.fsdb-empty,.fsdb-muted,.fsdb-meta,.fsdb-footnote,.fsdb-inspector-empty{color:var(--dsw-label-2)}
-.fsdb-footnote{margin:0;font-size:14px;font-weight:400}
-.fsdb-tags{display:inline-flex;gap:4px;flex-wrap:wrap;align-items:center}
-.fsdb-tag{display:inline-flex;align-items:center;height:22px;padding:0 6px;border-radius:4px;font-size:14px;font-weight:500;line-height:22px;color:var(--dsw-label);background:rgba(255,255,255,.08);white-space:nowrap;max-width:110px;overflow:hidden;text-overflow:ellipsis}
+.fsdb-empty,.fsdb-muted,.fsdb-meta,.fsdb-inspector-empty{color:var(--dsw-label-2)}
 .fsdb-action-btn{display:inline-flex;align-items:center;justify-content:center;height:26px;margin:0;border:0;border-radius:6px;padding:0 8px;background:var(--dsw-hover);color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;cursor:pointer}
 .fsdb-action-btn:hover{background:#2c2c2c}
-.fsdb-pill{display:inline-flex;align-items:center;gap:4px;height:22px;border-radius:4px;padding:0 6px;font-size:14px;font-weight:500;line-height:22px;color:var(--dsw-label);background:rgba(255,255,255,.08)}
-.fsdb-pill.is-doing,.fsdb-pill.is-high,.fsdb-pill.is-done,.fsdb-pill.is-todo,.fsdb-pill.is-low{background:rgba(255,255,255,.08);color:var(--dsw-label)}
-.fsdb-multi{display:flex;flex-wrap:wrap;gap:6px}
-.fsdb-check{display:inline-flex;align-items:center;gap:4px;color:var(--dsw-label);font-size:14px}
 @media (max-width:900px){.fsdb-page{flex-direction:column}.fsdb-views{width:100%}}
 `
 

--- a/packages/core-file-system/src/web/heading-outline.test.ts
+++ b/packages/core-file-system/src/web/heading-outline.test.ts
@@ -1,9 +1,10 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { headingElById, headingsFromHtml, headingsFromRoot } from './heading-outline.ts'
+import { headingsFromRoot } from './heading-outline.ts'
 
-test('headingsFromHtml extracts h1–h3 and skips chrome titles', () => {
-  const html = `
+test('headingsFromRoot extracts h1–h3 and skips chrome titles', () => {
+  const root = document.createElement('div')
+  root.innerHTML = `
     <h1 class="fsdb-detail-title">Record title</h1>
     <div class="page-editor">
       <h1>Intro</h1>
@@ -15,11 +16,14 @@ test('headingsFromHtml extracts h1–h3 and skips chrome titles', () => {
     </div>
     <h3 class="fsdb-detail-extra-title">Related</h3>
   `
-  assert.deepEqual(headingsFromHtml(html), [
-    { id: 'heading-0', text: 'Intro', level: 1 },
-    { id: 'heading-1', text: 'Section', level: 2 },
-    { id: 'heading-2', text: 'Detail', level: 3 },
-  ])
+  assert.deepEqual(
+    headingsFromRoot(root).map((item) => [item.id, item.text, item.level]),
+    [
+      ['heading-0', 'Intro', 1],
+      ['heading-1', 'Section', 2],
+      ['heading-2', 'Detail', 3],
+    ],
+  )
 })
 
 test('headingsFromRoot is read-only so TipTap headings do not trip MutationObserver', () => {
@@ -40,8 +44,6 @@ test('headingsFromRoot is read-only so TipTap headings do not trip MutationObser
       ['heading-2', 'C', 3],
     ],
   )
-  assert.equal(root.querySelector('[data-heading-outline]'), null)
   assert.equal(fires, 0)
   mo.disconnect()
-  assert.equal(headingElById(root, 'heading-2')?.textContent, 'C')
 })

--- a/packages/core-file-system/src/web/heading-outline.ts
+++ b/packages/core-file-system/src/web/heading-outline.ts
@@ -6,10 +6,6 @@ export type HeadingOutlineItem = {
 
 const SKIP = ['.fsdb-detail-title', '.fsdb-detail-extra-title']
 
-function headingText(html: string) {
-  return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim()
-}
-
 function asLevel(n: number): 1 | 2 | 3 {
   if (n === 1) return 1
   if (n === 2) return 2
@@ -26,23 +22,6 @@ function itemFromEl(el: HTMLElement, index: number): HeadingOutlineItem | null {
   const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim()
   if (!text) return null
   return { id: `heading-${index}`, text, level: asLevel(Number(el.tagName.slice(1))) }
-}
-
-/** 从 HTML 抽出 h1–h3，忽略详情页标题和附加栏标题。 */
-export function headingsFromHtml(html: string): HeadingOutlineItem[] {
-  const items: HeadingOutlineItem[] = []
-  const re = /<h([123])\b([^>]*)>([\s\S]*?)<\/h\1>/gi
-  let match: RegExpExecArray | null
-  let index = 0
-  while ((match = re.exec(html))) {
-    const attrs = match[2] ?? ''
-    if (/\bfsdb-detail-title\b/.test(attrs) || /\bfsdb-detail-extra-title\b/.test(attrs)) continue
-    const text = headingText(match[3] ?? '')
-    if (!text) continue
-    items.push({ id: `heading-${index}`, text, level: asLevel(Number(match[1])) })
-    index += 1
-  }
-  return items
 }
 
 /** 只读扫描。禁止给标题写 data-*：PageEditor / TipTap 拥有这些节点，写属性会触发 MutationObserver 死循环。 */

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { apply, name, navConflict } from './index.tsx'
+import { apply, name } from './index.tsx'
 import { DATA_MODULE_ID } from './database-path.ts'
 
 test('file-system web is the implementation plugin, not a domain module', () => {
@@ -14,13 +14,6 @@ test('shell matches the data module by extra.moduleId database', () => {
   const extra = { moduleId: DATA_MODULE_ID, tables: [] as never[] }
   const slotKey = 'fsdb-database'
   assert.equal(String(extra.moduleId ?? slotKey), 'database')
-})
-
-test('navConflict flags duplicate route and display name against existing modules', () => {
-  const modules = [{ id: 'tasks', label: 'Tasks', path: '/tasks' }]
-  assert.match(navConflict({ moduleId: 'x', route: '/tasks' }, 'X', modules, 'x') ?? '', /路由重复/)
-  assert.match(navConflict({ moduleId: 'x', route: '/other' }, 'Tasks', modules, 'x') ?? '', /名称重复/)
-  assert.equal(navConflict({ moduleId: 'tasks', route: '/tasks' }, 'Tasks', modules, 'tasks'), null)
 })
 
 test('database page no longer registers collection shortcuts on the dock', () => {

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -3,7 +3,7 @@ import type { Context } from 'cordis'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { CircleStackIcon } from '@heroicons/react/16/solid'
 import type { SlotProps } from '@biu/type-slots'
-import { DATABASE_CHANNEL, type CollectionInfo, type CollectionView } from '@biu/type-file-system'
+import { DATABASE_CHANNEL, type CollectionInfo } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import { isLegacyDatabasePath, parseAppPath } from '@biu/web-session-view'
 import { pathForCenter, pathForCrumbTarget, type CrumbTarget } from './sidebar-nav.ts'
@@ -50,15 +50,6 @@ type SnapshotService = {
   onMessage: (type: string, handler: (payload: unknown) => void) => () => void
   get?: () => { collections?: CollectionInfo[] }
   subscribe?: (fn: () => void) => () => void
-}
-
-export function navConflict(view: CollectionView, title: string, modules: AppModule[], selfId: string): string | null {
-  const route = normalizeCollectionPath(view.route)
-  const pathHit = modules.find((item) => item.id !== selfId && normalizeCollectionPath(item.path) === route)
-  if (pathHit) return `路由重复：${route} 已被「${pathHit.label}」占用，请换一个路由再登记`
-  const nameHit = modules.find((item) => item.id !== selfId && item.label === title)
-  if (nameHit) return `名称重复：导航已有「${title}」，请换一个名字`
-  return null
 }
 
 const EMPTY_CHROME: CollectionChrome = {}

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -4,7 +4,6 @@ import { databaseAllViewPath } from './database-path.ts'
 import {
   getInspectorDbPath,
   isInspectorDatabasePath,
-  seedInspectorDbPath,
   setInspectorDbPath,
   showRecordInInspector,
   showInInspector,
@@ -14,23 +13,21 @@ import {
   setInspectorAgentWorking,
 } from './inspector-db-route.ts'
 
-test('inspector database path does not overwrite after first seed', () => {
+test('inspector database path is set explicitly', () => {
   setInspectorDbPath('')
-  seedInspectorDbPath('/database/pages')
-  assert.equal(getInspectorDbPath(), '/database/pages')
-  seedInspectorDbPath('/database/tasks')
+  setInspectorDbPath('/database/pages')
   assert.equal(getInspectorDbPath(), '/database/pages')
   setInspectorDbPath('/database/tasks')
   assert.equal(getInspectorDbPath(), '/database/tasks')
 })
 
-test('chat routes are not seeded as inspector database paths', () => {
+test('chat routes are not inspector database paths', () => {
   setInspectorDbPath('')
   assert.equal(isInspectorDatabasePath('/s/abc'), false)
   assert.equal(isInspectorDatabasePath('/database/pages'), true)
-  seedInspectorDbPath('/s/abc')
+  setInspectorDbPath('/s/abc')
   assert.equal(getInspectorDbPath(), '')
-  seedInspectorDbPath('/database/pages')
+  setInspectorDbPath('/database/pages')
   assert.equal(getInspectorDbPath(), '/database/pages')
 })
 
@@ -39,8 +36,6 @@ test('each inspector database pane keeps its own path', () => {
   setInspectorDbPath('database::b', '/database/tasks')
   assert.equal(getInspectorDbPath('database::a'), '/database/pages')
   assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
-  seedInspectorDbPath('database::a', '/database/events')
-  assert.equal(getInspectorDbPath('database::a'), '/database/pages')
 })
 
 test('window reveal event opens the inspector record path', async () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -154,15 +154,6 @@ function savedViewFromPayload(raw: unknown, revealViewId: unknown): SavedView | 
   })
 }
 
-export function seedInspectorDbPath(paneId: string, pathname?: string) {
-  const id = pathname === undefined ? DEFAULT_PANE : paneId
-  const path = pathname === undefined ? paneId : pathname
-  if (panePath(id)) return
-  if (!isInspectorDatabasePath(path)) return
-  paths.set(id, path)
-  bump()
-}
-
 export const INSPECTOR_REVEAL_EVENT = 'biu:inspector-reveal'
 
 function onInspectorReveal(event: Event) {

--- a/packages/core-file-system/src/web/schema-field.tsx
+++ b/packages/core-file-system/src/web/schema-field.tsx
@@ -359,8 +359,3 @@ export function SchemaFieldEditor({
     </div>
   )
 }
-
-export function formatSchemaCell(value: unknown) {
-  const parsed = normalizeSchemaValue(value)
-  return parsed.tags.length ? parsed.tags.join(', ') : '—'
-}

--- a/packages/core-file-system/src/web/schema-tags-field.test.ts
+++ b/packages/core-file-system/src/web/schema-tags-field.test.ts
@@ -1,27 +1,15 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { addFacetField, loadFacets, persistFacets, registerFacetFieldKey } from './facet-catalog.ts'
-
-test('addFacetField appends an atomic field onto an existing facet pack', () => {
-  persistFacets([{ id: 'dp', label: '动态规划', fields: [] }])
-  assert.equal(addFacetField('dp', '复杂度', 'string'), true)
-  const facet = loadFacets().find((item) => item.id === 'dp')
-  assert.equal(facet?.fields[0]?.label, '复杂度')
-  assert.equal(facet?.fields[0]?.type, 'string')
-  assert.notEqual(facet?.fields[0]?.key, 'facet')
-  assert.equal(addFacetField('missing', 'x', 'string'), false)
-})
+import { persistFacets, registerFacetFieldKey } from './facet-catalog.ts'
 
 test('type pack fields cannot reuse file-system keys or labels', () => {
   persistFacets([{ id: 'dp', label: '动态规划', fields: [] }])
   assert.equal(registerFacetFieldKey('标签'), null)
-  assert.equal(addFacetField('dp', '标签', 'string'), false)
   assert.equal(registerFacetFieldKey('facet'), null)
   assert.equal(registerFacetFieldKey('标题'), null)
   assert.equal(registerFacetFieldKey('title'), null)
-  assert.equal(addFacetField('dp', '合集', 'string'), false)
-  assert.equal(addFacetField('dp', 'facet', 'string'), false)
-  assert.equal(addFacetField('dp', '复杂度', 'string'), true)
-  assert.equal(addFacetField('dp', '复杂度', 'number'), false)
-  assert.equal(loadFacets().find((item) => item.id === 'dp')?.fields.length, 1)
+  assert.equal(registerFacetFieldKey('合集'), null)
+  const ok = registerFacetFieldKey('复杂度')
+  assert.ok(ok)
+  assert.notEqual(ok, 'facet')
 })

--- a/packages/core-file-system/src/web/sidebar-preview.test.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.test.ts
@@ -9,7 +9,6 @@ import {
   crumbRecordLabel,
   rememberPreviewTotal,
   SIDEBAR_PREVIEW_PAGE,
-  tableTotalKey,
   viewTotalKey,
 } from './sidebar-preview.ts'
 
@@ -36,9 +35,8 @@ test('preview cache includes view query and filters', () => {
   assert.notEqual(a, b)
 })
 
-test('table total key is not a saved view key', () => {
+test('preview total key is cached per view', () => {
   const view = { id: 'v1', sortField: 'id', sortDir: 'asc' as const, filters: {}, query: '' }
-  assert.notEqual(tableTotalKey('/tasks'), viewTotalKey('/tasks', view))
   rememberPreviewTotal(viewTotalKey('/tasks', view), 12)
   assert.equal(getPreviewTotal(viewTotalKey('/tasks', view)), 12)
 })

--- a/packages/core-file-system/src/web/sidebar-preview.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.ts
@@ -47,14 +47,6 @@ export function nextPreviewLimit(loaded: number, total: number) {
   return Math.min(SIDEBAR_PREVIEW_PAGE, SIDEBAR_PREVIEW_MAX - loaded, total - loaded)
 }
 
-export const TABLE_TOTAL_VIEW = {
-  id: '__table__',
-  sortField: 'id',
-  sortDir: 'asc' as const,
-  filters: {} as Record<string, string>,
-  query: '',
-}
-
 const totalCache = new Map<string, number>()
 const totalListeners = new Set<() => void>()
 let totalsVersion = 0
@@ -83,10 +75,6 @@ export function subscribePreviewTotals(fn: () => void) {
 
 export function viewTotalKey(path: string, view: Pick<SavedView, 'id' | 'sortField' | 'sortDir' | 'filters' | 'query'>) {
   return previewCacheKey(path, view)
-}
-
-export function tableTotalKey(path: string) {
-  return previewCacheKey(path, TABLE_TOTAL_VIEW)
 }
 
 export async function fetchViewTotal(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
File System 里一批客户端辅助函数和 CSS 已无人引用：筛选/排序走 `/api/db/list`，视图走 `/api/db/saved-views`。

本 PR 删除：
- `matchesQuery` / `matchesFilters` / `sortRows` 及过时的 `bodyFieldKey` / `detailsFieldKey`
- 未接线的 `navConflict`、`seedInspectorDbPath`、`viewsCatalogHref`、`addFacetField`、`headingsFromHtml`、`tableTotalKey` 等
- 旧详情栏/schema chip/facet-collect 等无 DOM 的 CSS
- `POST /api/db/facets` 未读取的 `path` 字段

未动：`/api/db/*` 活路由、localStorage 视图缓存（启动仍会同步到 saved-views）、sidebar-nav 不变量测试。

`packages/core-file-system` 单测 160 通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

