### PR TITLE
fix: 去掉页面之间的整页淡入上浮动画

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -40,10 +40,8 @@ const CSS = `
 .fsdb-page{--fsdb-pager-lift:calc(1rem + 44px + 25px + 25px - 30px);--fsdb-check-gutter:26px;--fsdb-row-tools-w:72px}
 .fsdb-page:not(.inspector-database-page) .fsdb-main{padding-bottom:var(--fsdb-pager-lift)}
 .inspector-database-page .fsdb-main{padding-bottom:0}
-.fsdb-agent-follow{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden;animation:fsdb-inspector-in 220ms cubic-bezier(.22,1,.36,1)}
+.fsdb-agent-follow{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-agent-follow.is-working{box-shadow:inset 0 2px 0 #5b9fd6}
-@keyframes fsdb-inspector-in{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
-@media (prefers-reduced-motion:reduce){.fsdb-agent-follow{animation:none}}
 .fsdb-main > .fsdb-detail-title-row{flex:none}
 .fsdb-page .tasks-toolbar{display:flex;gap:12px;align-items:center;justify-content:space-between;min-width:0;flex:none}
 .fsdb-page .tasks-toolbar-left{display:flex;align-items:center;gap:6px;flex:1 1 auto;min-width:0}

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -54,7 +54,7 @@ test('refresh does not send unfinished plugin routes home', () => {
   assert.match(shell, /waitingOnNav/)
 })
 
-test('center stage keeps modules mounted and crossfades', () => {
+test('center stage keeps modules mounted without a page fade', () => {
   const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
   assert.match(shell, /className="app-stage"/)
@@ -71,7 +71,9 @@ test('center stage keeps modules mounted and crossfades', () => {
   assert.doesNotMatch(shell, /if \(moduleId !== activeId\) return null/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
   assert.match(css, /\.app-stage-pane[\s\S]*?content-visibility:\s*hidden/)
-  assert.match(css, /\.app-pane-in\s*\{[^}]*animation:\s*app-pane-in/s)
+  assert.doesNotMatch(css, /\.app-stage-pane\s*\{[^}]*transition:\s*[\s\S]*opacity 220ms/s)
+  assert.doesNotMatch(css, /@keyframes app-pane-in/)
+  assert.doesNotMatch(css, /\.app-pane-in\s*\{[^}]*animation:\s*app-pane-in/s)
 })
 
 test('left sidebar keeps chat and database lists mounted and folds smoothly', () => {

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -71,7 +71,7 @@ test('inspector header tabs sit on the same vertical center as the main header',
   assert.match(css, /\.inspector-tab\s*\{[^}]*padding:\s*0 8px/s)
   assert.doesNotMatch(css, /\.inspector-crumb-tab\s*\{[^}]*padding-right:\s*4px/s)
   assert.match(css, /\.inspector-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
-  assert.match(css, /\.inspector-stage-pane[\s\S]*?transition:/)
+  assert.doesNotMatch(css, /\.inspector-stage-pane,\s*\.app-stage-pane\s*\{[^}]*transition:\s*[\s\S]*opacity 220ms/s)
   assert.match(css, /\.inspector-stage-pane[\s\S]*?content-visibility:\s*hidden/)
   assert.match(css, /\.app-stage-pane\.is-active[\s\S]*?opacity:\s*1/)
 })

--- a/web/style.css
+++ b/web/style.css
@@ -1173,9 +1173,6 @@ body {
   pointer-events: none;
   visibility: hidden;
   content-visibility: hidden;
-  transition:
-    opacity 220ms cubic-bezier(0.22, 1, 0.36, 1),
-    visibility 0s linear 0s;
 }
 
 .inspector-stage-pane.is-active,
@@ -1187,18 +1184,12 @@ body {
   z-index: 1;
 }
 
-@keyframes app-pane-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: none; }
-}
-
 .app-pane-in {
   display: flex;
   min-height: 0;
   min-width: 0;
   flex: 1;
   flex-direction: column;
-  animation: app-pane-in 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .inspector-empty-list {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
排查后，整页级的进出动画有三处，都拿掉了：

- 聊天 / 数据模块叠在同一舞台上的 220ms 透明度交叉淡入
- 数据主区 `app-pane-in` 整页上浮淡入
- 检查器里打开数据表时的同样上浮淡入

侧栏分组折叠、Dock 弹出、吉祥物跳舞这些小动作或独立功能动画没动。

切换页面现在是立刻显示/隐藏（仍用 `content-visibility` 挂载，只是不再过渡）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

