### PR TITLE
悬浮窗输入框离底边抬高一点

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -79,6 +79,7 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).not.toMatch(/\.chat-overlay-panel \.chat-overlay-thread\s*\{[^}]*padding-bottom:\s*5\.5rem/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-stage\s*\{[^}]*padding-block:\s*0/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*position:\s*absolute/s)
+    expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*bottom:\s*20px/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*height:\s*auto/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*padding:\s*0/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*background:\s*transparent/s)

--- a/web/style.css
+++ b/web/style.css
@@ -1484,7 +1484,7 @@ body {
 .chat-overlay-panel .chat-pane .chat-composer-dock {
   position: absolute;
   inset-inline: 0;
-  bottom: 0;
+  bottom: 20px;
   z-index: 20;
   flex: none;
   height: auto;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
悬浮聊天窗的输入框仍叠在消息上，但相对窗口底边抬高 20px，不再贴着底框。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

