### PR TITLE
审批卡片背景改为 #202020

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -2967,7 +2967,7 @@ body {
 .dock-approval-card {
   border: 1px solid rgba(250, 204, 100, 0.35);
   border-radius: 12px;
-  background: rgba(250, 204, 100, 0.1);
+  background: #202020;
   padding: 8px 12px;
   font-size: var(--dsw-chat-ui-font-size);
   color: var(--dsw-label);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天栏待确认工具卡片（`.dock-approval-card`）背景从半透明黄改成 `#202020`。边框仍是原来的浅黄描边。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

