### PR TITLE
fix: 会话详情悬浮目录挂到 body，避免被壳层清掉

### DIFF
--- a/packages/host-sessions/src/host/sessions-collection.test.ts
+++ b/packages/host-sessions/src/host/sessions-collection.test.ts
@@ -31,6 +31,7 @@ test('sessionsCollection maps summaries and writes title/pinned/tags', async () 
     },
   })
   assert.equal(spec.path, '/sessions')
+  assert.equal(spec.schema.contentField, 'content')
   assert.equal(spec.view?.moduleId, 'sessions-db')
   assert.deepEqual(spec.records, { update: true, create: false, delete: true })
   const rows = await spec.list()

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -140,6 +140,7 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
     records: { update: true, create: Boolean(sessions.create), delete: true },
     schema: {
       labelField: 'title',
+      contentField: 'content',
       columns: ['title', 'pinned', 'tags', 'eventCount', 'project', 'updatedAt'],
       fields: {
         ...REQUIRED_RECORD_FIELDS,

--- a/packages/public-ui/src/index.ts
+++ b/packages/public-ui/src/index.ts
@@ -26,5 +26,5 @@ export {
   CHAT_DOCK_STACK,
 } from './chat-pane.tsx'
 export { OutlineNav, type OutlineNavItem } from './outline-nav.tsx'
-export { findOutlineSidebarHost, OUTLINE_SIDEBAR_HOST } from './outline-sidebar.ts'
+export { findOutlineSidebarHost, OUTLINE_SIDEBAR_HOST_ID } from './outline-sidebar.ts'
 export { SidebarOutlinePortal } from './outline-portal.tsx'

--- a/packages/public-ui/src/outline-portal.test.ts
+++ b/packages/public-ui/src/outline-portal.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
-test('SidebarOutlinePortal mounts on app-shell and hides when agent center is hidden', () => {
+test('SidebarOutlinePortal mounts on a body host and hides when agent center is hidden', () => {
   const src = readFileSync(resolve(import.meta.dirname, './outline-portal.tsx'), 'utf8')
   assert.match(src, /findOutlineSidebarHost/)
   assert.match(src, /sidebar-outline-host/)

--- a/packages/public-ui/src/outline-portal.tsx
+++ b/packages/public-ui/src/outline-portal.tsx
@@ -27,15 +27,18 @@ export function SidebarOutlinePortal({
       setAllowed(agentCenterAllowsOutline(mark.current))
     }
     sync()
+    const mo = new MutationObserver(sync)
     const center = mark.current?.closest('[data-testid="agent-center"]')
-    const mo =
-      center instanceof HTMLElement
-        ? new MutationObserver(sync)
-        : null
-    mo?.observe(center as HTMLElement, { attributes: true, attributeFilter: ['class', 'aria-hidden'] })
+    if (center instanceof HTMLElement) {
+      mo.observe(center, { attributes: true, attributeFilter: ['class', 'aria-hidden'] })
+    }
+    const shell = document.querySelector('[data-testid="app-shell"]')
+    if (shell instanceof HTMLElement) {
+      mo.observe(shell, { attributes: true, attributeFilter: ['style', 'class'] })
+    }
     const frame = requestAnimationFrame(sync)
     return () => {
-      mo?.disconnect()
+      mo.disconnect()
       cancelAnimationFrame(frame)
     }
   })

--- a/packages/public-ui/src/outline-sidebar.test.ts
+++ b/packages/public-ui/src/outline-sidebar.test.ts
@@ -1,12 +1,18 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { findOutlineSidebarHost, OUTLINE_SIDEBAR_HOST } from './outline-sidebar.ts'
+import { findOutlineSidebarHost, OUTLINE_SIDEBAR_HOST_ID } from './outline-sidebar.ts'
 
-test('outline host is the app shell so all floating tocs sit on the left sidebar', () => {
-  assert.equal(OUTLINE_SIDEBAR_HOST, '[data-testid="app-shell"]')
+test('outline host is a body layer so React shell updates cannot wipe the toc', () => {
+  assert.equal(OUTLINE_SIDEBAR_HOST_ID, 'biu-outline-sidebar-host')
   const shell = document.createElement('div')
   shell.setAttribute('data-testid', 'app-shell')
+  shell.style.setProperty('--sidebar-col', '160px')
   document.body.append(shell)
-  assert.equal(findOutlineSidebarHost(), shell)
+  const host = findOutlineSidebarHost()
+  assert.ok(host)
+  assert.equal(host.id, OUTLINE_SIDEBAR_HOST_ID)
+  assert.equal(host.parentElement, document.body)
+  assert.equal(host.style.getPropertyValue('--sidebar-col'), '160px')
+  host.remove()
   shell.remove()
 })

--- a/packages/public-ui/src/outline-sidebar.ts
+++ b/packages/public-ui/src/outline-sidebar.ts
@@ -1,7 +1,26 @@
-/** 所有悬浮目录都挂在壳层左侧栏：相对 --sidebar-col 贴在栏右缘。 */
-export const OUTLINE_SIDEBAR_HOST = '[data-testid="app-shell"]'
+/** 独立挂到 body，避免 portal 进 React 管理的 app-shell 后被重绘清掉。 */
+export const OUTLINE_SIDEBAR_HOST_ID = 'biu-outline-sidebar-host'
+
+function syncSidebarCol(host: HTMLElement) {
+  const shell = document.querySelector('[data-testid="app-shell"]')
+  if (!(shell instanceof HTMLElement)) {
+    host.style.setProperty('--sidebar-col', '0px')
+    return
+  }
+  const col = getComputedStyle(shell).getPropertyValue('--sidebar-col').trim() || '0px'
+  host.style.setProperty('--sidebar-col', col)
+}
 
 export function findOutlineSidebarHost(): HTMLElement | null {
-  const el = document.querySelector(OUTLINE_SIDEBAR_HOST)
-  return el instanceof HTMLElement ? el : null
+  if (typeof document === 'undefined') return null
+  let host = document.getElementById(OUTLINE_SIDEBAR_HOST_ID)
+  if (!host) {
+    host = document.createElement('div')
+    host.id = OUTLINE_SIDEBAR_HOST_ID
+    host.className = 'sidebar-outline-host'
+    host.setAttribute('data-testid', 'outline-sidebar-host')
+    document.body.append(host)
+  }
+  syncSidebarCol(host)
+  return host
 }

--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -34,6 +34,7 @@ test('message outline is a left rail of ticks with a hover menu', () => {
   const outline = readFileSync(resolve(import.meta.dirname, '../../../public-ui/src/outline-nav.tsx'), 'utf8')
   const bound = readFileSync(resolve(import.meta.dirname, '../../../cap-chat/src/web/message-outline.tsx'), 'utf8')
   const shell = readFileSync(resolve(import.meta.dirname, '../../../web-app-shell/src/web/index.tsx'), 'utf8')
+  assert.match(css, /\.sidebar-outline-host\s*\{[^}]*position:\s*fixed/s)
   assert.match(css, /\.chat-outline\s*\{[^}]*position:\s*fixed/s)
   assert.match(css, /\.chat-outline\s*\{[^}]*left:\s*calc\(var\(--sidebar-col, 0px\) \+ 20px\)/s)
   assert.match(css, /\.chat-outline-rail\s*\{[^}]*align-items:\s*flex-start/s)

--- a/web/style.css
+++ b/web/style.css
@@ -178,7 +178,7 @@ body {
 }
 
 .sidebar-outline-host {
-  position: absolute;
+  position: fixed;
   inset: 0;
   z-index: 40;
   pointer-events: none;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开会话详情后悬浮目录消失，是因为目录被 portal 进 React 正在协调的 `app-shell`，壳层一更新就把额外 DOM 清掉。

现在改为在 `document.body` 上挂独立宿主（`#biu-outline-sidebar-host`），位置仍用 `--sidebar-col` 贴左侧栏。Immersive Translate 的 `sync rules error` 是浏览器翻译插件自己的网络失败，与本仓库无关。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

