### PR TITLE
编辑器代码块盖过 Tailwind 重置

### DIFF
--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -73,6 +73,9 @@ test('slash suggestion uses a fixed high stacking context', async () => {
   assert.match(css, /\.page-editor \.page-block\{[^}]*isolation:isolate/)
   assert.match(css, /\.page-editor \.tiptap ul\{list-style-type:disc\}/)
   assert.match(css, /\.page-editor \.tiptap ol\{list-style-type:decimal\}/)
+  assert.match(css, /\.page-editor \.tiptap pre\{[^}]*background:var\(--dsw-chat-code-bg/)
+  assert.match(css, /\.page-editor \.tiptap pre\{[^}]*white-space:pre/)
+  assert.match(css, /\.page-editor \.tiptap code\{[^}]*background:var\(--dsw-hover\)/)
 })
 
 test('slash command turns the current block into a heading', () => {

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -21,9 +21,9 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .tiptap li p{min-height:0;margin:0}
 .page-editor .tiptap blockquote{margin-left:0;padding-left:14px;border-left:3px solid var(--dsw-border);color:var(--dsw-label-2)}
 .page-editor .tiptap hr{border:0;border-top:1px solid var(--dsw-border);margin:18px 0}
-.page-editor .tiptap code{padding:.12em .35em;border-radius:4px;background:var(--dsw-hover);font-family:var(--font-mono);font-size:.9em}
-.page-editor .tiptap pre{padding:12px 14px;border-radius:6px;background:var(--dsw-input);overflow:auto}
-.page-editor .tiptap pre code{padding:0;background:transparent;font-size:13px;line-height:1.6}
+.page-editor .tiptap code{display:inline;padding:.12em .35em;border-radius:4px;background:var(--dsw-hover);font-family:var(--font-mono);font-size:.9em}
+.page-editor .tiptap pre{display:block;margin:8px 0;padding:10px 12px;border:1px solid var(--dsw-border);border-radius:10px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));overflow-x:auto;white-space:pre;font-family:var(--font-mono)}
+.page-editor .tiptap pre code{display:block;padding:0;background:transparent;font-size:13px;line-height:1.6;white-space:inherit}
 .page-editor .tiptap a{color:var(--dsw-business);text-underline-offset:2px}
 .page-editor .tiptap p.is-editor-empty:first-child::before,
 .page-editor .tiptap .is-empty::before{content:attr(data-placeholder);float:left;height:0;pointer-events:none;color:var(--dsw-placeholder)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
编辑器代码块原先用 `--dsw-input`，而这个变量等于页面背景，再叠 Tailwind 的全局 `padding: 0`，看起来像没样式。改成和聊天一致的 `--dsw-chat-code-bg`、边框、等宽字体和 `white-space: pre`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

