### PR TITLE
fix: 点每页条数不再重渲染整张表

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
-import { createPortal, flushSync } from 'react-dom'
+import { flushSync } from 'react-dom'
 import {
   ArrowDownIcon,
   ArrowPathIcon,
@@ -66,7 +66,8 @@ import { CrumbTrail } from './crumb-trail.tsx'
 import { pickDomAttrs, recordPickKind } from './pick-dom.ts'
 import { normalizeRecordEmoji, recordPreviewEmoji, crumbRecordLabel } from './sidebar-preview.ts'
 import { recordPreviewMascot, RecordMark } from './record-mark.tsx'
-import { normalizeSavedView, normalizePageSize, PAGE_SIZES, viewStateKey, type SavedView } from './saved-view.ts'
+import { normalizeSavedView, normalizePageSize, viewStateKey, type SavedView } from './saved-view.ts'
+import { PagerSizeControl } from './pager-size.tsx'
 import {
   actionIcon,
   ActionCell,
@@ -287,7 +288,6 @@ export function CollectionBrowser({
   const [filterOpen, setFilterOpen] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)
   const [groupOpen, setGroupOpen] = useState(false)
-  const [pageSizeOpen, setPageSizeOpen] = useState(false)
   const [layoutOpen, setLayoutOpen] = useState(false)
   const [wrapCells, setWrapCells] = useState(!!initialView?.wrap)
   const [truncateCells, setTruncateCells] = useState(initialView?.truncate !== false)
@@ -327,10 +327,7 @@ export function CollectionBrowser({
   const filterRef = useRef<HTMLDivElement>(null)
   const configRef = useRef<HTMLDivElement>(null)
   const groupRef = useRef<HTMLDivElement>(null)
-  const pageSizeRef = useRef<HTMLDivElement>(null)
   const layoutRef = useRef<HTMLDivElement>(null)
-  const pageSizeMenuRef = useRef<HTMLDivElement>(null)
-  const [pageSizeMenuPos, setPageSizeMenuPos] = useState<{ right: number; bottom: number } | null>(null)
   const searchRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const searchExpanded = searchOpen || query.length > 0
@@ -404,7 +401,6 @@ export function CollectionBrowser({
         setFilterOpen(false)
         setConfigOpen(false)
         setGroupOpen(false)
-        setPageSizeOpen(false)
         setLayoutOpen(false)
       },
       (target) => {
@@ -419,8 +415,6 @@ export function CollectionBrowser({
             filterRef.current?.contains(target) ||
             configRef.current?.contains(target) ||
             groupRef.current?.contains(target) ||
-            pageSizeRef.current?.contains(target) ||
-            pageSizeMenuRef.current?.contains(target) ||
             layoutRef.current?.contains(target),
         )
       },
@@ -449,24 +443,11 @@ export function CollectionBrowser({
     }
   }, [sheet, views, searchExpanded])
 
-  useLayoutEffect(() => {
-    if (!pageSizeOpen) {
-      setPageSizeMenuPos(null)
-      return
-    }
-    const box = pageSizeRef.current?.getBoundingClientRect()
-    if (!box) return
-    setPageSizeMenuPos({
-      right: Math.max(8, window.innerWidth - box.right),
-      bottom: Math.max(8, window.innerHeight - box.top + 6),
-    })
-  }, [pageSizeOpen])
-
   useEffect(() => {
     if (searchOpen) searchInputRef.current?.focus()
   }, [searchOpen])
 
-  function toggleMenu(which: 'view' | 'mode' | 'sort' | 'columns' | 'filter' | 'config' | 'group' | 'pageSize' | 'layout') {
+  function toggleMenu(which: 'view' | 'mode' | 'sort' | 'columns' | 'filter' | 'config' | 'group' | 'layout') {
     setViewMenuOpen(which === 'view' && !viewMenuOpen)
     setModeMenuOpen(which === 'mode' && !modeMenuOpen)
     setSortMenuOpen(which === 'sort' && !sortMenuOpen)
@@ -474,7 +455,6 @@ export function CollectionBrowser({
     setFilterOpen(which === 'filter' && !filterOpen)
     setConfigOpen(which === 'config' && !configOpen)
     setGroupOpen(which === 'group' && !groupOpen)
-    setPageSizeOpen(which === 'pageSize' && !pageSizeOpen)
     setLayoutOpen(which === 'layout' && !layoutOpen)
   }
 
@@ -2529,47 +2509,7 @@ export function CollectionBrowser({
               <span>{total}</span>
             </span>
             <div className="fsdb-pager-nav">
-              <div className="fsdb-pager-size" ref={pageSizeRef}>
-                <button
-                  type="button"
-                  className={`tasks-icon-btn fsdb-pager-size-btn${pageSizeOpen ? ' is-active' : ''}`}
-                  aria-label={`每页 ${pageSize} 条`}
-                  aria-haspopup="menu"
-                  aria-expanded={pageSizeOpen}
-                  title={`每页 ${pageSize} 条`}
-                  onClick={() => toggleMenu('pageSize')}
-                >
-                  <Bars3BottomLeftIcon aria-hidden className="size-[14px]" />
-                  <span>{pageSize}</span>
-                </button>
-                {pageSizeOpen && pageSizeMenuPos
-                  ? createPortal(
-                      <div
-                        ref={pageSizeMenuRef}
-                        className="fsdb-pager-size-menu"
-                        role="menu"
-                        style={{ right: pageSizeMenuPos.right, bottom: pageSizeMenuPos.bottom }}
-                      >
-                        {PAGE_SIZES.map((size) => (
-                          <button
-                            key={size}
-                            type="button"
-                            className={`fsdb-pager-size-option${size === pageSize ? ' is-active' : ''}`}
-                            role="menuitem"
-                            onClick={() => {
-                              setPageSize(normalizePageSize(size))
-                              setPageSizeOpen(false)
-                            }}
-                          >
-                            {size}
-                            {size === pageSize ? <CheckIcon aria-hidden className="size-[14px]" /> : null}
-                          </button>
-                        ))}
-                      </div>,
-                      document.body,
-                    )
-                  : null}
-              </div>
+              <PagerSizeControl pageSize={pageSize} onChange={setPageSize} />
               <button
                 type="button"
                 className="tasks-icon-btn"

--- a/packages/core-file-system/src/web/pager-size.test.ts
+++ b/packages/core-file-system/src/web/pager-size.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+
+const pager = readFileSync(resolve(import.meta.dirname, './pager-size.tsx'), 'utf8')
+const browser = readFileSync(resolve(import.meta.dirname, './browser.tsx'), 'utf8')
+
+test('page-size menu is a local control, not CollectionBrowser state', () => {
+  assert.match(browser, /<PagerSizeControl/)
+  assert.match(browser, /onChange=\{setPageSize\}/)
+  assert.doesNotMatch(browser, /pageSizeOpen/)
+  assert.doesNotMatch(browser, /toggleMenu\('pageSize'\)/)
+  assert.doesNotMatch(browser, /pageSizeMenuPos/)
+  assert.match(pager, /setPos\(menuPos\(wrapRef\.current\)\)/)
+  assert.match(pager, /if \(next !== pageSize\) onChange\(next\)/)
+})

--- a/packages/core-file-system/src/web/pager-size.tsx
+++ b/packages/core-file-system/src/web/pager-size.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Bars3BottomLeftIcon, CheckIcon } from '@heroicons/react/16/solid'
+import { listenOutsideDismiss } from '@biu/public-ui'
+import { normalizePageSize, PAGE_SIZES } from './saved-view.ts'
+
+function menuPos(el: HTMLElement | null) {
+  const box = el?.getBoundingClientRect()
+  if (!box) return null
+  return {
+    right: Math.max(8, window.innerWidth - box.right),
+    bottom: Math.max(8, window.innerHeight - box.top + 6),
+  }
+}
+
+/** 每页条数菜单自己管开合，避免点开时把整张表跟着 setState。 */
+export function PagerSizeControl({
+  pageSize,
+  onChange,
+}: {
+  pageSize: number
+  onChange: (size: number) => void
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const [open, setOpen] = useState(false)
+  const [pos, setPos] = useState<{ right: number; bottom: number } | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    return listenOutsideDismiss(
+      () => setOpen(false),
+      (target) => Boolean(wrapRef.current?.contains(target) || menuRef.current?.contains(target)),
+    )
+  }, [open])
+
+  return (
+    <div className="fsdb-pager-size" ref={wrapRef}>
+      <button
+        type="button"
+        className={`tasks-icon-btn fsdb-pager-size-btn${open ? ' is-active' : ''}`}
+        aria-label={`每页 ${pageSize} 条`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={`每页 ${pageSize} 条`}
+        onClick={() => {
+          if (open) {
+            setOpen(false)
+            return
+          }
+          setPos(menuPos(wrapRef.current))
+          setOpen(true)
+        }}
+      >
+        <Bars3BottomLeftIcon aria-hidden className="size-[14px]" />
+        <span>{pageSize}</span>
+      </button>
+      {open && pos
+        ? createPortal(
+            <div
+              ref={menuRef}
+              className="fsdb-pager-size-menu"
+              role="menu"
+              style={{ right: pos.right, bottom: pos.bottom }}
+            >
+              {PAGE_SIZES.map((size) => (
+                <button
+                  key={size}
+                  type="button"
+                  className={`fsdb-pager-size-option${size === pageSize ? ' is-active' : ''}`}
+                  role="menuitem"
+                  onClick={() => {
+                    setOpen(false)
+                    const next = normalizePageSize(size)
+                    if (next !== pageSize) onChange(next)
+                  }}
+                >
+                  {size}
+                  {size === pageSize ? <CheckIcon aria-hidden className="size-[14px]" /> : null}
+                </button>
+              ))}
+            </div>,
+            document.body,
+          )
+        : null}
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点每页条数数字只是开菜单，但开合状态写在 `CollectionBrowser` 里，整张表会跟着 `setState` 渲一遍；菜单还要等 layout 量完位置才出现，所以开和关都慢。

现在菜单是独立组件：点开/点关只更新它自己；量位置放在 click 里一次完成；选中当前条数不会回调父组件。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

