### PR TITLE
style: 详情属性列 key/icon 灰色，value 用 F0EFED

### DIFF
--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -7,7 +7,6 @@ import {
   Bars3BottomLeftIcon,
   CalendarDaysIcon,
   CheckIcon,
-  ClipboardDocumentListIcon,
   DocumentTextIcon,
   HashtagIcon,
   LinkIcon,
@@ -109,7 +108,7 @@ export function fromDatetimeLocal(value: string) {
 
 export function FieldGlyph({ kind }: { kind: FieldType }) {
   const cls = 'size-[14px] shrink-0 opacity-80'
-  if (kind === 'boolean') return <ClipboardDocumentListIcon aria-hidden className={cls} />
+  if (kind === 'boolean') return <span aria-hidden className="fsdb-field-bool-glyph"><BoolBox on={false} /></span>
   if (kind === 'select') return <ListBulletIcon aria-hidden className={cls} />
   if (kind === 'multi-select') return <RectangleStackIcon aria-hidden className={cls} />
   if (kind === 'datetime') return <CalendarDaysIcon aria-hidden className={cls} />

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -258,6 +258,8 @@ const CSS = `
 .fsdb-bool{display:inline-flex;align-items:center;flex:none;line-height:0;vertical-align:middle}
 .fsdb-boolbtn{border:0;background:transparent;padding:0;cursor:pointer;display:inline-flex;align-items:center;flex:none;line-height:0;vertical-align:middle}
 .fsdb-boolbox{width:16px;height:16px;border-radius:4px;border:1.5px solid var(--dsw-border);display:inline-flex;align-items:center;justify-content:center;background:transparent;color:var(--dsw-bg);box-sizing:border-box}
+.fsdb-field-bool-glyph{display:inline-flex;flex:none;align-items:center;line-height:0}
+.fsdb-field-bool-glyph .fsdb-boolbox{width:14px;height:14px}
 .fsdb-boolbox.is-on{background:var(--dsw-pick,#2383e2);border-color:transparent;color:var(--dsw-bg)}
 .fsdb-boolbox.is-locked{cursor:default;opacity:.9}
 .fsdb-boolbox.is-locked.is-on{background:var(--dsw-pick,#2383e2);border-color:transparent;color:var(--dsw-bg)}
@@ -280,6 +282,10 @@ const CSS = `
 .fsdb-page.is-sheet .tasks-main{padding:0 0 0 var(--fsdb-check-gutter);gap:8px;max-width:none}
 .fsdb-page.is-sheet .fsdb-right-body{overflow:hidden}
 .fsdb-detail-aside{display:flex;flex-direction:column;gap:2px;padding:0 0 12px}
+.fsdb-detail-aside .fsdb-proprow-k,.fsdb-detail-aside .fsdb-prop>span:first-child,.fsdb-detail-aside .fsdb-proprow-label{color:#ACA9A4}
+.fsdb-detail-aside .fsdb-proprow-k svg,.fsdb-detail-aside .fsdb-prop>span:first-child svg{color:#ACA9A4;opacity:1}
+.fsdb-detail-aside .fsdb-field-bool-glyph .fsdb-boolbox{border-color:#ACA9A4}
+.fsdb-detail-aside .fsdb-proprow-v,.fsdb-detail-aside .fsdb-prop-val,.fsdb-detail-aside .fsdb-detail-id,.fsdb-detail-aside .fsdb-plain-input{color:#F0EFED}
 .fsdb-proprow,.fsdb-prop{display:grid;grid-template-columns:108px minmax(0,1fr);align-items:center;gap:8px;min-height:32px;font-size:14px;color:#7B7B79}
 .fsdb-proprow-k,.fsdb-prop>span:first-child{font-size:14px;font-weight:500;color:#7B7B79;display:inline-flex;align-items:center;gap:6px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-proprow-k svg,.fsdb-prop>span:first-child svg,.fsdb-schema-prop-k svg{color:#F0EFED;opacity:1}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -353,6 +353,12 @@ test('page collection uses a document glyph, not the table/database icon', () =>
   assert.match(glyphs, /<DocumentIcon/)
 })
 
+test('boolean field glyph is a checkbox, not the document list icon', () => {
+  const cells = readFileSync(resolve(import.meta.dirname, './fsdb-cells.tsx'), 'utf8')
+  assert.match(cells, /kind === 'boolean'\) return <span aria-hidden className="fsdb-field-bool-glyph"><BoolBox on=\{false\}/)
+  assert.doesNotMatch(cells, /kind === 'boolean'\) return <ClipboardDocumentListIcon/)
+})
+
 test('facet field glyph matches the collection stack icon', () => {
   const glyphs = readFileSync(resolve(import.meta.dirname, './table-glyph.tsx'), 'utf8')
   const cells = readFileSync(resolve(import.meta.dirname, './fsdb-cells.tsx'), 'utf8')

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -84,11 +84,14 @@ test('title cell hover icons use F0EFED', () => {
   assert.match(css, /\.fsdb-page \.tasks-row-tools \.tasks-icon-btn,\.fsdb-page \.tasks-row-actions \.tasks-icon-btn\{[^}]*color:#F0EFED/)
 })
 
-test('list and detail properties share key and value colors', () => {
+test('list properties keep muted colors; detail property column uses ACA9A4 keys and F0EFED values', () => {
   assert.match(css, /\.fsdb-proprow-k,\.fsdb-prop>span:first-child\{[^}]*color:#7B7B79/)
   assert.match(css, /\.fsdb-proprow-v,\.fsdb-prop-val,\.fsdb-detail-id\{[^}]*color:#7C7A76/)
   assert.match(css, /\.fsdb-schema-prop-k\{[^}]*color:#7B7B79/)
   assert.match(css, /\.fsdb-proprow-k svg,\.fsdb-prop>span:first-child svg,\.fsdb-schema-prop-k svg\{[^}]*color:#F0EFED/)
+  assert.match(css, /\.fsdb-detail-aside \.fsdb-proprow-k,\.fsdb-detail-aside \.fsdb-prop>span:first-child,\.fsdb-detail-aside \.fsdb-proprow-label\{[^}]*color:#ACA9A4/)
+  assert.match(css, /\.fsdb-detail-aside \.fsdb-proprow-k svg,\.fsdb-detail-aside \.fsdb-prop>span:first-child svg\{[^}]*color:#ACA9A4/)
+  assert.match(css, /\.fsdb-detail-aside \.fsdb-proprow-v,\.fsdb-detail-aside \.fsdb-prop-val,\.fsdb-detail-aside \.fsdb-detail-id,\.fsdb-detail-aside \.fsdb-plain-input\{[^}]*color:#F0EFED/)
 })
 
 test('usage figures in collection cells match the table font size', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格记录点进详情后，左侧那一列属性：

- 类型 icon 和字段名（key）用 `#ACA9A4`
- 值（文字/数字/ID）用 `#F0EFED`

另外布尔类型字段的类型图标改成选框，不再用文件清单图标。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

