### PR TITLE
fix: 开关侧栏不再拖垮数据页，搜索能打开已有检查器里的记录

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -132,6 +132,22 @@ function recordsFingerprint(rows: Array<DbRecord & { path?: string }>) {
   return JSON.stringify(rows)
 }
 
+const LIST_CACHE_MAX = 8
+const listCache = new Map<string, { items: Array<DbRecord & { path?: string }>; total: number; stat: StatResult | null }>()
+
+function rememberListCache(
+  path: string,
+  snap: { items: Array<DbRecord & { path?: string }>; total: number; stat: StatResult | null },
+) {
+  if (listCache.has(path)) listCache.delete(path)
+  listCache.set(path, snap)
+  while (listCache.size > LIST_CACHE_MAX) {
+    const first = listCache.keys().next().value
+    if (first === undefined) break
+    listCache.delete(first)
+  }
+}
+
 const EMPTY_FILTERS: Record<string, string> = {}
 
 export function CollectionBrowser({
@@ -482,6 +498,7 @@ export function CollectionBrowser({
       )
       setItems((prev) => (recordsFingerprint(prev) === recordsFingerprint(listed.items) ? prev : listed.items))
       setTotal(listed.total)
+      rememberListCache(dataPath, { items: listed.items, total: listed.total, stat: { ...nextStat, schema: nextSchema } })
       if (activeViewId) {
         rememberPreviewTotal(
           viewTotalKey(collectionPath, {
@@ -539,8 +556,10 @@ export function CollectionBrowser({
     hydratePath.current = ''
     setCollapsed({})
     hydratedDetail.current = ''
-    setItems([])
-    setStat(null)
+    const cached = listCache.get(dataPath)
+    setItems(cached?.items ?? [])
+    setStat(cached?.stat ?? null)
+    setTotal(cached?.total ?? 0)
     setError('')
     setPage(0)
     const stored = viewForPath(collectionPath, routeViewId)

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -388,11 +388,12 @@ export const DataSidebar = memo(function DataSidebar({
   useEffect(() => {
     let cancelled = false
     void Promise.all(
-      countJobs.map((job) =>
-        fetchViewTotal(job.path, job.view).catch(() => {
+      countJobs.map((job) => {
+        if (getPreviewTotal(viewTotalKey(job.path, job.view)) != null) return Promise.resolve()
+        return fetchViewTotal(job.path, job.view).catch(() => {
           if (cancelled) return
-        }),
-      ),
+        })
+      }),
     )
     return () => {
       cancelled = true

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -69,6 +69,14 @@ test('window reveal event opens the inspector record path', async () => {
   window.removeEventListener('biu:inspector-tab', onTab)
 })
 
+test('showRecordInInspector updates an already-open repeatable pane, not just the canonical tab id', async () => {
+  const pane = 'database:/pages::abc123'
+  setInspectorDbPath(pane, '/database/pages/view/builtin-all:/pages')
+  showRecordInInspector('/pages', 'p1')
+  assert.equal(getInspectorDbPath(pane), '/database/pages/record/p1')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
+})
+
 test('showRecordInInspector opens the inspector on this record', async () => {
   const tabs: string[] = []
   const onTab = (event: Event) => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -16,6 +16,29 @@ function storageKey(paneId: string) {
   return `${STORAGE_PREFIX}${paneId}`
 }
 
+function slotTabId(openedId: string) {
+  const split = openedId.indexOf('::')
+  return split === -1 ? openedId : openedId.slice(0, split)
+}
+
+function paneIdsForTab(tabId: string) {
+  const ids = new Set<string>([tabId])
+  for (const id of paths.keys()) {
+    if (id === tabId || slotTabId(id) === tabId) ids.add(id)
+  }
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i) ?? ''
+      if (!key.startsWith(STORAGE_PREFIX)) continue
+      const id = key.slice(STORAGE_PREFIX.length)
+      if (id === tabId || slotTabId(id) === tabId) ids.add(id)
+    }
+  } catch {
+    /* ignore */
+  }
+  return [...ids]
+}
+
 function readStoredPath(paneId: string) {
   try {
     const raw = localStorage.getItem(storageKey(paneId)) ?? ''
@@ -115,10 +138,10 @@ export function inspectorCollectionTabId(collection: string) {
   return `database:${collection}`
 }
 
-/** 右侧检查器打开这条路径，中间主界面不动。 */
+/** 右侧检查器打开这条路径，中间主界面不动。已打开的同表实例（含 :: 副本）一起改路径。 */
 export function showInInspector(collection: string, href: string) {
   const tabId = inspectorCollectionTabId(collection)
-  setInspectorDbPath(tabId, href)
+  for (const paneId of paneIdsForTab(tabId)) setInspectorDbPath(paneId, href)
   window.dispatchEvent(new Event('biu:inspector-open'))
   window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
 }

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -67,6 +67,8 @@ test('center stage keeps modules mounted and crossfades', () => {
   assert.match(shell, /onWidthLive=\{onSidebarWidthLive\}/)
   assert.match(shell, /onWidthLive=\{onInspectorWidthLive\}/)
   assert.match(shell, /applyShellColumnCssVars/)
+  assert.match(shell, /const PluginModuleStage = memo\(function PluginModuleStage/)
+  assert.match(shell, /paintLiveLayout/)
   assert.match(shell, /paintColumnDrag/)
   assert.doesNotMatch(shell, /if \(moduleId !== activeId\) return null/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -180,7 +180,7 @@ const AgentMainPanels = memo(function AgentMainPanels({
   )
 })
 
-function PluginModuleStage({
+const PluginModuleStage = memo(function PluginModuleStage({
   slots,
   activeId,
   renderSlot,
@@ -212,7 +212,7 @@ function PluginModuleStage({
       })}
     </>
   )
-}
+})
 
 function Shell(props: SlotProps) {
   const useSnapshot = props.useSnapshot as ReturnType<typeof bindSnapshot>
@@ -273,6 +273,7 @@ function Shell(props: SlotProps) {
   const lastWideSidebar = useRef(sidebarWidth >= SIDEBAR_LABEL_AT ? sidebarWidth : SIDEBAR_MAX)
   const persistSidebar = useCallback((width: number, collapsed: boolean) => {
     if (collapsed) {
+      paintLiveLayoutRef.current({ sidebarCollapsed: true })
       setSidebarCollapsed(true)
       try {
         localStorage.setItem('cordis.sidebar.collapsed', '1')
@@ -283,6 +284,7 @@ function Shell(props: SlotProps) {
     }
     const next = clampSidebarWidth(width)
     if (next === 0) {
+      paintLiveLayoutRef.current({ sidebarCollapsed: true })
       setSidebarCollapsed(true)
       try {
         localStorage.setItem('cordis.sidebar.collapsed', '1')
@@ -293,6 +295,7 @@ function Shell(props: SlotProps) {
     }
     setSidebarWidth(next)
     setSidebarCollapsed(false)
+    paintLiveLayoutRef.current({ sidebarCollapsed: false, sidebarWidth: next })
     if (next >= SIDEBAR_LABEL_AT) lastWideSidebar.current = next
     try {
       localStorage.setItem('cordis.sidebar.width', String(next))
@@ -302,6 +305,7 @@ function Shell(props: SlotProps) {
     }
   }, [])
   const collapseSidebar = useCallback(() => {
+    paintLiveLayoutRef.current({ sidebarCollapsed: true })
     setSidebarCollapsed(true)
     try {
       localStorage.setItem('cordis.sidebar.collapsed', '1')
@@ -377,6 +381,7 @@ function Shell(props: SlotProps) {
   const toggleInspector = useCallback(() => {
     setInspectorOpen((prev) => {
       const next = !prev
+      paintLiveLayoutRef.current({ inspectorOpen: next })
       try {
         localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
       } catch {
@@ -406,6 +411,7 @@ function Shell(props: SlotProps) {
   }, [onInspectorWidthChange])
   useEffect(() => {
     const persist = (next: boolean) => {
+      paintLiveLayoutRef.current({ inspectorOpen: next })
       setInspectorOpen(next)
       try {
         localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
@@ -418,6 +424,7 @@ function Shell(props: SlotProps) {
     const onToggle = () => {
       setInspectorOpen((prev) => {
         const next = !prev
+        paintLiveLayoutRef.current({ inspectorOpen: next })
         try {
           localStorage.setItem('cordis.inspector.open', next ? '1' : '0')
         } catch {
@@ -498,6 +505,23 @@ function Shell(props: SlotProps) {
   if (!columnResizing) paintedCols.current = { left: shellColumns.left, inspector: shellColumns.inspector }
   const dragPaintRaf = useRef(0)
   const dragPaintPending = useRef<{ sidebar?: number; inspector?: number }>({})
+  const paintLiveLayout = useCallback((patch: { inspectorOpen?: boolean; sidebarCollapsed?: boolean; sidebarWidth?: number }) => {
+    const snap = layoutSnap.current
+    const inspectorOpen = patch.inspectorOpen ?? snap.inspectorVisible
+    const sidebarCollapsed = patch.sidebarCollapsed ?? snap.sidebarCollapsed
+    const width = patch.sidebarWidth ?? snap.sidebarWidth
+    const cols = allocateShellColumns({
+      viewportWidth: window.innerWidth,
+      leftPane: snap.leftPane,
+      leftWidth: snap.leftPane ? (sidebarCollapsed ? 0 : width) : undefined,
+      inspectorOpen,
+      inspectorWidth: snap.inspectorWidth,
+    })
+    paintedCols.current = { left: cols.left, inspector: cols.inspector }
+    applyShellColumnCssVars(shellRef.current, cols)
+  }, [])
+  const paintLiveLayoutRef = useRef(paintLiveLayout)
+  paintLiveLayoutRef.current = paintLiveLayout
   const paintColumnDrag = useCallback((patch: { sidebar?: number; inspector?: number }) => {
     Object.assign(dragPaintPending.current, patch)
     if (dragPaintRaf.current) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据页开关左右栏会卡、搜索回车进不了已打开的视图，是两件独立的事。

**为什么聊天不卡、数据卡：** 聊天中间栏是 `memo` 的，开关检查器时不会整树重绘。数据模块舞台每次 Shell `setState` 都会再跑一遍 `CollectionBrowser`（整张表），所以点一下要等大约一帧很重的 React 提交，看起来像没反应。

**这次：**
- `PluginModuleStage` 也 memo，开关左右栏不再拖着数据表重绘
- 点击当下就写 `--sidebar-col` / `--inspector-width`，和拖分隔条同一套
- 侧栏切表时用最近几份列表缓存，先画出上次的行，不再先清空
- 搜索回车把记录路径写到该表所有已打开的检查器实例（含 `database:/pages::…`），不会停在视图列表

本地相关测试已过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

