### PR TITLE
fix: 数据库分页点击后不再弹回第一页

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -221,7 +221,11 @@ export function CollectionBrowser({
   const [filters, setFilters] = useState<Record<string, string>>(initialView?.filters ?? {})
   const [columnKeys, setColumnKeys] = useState<string[]>(initialView?.columns ?? [])
   const [facetCatalog, setFacetCatalog] = useState(() => loadFacets())
-  const tablePathsKey = tables.map((table) => `${table.path}\t${table.view?.title ?? table.label ?? ''}`).join('\n')
+  const tablePathsKey = tables
+    .map((table) => table.path)
+    .slice()
+    .sort()
+    .join('\n')
   const [views, setViews] = useState<SavedView[]>(() => loadViews(collectionPath))
   const [activeViewId, setActiveViewId] = useState<string | null>(initialView?.id ?? null)
   const catalogLocks = useMemo(() => {
@@ -231,6 +235,7 @@ export function CollectionBrowser({
     return { ...current.filters, ...lockedFilters }
   }, [activeViewId, lockedFilters, sheet, views])
   const queryFilters = useMemo(() => ({ ...filters, ...catalogLocks }), [catalogLocks, filters])
+  const queryFiltersKey = JSON.stringify(queryFilters)
   const lockedFilterKeys = Object.keys(catalogLocks)
   const lockedSource = catalogLocks.tablePath ?? ''
   useEffect(() => {
@@ -532,7 +537,7 @@ export function CollectionBrowser({
 
   useEffect(() => {
     setPage((prev) => (prev === 0 ? prev : 0))
-  }, [fetchQuery, queryFilters, sortField, sortDir, pageSize, collectionPath, dataPath])
+  }, [fetchQuery, queryFiltersKey, sortField, sortDir, pageSize, collectionPath, dataPath])
 
   async function refreshNow() {
     if (refreshing) return

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -53,6 +53,7 @@ type SnapshotService = {
 }
 
 const EMPTY_CHROME: CollectionChrome = {}
+const EMPTY_FILTERS: Record<string, string> = {}
 
 function CollectionPage(props: SlotProps) {
   const tables = (props.tables as CollectionInfo[] | undefined) ?? []
@@ -130,7 +131,7 @@ function CollectionPage(props: SlotProps) {
     go({ collection: first.path, viewId: defaultViewId(first.path) }, { replace: true })
   }, [collectionFromRoute, orderedTables])
 
-  const lockedFilters = chrome.lockedFiltersFromSearch?.(location.search) ?? {}
+  const lockedFilters = chrome.lockedFiltersFromSearch?.(location.search) ?? EMPTY_FILTERS
   if (!currentPath) return null
   const title = row?.view?.title ?? row?.label ?? currentPath.replace(/^\//, '')
   return (

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -36,6 +36,7 @@ export function collectionTabIcon(icon?: string) {
 }
 
 const EMPTY_CHROME: CollectionChrome = {}
+const EMPTY_FILTERS: Record<string, string> = {}
 
 type InspectorSnapshot = {
   subscribe: (fn: () => void) => () => void
@@ -324,7 +325,7 @@ export function DatabaseInspectorBrowse(props: SlotProps) {
     () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
     () => (currentPath ? ui?.chrome(currentPath) ?? EMPTY_CHROME : EMPTY_CHROME),
   )
-  const lockedFilters = chrome.lockedFiltersFromSearch?.(search) ?? {}
+  const lockedFilters = chrome.lockedFiltersFromSearch?.(search) ?? EMPTY_FILTERS
   const table = tables.find((item) => item.path === currentPath)
   const title = table ? tableLabel(table) : '数据'
   const liveWorking = useInspectorAgentWorking(currentPath)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -349,6 +349,20 @@ test('collection reload does not follow callback identity', () => {
   assert.doesNotMatch(browser, /pullFacets\(\),\s*\n\s*\]\)/)
 })
 
+test('pager keeps the current page when filter objects are only recreated', () => {
+  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  const inspector = readFileSync(resolve(import.meta.dirname, './inspector-database.tsx'), 'utf8')
+  assert.match(browser, /const queryFiltersKey = JSON.stringify\(queryFilters\)/)
+  assert.match(browser, /\[fetchQuery, queryFiltersKey, sortField, sortDir, pageSize, collectionPath, dataPath\]/)
+  assert.doesNotMatch(browser, /\[fetchQuery, queryFilters, sortField/)
+  assert.match(browser, /tables\s*\n\s*\.map\(\(table\) => table\.path\)/)
+  assert.doesNotMatch(browser, /tablePathsKey = tables\.map/)
+  assert.match(page, /lockedFiltersFromSearch\?\.\(location\.search\) \?\? EMPTY_FILTERS/)
+  assert.doesNotMatch(page, /lockedFiltersFromSearch\?\.\(location\.search\) \?\? \{\}/)
+  assert.match(inspector, /lockedFiltersFromSearch\?\.\(search\) \?\? EMPTY_FILTERS/)
+  assert.doesNotMatch(inspector, /lockedFiltersFromSearch\?\.\(search\) \?\? \{\}/)
+})
+
 test('page collection uses a document glyph, not the table/database icon', () => {
   const glyphs = readFileSync(resolve(import.meta.dirname, './table-glyph.tsx'), 'utf8')
   assert.match(glyphs, /name === 'document' \|\| name === 'document-text' \|\| name === 'page'/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点下一页后列表会立刻回到第 1 页。原因是父组件每次渲染都会给 `lockedFilters` 一个新的 `{}`，分页重置 effect 又拿 `queryFilters` 的对象引用当依赖；快照/视图刷新一来，就被当成「筛选变了」而 `setPage(0)`。

改动：
- 分页重置改看筛选内容（`JSON.stringify`），不再看对象身份
- `lockedFilters` 回退用稳定的 `EMPTY_FILTERS`
- 表清单 hydrate 只按 path，标题变化不再整表重置

关于控制台另外两条：
- `Immersive Translate ERROR` 来自浏览器「沉浸式翻译」扩展，不是应用代码
- `flushSync was called from inside a lifecycle method` 多为 antd DatePicker / rc-trigger，本 PR 未改那条
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

