### PR TITLE
Agent 调用 db_delete 必须经审批

### DIFF
--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -963,7 +963,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_delete',
-    description: '按条件删除记录。路径为 /<表>，必须带 ids、q 或 filter 之一，禁止无条件清空全表。能否删除看 db_stat 的 caps 与 schema.records。',
+    description: '按条件删除记录。路径为 /<表>，必须带 ids、q 或 filter 之一，禁止无条件清空全表。能否删除看 db_stat 的 caps 与 schema.records。调用后会进入审批，用户同意才真正删。',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/host-approvals/src/host/index.test.ts
+++ b/packages/host-approvals/src/host/index.test.ts
@@ -59,3 +59,38 @@ test('non-sensitive tools skip hold', async () => {
   assert.equal(await ctx.tools.invoke('echo'), 'ok')
   assert.equal(ctx.approvals.list().length, 0)
 })
+
+test('db_delete waits for approval even in auto mode', async () => {
+  const ctx = await setup()
+  ctx.tools.register({
+    name: 'db_delete',
+    description: 'delete',
+    parameters: { type: 'object', properties: {} },
+    execute: () => 'deleted',
+  })
+  ctx.approvals.mode = 'auto'
+  const invoke = ctx.tools.invoke('db_delete', { path: '/tasks', ids: ['t1'] })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const pending = ctx.approvals.list()
+  assert.equal(pending.length, 1)
+  assert.equal(pending[0]?.name, 'db_delete')
+  ctx.approvals.decide(pending[0]!.id, true)
+  assert.equal(await invoke, 'deleted')
+})
+
+test('db_delete deny in auto mode blocks the tool', async () => {
+  const ctx = await setup()
+  ctx.tools.register({
+    name: 'db_delete',
+    description: 'delete',
+    parameters: { type: 'object', properties: {} },
+    execute: () => 'deleted',
+  })
+  ctx.approvals.mode = 'auto'
+  const invoke = ctx.tools.invoke('db_delete', { path: '/tasks', ids: ['t1'] })
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const [item] = ctx.approvals.list()
+  assert.ok(item)
+  ctx.approvals.decide(item.id, false)
+  await assert.rejects(() => invoke, /denied: db_delete/)
+})

--- a/packages/host-approvals/src/host/index.ts
+++ b/packages/host-approvals/src/host/index.ts
@@ -15,8 +15,7 @@ export class ApprovalsService extends Service {
   constructor(ctx: Context) {
     super(ctx, 'approvals')
     ctx.tools.guard(async (req) => {
-      if (this.mode === 'auto') return req
-      if (this.mode === 'hold' && !sensitive(req.name)) return req
+      if (!needsApproval(req.name, this.mode)) return req
       const id = crypto.randomUUID()
       const allow = await new Promise<boolean>((resolve) => {
         const timer = setTimeout(() => {
@@ -47,6 +46,12 @@ export class ApprovalsService extends Service {
     item.resolve(allow)
     return { ok: true }
   }
+}
+
+function needsApproval(name: string, mode: 'auto' | 'hold') {
+  if (name === 'db_delete') return true
+  if (mode === 'auto') return false
+  return sensitive(name)
 }
 
 function sensitive(name: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 通过工具 `db_delete` 删除 File System 记录时，无论审批模式是 auto 还是 hold，都会进入现有待确认队列，用户同意后才真正删除；拒绝或超时则工具报 `denied: db_delete`。

界面里点删仍走 `POST /api/db/delete`，不排队。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

