### PR TITLE
悬浮目录圆角调小

### DIFF
--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -40,7 +40,7 @@ test('message outline is a left rail of ticks with a hover menu', () => {
   assert.match(css, /\.chat-outline-tick::after/)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*left:\s*36px/s)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*top:\s*50%/s)
-  assert.match(css, /\.chat-outline-panel\s*\{[^}]*border:\s*0/s)
+  assert.match(css, /\.chat-outline-panel\s*\{[^}]*border-radius:\s*8px/s)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*backdrop-filter:\s*blur\(16px\)\s*saturate\(1\.2\)/s)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s)
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*width:\s*6px/s)

--- a/web/style.css
+++ b/web/style.css
@@ -4373,7 +4373,7 @@ body {
   overflow: auto;
   transform: translateY(-50%);
   border: 0;
-  border-radius: 18px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.1);
   padding: 6px;
   box-shadow: 0 1px 2px rgba(15, 15, 15, 0.04), 0 10px 32px rgba(0, 0, 0, 0.28);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天区和页面共用的悬浮目录面板（`.chat-outline-panel`）圆角从 18px 收到 8px。刻度条和条目圆角未改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

