### PR TITLE
keep page slash closed when the editor is hidden

### DIFF
--- a/packages/core-editor/src/web/editor-live.test.ts
+++ b/packages/core-editor/src/web/editor-live.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { editorHostIsLive, slashMayOpen } from './editor-live.ts'
+
+test('slash stays closed when the page editor is hidden or unfocused', () => {
+  const host = document.createElement('div')
+  host.setAttribute('aria-hidden', 'true')
+  const dom = document.createElement('div')
+  host.append(dom)
+  document.body.append(host)
+  const hidden = { isDestroyed: false, isFocused: true, view: { dom }, isActive: () => false }
+  assert.equal(editorHostIsLive(hidden), false)
+  assert.equal(slashMayOpen(hidden), false)
+  host.remove()
+
+  const liveDom = document.createElement('div')
+  document.body.append(liveDom)
+  const unfocused = { isDestroyed: false, isFocused: false, view: { dom: liveDom }, isActive: () => false }
+  assert.equal(editorHostIsLive(unfocused), true)
+  assert.equal(slashMayOpen(unfocused), false)
+  const focused = { ...unfocused, isFocused: true }
+  assert.equal(slashMayOpen(focused), true)
+  liveDom.remove()
+})

--- a/packages/core-editor/src/web/editor-live.ts
+++ b/packages/core-editor/src/web/editor-live.ts
@@ -1,0 +1,14 @@
+/** Slash 菜单挂在 window 上。隐藏检查器里的编辑器若仍触发 suggestion，会飞到视口右下角。 */
+export function editorHostIsLive(editor: { isDestroyed?: boolean; isFocused?: boolean; view?: { dom?: Element | null } }) {
+  if (editor.isDestroyed) return false
+  const el = editor.view?.dom
+  if (!(el instanceof HTMLElement) || !el.isConnected) return false
+  if (el.closest('[inert], [aria-hidden="true"]')) return false
+  return true
+}
+
+export function slashMayOpen(editor: { isDestroyed?: boolean; isFocused?: boolean; view?: { dom?: Element | null } } & { isActive?: (name: string) => boolean }) {
+  if (!editor.isFocused) return false
+  if (typeof editor.isActive === 'function' && editor.isActive('codeBlock')) return false
+  return editorHostIsLive(editor)
+}

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -65,6 +65,7 @@ test('slash suggestion uses a fixed high stacking context', async () => {
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './slash.ts'), 'utf8')
   const css = await readFile(resolve(import.meta.dirname, './style.ts'), 'utf8')
+  assert.match(src, /slashMayOpen\(editor\)/)
   assert.match(src, /strategy: 'fixed'/)
   assert.match(src, /keepInWindow/)
   assert.match(src, /placeSlashInWindow/)

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -89,6 +89,7 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /handleKeyDown/)
   assert.match(src, /FOCUS_RECORD_TITLE/)
   assert.match(src, /FOCUS_RECORD_CONTENT/)
+  assert.match(src, /editorHostIsLive\(editor\)/)
   assert.match(src, /Selection\.atStart/)
 })
 

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -5,6 +5,7 @@ import type { Editor } from '@tiptap/core'
 import { Selection } from '@tiptap/pm/state'
 import type { FsContentProps } from '@biu/type-file-system/ui'
 import { pageEditorExtensions } from './kit.ts'
+import { editorHostIsLive } from './editor-live.ts'
 import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
 
 function asMarkdown(value: unknown) {
@@ -130,7 +131,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
     const onFocus = () => {
-      if (editor.isDestroyed) return
+      if (editor.isDestroyed || !editorHostIsLive(editor)) return
       editor.commands.focus('start')
     }
     window.addEventListener(FOCUS_RECORD_CONTENT, onFocus)

--- a/packages/core-editor/src/web/slash.ts
+++ b/packages/core-editor/src/web/slash.ts
@@ -4,6 +4,7 @@ import { ReactRenderer } from '@tiptap/react'
 import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion'
 import { SlashList } from './slash-list.tsx'
 import { placeSlashInWindow } from './slash-place.ts'
+import { slashMayOpen } from './editor-live.ts'
 import { getPageEditor, type SlashInsert } from './service.ts'
 
 export type SlashItem = {
@@ -173,7 +174,7 @@ function renderSlash() {
     onStart(props: { editor: Editor; mount: (el: HTMLElement) => () => void } & Record<string, unknown>) {
       cancelled = false
       pending = props
-      if (props.editor.isActive('codeBlock')) return
+      if (!slashMayOpen(props.editor)) return
       // TipTap 文档：事务是同步的，ReactRenderer 的 flushSync 不能落在 React effect 里。
       queueMicrotask(() => {
         if (cancelled || !pending) return
@@ -217,7 +218,7 @@ export const slashCommand = Extension.create({
     return {
       suggestion: {
         char: '/',
-        allow: ({ editor }) => !editor.isActive('codeBlock'),
+        allow: ({ editor }) => slashMayOpen(editor),
         items: ({ query }) => filterSlashItems(query),
         command: ({ editor, range, props }) => {
           props.command({ editor, range })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右栏关掉后，检查器里的页面编辑器其实还挂着。某个会话如果打开过对应 page，搜索把它放进左栏会重新 hydrate 编辑器；正文里残留的 `/` 或未聚焦的 suggestion 会把 `position: fixed` 的 slash 菜单按畸形光标坐标夹到窗口右下角。

现在 slash 只在编辑器真正可见且聚焦时打开。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

