### PR TITLE
表格可写格恢复行内编辑

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1316,7 +1316,6 @@ export function CollectionBrowser({
     if (flat) {
       const source = facetSourceKey(schema)
       const value = readFacetFlatValue(row, key, source)
-      if (pop) return <DefaultCell field={field} value={value} />
       if (field.writable && kind !== 'file') {
         return (
           <FieldEditor
@@ -1368,7 +1367,6 @@ export function CollectionBrowser({
     const Custom = chrome?.cells?.[key]
     const fallback = formatField(field, row[key])
     if (Custom) return <Custom field={key} spec={field} value={row[key]} record={row} fallback={fallback} />
-    if (pop) return <DefaultCell field={field} value={row[key]} fieldKey={key} />
     if (field.writable && kind !== 'file') {
       return (
         <FieldEditor
@@ -1393,7 +1391,7 @@ export function CollectionBrowser({
     const col = columns.find((item) => item.key === cellPick.key)
     if (!row || !col) return null
     return (
-      <CellPop open anchor={cellAnchorRef.current} onClose={() => setCellPopOpen(false)}>
+      <CellPop key={`${cellPick.id}:${cellPick.key}`} open anchor={cellAnchorRef.current} onClose={() => setCellPopOpen(false)}>
         {renderCell(row, col.key, col.field, 'detail')}
       </CellPop>
     )
@@ -1752,8 +1750,7 @@ export function CollectionBrowser({
                   cellAnchorRef.current = event.currentTarget
                   setCellPick({ id: row.id, key: col.key })
                   const kind = resolveFieldType(col.field)
-                  const custom = Boolean(chrome?.cells?.[col.key])
-                  setCellPopOpen(Boolean(cellUsesPop(kind, col.field.writable) && !custom))
+                  setCellPopOpen(Boolean(cellUsesPop(kind, col.field.writable)))
                 }}
               >
                 {index === 0 ? <RowCheck id={row.id} /> : null}

--- a/packages/core-file-system/src/web/cell-pop.tsx
+++ b/packages/core-file-system/src/web/cell-pop.tsx
@@ -1,10 +1,10 @@
-import type { ReactNode } from 'react'
+import { useRef, type ReactNode } from 'react'
 import { AnchorMenu } from '@biu/public-ui'
 import type { FieldType } from '@biu/type-file-system'
 
 export function cellUsesPop(kind: FieldType, writable?: boolean) {
   if (!writable) return false
-  return kind !== 'boolean' && kind !== 'action' && kind !== 'file'
+  return kind === 'facet'
 }
 
 export function CellPop({
@@ -18,11 +18,15 @@ export function CellPop({
   onClose: () => void
   children: ReactNode
 }) {
+  const openedAt = useRef(performance.now())
   if (!open || !anchor) return null
   return (
     <AnchorMenu
       anchor={anchor}
-      onClose={onClose}
+      onClose={() => {
+        if (performance.now() - openedAt.current < 400) return
+        onClose()
+      }}
       className="fsdb-cell-pop"
       role="dialog"
       minWidth={280}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -164,6 +164,8 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(browser, /const Custom = chrome\?\.cells\?\.\[key\][\s\S]*if \(field.writable && kind !== 'file'\)/)
   assert.match(browser, /key && field\?\.writable \?/)
   assert.match(browser, /cellUsesPop/)
+  assert.doesNotMatch(browser, /if \(pop\) return <DefaultCell field=\{field\} value=\{row\[key\]\}/)
+  assert.match(browser, /renderCell\(row, key, field, 'table'\)/)
   assert.match(browser, /is-cell-on/)
   assert.match(browser, /is-cell-ro/)
   assert.match(browser, /cellFieldWritable/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一轮把表格可写格改成只读预览、编辑全靠悬浮层。悬浮层又被同一次点击关掉，所以标题等全部编不了。

这次：文本/单选多选/图片附件回到格子里直接编；蓝/灰选中框还在。只有合集继续用悬浮层（并避开打开那一下的误关）。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

