### PR TITLE
审批 Allow/Deny 按钮靠右

### DIFF
--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -262,7 +262,7 @@ export function ApprovalsRail(props: SlotProps) {
               <pre className="mb-2 max-h-20 overflow-auto whitespace-pre-wrap text-(--dsw-label-2)">
                 {JSON.stringify(item.args, null, 2)}
               </pre>
-              <div className="flex gap-2">
+              <div className="flex justify-end gap-2">
                 <button
                   type="button"
                   className="rounded-full px-3 py-1 text-(length:--dsw-chat-ui-font-size) text-(--dsw-bg)"

--- a/web/style.css
+++ b/web/style.css
@@ -2965,7 +2965,7 @@ body {
 }
 
 .dock-approval-card {
-  border: 1px solid rgba(250, 204, 100, 0.35);
+  border: 1px solid #2f2f2f;
   border-radius: 12px;
   background: #202020;
   padding: 8px 12px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
待确认工具卡片上的 Allow / Deny 按钮行改为右对齐（`justify-end`）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

