### PR TITLE
覆盖 Tailwind，让编辑器列表显示圆点和编号

### DIFF
--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -37,6 +37,8 @@ const a = 1
   const out = editor.getMarkdown()
   assert.match(html, /<h1>大标题<\/h1>/)
   assert.match(html, /<strong>粗<\/strong>/)
+  assert.match(html, /<ul>/)
+  assert.match(html, /<ol>/)
   assert.match(out, /^# 大标题/m)
   assert.match(out, /\*\*粗\*\*/)
   assert.match(out, /苹果/)
@@ -69,6 +71,8 @@ test('slash suggestion uses a fixed high stacking context', async () => {
   assert.match(src, /zIndex = '10000'/)
   assert.match(css, /\.page-slash\{[^}]*z-index:10000/)
   assert.match(css, /\.page-editor \.page-block\{[^}]*isolation:isolate/)
+  assert.match(css, /\.page-editor \.tiptap ul\{list-style-type:disc\}/)
+  assert.match(css, /\.page-editor \.tiptap ol\{list-style-type:decimal\}/)
 })
 
 test('slash command turns the current block into a heading', () => {

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -12,8 +12,13 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
 .page-editor .page-block-missing{padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
-.page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em}
-.page-editor .tiptap li{margin:1px 0}
+.page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em;list-style-position:outside}
+.page-editor .tiptap ul{list-style-type:disc}
+.page-editor .tiptap ol{list-style-type:decimal}
+.page-editor .tiptap ul ul{list-style-type:circle}
+.page-editor .tiptap ul ul ul{list-style-type:square}
+.page-editor .tiptap li{display:list-item;margin:1px 0}
+.page-editor .tiptap li p{min-height:0;margin:0}
 .page-editor .tiptap blockquote{margin-left:0;padding-left:14px;border-left:3px solid var(--dsw-border);color:var(--dsw-label-2)}
 .page-editor .tiptap hr{border:0;border-top:1px solid var(--dsw-border);margin:18px 0}
 .page-editor .tiptap code{padding:.12em .35em;border-radius:4px;background:var(--dsw-hover);font-family:var(--font-mono);font-size:.9em}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tailwind preflight 把 `ul`/`ol` 设成 `list-style: none`，列表内容能渲染但看不到圆点和编号。在 `.page-editor` 里显式设回 disc / decimal（嵌套 circle / square），并去掉列表项里段落的 min-height。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

