### PR TITLE
feat: 流式回合中实时显示 token / step / 工具数

### DIFF
--- a/packages/cap-chat/src/web/sticky-user.test.tsx
+++ b/packages/cap-chat/src/web/sticky-user.test.tsx
@@ -99,6 +99,40 @@ describe('sticky user message markers', () => {
     expect(document.querySelector('[data-testid="user-bubble"] [data-testid="user-sender-human"]')).toBeNull()
   })
 
+  it('shows live usage while the reply is still streaming', () => {
+    const onInspect = vi.fn()
+    const onFork = vi.fn(async () => {})
+    render(
+      <ChatNodeList
+        nodes={[
+          { id: 'u-live', kind: 'user', text: 'go', ts: Date.parse('2026-08-22T10:30:00') },
+          {
+            id: 'r-live',
+            kind: 'reply',
+            parts: [
+              { id: 'a-live', kind: 'assistant', text: 'thinking' },
+              { id: 't-live', kind: 'tool', callId: 'c1', name: 'bash', arguments: '{}' },
+            ],
+            copyText: 'thinking',
+            streaming: true,
+            finished: false,
+            turn: 1,
+            stepCount: 1,
+            usage: { inputTokens: 12, outputTokens: 4, totalTokens: 16 },
+          },
+        ]}
+        onInspect={onInspect}
+        onFork={onFork}
+      />,
+    )
+    const user = document.querySelector('[data-node-id="u-live"]')
+    expect(user?.querySelector('[data-testid="user-turn-bar"]')).toBeTruthy()
+    expect(user?.querySelector('[data-testid="user-tool-count"]')?.textContent).toBe('1')
+    expect(user?.querySelector('.chat-reply-meta')?.textContent).toMatch(/12/)
+    expect(user?.querySelector('[data-testid="user-turn-end-status"]')).toBeNull()
+    expect(user?.querySelector('[data-testid="details-toggle"]')).toBeNull()
+  })
+
   it('puts stats under user message; copy/fork stay on reply', () => {
     const onInspect = vi.fn()
     const onFork = vi.fn(async () => {})

--- a/packages/cap-chat/src/web/thread.tsx
+++ b/packages/cap-chat/src/web/thread.tsx
@@ -396,13 +396,12 @@ function UserTurnBar({
 }) {
   const streaming = Boolean(reply?.streaming)
   const { hasDetails } = reply && !streaming ? splitReplyForDisplay(reply) : { hasDetails: false }
-  const toolCount = reply && !streaming ? replyToolCount(reply) : 0
+  const toolCount = reply ? replyToolCount(reply) : 0
   const hasMeta =
-    !streaming &&
     reply != null &&
     (reply.turn != null ||
       reply.stepCount != null ||
-      reply.durationMs != null ||
+      (!streaming && reply.durationMs != null) ||
       Boolean(reply.usage) ||
       toolCount > 0)
   const sentLabel = user.ts != null ? formatSentAt(user.ts) : ''

--- a/packages/web-session-view/src/web/session-project.test.ts
+++ b/packages/web-session-view/src/web/session-project.test.ts
@@ -96,6 +96,39 @@ test('keeps reply streaming across tools until turn/end (Details stay open)', ()
   }
 })
 
+test('accumulates usage and stepCount while the turn is still streaming', () => {
+  const nodes = projectNodes([
+    { type: 'turn/start', turn: 1, seq: 0, ts: 1 },
+    { type: 'user/message', text: 'hi', kind: 'wake', seq: 1, ts: 2 },
+    { type: 'step/start', turn: 1, step: 0, seq: 2, ts: 3 },
+    {
+      type: 'assistant/message',
+      text: 'thinking',
+      tool_calls: [{ id: 'c1', name: 'bash', arguments: '{}' }],
+      usage: { inputTokens: 12, outputTokens: 4 },
+      seq: 3,
+      ts: 4,
+    },
+    { type: 'tool/call', id: 'c1', name: 'bash', arguments: '{}', seq: 4, ts: 5 },
+    { type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 5, ts: 6 },
+    { type: 'step/end', turn: 1, step: 0, seq: 6, ts: 7 },
+    { type: 'step/start', turn: 1, step: 1, seq: 7, ts: 8 },
+    { type: 'assistant/message', text: 'more', usage: { inputTokens: 8, outputTokens: 3 }, seq: 8, ts: 9 },
+  ])
+  const reply = nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  assert.equal(reply.streaming, true)
+  assert.equal(reply.finished, false)
+  assert.equal(reply.durationMs, undefined)
+  assert.equal(reply.stepCount, 2)
+  assert.deepEqual(reply.usage, {
+    inputTokens: 20,
+    outputTokens: 7,
+    totalTokens: 27,
+  })
+})
+
 test('tool/call after tool/result keeps a single completed tool part', () => {
   const nodes = projectNodes([
     { type: 'tool/result', id: 'c1', name: 'bash', ok: true, detail: 'ok', seq: 1, ts: 1 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
用户气泡上方的回合统计不再等整轮 `turn/end` 才出现。

- 流式过程中：有累计 usage、stepCount 或工具次数就立刻画在 `user-turn-bar`
- 回合耗时和完成勾仍等结束
- Details 仍等非 streaming（避免中途收起）

测试：`session-project` 中途累计 usage；`sticky-user` 流式时能看到 UsageInline 与工具数。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

