### PR TITLE
fix: action 悬浮提示和菜单盖过表格

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -164,6 +164,8 @@ const CSS = `
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-cell{overflow:hidden;max-width:100%;max-height:2.8em}
 .fsdb-page .tasks-table.is-wrap.is-truncate .fsdb-title-text{display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:2;overflow:hidden;white-space:normal}
 .fsdb-page .tasks-table th,.fsdb-page .tasks-table td{overflow:visible}
+.fsdb-page .tasks-table tbody tr:hover{position:relative;z-index:6}
+.fsdb-page .tasks-table [data-dock-tip]::after{z-index:80}
 .fsdb-page .tasks-table th{padding:6px 6px;color:var(--dsw-label-2);font-size:14px;font-weight:600;position:sticky;top:0;background:var(--dsw-surface);z-index:5;white-space:nowrap}
 .fsdb-row-check{position:absolute;top:50%;left:0;z-index:3;display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;margin:0;transform:translate(-100%,-50%);opacity:0;pointer-events:none}
 .fsdb-page .tasks-table td:first-child{position:relative}

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -45,6 +45,8 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.fsdb-page \.tasks-row-tools-slot\{[^}]*display:inline-flex/)
   assert.match(css, /\.fsdb-page \.tasks-row-tools-slot\{[^}]*right:8px/)
   assert.match(css, /\.fsdb-page \.tasks-table th\{[^}]*z-index:5/)
+  assert.match(css, /\.fsdb-page \.tasks-table tbody tr:hover\{[^}]*z-index:6/)
+  assert.match(css, /\.fsdb-page \.tasks-table \[data-dock-tip\]::after\{[^}]*z-index:80/)
   assert.match(css, /\.fsdb-page \.tasks-table-wrap\{[^}]*padding-left:var\(--fsdb-check-gutter\)/)
   assert.doesNotMatch(css, /\.inspector-database-page \.fsdb-main,\.inspector-database-page \.fsdb-detail-main\{[^}]*padding-left:28px/)
   assert.doesNotMatch(css, /inspector-database-page[^{]*\{[^}]*padding-left:28px/)

--- a/packages/public-ui/src/anchor-menu.tsx
+++ b/packages/public-ui/src/anchor-menu.tsx
@@ -8,7 +8,7 @@ export function AnchorMenu({
   children,
   className = 'fsdb-cellselect-menu',
   role = 'listbox',
-  zIndex = 80,
+  zIndex = 200,
   ...rest
 }: {
   anchor: HTMLElement | null

--- a/packages/public-ui/src/outside-dismiss.test.ts
+++ b/packages/public-ui/src/outside-dismiss.test.ts
@@ -9,4 +9,5 @@ test('outside dismiss listens in the capture phase', () => {
   assert.match(src, /addEventListener\('mousedown', onDown, true\)/)
   assert.match(src, /removeEventListener\('mousedown', onDown, true\)/)
   assert.match(menu, /listenOutsideDismiss/)
+  assert.match(menu, /zIndex = 200/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格后一行会把标题列 action 的 hover 提示盖住。悬停行提到表头之上，提示本身也提高 z-index；锚点菜单默认 200，避免被表头或检查器挡住。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

