### PR TITLE
保留表格查看模式按钮

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2068,7 +2068,6 @@ export function CollectionBrowser({
                 />
               ) : null}
             </div>
-            {extraViews.length ? (
             <div className="tasks-sort-wrap" ref={modeRef}>
               <button
                 type="button"
@@ -2098,7 +2097,6 @@ export function CollectionBrowser({
                 </div>
               ) : null}
             </div>
-            ) : null}
             <div className="tasks-sort-wrap" ref={sortRef}>
               <button
                 type="button"

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -221,6 +221,8 @@ test('filesystem list is table-only; extra modes come from registerView', () => 
   assert.match(browser, /function RecordRowTools/)
   assert.match(browser, /className="fsdb-title-host"/)
   assert.doesNotMatch(browser, /<th>操作<\/th>/)
+  assert.match(browser, /aria-label="查看模式"/)
+  assert.doesNotMatch(browser, /extraViews\.length \?/)
 })
 
 test('filesystem header expands the shared left sidebar and toggles the right inspector', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
看板 / 列表 / 卡片仍然不渲染。工具栏上的「查看模式」按钮始终显示（哪怕现在只有表格），方便之后在菜单里加「让 Agent 生成插件视图」。这次不实现添加功能。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

