### PR TITLE
fix: 右侧检查器加号去掉视图和事件

### DIFF
--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -23,6 +23,7 @@ test('viewsCollection lists saved views with source table', async () => {
   const spec = viewsCollection(store, () => [{ path: '/tasks', id: 'tasks', kind: 'collection', label: 'Task', view: { moduleId: 'tasks', route: '/tasks', title: 'Task' } }])
   assert.equal(spec.path, '/views')
   assert.equal(spec.view?.title, '视图')
+  assert.equal(spec.view?.inspector, false)
   const rows = await spec.list()
   const all = rows.find((row) => row.viewId === builtinAllViewId('/tasks'))
   const user = rows.find((row) => row.id === 'tasks::v1')

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -280,7 +280,7 @@ export function viewsCollection(store: SavedViewsStore, tables: () => Collection
       moduleId: 'views-db',
       route: '/db-views',
       title: '视图',
-      inspector: true,
+      inspector: false,
       blurb: '各表已保存的视图（筛选/排序/呈现）。列表 db_list /views。新建 db_create /views records=[{title, tablePath, mode}]，tablePath 如 /tasks，mode 为 table / board / cards / queue。改筛选 filters（JSON 字符串）、列 columns、排序 sortField/sortDir、搜索 query、分组 groupBy、每页 pageSize 用 db_update。内置「全部 xx」只读。本表没有 db_action。',
       order: 17,
       icon: 'eye',

--- a/packages/host-hub/src/host/events-collection.test.ts
+++ b/packages/host-hub/src/host/events-collection.test.ts
@@ -10,6 +10,7 @@ test('eventsCollection is a read-only File System table over hub buffer', () => 
   })
   assert.equal(spec.path, '/events')
   assert.equal(spec.view?.moduleId, 'events-db')
+  assert.equal(spec.view?.inspector, false)
   assert.equal(spec.update, undefined)
   assert.deepEqual(spec.records, { update: false, create: false, delete: false })
   const rows = spec.list()

--- a/packages/host-hub/src/host/events-collection.ts
+++ b/packages/host-hub/src/host/events-collection.ts
@@ -40,7 +40,7 @@ export function eventsCollection(hub: HubLike): CollectionSpec {
       moduleId: 'events-db',
       route: '/db-events',
       title: '事件',
-      inspector: true,
+      inspector: false,
       blurb: 'Hub 已缓冲的 internal/dispatch 事件，大约最多 80 条，只读。浏览 db_list /events（可 q 搜 name）。不能 create/update/delete。本表没有 db_action。不是任务队列也不是会话时间线。',
       order: 19,
       icon: 'bolt',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧 inspector 加号不再提供「视图」和「事件」。

两张表仍在 File System / 侧栏系统数据里，只是 `view.inspector` 关掉，`syncInspectorOffers` 不会再把它们放进 `inspector-panels`。会话、任务、页面等仍可添加。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

