### PR TITLE
feat: 时间格子用 antd DatePicker，夜间 Notion 风格

### DIFF
--- a/packages/database-ui/package.json
+++ b/packages/database-ui/package.json
@@ -8,6 +8,8 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
+    "antd": "^6.6.1",
+    "dayjs": "^1.11.13",
     "@biu/public-ui": "0.1.0"
   },
   "peerDependencies": {

--- a/packages/database-ui/src/cell-datetime.tsx
+++ b/packages/database-ui/src/cell-datetime.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useRef, useState } from 'react'
-import { DbMenu, ensureDbSearchStyle } from './search-menu.tsx'
+import { DatePicker, ConfigProvider, theme } from 'antd'
+import zhCN from 'antd/locale/zh_CN'
+import dayjs from 'dayjs'
+import 'dayjs/locale/zh-cn'
+import { ensureDbSearchStyle } from './search-menu.tsx'
 
-const WEEK = ['一', '二', '三', '四', '五', '六', '日']
-const HOURS = Array.from({ length: 24 }, (_, i) => i)
-const MINUTES = Array.from({ length: 60 }, (_, i) => i)
+dayjs.locale('zh-cn')
 
 function asStamp(value: unknown) {
   const n = Number(value)
@@ -23,42 +24,37 @@ export function formatDateTimeLabel(value: unknown) {
   })
 }
 
-function monthCells(year: number, month: number) {
-  const first = new Date(year, month, 1)
-  const pad = (first.getDay() + 6) % 7
-  const last = new Date(year, month + 1, 0).getDate()
-  const cells: Array<number | null> = []
-  for (let i = 0; i < pad; i += 1) cells.push(null)
-  for (let day = 1; day <= last; day += 1) cells.push(day)
-  while (cells.length % 7) cells.push(null)
-  return cells
+const NOTION_DARK = {
+  algorithm: theme.darkAlgorithm,
+  token: {
+    colorBgBase: '#191919',
+    colorBgContainer: '#202020',
+    colorBgElevated: '#202020',
+    colorBgLayout: '#191919',
+    colorBorder: 'rgba(242, 241, 237, 0.1)',
+    colorBorderSecondary: 'rgba(242, 241, 237, 0.08)',
+    colorText: '#F0EFED',
+    colorTextSecondary: '#bcbab6',
+    colorTextTertiary: 'rgba(242, 241, 237, 0.45)',
+    colorTextPlaceholder: '#5F5F5A',
+    colorPrimary: '#5b9fd6',
+    colorPrimaryHover: '#7eb3e0',
+    colorFillSecondary: '#2c2c2c',
+    colorFillTertiary: '#2c2c2c',
+    controlOutline: 'transparent',
+    borderRadius: 6,
+    fontSize: 13,
+    fontFamily: 'inherit',
+    boxShadowSecondary: '0 0 0 1px rgba(242, 241, 237, 0.06), 0 8px 24px rgba(0, 0, 0, 0.35)',
+  },
+  components: {
+    DatePicker: {
+      cellHeight: 28,
+      cellWidth: 32,
+      timeColumnWidth: 48,
+    },
+  },
 }
-
-function combine(year: number, month: number, day: number, hours: number, minutes: number) {
-  return new Date(year, month, day, hours, minutes, 0, 0).getTime()
-}
-
-function Chevron({ dir }: { dir: 'prev' | 'next' }) {
-  return (
-    <svg aria-hidden viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
-      {dir === 'prev' ? (
-        <path d="M9.78 4.22a.75.75 0 0 1 0 1.06L6.06 9l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z" />
-      ) : (
-        <path d="M6.22 4.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 1 1-1.06-1.06L9.94 9 6.22 5.28a.75.75 0 0 1 0-1.06Z" />
-      )}
-    </svg>
-  )
-}
-
-function CalendarMark() {
-  return (
-    <svg aria-hidden viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
-      <path d="M5.75 1a.75.75 0 0 1 .75.75V3h3.5V1.75a.75.75 0 0 1 1.5 0V3H12.5A1.5 1.5 0 0 1 14 4.5v8A1.5 1.5 0 0 1 12.5 14h-9A1.5 1.5 0 0 1 2 12.5v-8A1.5 1.5 0 0 1 3.5 3H5V1.75A.75.75 0 0 1 5.75 1ZM3.5 6.5v6h9v-6h-9Z" />
-    </svg>
-  )
-}
-
-const pad = (n: number) => String(n).padStart(2, '0')
 
 export function CellDateTime({
   value,
@@ -73,137 +69,26 @@ export function CellDateTime({
 }) {
   ensureDbSearchStyle()
   const stamp = asStamp(value)
-  const selected = stamp ? new Date(stamp) : null
-  const [open, setOpen] = useState(false)
-  const [cursor, setCursor] = useState(() => selected ?? new Date())
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const hours = selected?.getHours() ?? 9
-  const minutes = selected?.getMinutes() ?? 0
-  const days = useMemo(() => monthCells(cursor.getFullYear(), cursor.getMonth()), [cursor])
-  const label = formatDateTimeLabel(stamp)
-  const close = () => setOpen(false)
-  const write = (next: number | null) => {
-    onChange(next)
-    if (next) setCursor(new Date(next))
-  }
-  const pickDay = (day: number) => {
-    write(combine(cursor.getFullYear(), cursor.getMonth(), day, hours, minutes))
-  }
-  const pickTime = (nextHours: number, nextMinutes: number) => {
-    const base = selected ?? new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate())
-    write(combine(base.getFullYear(), base.getMonth(), base.getDate(), nextHours, nextMinutes))
-  }
   return (
     <div
-      className="db-datetime"
+      className={`db-datetime${overdue ? ' is-overdue' : ''}`}
       onClick={(event) => event.stopPropagation()}
       onMouseDown={(event) => event.stopPropagation()}
     >
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`db-datetime-trigger${label ? '' : ' is-empty'}${overdue ? ' is-overdue' : ''}`}
-        data-open={open || undefined}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-label={empty}
-        onClick={() => {
-          setCursor(selected ?? new Date())
-          setOpen((prev) => !prev)
-        }}
-      >
-        <CalendarMark />
-        <span className="db-datetime-label">{label || empty}</span>
-      </button>
-      {open ? (
-        <DbMenu
-          anchor={triggerRef.current}
-          onClose={close}
-          className="db-datetime-pop"
-          role="dialog"
-          minWidth={268}
-        >
-          <div className="db-datetime-head">
-            <button
-              type="button"
-              className="db-datetime-nav"
-              aria-label="上个月"
-              onClick={() => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() - 1, 1))}
-            >
-              <Chevron dir="prev" />
-            </button>
-            <span className="db-datetime-month">
-              {cursor.getFullYear()}年{cursor.getMonth() + 1}月
-            </span>
-            <button
-              type="button"
-              className="db-datetime-nav"
-              aria-label="下个月"
-              onClick={() => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1))}
-            >
-              <Chevron dir="next" />
-            </button>
-          </div>
-          <div className="db-datetime-week">
-            {WEEK.map((item) => (
-              <span key={item}>{item}</span>
-            ))}
-          </div>
-          <div className="db-datetime-grid">
-            {days.map((day, index) => {
-              const on =
-                day != null &&
-                selected != null &&
-                selected.getFullYear() === cursor.getFullYear() &&
-                selected.getMonth() === cursor.getMonth() &&
-                selected.getDate() === day
-              return (
-                <button
-                  key={`${cursor.getFullYear()}-${cursor.getMonth()}-${index}`}
-                  type="button"
-                  className={`db-datetime-day${day == null ? ' is-empty' : ''}${on ? ' is-on' : ''}`}
-                  disabled={day == null}
-                  onClick={() => day != null && pickDay(day)}
-                >
-                  {day ?? ''}
-                </button>
-              )
-            })}
-          </div>
-          <div className="db-datetime-time">
-            <select
-              aria-label="时"
-              value={hours}
-              onChange={(event) => pickTime(Number(event.target.value), minutes)}
-            >
-              {HOURS.map((item) => (
-                <option key={item} value={item}>
-                  {pad(item)} 时
-                </option>
-              ))}
-            </select>
-            <select
-              aria-label="分"
-              value={minutes}
-              onChange={(event) => pickTime(hours, Number(event.target.value))}
-            >
-              {MINUTES.map((item) => (
-                <option key={item} value={item}>
-                  {pad(item)} 分
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="db-datetime-foot">
-            <button type="button" onClick={() => write(null)}>
-              清除
-            </button>
-            <button type="button" onClick={() => write(Date.now())}>
-              现在
-            </button>
-          </div>
-        </DbMenu>
-      ) : null}
+      <ConfigProvider locale={zhCN} theme={NOTION_DARK} wave={{ disabled: true }}>
+        <DatePicker
+          showTime={{ format: 'HH:mm' }}
+          needConfirm={false}
+          allowClear
+          size="small"
+          variant="borderless"
+          placeholder={empty}
+          format="YYYY/MM/DD HH:mm"
+          value={stamp ? dayjs(stamp) : null}
+          onChange={(next) => onChange(next ? next.valueOf() : null)}
+          getPopupContainer={() => document.body}
+        />
+      </ConfigProvider>
     </div>
   )
 }

--- a/packages/database-ui/src/index.test.ts
+++ b/packages/database-ui/src/index.test.ts
@@ -28,13 +28,13 @@ test('database-ui ships one search menu for select and multi-select', () => {
   assert.match(select, /Boolean\(item\.value\)/)
 })
 
-test('datetime cell uses a calendar popover instead of datetime-local', () => {
+test('datetime cell uses antd DatePicker, not datetime-local', () => {
   const picker = readFileSync(resolve(import.meta.dirname, './cell-datetime.tsx'), 'utf8')
-  const menu = readFileSync(resolve(import.meta.dirname, './search-menu.tsx'), 'utf8')
   const index = readFileSync(resolve(import.meta.dirname, './index.ts'), 'utf8')
-  assert.match(picker, /function CellDateTime/)
-  assert.match(picker, /<DbMenu/)
+  assert.match(picker, /DatePicker/)
+  assert.match(picker, /from 'antd'/)
+  assert.match(picker, /darkAlgorithm/)
   assert.doesNotMatch(picker, /datetime-local/)
-  assert.match(menu, /\.db-datetime-grid/)
+  assert.doesNotMatch(picker, /<DbMenu/)
   assert.match(index, /CellDateTime/)
 })

--- a/packages/database-ui/src/search-menu.tsx
+++ b/packages/database-ui/src/search-menu.tsx
@@ -28,27 +28,10 @@ const CSS = `
 .db-cell-multi-box{display:inline-flex;flex-wrap:wrap;align-items:center;gap:4px;width:auto;max-width:100%;min-height:20px;border:0;border-radius:6px;padding:0;background:transparent;color:inherit;font:inherit;text-align:left;cursor:pointer}
 .db-cell-multi-box:hover,.db-cell-multi-box[aria-expanded="true"]{background:var(--dsw-hover)}
 .db-datetime{display:inline-flex;position:relative;min-width:0;max-width:100%;vertical-align:middle}
-.db-datetime-trigger{display:inline-flex;align-items:center;gap:5px;max-width:100%;height:22px;border:0;border-radius:4px;padding:0 6px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;font-weight:500;line-height:22px;cursor:pointer;text-align:left}
-.db-datetime-trigger:hover,.db-datetime-trigger[data-open]{background:var(--dsw-hover)}
-.db-datetime-trigger.is-empty{color:var(--dsw-label-3);font-weight:500}
-.db-datetime-trigger.is-overdue{color:var(--dsw-danger)}
-.db-datetime-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.db-datetime-pop{box-sizing:border-box;padding:8px}
-.db-datetime-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin:0 0 6px}
-.db-datetime-month{font-size:14px;font-weight:650;color:var(--dsw-label)}
-.db-datetime-nav{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label);cursor:pointer}
-.db-datetime-nav:hover{background:var(--dsw-hover)}
-.db-datetime-week,.db-datetime-grid{display:grid;grid-template-columns:repeat(7,1fr);gap:2px}
-.db-datetime-week span{text-align:center;font-size:11px;color:var(--dsw-label-3);padding:4px 0}
-.db-datetime-day{border:0;border-radius:6px;height:28px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;cursor:pointer}
-.db-datetime-day:hover{background:var(--dsw-hover)}
-.db-datetime-day.is-on{background:color-mix(in srgb,var(--dsw-business) 18%,transparent);color:var(--dsw-business);font-weight:650}
-.db-datetime-day.is-empty{visibility:hidden;pointer-events:none}
-.db-datetime-time{display:flex;align-items:center;gap:6px;margin-top:8px;padding-top:8px;border-top:1px solid var(--dsw-border)}
-.db-datetime-time select{flex:1;min-width:0;height:28px;border:1px solid var(--dsw-border);border-radius:6px;padding:0 6px;background:var(--dsw-input);color:var(--dsw-label);font:inherit;font-size:14px}
-.db-datetime-foot{display:flex;justify-content:space-between;gap:8px;margin-top:6px}
-.db-datetime-foot button{border:0;border-radius:6px;padding:4px 6px;background:transparent;color:var(--dsw-label-2);font:inherit;font-size:13px;cursor:pointer}
-.db-datetime-foot button:hover{background:var(--dsw-hover);color:var(--dsw-label)}
+.db-datetime .ant-picker{width:auto;max-width:100%;padding:0 4px;background:transparent;border:0;box-shadow:none}
+.db-datetime .ant-picker-input > input{font-size:14px;font-weight:500;color:var(--dsw-label)}
+.db-datetime.is-overdue .ant-picker-input > input{color:var(--dsw-danger)}
+.db-datetime .ant-picker-suffix,.db-datetime .ant-picker-clear{color:var(--dsw-label-3)}
 `
 
 export function ensureDbSearchStyle() {

--- a/packages/public-ui/src/outside-dismiss.ts
+++ b/packages/public-ui/src/outside-dismiss.ts
@@ -3,6 +3,8 @@ export function listenOutsideDismiss(onClose: () => void, isInside: (target: Nod
   const onDown = (event: MouseEvent) => {
     const target = event.target
     if (!(target instanceof Node) || isInside(target)) return
+    const active = document.activeElement
+    if (active instanceof Node && isInside(active)) return
     onClose()
   }
   document.addEventListener('mousedown', onDown, true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
仓库里已经有 Ant Design。可写时间格子改用 `DatePicker`（带时分），并用暗色 token 对齐现有夜间色：`#191919` / `#202020`、细描边、选中色 `#5b9fd6`。不再自制月历，也不再用系统 `datetime-local`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

