### PR TITLE
合集单元格只弹一个窗，和单选多选同一套

### DIFF
--- a/packages/core-file-system/src/web/cell-pop-draft.tsx
+++ b/packages/core-file-system/src/web/cell-pop-draft.tsx
@@ -1,10 +1,18 @@
 import { useEffect, useRef, useState } from 'react'
-import type { DbRecord, FieldSpec } from '@biu/type-file-system'
+import {
+  normalizeSchemaValue,
+  type CollectionSchemaPack,
+  type DbRecord,
+  type FieldSpec,
+  type SchemaFieldValue,
+} from '@biu/type-file-system'
 import { TagChip, TagChips } from '@biu/public-ui'
 import { DbSearchOption, ensureDbSearchStyle } from '@biu/database-ui'
 import { FieldEditor, fieldDraftValue, parseFieldValue } from './fsdb-cells.tsx'
-import { SchemaFieldEditor } from './schema-field.tsx'
 import { asStringList, parseFacetFlatColumnKey, resolveFieldType } from './fields.ts'
+import { loadFacets, persistFacets, slugFacetId, subscribeFacets } from './facet-catalog.ts'
+
+type TagOption = { value: string; label: string }
 
 function TagPickPanel({
   values,
@@ -14,7 +22,7 @@ function TagPickPanel({
   onPicked,
 }: {
   values: string[]
-  options: string[]
+  options: TagOption[]
   multiple: boolean
   onChange: (next: string[]) => void
   onPicked?: () => void
@@ -22,11 +30,18 @@ function TagPickPanel({
   ensureDbSearchStyle()
   const [query, setQuery] = useState('')
   const q = query.trim().toLowerCase()
+  const byValue = new Map(options.map((item) => [item.value, item.label]))
   const available = options.filter(
-    (item) => Boolean(item) && !values.includes(item) && (!q || item.toLowerCase().includes(q)),
+    (item) =>
+      Boolean(item.value) &&
+      !values.includes(item.value) &&
+      (!q || item.label.toLowerCase().includes(q) || item.value.toLowerCase().includes(q)),
   )
   const draft = query.trim()
-  const canCreate = Boolean(draft) && !values.includes(draft) && !options.includes(draft)
+  const canCreate =
+    Boolean(draft) &&
+    !values.includes(draft) &&
+    !options.some((item) => item.value === draft || item.label === draft)
   function add(value: string) {
     if (!value) return
     if (multiple) {
@@ -43,7 +58,12 @@ function TagPickPanel({
         <div className="fsdb-cell-pop-picked">
           <TagChips>
             {values.map((value) => (
-              <TagChip key={value} id={value} label={value} onRemove={() => onChange(values.filter((item) => item !== value))} />
+              <TagChip
+                key={value}
+                id={value}
+                label={byValue.get(value) ?? value}
+                onRemove={() => onChange(values.filter((item) => item !== value))}
+              />
             ))}
           </TagChips>
         </div>
@@ -57,7 +77,7 @@ function TagPickPanel({
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
               event.preventDefault()
-              if (available[0]) add(available[0])
+              if (available[0]) add(available[0].value)
               else if (canCreate) add(draft)
             }
           }}
@@ -65,8 +85,8 @@ function TagPickPanel({
       </label>
       <div className="db-search-list">
         {available.map((item) => (
-          <DbSearchOption key={item} onClick={() => add(item)}>
-            <TagChip id={item} label={item} />
+          <DbSearchOption key={item.value} onClick={() => add(item.value)}>
+            <TagChip id={item.value} label={item.label} />
           </DbSearchOption>
         ))}
         {canCreate ? (
@@ -79,8 +99,45 @@ function TagPickPanel({
   )
 }
 
+function applyFacetTags(parsed: SchemaFieldValue, catalog: CollectionSchemaPack[], nextIds: string[]) {
+  let packs = catalog
+  const used = new Set(packs.map((tag) => tag.id))
+  const resolved: string[] = []
+  for (const item of nextIds) {
+    if (used.has(item)) {
+      resolved.push(item)
+      continue
+    }
+    const hit = packs.find((tag) => tag.label === item)
+    if (hit) {
+      resolved.push(hit.id)
+      continue
+    }
+    const id = slugFacetId(item, used)
+    packs = [...packs, { id, label: item, fields: [] }]
+    used.add(id)
+    resolved.push(id)
+  }
+  if (packs !== catalog) persistFacets(packs)
+  return { tags: resolved, values: parsed.values }
+}
+
+function FacetPickPanel({ value, onChange }: { value: unknown; onChange: (next: SchemaFieldValue) => void }) {
+  const parsed = normalizeSchemaValue(value)
+  const [catalog, setCatalog] = useState(() => loadFacets())
+  useEffect(() => subscribeFacets(undefined, () => setCatalog(loadFacets())), [])
+  return (
+    <TagPickPanel
+      values={parsed.tags}
+      options={catalog.map((tag) => ({ value: tag.id, label: tag.label }))}
+      multiple
+      onChange={(next) => onChange(applyFacetTags(parsed, catalog, next))}
+    />
+  )
+}
+
 export function CellPopDraft({
-  record,
+  record: _record,
   fieldKey,
   field,
   initial,
@@ -127,7 +184,7 @@ export function CellPopDraft({
     return (
       <TagPickPanel
         values={selected}
-        options={list}
+        options={list.map((item) => ({ value: item, label: item }))}
         multiple={kind === 'multi-select'}
         onChange={(next) => {
           const value = kind === 'multi-select' ? next : next[0] ?? ''
@@ -140,9 +197,7 @@ export function CellPopDraft({
   }
 
   if (kind === 'facet') {
-    return (
-      <SchemaFieldEditor collectionPath={collectionPath} record={record} value={raw} writable autoOpen onChange={(next) => put(next)} />
-    )
+    return <FacetPickPanel value={raw} onChange={(next) => put(next)} />
   }
 
   if (kind === 'datetime' || kind === 'image' || kind === 'attachment' || kind === 'url') {

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -424,7 +424,7 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-thumbs{display:inline-flex;align-items:center;gap:2px;min-width:0;max-width:100%}
 .fsdb-fileview-imgs{display:flex;flex-wrap:wrap;gap:8px}
 .fsdb-cell-pop{box-sizing:border-box;padding:8px;background:#202020;border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 1px 2px rgba(15,15,15,.04),0 10px 32px rgba(0,0,0,.28);display:flex;flex-direction:column;gap:8px;max-height:min(70vh,480px);overflow:auto;font-size:14px}
-.fsdb-cell-pop.is-select,.fsdb-cell-pop.is-multi-select{min-width:260px;padding:8px}
+.fsdb-cell-pop.is-select,.fsdb-cell-pop.is-multi-select,.fsdb-cell-pop.is-facet{min-width:260px;padding:8px}
 .fsdb-cell-pop.is-string,.fsdb-cell-pop.is-title,.fsdb-cell-pop.is-number{padding:6px 8px}
 .fsdb-cell-pop-tags{display:flex;flex-direction:column;gap:8px;min-width:0}
 .fsdb-cell-pop-picked{display:flex;min-width:0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -177,6 +177,8 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.doesNotMatch(popDraft, /取消/)
   assert.match(popDraft, /fsdb-cell-pop-tags/)
   assert.match(popDraft, /fsdb-cell-pop-text/)
+  assert.match(popDraft, /kind === 'facet'/)
+  assert.doesNotMatch(popDraft, /SchemaFieldEditor/)
   assert.doesNotMatch(browser, /if \(pop\) return <DefaultCell field=\{field\} value=\{row\[key\]\}/)
   const pop = readFileSync(resolve(import.meta.dirname, './cell-pop.tsx'), 'utf8')
   assert.match(pop, /top: rect\.top/)

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -126,5 +126,5 @@ test('selected table cells use Super Tag blue when writable and gray when locked
   assert.match(css, /\.fsdb-media-field\{[^}]*flex-wrap:nowrap/)
   assert.match(css, /\.fsdb-media-field\{[^}]*height:22px/)
   assert.match(css, /\.fsdb-cell-pop\{[^}]*background:#202020/)
-  assert.match(css, /\.fsdb-cell-pop-tags\{[^}]*flex-direction:column/)
+  assert.match(css, /\.fsdb-cell-pop\.is-select,\.fsdb-cell-pop\.is-multi-select,\.fsdb-cell-pop\.is-facet\{[^}]*min-width:260px/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格里点合集不再套 `SchemaFieldEditor` 再弹第二个搜索窗。和单选/多选一样，当前标签在上，下面同一份搜索/点选/新建列表。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

