### PR TITLE
fix: 检查器刷新后记住当前视图和记录

### DIFF
--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -5,6 +5,7 @@ import {
   getInspectorDbPath,
   isInspectorDatabasePath,
   setInspectorDbPath,
+  resetInspectorDbPathMemory,
   showRecordInInspector,
   showInInspector,
   applyDatabaseReveal,
@@ -36,6 +37,17 @@ test('each inspector database pane keeps its own path', () => {
   setInspectorDbPath('database::b', '/database/tasks')
   assert.equal(getInspectorDbPath('database::a'), '/database/pages')
   assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
+})
+
+test('inspector pane remembers view and record after a memory reset', () => {
+  const pane = 'database:/sessions'
+  setInspectorDbPath(pane, '/database/sessions/view/mine')
+  setInspectorDbPath(pane, '/database/sessions/record/s1?view=mine')
+  resetInspectorDbPathMemory()
+  assert.equal(getInspectorDbPath(pane), '/database/sessions/record/s1?view=mine')
+  setInspectorDbPath(pane, '/database/sessions/view/board-1')
+  resetInspectorDbPathMemory()
+  assert.equal(getInspectorDbPath(pane), '/database/sessions/view/board-1')
 })
 
 test('window reveal event opens the inspector record path', async () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -6,10 +6,33 @@ import { upsertSavedView } from './view-storage.ts'
 import { normalizeSavedView, type SavedView } from './saved-view.ts'
 
 const DEFAULT_PANE = 'database'
+const STORAGE_PREFIX = 'inspector.dbPath:'
 const listeners = new Set<() => void>()
 const paths = new Map<string, string>()
 const working = new Set<string>()
 const workingListeners = new Set<() => void>()
+
+function storageKey(paneId: string) {
+  return `${STORAGE_PREFIX}${paneId}`
+}
+
+function readStoredPath(paneId: string) {
+  try {
+    const raw = localStorage.getItem(storageKey(paneId)) ?? ''
+    return isInspectorDatabasePath(raw) ? raw : ''
+  } catch {
+    return ''
+  }
+}
+
+function writeStoredPath(paneId: string, path: string) {
+  try {
+    if (!path) localStorage.removeItem(storageKey(paneId))
+    else localStorage.setItem(storageKey(paneId), path)
+  } catch {
+    /* ignore */
+  }
+}
 
 export function subscribeInspectorAgentWorking(fn: () => void) {
   workingListeners.add(fn)
@@ -58,21 +81,33 @@ export function isInspectorDatabasePath(pathname: string) {
 }
 
 function panePath(paneId = DEFAULT_PANE) {
-  const path = paths.get(paneId) ?? ''
-  return isInspectorDatabasePath(path) ? path : ''
+  const mem = paths.get(paneId)
+  if (mem !== undefined) return isInspectorDatabasePath(mem) ? mem : ''
+  const stored = readStoredPath(paneId)
+  if (stored) paths.set(paneId, stored)
+  return stored
 }
 
 export function getInspectorDbPath(paneId = DEFAULT_PANE) {
   return panePath(paneId)
 }
 
+/** 测试用：清空内存路径，模拟整页刷新后只剩 localStorage。 */
+export function resetInspectorDbPathMemory() {
+  paths.clear()
+}
+
 export function setInspectorDbPath(paneId: string, next?: string) {
   const id = next === undefined ? DEFAULT_PANE : paneId
   const path = next === undefined ? paneId : next
   const stored = isInspectorDatabasePath(path) ? path : ''
-  if ((paths.get(id) ?? '') === stored) return
+  if ((paths.get(id) ?? '') === stored) {
+    writeStoredPath(id, stored)
+    return
+  }
   if (!stored) paths.delete(id)
   else paths.set(id, stored)
+  writeStoredPath(id, stored)
   bump()
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
检查器只把「打开了会话/任务/页面哪个 tab」写进 localStorage，每个 tab 里当前是哪条视图、哪条记录只在模块内存的 `Map` 里。

浏览器刷新会重建整个 JS 运行时，这块内存会丢。绑定时路径为空，就会回落到「全部会话 / 全部任务 / 全部页面」。

这次按 pane 把完整 `/database/...` 路径一并写入 `inspector.dbPath:${paneId}`，刷新后从 localStorage 恢复。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

