### PR TITLE
style: 主聊天目录刻度与详情页一级标题一样长

### DIFF
--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -20,11 +20,11 @@ test('deriveChatOutline can hide robot-initiated user nodes', () => {
     ['u-1', 'u-3'],
   )
   assert.deepEqual(
-    deriveChatOutline(nodes, 'all').map((item) => [item.id, item.robot]),
+    deriveChatOutline(nodes, 'all').map((item) => [item.id, item.robot, item.level]),
     [
-      ['u-1', false],
-      ['u-2', true],
-      ['u-3', false],
+      ['u-1', false, 1],
+      ['u-2', true, 1],
+      ['u-3', false, 1],
     ],
   )
 })
@@ -43,7 +43,7 @@ test('message outline is a left rail of ticks with a hover menu', () => {
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*border-radius:\s*8px/s)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*backdrop-filter:\s*blur\(16px\)\s*saturate\(1\.2\)/s)
   assert.match(css, /\.chat-outline-panel\s*\{[^}]*background:\s*rgba\(255,\s*255,\s*255,\s*0\.1\)/s)
-  assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*width:\s*6px/s)
+  assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*width:\s*10px/s)
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*height:\s*2px/s)
   assert.match(css, /\.chat-outline-tick::after\s*\{[^}]*opacity:\s*0\.3/s)
   assert.match(css, /\.chat-outline-tick\.is-h1::after\s*\{[^}]*width:\s*10px/s)

--- a/packages/web-session-view/src/web/chat-outline.ts
+++ b/packages/web-session-view/src/web/chat-outline.ts
@@ -6,6 +6,7 @@ export type ChatOutlineItem = {
   id: string
   text: string
   robot: boolean
+  level: 1
 }
 
 const OPEN_KEY = 'cordis.chatOutline.open'
@@ -74,7 +75,7 @@ export function deriveChatOutline(nodes: ChatNode[], filter: ChatOutlineFilter):
     if (node.kind !== 'user') continue
     const robot = !isHumanUserNode(node)
     if (filter === 'user' && robot) continue
-    items.push({ id: node.id, text: outlinePreview(node.text), robot })
+    items.push({ id: node.id, text: outlinePreview(node.text), robot, level: 1 })
   }
   return items
 }

--- a/web/style.css
+++ b/web/style.css
@@ -4331,7 +4331,7 @@ body {
 .chat-outline-tick::after {
   content: '';
   display: block;
-  width: 6px;
+  width: 10px;
   height: 2px;
   margin: 0;
   border-radius: 1px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
主聊天左侧目录布局不变，只把用户消息刻度拉到和详情页一级标题一样长（默认 6px → 10px，并标成 h1）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

