### PR TITLE
fix: action 失败提示改到屏幕中央弹窗

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -309,6 +309,7 @@ export function CollectionBrowser({
     | { kind: 'rename'; view: SavedView }
     | { kind: 'delete'; view: SavedView }
     | { kind: 'action'; row: DbRecord; action: CollectionActionInfo }
+    | { kind: 'alert'; title: string; body: string }
     | { kind: 'delete-record'; row: DbRecord }
     | { kind: 'delete-records'; ids: string[] }
     | null
@@ -1113,7 +1114,7 @@ export function CollectionBrowser({
       quietUntil.current = 0
       await reload()
     } catch (err) {
-      setError(String(err))
+      setDlg({ kind: 'alert', title: `${action.label}失败`, body: String(err) })
     } finally {
       setBusyKey(null)
     }
@@ -2617,6 +2618,16 @@ export function CollectionBrowser({
             void executeAction(row, action)
           }}
           body={<p>{dlg.action.confirm}</p>}
+        />
+      ) : null}
+      {dlg?.kind === 'alert' ? (
+        <AppDialog
+          title={dlg.title}
+          confirm="知道了"
+          hideCancel
+          onCancel={() => setDlg(null)}
+          onConfirm={() => setDlg(null)}
+          body={<p>{dlg.body}</p>}
         />
       ) : null}
     </div>

--- a/packages/core-file-system/src/web/controls.test.tsx
+++ b/packages/core-file-system/src/web/controls.test.tsx
@@ -37,6 +37,22 @@ test('named AppDialog keeps draft local so the parent does not re-render while t
   assert.equal(confirmed, '列表改名')
 })
 
+test('AppDialog can hide cancel so an alert only has a confirm button', () => {
+  render(
+    <AppDialog
+      title="安装失败"
+      confirm="知道了"
+      hideCancel
+      body={<p>语法错误</p>}
+      onCancel={() => {}}
+      onConfirm={() => {}}
+    />,
+  )
+  assert.equal(screen.queryByRole('button', { name: '取消' }), null)
+  assert.ok(screen.getByRole('button', { name: '知道了' }))
+  assert.ok(screen.getByRole('dialog', { name: '打包失败' }))
+})
+
 test('LocalText keeps keystrokes inside the field and only commits on blur', () => {
   let parentRenders = 0
   let committed = ''

--- a/packages/core-file-system/src/web/controls.test.tsx
+++ b/packages/core-file-system/src/web/controls.test.tsx
@@ -50,7 +50,7 @@ test('AppDialog can hide cancel so an alert only has a confirm button', () => {
   )
   assert.equal(screen.queryByRole('button', { name: '取消' }), null)
   assert.ok(screen.getByRole('button', { name: '知道了' }))
-  assert.ok(screen.getByRole('dialog', { name: '打包失败' }))
+  assert.ok(screen.getByRole('dialog', { name: '安装失败' }))
 })
 
 test('LocalText keeps keystrokes inside the field and only commits on blur', () => {

--- a/packages/core-file-system/src/web/controls.tsx
+++ b/packages/core-file-system/src/web/controls.tsx
@@ -67,6 +67,7 @@ export function AppDialog({
   confirm,
   danger,
   disabled,
+  hideCancel,
   onCancel,
   onConfirm,
   input,
@@ -78,6 +79,7 @@ export function AppDialog({
   confirm: string
   danger?: boolean
   disabled?: boolean
+  hideCancel?: boolean
   onCancel: () => void
   onConfirm: (name?: string) => void
   input?: {
@@ -130,9 +132,11 @@ export function AppDialog({
           {error ? <div className="fsdb-dlg-error">{error}</div> : null}
         </div>
         <div className="fsdb-dlg-actions">
-          <button type="button" className="fsdb-dlg-cancel" disabled={disabled} onClick={onCancel}>
-            取消
-          </button>
+          {hideCancel ? null : (
+            <button type="button" className="fsdb-dlg-cancel" disabled={disabled} onClick={onCancel}>
+              取消
+            </button>
+          )}
           <button type="button" className={`fsdb-dlg-ok${danger ? ' is-danger' : ''}`} disabled={disabled} onClick={submit}>
             {confirm}
           </button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格行上的 action 失败后，不再写入表格上方的 `tasks-error` 横幅。

改为打开已有的居中 `AppDialog`（标题为「{动作名}失败」，确认按钮「知道了」，无取消）。列表加载等其它错误仍走表格上方横幅。

只改了 `core-file-system` 的 browser / AppDialog，没有动插件打包或 page-excalidraw。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

