### PR TITLE
弹层统一用无样式 Radix，点外面即关

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,6 +2146,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.0.tgz",
@@ -8751,8 +8784,116 @@
     "packages/public-ui": {
       "name": "@biu/public-ui",
       "version": "0.1.0",
+      "dependencies": {
+        "@radix-ui/react-dismissable-layer": "^1.1.19",
+        "@radix-ui/react-popover": "^1.1.6"
+      },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "packages/public-ui/node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "packages/public-ui/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/public-ui/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+      "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-callback-ref": "1.1.4",
+        "@radix-ui/react-use-effect-event": "0.0.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/public-ui/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/public-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "packages/public-ui/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+      "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "packages/type-agent-loop": {

--- a/packages/cap-chat/src/web/approvals.tsx
+++ b/packages/cap-chat/src/web/approvals.tsx
@@ -11,6 +11,7 @@ import {
 import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type ChatNode, type DispatchedTaskRow, type SessionViewService } from '@biu/web-session-view'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { SessionProjectPanel } from './project-panel.tsx'
 
 type AgentMode = 'minimal' | 'standard'
@@ -65,6 +66,7 @@ function DockIconMenu<T extends string>({
         {current.icon}
       </button>
       {open ? (
+        <HeadlessDismiss onDismiss={() => onOpenChange(false)} insideRef={wrapRef}>
         <div className="dock-icon-menu" role="menu">
           <div className="dock-icon-head">{label}</div>
           {options.map((opt) => (
@@ -100,6 +102,7 @@ function DockIconMenu<T extends string>({
             </button>
           ))}
         </div>
+        </HeadlessDismiss>
       ) : null}
     </div>
   )
@@ -172,29 +175,6 @@ export function ApprovalsRail(props: SlotProps) {
   useEffect(() => {
     void refreshAgentMode()
   }, [refreshAgentMode])
-
-  useEffect(() => {
-    if (!agentMenuOpen && !approvalMenuOpen) return
-    const onDown = (event: MouseEvent) => {
-      const node = event.target as Node
-      if (agentMenuRef.current?.contains(node) || approvalMenuRef.current?.contains(node)) {
-        return
-      }
-      setAgentMenuOpen(false)
-      setApprovalMenuOpen(false)
-    }
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      setAgentMenuOpen(false)
-      setApprovalMenuOpen(false)
-    }
-    window.addEventListener('mousedown', onDown, true)
-    window.addEventListener('keydown', onKey)
-    return () => {
-      window.removeEventListener('mousedown', onDown, true)
-      window.removeEventListener('keydown', onKey)
-    }
-  }, [agentMenuOpen, approvalMenuOpen])
 
   // 快捷键：command+e / ctrl+e 触发清空上下文（在输入框中同样生效）
   const clearContextRef = useRef<() => void>(() => {})

--- a/packages/cap-chat/src/web/composer.tsx
+++ b/packages/cap-chat/src/web/composer.tsx
@@ -7,6 +7,7 @@ import type { SlotProps } from '@biu/web-slots'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { pickKey, usePickState, type PickService } from '@biu/cap-pick/web'
 import { BrandCornerMascot } from '@biu/public-mascot'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { composerDocExtensions } from './composer-kit.ts'
 import {
   collectPickKeys,
@@ -402,13 +403,6 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       .catch(() => {
         /* ignore */
       })
-    const onPointer = (event: MouseEvent) => {
-      const target = event.target as HTMLElement | null
-      if (target?.closest('.composer-model')) return
-      setModelOpen(false)
-    }
-    window.addEventListener('mousedown', onPointer, true)
-    return () => window.removeEventListener('mousedown', onPointer, true)
     // endpointLabels 仅作合并基础，不纳入依赖避免循环刷新
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modelOpen])
@@ -906,6 +900,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               <ChevronDownIcon className="size-3.5 opacity-70" />
             </button>
             {modelOpen ? (
+              <HeadlessDismiss onDismiss={() => setModelOpen(false)} inside={(node) => Boolean((node instanceof Element ? node.closest('.composer-model') : null))}>
               <div className="composer-model-menu" role="listbox" aria-label="模型">
                 <div className="composer-model-config-head">
                   <span className="composer-model-config-title">Models</span>
@@ -977,6 +972,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   })
                 })()}
               </div>
+              </HeadlessDismiss>
             ) : null}
           </div>
 

--- a/packages/cap-chat/src/web/config.tsx
+++ b/packages/cap-chat/src/web/config.tsx
@@ -8,6 +8,7 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIcon, SignalSlashIcon, XMarkIcon } from '@heroicons/react/16/solid'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
@@ -195,24 +196,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     const exact = presets.some((e) => e.label.toLowerCase() === q.toLowerCase() || e.id === q)
     return !exact
   }, [pickerQuery, presets])
-
-  useEffect(() => {
-    if (!pickerOpen) return
-    function onDoc(e: MouseEvent) {
-      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-        setPickerOpen(false)
-      }
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setPickerOpen(false)
-    }
-    document.addEventListener('mousedown', onDoc, true)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDoc, true)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [pickerOpen])
 
   function resetAddForm() {
     setPresetId('')
@@ -749,6 +732,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                     )}
 
                     {pickerOpen ? (
+                      <HeadlessDismiss onDismiss={() => setPickerOpen(false)} insideRef={pickerRef}>
                       <div
                         id="connection-picker-menu"
                         role="listbox"
@@ -841,6 +825,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                           </>
                         ) : null}
                       </div>
+                      </HeadlessDismiss>
                     ) : null}
                   </div>
                 </div>

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -33,7 +33,7 @@ import {
 import type { CollectionActionInfo, CollectionInfo, CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
 import type { CollectionChrome, CollectionViewType, DatabaseUi } from '@biu/type-file-system/ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
-import { BoolBox, ChatCount, RecordEmojiBoard, listenOutsideDismiss } from '@biu/public-ui'
+import { BoolBox, ChatCount, RecordEmojiBoard, HeadlessDismiss } from '@biu/public-ui'
 import {
   contentFieldKey,
   defaultColumnKeys,
@@ -410,36 +410,6 @@ export function CollectionBrowser({
       window.removeEventListener('biu:inspector-toggle', onToggle)
     }
   }, [nested])
-
-  useEffect(() => {
-    return listenOutsideDismiss(
-      () => {
-        setViewMenuOpen(false)
-        setModeMenuOpen(false)
-        setSortMenuOpen(false)
-        setColumnMenuOpen(false)
-        setFilterOpen(false)
-        setConfigOpen(false)
-        setGroupOpen(false)
-        setLayoutOpen(false)
-        setSearchOpen((open) => (query ? open : false))
-      },
-      (target) =>
-        Boolean(
-          crumbRef.current?.contains(target) ||
-            (target instanceof Element && target.closest('[data-fsdb-crumb-menu]')) ||
-            searchRef.current?.contains(target) ||
-            viewRef.current?.contains(target) ||
-            modeRef.current?.contains(target) ||
-            sortRef.current?.contains(target) ||
-            columnRef.current?.contains(target) ||
-            filterRef.current?.contains(target) ||
-            configRef.current?.contains(target) ||
-            groupRef.current?.contains(target) ||
-            layoutRef.current?.contains(target),
-        ),
-    )
-  }, [query])
 
   useLayoutEffect(() => {
     if (sheet) return
@@ -2009,6 +1979,7 @@ export function CollectionBrowser({
                 <AdjustmentsHorizontalIcon aria-hidden className="size-4" />
               </button>
               {layoutOpen ? (
+                <HeadlessDismiss onDismiss={() => setLayoutOpen(false)} insideRef={layoutRef}>
                 <div className="fsdb-layout-menu" role="menu" data-testid="fsdb-layout-menu">
                   <button
                     type="button"
@@ -2035,6 +2006,7 @@ export function CollectionBrowser({
                     <ArrowsPointingOutIcon aria-hidden className="size-4" />
                   </button>
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             <button
@@ -2116,6 +2088,7 @@ export function CollectionBrowser({
                 ) : null}
               </div>
               {viewMenuOpen ? (
+                <HeadlessDismiss onDismiss={() => setViewMenuOpen(false)} insideRef={viewRef}>
                 <div className="tasks-viewdd-menu" role="menu">
                   <div className="tasks-viewdd-head">视图</div>
                   {views.length === 0 ? <div className="tasks-viewdd-empty">还没有已保存的视图</div> : null}
@@ -2148,6 +2121,7 @@ export function CollectionBrowser({
                     </button>
                   </div>
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             )}
@@ -2160,6 +2134,15 @@ export function CollectionBrowser({
             ) : null}
           </div>
           <div className="tasks-toolbar-right" ref={toolbarRightRef}>
+            <HeadlessDismiss
+              enabled={searchExpanded}
+              onDismiss={() => {
+                if (!query) setSearchOpen(false)
+              }}
+              onEscapeKeyDown={(event) => {
+                if (query) event.preventDefault()
+              }}
+            >
             <div className={`tasks-search-wrap${searchExpanded ? ' is-open' : ''}`} ref={searchRef}>
               <button
                 type="button"
@@ -2187,6 +2170,7 @@ export function CollectionBrowser({
                 />
               ) : null}
             </div>
+            </HeadlessDismiss>
             <div className="tasks-sort-wrap" ref={modeRef}>
               <button
                 type="button"
@@ -2198,6 +2182,7 @@ export function CollectionBrowser({
                 <ModeGlyph id={mode} extra={extraViews} />
               </button>
               {modeMenuOpen ? (
+                <HeadlessDismiss onDismiss={() => setModeMenuOpen(false)} insideRef={modeRef}>
                 <div className="tasks-sort-menu" role="menu">
                   <div className="tasks-sort-head">查看模式</div>
                   {modeChoices.map((opt) => (
@@ -2214,6 +2199,7 @@ export function CollectionBrowser({
                     />
                   ))}
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             <div className="tasks-sort-wrap" ref={sortRef}>
@@ -2227,6 +2213,7 @@ export function CollectionBrowser({
                 <ArrowsUpDownIcon aria-hidden className="size-[14px]" />
               </button>
               {sortMenuOpen ? (
+                <HeadlessDismiss onDismiss={() => setSortMenuOpen(false)} insideRef={sortRef}>
                 <div className="tasks-sort-menu" role="menu">
                   <div className="tasks-sort-head">排序依据</div>
                   {sortFields.map((item) => {
@@ -2257,6 +2244,7 @@ export function CollectionBrowser({
                     )
                   })}
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             <div className="tasks-sort-wrap" ref={groupRef}>
@@ -2270,6 +2258,7 @@ export function CollectionBrowser({
                 <RectangleStackIcon aria-hidden className="size-[14px]" />
               </button>
               {groupOpen ? (
+                <HeadlessDismiss onDismiss={() => setGroupOpen(false)} insideRef={groupRef}>
                 <div className="tasks-sort-menu" role="menu">
                   <div className="tasks-sort-head">分组依据</div>
                   <CheckRow
@@ -2298,6 +2287,7 @@ export function CollectionBrowser({
                     <div className="tasks-viewdd-empty">没有单选或多选字段</div>
                   )}
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             <div className="tasks-sort-wrap" ref={columnRef}>
@@ -2312,6 +2302,7 @@ export function CollectionBrowser({
                 {columnCustom ? <span className="tasks-sort-dot" aria-hidden /> : null}
               </button>
               {columnMenuOpen ? (
+                <HeadlessDismiss onDismiss={() => setColumnMenuOpen(false)} insideRef={columnRef}>
                 <div className="tasks-sort-menu fsdb-col-menu" role="menu">
                   <div className="tasks-sort-head">可见列</div>
                   <div className="fsdb-col-menu-list">
@@ -2341,6 +2332,7 @@ export function CollectionBrowser({
                   })}
                   </div>
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             {activeView?.builtin ? null : (
@@ -2356,6 +2348,7 @@ export function CollectionBrowser({
                 {filterActive ? <span className="tasks-filter-dot" aria-hidden /> : null}
               </button>
               {filterOpen ? (
+                <HeadlessDismiss onDismiss={() => setFilterOpen(false)} insideRef={filterRef}>
                 <div className="tasks-filter-menu" role="menu">
                   {filterFields.map((item) => {
                     const options =
@@ -2400,6 +2393,7 @@ export function CollectionBrowser({
                     </button>
                   ) : null}
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             )}
@@ -2418,6 +2412,7 @@ export function CollectionBrowser({
                 ) : null}
               </button>
               {configOpen ? (
+                <HeadlessDismiss onDismiss={() => setConfigOpen(false)} insideRef={configRef}>
                 <div className="tasks-filter-menu" role="menu">
                   <div className="tasks-sort-head">表格显示</div>
                   <CheckRow
@@ -2441,6 +2436,7 @@ export function CollectionBrowser({
                     />
                   ) : null}
                 </div>
+                </HeadlessDismiss>
               ) : null}
             </div>
             ) : null}

--- a/packages/core-file-system/src/web/cell-pop.tsx
+++ b/packages/core-file-system/src/web/cell-pop.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessDismiss, HEADLESS_DISMISS_IGNORE } from '@biu/public-ui'
 import type { FieldType } from '@biu/type-file-system'
 
 export function cellUsesPop(kind: FieldType, writable?: boolean) {
@@ -22,12 +22,10 @@ export function CellPop({
   children: ReactNode
 }) {
   const menuRef = useRef<HTMLDivElement>(null)
-  const openedAt = useRef(performance.now())
   const [box, setBox] = useState({ top: 0, left: 0, width: 200, minHeight: 32 })
 
   useLayoutEffect(() => {
     if (!open || !anchor) return
-    openedAt.current = performance.now()
     const place = () => {
       const rect = anchor.getBoundingClientRect()
       setBox({
@@ -46,38 +44,22 @@ export function CellPop({
     }
   }, [anchor, open])
 
-  useEffect(() => {
-    if (!open) return
-    const close = () => {
-      if (performance.now() - openedAt.current < 200) return
-      onClose()
-    }
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') close()
-    }
-    window.addEventListener('keydown', onKey)
-    const stop = listenOutsideDismiss(close, (target) => {
-      if (!(target instanceof Element)) return Boolean(menuRef.current?.contains(target) || anchor?.contains(target))
-      if (menuRef.current?.contains(target) || anchor?.contains(target)) return true
-      return Boolean(target.closest('.db-search-menu, .fsdb-cellselect-menu, .fsdb-cell-pop, .ant-picker-dropdown'))
-    })
-    return () => {
-      window.removeEventListener('keydown', onKey)
-      stop()
-    }
-  }, [anchor, onClose, open])
-
   if (!open || !anchor) return null
   return createPortal(
-    <div
-      ref={menuRef}
-      className={`fsdb-cell-pop${className ? ` ${className}` : ''}`}
-      role="dialog"
-      style={{ position: 'fixed', top: box.top, left: box.left, width: box.width, minHeight: box.minHeight, zIndex: 180 }}
-      onMouseDown={(event) => event.stopPropagation()}
+    <HeadlessDismiss
+      onDismiss={onClose}
+      inside={(node) => Boolean(anchor.contains(node))}
+      ignoreSelector={`${HEADLESS_DISMISS_IGNORE}, .db-search-menu, .fsdb-cellselect-menu`}
     >
-      {children}
-    </div>,
+      <div
+        ref={menuRef}
+        className={`fsdb-cell-pop${className ? ` ${className}` : ''}`}
+        role="dialog"
+        style={{ position: 'fixed', top: box.top, left: box.left, width: box.width, minHeight: box.minHeight, zIndex: 180 }}
+      >
+        {children}
+      </div>
+    </HeadlessDismiss>,
     document.body,
   )
 }

--- a/packages/core-file-system/src/web/crumb-header.test.ts
+++ b/packages/core-file-system/src/web/crumb-header.test.ts
@@ -37,7 +37,7 @@ describe('顶栏三级标题', () => {
     expect(trail).not.toContain('useLayoutEffect')
     expect(style).toContain('anchor-name:--fsdb-crumb')
     expect(style).toContain('anchor(--fsdb-crumb left)')
-    expect(trail).toContain('listenOutsideDismiss')
+    expect(trail).toContain('HeadlessDismiss')
     expect(browser).not.toContain('setCrumbOpen')
     expect(browser).not.toContain('openId={crumbOpen}')
     expect(browser).not.toContain('if (!searchRef.current?.contains(target) && !query) setSearchOpen(false)')

--- a/packages/core-file-system/src/web/crumb-trail.tsx
+++ b/packages/core-file-system/src/web/crumb-trail.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState, type PointerEvent, type Ref } from 'react'
+import { useEffect, useMemo, useRef, useState, type PointerEvent, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
 import { MagnifyingGlassIcon, PlusIcon } from '@heroicons/react/16/solid'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { CrumbItemGlyph, TableGlyph } from './nav-glyphs.tsx'
 import { crumbButtonAction, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 
@@ -23,6 +23,7 @@ function CrumbMenu({
   onCreate,
   canCreateView,
   canCreateRecord,
+  trailRef,
 }: {
   crumb: Crumb
   crumbs: Crumb[]
@@ -31,6 +32,7 @@ function CrumbMenu({
   onCreate?: (kind: 'view' | 'record') => void
   canCreateView?: boolean
   canCreateRecord?: boolean
+  trailRef: RefObject<HTMLElement | null>
 }) {
   const [query, setQuery] = useState('')
   const q = query.trim().toLowerCase()
@@ -43,6 +45,7 @@ function CrumbMenu({
     (createKind === 'view' && canCreateView && onCreate) || (createKind === 'record' && canCreateRecord && onCreate)
 
   return (
+    <HeadlessDismiss onDismiss={() => onOpenId(null)} insideRef={trailRef}>
     <div
       className="fsdb-crumb-menu is-fixed"
       role="menu"
@@ -126,6 +129,7 @@ function CrumbMenu({
         </div>
       ) : null}
     </div>
+    </HeadlessDismiss>
   )
 }
 
@@ -165,17 +169,6 @@ export function CrumbTrail({
   useEffect(() => {
     if (!allowMenu) setOpenId(null)
   }, [allowMenu])
-
-  useEffect(() => {
-    return listenOutsideDismiss(
-      () => setOpenId(null),
-      (target) =>
-        Boolean(
-          trailRef.current?.contains(target) ||
-            (target instanceof Element && target.closest('[data-fsdb-crumb-menu]')),
-        ),
-    )
-  }, [])
 
   return (
     <nav
@@ -254,6 +247,7 @@ export function CrumbTrail({
               key={openCrumb.id}
               crumb={openCrumb}
               crumbs={crumbs}
+              trailRef={trailRef}
               onPick={onPick}
               onOpenId={(id) => {
                 if (!id) setOpenId(null)

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -254,7 +254,7 @@ const CSS = `
 .fsdb-pager-nav{display:inline-flex;align-items:center;gap:2px;flex:none;margin-left:auto}
 .fsdb-pager-size{position:relative;display:inline-flex;align-items:center}
 .fsdb-pager-size-btn{gap:4px;width:auto;min-width:0;height:26px;padding:0 6px;border-radius:6px;font-variant-numeric:tabular-nums}
-.fsdb-pager-size-menu{position:fixed;z-index:130;min-width:96px;padding:6px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:2px}
+.fsdb-pager-size-menu{z-index:130;min-width:96px;padding:6px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18);display:flex;flex-direction:column;gap:2px}
 .fsdb-pager-size-option{display:inline-flex;align-items:center;justify-content:space-between;gap:8px;width:100%;border:0;border-radius:7px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;cursor:pointer;text-align:left}
 .fsdb-pager-size-option:hover{background:var(--dsw-hover)}
 .fsdb-pager-size-option.is-active{color:var(--dsw-business);font-weight:650}
@@ -326,7 +326,7 @@ const CSS = `
 .fsdb-schema-type-btn{display:inline-flex;align-items:center;gap:4px;height:28px;padding:0 6px;border:0;border-radius:6px;background:transparent;color:var(--dsw-label-2);font:inherit;font-size:13px;cursor:pointer}
 .fsdb-schema-type-btn:hover{background:var(--dsw-hover);color:var(--dsw-label)}
 .fsdb-schema-type-caret{opacity:.55}
-.fsdb-schema-type-menu{position:absolute;right:0;top:calc(100% + 4px);z-index:70;display:flex;flex-direction:column;min-width:160px;max-height:240px;overflow:auto;padding:4px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
+.fsdb-schema-type-menu{z-index:70;display:flex;flex-direction:column;min-width:160px;max-height:240px;overflow:auto;padding:4px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .fsdb-schema-type-option{display:flex;align-items:center;gap:6px;width:100%;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;text-align:left;cursor:pointer}
 .fsdb-schema-type-option:hover,.fsdb-schema-type-option.is-on{background:var(--dsw-hover)}
 .fsdb-prop-val{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#7C7A76}

--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -4,7 +4,7 @@ import type { SlotProps } from '@biu/type-slots'
 import type { CollectionInfo } from '@biu/type-file-system'
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import { parseAppPath } from '@biu/web-session-view'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessDismiss, HEADLESS_DISMISS_IGNORE } from '@biu/public-ui'
 import { buildCrumbs, pathForCrumbTarget, type Crumb, type CrumbTarget } from './sidebar-nav.ts'
 import { CollectionBrowser } from './browser.tsx'
 import { CrumbTrail } from './crumb-trail.tsx'
@@ -196,15 +196,6 @@ export function DatabaseInspectorTab({
   const crumbRef = useRef<HTMLElement>(null)
   const tabRef = useRef<HTMLDivElement>(null)
   useViewTick()
-  useEffect(() => {
-    return listenOutsideDismiss(
-      () => {
-        setTrailOpen(false)
-      },
-      (target) =>
-        Boolean(tabRef.current?.contains(target) || (target instanceof Element && target.closest('[data-fsdb-crumb-menu]'))),
-    )
-  }, [])
   const { crumbs } = crumbsForRoute(inspectorPath, tables)
   const leaf = crumbs.at(-1)
   const leafChoice = leaf?.choices.find((item) => item.id === leaf.id)
@@ -224,6 +215,11 @@ export function DatabaseInspectorTab({
   }, [id, leaf?.id, leaf?.kind, leaf?.label, leafChoice?.emoji, leafChoice?.icon, leafChoice?.mode])
 
   return (
+    <HeadlessDismiss
+      enabled={trailOpen}
+      onDismiss={() => setTrailOpen(false)}
+      ignoreSelector={`${HEADLESS_DISMISS_IGNORE}, [data-fsdb-crumb-menu]`}
+    >
     <div
       ref={tabRef}
       className={`inspector-tab inspector-crumb-tab${active ? ' is-active' : ''}${trailOpen ? ' is-crumb-open' : ''}${agentWorking ? ' is-agent-working' : ''}`}
@@ -295,6 +291,7 @@ export function DatabaseInspectorTab({
         ) : null}
       </span>
     </div>
+    </HeadlessDismiss>
   )
 }
 

--- a/packages/core-file-system/src/web/pager-size.test.ts
+++ b/packages/core-file-system/src/web/pager-size.test.ts
@@ -12,6 +12,6 @@ test('page-size menu is a local control, not CollectionBrowser state', () => {
   assert.doesNotMatch(browser, /pageSizeOpen/)
   assert.doesNotMatch(browser, /toggleMenu\('pageSize'\)/)
   assert.doesNotMatch(browser, /pageSizeMenuPos/)
-  assert.match(pager, /setPos\(menuPos\(wrapRef\.current\)\)/)
+  assert.match(pager, /HeadlessPopover/)
   assert.match(pager, /if \(next !== pageSize\) onChange\(next\)/)
 })

--- a/packages/core-file-system/src/web/pager-size.tsx
+++ b/packages/core-file-system/src/web/pager-size.tsx
@@ -1,17 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useState } from 'react'
 import { Bars3BottomLeftIcon, CheckIcon } from '@heroicons/react/16/solid'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessPopover } from '@biu/public-ui'
 import { normalizePageSize, PAGE_SIZES } from './saved-view.ts'
-
-function menuPos(el: HTMLElement | null) {
-  const box = el?.getBoundingClientRect()
-  if (!box) return null
-  return {
-    right: Math.max(8, window.innerWidth - box.right),
-    bottom: Math.max(8, window.innerHeight - box.top + 6),
-  }
-}
 
 /** 每页条数菜单自己管开合，避免点开时把整张表跟着 setState。 */
 export function PagerSizeControl({
@@ -21,68 +11,48 @@ export function PagerSizeControl({
   pageSize: number
   onChange: (size: number) => void
 }) {
-  const wrapRef = useRef<HTMLDivElement>(null)
-  const menuRef = useRef<HTMLDivElement>(null)
   const [open, setOpen] = useState(false)
-  const [pos, setPos] = useState<{ right: number; bottom: number } | null>(null)
-
-  useEffect(() => {
-    if (!open) return
-    return listenOutsideDismiss(
-      () => setOpen(false),
-      (target) => Boolean(wrapRef.current?.contains(target) || menuRef.current?.contains(target)),
-    )
-  }, [open])
 
   return (
-    <div className="fsdb-pager-size" ref={wrapRef}>
-      <button
-        type="button"
-        className={`tasks-icon-btn fsdb-pager-size-btn${open ? ' is-active' : ''}`}
-        aria-label={`每页 ${pageSize} 条`}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={`每页 ${pageSize} 条`}
-        onClick={() => {
-          if (open) {
-            setOpen(false)
-            return
-          }
-          setPos(menuPos(wrapRef.current))
-          setOpen(true)
-        }}
+    <div className="fsdb-pager-size">
+      <HeadlessPopover
+        open={open}
+        onOpenChange={setOpen}
+        side="top"
+        align="end"
+        trigger={
+          <button
+            type="button"
+            className={`tasks-icon-btn fsdb-pager-size-btn${open ? ' is-active' : ''}`}
+            aria-label={`每页 ${pageSize} 条`}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            title={`每页 ${pageSize} 条`}
+          >
+            <Bars3BottomLeftIcon aria-hidden className="size-[14px]" />
+            <span>{pageSize}</span>
+          </button>
+        }
       >
-        <Bars3BottomLeftIcon aria-hidden className="size-[14px]" />
-        <span>{pageSize}</span>
-      </button>
-      {open && pos
-        ? createPortal(
-            <div
-              ref={menuRef}
-              className="fsdb-pager-size-menu"
-              role="menu"
-              style={{ right: pos.right, bottom: pos.bottom }}
+        <div className="fsdb-pager-size-menu" role="menu">
+          {PAGE_SIZES.map((size) => (
+            <button
+              key={size}
+              type="button"
+              className={`fsdb-pager-size-option${size === pageSize ? ' is-active' : ''}`}
+              role="menuitem"
+              onClick={() => {
+                setOpen(false)
+                const next = normalizePageSize(size)
+                if (next !== pageSize) onChange(next)
+              }}
             >
-              {PAGE_SIZES.map((size) => (
-                <button
-                  key={size}
-                  type="button"
-                  className={`fsdb-pager-size-option${size === pageSize ? ' is-active' : ''}`}
-                  role="menuitem"
-                  onClick={() => {
-                    setOpen(false)
-                    const next = normalizePageSize(size)
-                    if (next !== pageSize) onChange(next)
-                  }}
-                >
-                  {size}
-                  {size === pageSize ? <CheckIcon aria-hidden className="size-[14px]" /> : null}
-                </button>
-              ))}
-            </div>,
-            document.body,
-          )
-        : null}
+              {size}
+              {size === pageSize ? <CheckIcon aria-hidden className="size-[14px]" /> : null}
+            </button>
+          ))}
+        </div>
+      </HeadlessPopover>
     </div>
   )
 }

--- a/packages/core-file-system/src/web/schema-field.tsx
+++ b/packages/core-file-system/src/web/schema-field.tsx
@@ -11,7 +11,7 @@ import {
   type SchemaPackField,
 } from '@biu/type-file-system'
 import { ChevronDownIcon, PlusIcon, XMarkIcon } from '@heroicons/react/16/solid'
-import { TagChip, TagChips, tagTone, listenOutsideDismiss } from '@biu/public-ui'
+import { TagChip, TagChips, tagTone, HeadlessPopover } from '@biu/public-ui'
 import { CellMulti } from '@biu/database-ui'
 import { FieldEditor, FieldGlyph, fieldDraftValue, parseFieldValue } from './fsdb-cells.tsx'
 import { loadFacets, persistFacets, registerFacetFieldKey, slugFacetId, subscribeFacets } from './facet-catalog.ts'
@@ -68,22 +68,19 @@ export function SchemaChips({ value, tags }: { value: unknown; tags: CollectionS
 
 function TypeMenu({ value, onChange }: { value: AtomicFieldType; onChange: (next: AtomicFieldType) => void }) {
   const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    if (!open) return
-    return listenOutsideDismiss(
-      () => setOpen(false),
-      (target) => Boolean(ref.current?.contains(target)),
-    )
-  }, [open])
   return (
-    <div className="fsdb-schema-type" ref={ref}>
-      <button type="button" className="fsdb-schema-type-btn" onClick={() => setOpen((prev) => !prev)}>
-        <FieldGlyph kind={value} />
-        <span>{TYPE_LABEL[value]}</span>
-        <ChevronDownIcon aria-hidden className="size-3 fsdb-schema-type-caret" />
-      </button>
-      {open ? (
+    <div className="fsdb-schema-type">
+      <HeadlessPopover
+        open={open}
+        onOpenChange={setOpen}
+        trigger={
+          <button type="button" className="fsdb-schema-type-btn">
+            <FieldGlyph kind={value} />
+            <span>{TYPE_LABEL[value]}</span>
+            <ChevronDownIcon aria-hidden className="size-3 fsdb-schema-type-caret" />
+          </button>
+        }
+      >
         <div className="fsdb-schema-type-menu" role="listbox">
           {ATOMIC_FIELD_TYPES.map((type) => (
             <button
@@ -100,7 +97,7 @@ function TypeMenu({ value, onChange }: { value: AtomicFieldType; onChange: (next
             </button>
           ))}
         </div>
-      ) : null}
+      </HeadlessPopover>
     </div>
   )
 }

--- a/packages/core-task-system/src/web/chrome.tsx
+++ b/packages/core-task-system/src/web/chrome.tsx
@@ -10,7 +10,7 @@ import {
   UserIcon,
   XMarkIcon,
 } from '@heroicons/react/16/solid'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { CellMulti, CellSelect, CellDateTime } from '@biu/database-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import type { DbRecord } from '@biu/type-file-system'
@@ -123,12 +123,9 @@ function FloatMenu({
     }
   }, [anchor, minWidth])
 
-  useEffect(() => {
-    return listenOutsideDismiss(onClose, (target) => Boolean(menuRef.current?.contains(target) || anchor?.contains(target)))
-  }, [anchor, onClose])
-
   if (!anchor) return null
   return createPortal(
+    <HeadlessDismiss onDismiss={onClose} inside={(node) => Boolean(anchor.contains(node))}>
     <div
       ref={menuRef}
       className="tasks-float-menu"
@@ -136,7 +133,8 @@ function FloatMenu({
       style={{ position: 'fixed', top: box.top, left: box.left, minWidth: box.width, zIndex: 80 }}
     >
       {children}
-    </div>,
+    </div>
+    </HeadlessDismiss>,
     document.body,
   )
 }

--- a/packages/public-mascot/package.json
+++ b/packages/public-mascot/package.json
@@ -7,6 +7,9 @@
   "exports": {
     ".": "./src/web/index.ts"
   },
+  "dependencies": {
+    "@biu/public-ui": "0.1.0"
+  },
   "peerDependencies": {
     "react": "^19.1.1"
   }

--- a/packages/public-mascot/src/web/brand-mascot.tsx
+++ b/packages/public-mascot/src/web/brand-mascot.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { isValidElement, useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot } from './sidebar-mascot.tsx'
 import { resolveSessionMascot } from './session-mascot.ts'
 
@@ -115,26 +116,12 @@ export function BrandCornerMascot({
   size?: number
 }) {
   const [agentsOpen, setAgentsOpen] = useState(false)
-  const rootRef = useRef<HTMLDivElement>(null)
   const ranked = useMemo(() => rankCornerAgents(agents), [agents])
   const current = ranked.find((item) => item.id === activeId) ?? ranked[0]
   const identity = current ? resolveSessionMascot(current.id, current.mascot) : undefined
   const name = current?.title?.trim() || (onToggle ? '聊天' : '切换 Agent')
   const closeMenu = useCallback(() => setAgentsOpen(false), [])
   const expanded = onToggle ? Boolean(open) : agentsOpen
-
-  useEffect(() => {
-    if (!agentsOpen || onToggle) return
-    function onPointer(event: MouseEvent) {
-      const target = event.target as Node | null
-      if (rootRef.current?.contains(target)) return
-      if (target instanceof Element && target.closest('[data-testid="chat-session-delete-dialog"]')) return
-      setAgentsOpen(false)
-    }
-    window.addEventListener('mousedown', onPointer, true)
-    return () => window.removeEventListener('mousedown', onPointer, true)
-  }, [agentsOpen, onToggle])
-
   const panel = onToggle || !agentsOpen
     ? null
     : menu
@@ -153,7 +140,7 @@ export function BrandCornerMascot({
       )
 
   return (
-    <div className="brand-corner-cluster" ref={rootRef} data-testid="brand-corner-mascot">
+    <div className="brand-corner-cluster" data-testid="brand-corner-mascot">
       {leading ? <div className="brand-corner-leading">{leading}</div> : null}
       <div className="brand-corner-mascot">
         <button
@@ -179,7 +166,18 @@ export function BrandCornerMascot({
             <BrandMascot className="size-9" />
           )}
         </button>
-        {panel}
+        {isValidElement(panel) ? (
+          <HeadlessDismiss
+            onDismiss={closeMenu}
+            inside={(node) =>
+              Boolean(node instanceof Element && node.closest('.brand-corner-cluster, [data-testid="chat-session-delete-dialog"]'))
+            }
+          >
+            {panel as ReactElement}
+          </HeadlessDismiss>
+        ) : (
+          panel
+        )}
       </div>
     </div>
   )

--- a/packages/public-ui/package.json
+++ b/packages/public-ui/package.json
@@ -9,5 +9,9 @@
   },
   "peerDependencies": {
     "react": "^19.1.1"
+  },
+  "dependencies": {
+    "@radix-ui/react-dismissable-layer": "^1.1.19",
+    "@radix-ui/react-popover": "^1.1.6"
   }
 }

--- a/packages/public-ui/src/anchor-menu.tsx
+++ b/packages/public-ui/src/anchor-menu.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState, type HTMLAttributes, type ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type HTMLAttributes, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
-import { listenOutsideDismiss } from './outside-dismiss.ts'
+import { HeadlessDismiss } from './headless-dismiss.tsx'
 
 export function AnchorMenu({
   anchor,
@@ -41,21 +41,19 @@ export function AnchorMenu({
     }
   }, [anchor, minWidth])
 
-  useEffect(() => {
-    return listenOutsideDismiss(onClose, (target) => Boolean(menuRef.current?.contains(target) || anchor?.contains(target)))
-  }, [anchor, onClose])
-
   if (!anchor) return null
   return createPortal(
-    <div
-      ref={menuRef}
-      className={className}
-      role={role}
-      style={{ position: 'fixed', top: box.top, left: box.left, width: box.width, zIndex }}
-      {...rest}
-    >
-      {children}
-    </div>,
+    <HeadlessDismiss onDismiss={onClose} inside={(node) => Boolean(anchor.contains(node))}>
+      <div
+        ref={menuRef}
+        className={className}
+        role={role}
+        style={{ position: 'fixed', top: box.top, left: box.left, width: box.width, zIndex }}
+        {...rest}
+      >
+        {children}
+      </div>
+    </HeadlessDismiss>,
     document.body,
   )
 }

--- a/packages/public-ui/src/emoji-board.tsx
+++ b/packages/public-ui/src/emoji-board.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { listenOutsideDismiss } from './outside-dismiss.ts'
+import { HeadlessDismiss } from './headless-dismiss.tsx'
 
 const RECORD_EMOJI_PRESETS = ['⭐', '🔥', '✅', '📌', '💡', '🎯', '📦', '🧩', '📄', '⚡']
 
@@ -37,14 +37,9 @@ export function RecordEmojiBoard({
       window.removeEventListener('scroll', place, true)
     }
   }, [anchor])
-  useEffect(() => {
-    return listenOutsideDismiss(onClose, (target) => {
-      if (anchor.contains(target)) return true
-      return target instanceof Element && Boolean(target.closest('.fsdb-emoji-picker'))
-    })
-  }, [anchor, onClose])
   if (typeof document === 'undefined') return null
   return createPortal(
+    <HeadlessDismiss onDismiss={onClose} inside={(node) => anchor.contains(node)}>
     <div
       className="fsdb-emoji-picker is-fixed"
       data-biu-ignore
@@ -78,7 +73,8 @@ export function RecordEmojiBoard({
       <button type="button" className="fsdb-emoji-picker-clear" onClick={onClear}>
         恢复默认
       </button>
-    </div>,
+    </div>
+    </HeadlessDismiss>,
     document.body,
   )
 }

--- a/packages/public-ui/src/headless-dismiss.tsx
+++ b/packages/public-ui/src/headless-dismiss.tsx
@@ -1,0 +1,53 @@
+import { DismissableLayer } from '@radix-ui/react-dismissable-layer'
+import type { ReactElement, RefObject } from 'react'
+
+/** 第三方 portal（日期面板、删除确认）不算点在外面。 */
+export const HEADLESS_DISMISS_IGNORE =
+  '.ant-picker-dropdown, .ant-picker-panel-container, .ant-select-dropdown, [data-testid="chat-session-delete-dialog"]'
+
+function asNode(target: EventTarget | null): Node | null {
+  return target instanceof Node ? target : null
+}
+
+function shouldIgnore(target: EventTarget | null, ignoreSelector: string, insideRef?: RefObject<HTMLElement | null>, inside?: (node: Node) => boolean) {
+  const node = asNode(target)
+  if (!node) return false
+  if (insideRef?.current?.contains(node) || inside?.(node)) return true
+  return Boolean(ignoreSelector && node instanceof Element && node.closest(ignoreSelector))
+}
+
+/** 无样式：点外面 / Esc 关闭。底层是 Radix DismissableLayer。 */
+export function HeadlessDismiss({
+  onDismiss,
+  insideRef,
+  inside,
+  ignoreSelector = HEADLESS_DISMISS_IGNORE,
+  enabled = true,
+  onEscapeKeyDown,
+  children,
+}: {
+  onDismiss: () => void
+  insideRef?: RefObject<HTMLElement | null>
+  inside?: (node: Node) => boolean
+  ignoreSelector?: string
+  enabled?: boolean
+  onEscapeKeyDown?: (event: KeyboardEvent) => void
+  children: ReactElement
+}) {
+  if (!enabled) return children
+  return (
+    <DismissableLayer
+      asChild
+      onEscapeKeyDown={onEscapeKeyDown}
+      onPointerDownOutside={(event) => {
+        if (shouldIgnore(event.target, ignoreSelector, insideRef, inside)) event.preventDefault()
+      }}
+      onFocusOutside={(event) => {
+        if (shouldIgnore(event.target, ignoreSelector, insideRef, inside)) event.preventDefault()
+      }}
+      onDismiss={onDismiss}
+    >
+      {children}
+    </DismissableLayer>
+  )
+}

--- a/packages/public-ui/src/headless-popover.tsx
+++ b/packages/public-ui/src/headless-popover.tsx
@@ -1,0 +1,59 @@
+import * as Popover from '@radix-ui/react-popover'
+import type { ReactElement } from 'react'
+import { HEADLESS_DISMISS_IGNORE } from './headless-dismiss.tsx'
+
+/** 无头 Popover：自带定位、Portal、点外关闭、Esc。不带视觉样式。 */
+export function HeadlessPopover({
+  open,
+  defaultOpen,
+  onOpenChange,
+  trigger,
+  children,
+  side = 'bottom',
+  align = 'start',
+  sideOffset = 4,
+  modal = false,
+  autoFocus = false,
+  ignoreSelector = HEADLESS_DISMISS_IGNORE,
+}: {
+  open?: boolean
+  defaultOpen?: boolean
+  onOpenChange?: (open: boolean) => void
+  trigger: ReactElement
+  children: ReactElement
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  align?: 'start' | 'center' | 'end'
+  sideOffset?: number
+  modal?: boolean
+  autoFocus?: boolean
+  ignoreSelector?: string
+}) {
+  return (
+    <Popover.Root open={open} defaultOpen={defaultOpen} onOpenChange={onOpenChange} modal={modal}>
+      <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Content
+          asChild
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          collisionPadding={8}
+          onOpenAutoFocus={(event) => {
+            if (!autoFocus) event.preventDefault()
+          }}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onPointerDownOutside={(event) => {
+            const target = event.target
+            if (target instanceof Element && ignoreSelector && target.closest(ignoreSelector)) event.preventDefault()
+          }}
+          onFocusOutside={(event) => {
+            const target = event.target
+            if (target instanceof Element && ignoreSelector && target.closest(ignoreSelector)) event.preventDefault()
+          }}
+        >
+          {children}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  )
+}

--- a/packages/public-ui/src/index.ts
+++ b/packages/public-ui/src/index.ts
@@ -2,6 +2,8 @@ export { SidebarFold } from './sidebar-fold.tsx'
 export { ChatCount } from './chat-count.tsx'
 export { BoolBox } from './bool-box.tsx'
 export { listenOutsideDismiss } from './outside-dismiss.ts'
+export { HeadlessDismiss, HEADLESS_DISMISS_IGNORE } from './headless-dismiss.tsx'
+export { HeadlessPopover } from './headless-popover.tsx'
 export { AnchorMenu } from './anchor-menu.tsx'
 export { RecordEmojiBoard } from './emoji-board.tsx'
 export {

--- a/packages/public-ui/src/outside-dismiss.test.ts
+++ b/packages/public-ui/src/outside-dismiss.test.ts
@@ -3,12 +3,14 @@ import { resolve } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 
-test('outside dismiss listens in the capture phase', () => {
-  const src = readFileSync(resolve(import.meta.dirname, './outside-dismiss.ts'), 'utf8')
+test('headless dismiss uses radix dismissable layer', () => {
+  const dismiss = readFileSync(resolve(import.meta.dirname, './headless-dismiss.tsx'), 'utf8')
+  const pop = readFileSync(resolve(import.meta.dirname, './headless-popover.tsx'), 'utf8')
   const menu = readFileSync(resolve(import.meta.dirname, './anchor-menu.tsx'), 'utf8')
-  assert.match(src, /addEventListener\('mousedown', onDown, true\)/)
-  assert.match(src, /removeEventListener\('mousedown', onDown, true\)/)
-  assert.match(menu, /listenOutsideDismiss/)
+  assert.match(dismiss, /@radix-ui\/react-dismissable-layer/)
+  assert.match(dismiss, /DismissableLayer/)
+  assert.match(pop, /@radix-ui\/react-popover/)
+  assert.match(menu, /HeadlessDismiss/)
   assert.match(menu, /zIndex = 200/)
   assert.match(menu, /minWidth = 220/)
 })

--- a/packages/public-ui/src/outside-dismiss.ts
+++ b/packages/public-ui/src/outside-dismiss.ts
@@ -1,4 +1,4 @@
-/** Capture-phase：格子上的 stopPropagation 挡不住，点别处会关掉已打开的弹层。 */
+/** 兼容旧调用。新产品弹层请用 HeadlessDismiss / HeadlessPopover（Radix，无样式）。 */
 export function listenOutsideDismiss(onClose: () => void, isInside: (target: Node) => boolean) {
   const onDown = (event: MouseEvent) => {
     const target = event.target

--- a/packages/web-app-shell/src/web/chat-session-title.tsx
+++ b/packages/web-app-shell/src/web/chat-session-title.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState } from 'react'
 import { bindSessionView, type SessionViewService } from '@biu/web-session-view'
 import { BrandCornerMascot } from '@biu/public-mascot'
-import { listenOutsideDismiss } from '@biu/public-ui'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { ChatSidebar } from './chat-sidebar.tsx'
 
 export const ChatSessionTitle = memo(function ChatSessionTitle({
@@ -33,7 +33,6 @@ export const ChatSessionTitle = memo(function ChatSessionTitle({
     if (!open) return
     inputRef.current?.focus()
     inputRef.current?.select()
-    return listenOutsideDismiss(() => setOpen(false), (target) => Boolean(wrapRef.current?.contains(target)))
   }, [open])
 
   function commit() {
@@ -65,27 +64,29 @@ export const ChatSessionTitle = memo(function ChatSessionTitle({
         {title || '未命名会话'}
       </button>
       {open ? (
-        <div className="chat-view-session-title-pop" data-testid="chat-session-title-pop">
-          <input
-            ref={inputRef}
-            className="chat-view-session-title-input"
-            value={draft}
-            placeholder="未命名会话"
-            aria-label="编辑会话名称"
-            onChange={(event) => setDraft(event.target.value)}
-            onBlur={commit}
-            onKeyDown={(event) => {
-              if (event.key === 'Escape') {
-                setDraft(title)
-                setOpen(false)
-                return
-              }
-              if (event.key !== 'Enter') return
-              event.preventDefault()
-              commit()
-            }}
-          />
-        </div>
+        <HeadlessDismiss onDismiss={() => setOpen(false)} insideRef={wrapRef}>
+          <div className="chat-view-session-title-pop" data-testid="chat-session-title-pop">
+            <input
+              ref={inputRef}
+              className="chat-view-session-title-input"
+              value={draft}
+              placeholder="未命名会话"
+              aria-label="编辑会话名称"
+              onChange={(event) => setDraft(event.target.value)}
+              onBlur={commit}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  setDraft(title)
+                  setOpen(false)
+                  return
+                }
+                if (event.key !== 'Enter') return
+                event.preventDefault()
+                commit()
+              }}
+            />
+          </div>
+        </HeadlessDismiss>
       ) : null}
       {showMascot ? (
         <BrandCornerMascot

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -26,6 +26,7 @@ import type { SlotsService } from '@biu/web-slots'
 import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts'
 import { getInspectorCaption, getInspectorCaptionVersion, subscribeInspectorCaptions } from './inspector-captions.ts'
 import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
+import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 
 function captionTableIcon(icon?: string) {
@@ -259,16 +260,6 @@ export const SessionInspector = memo(function SessionInspector({
   }, [plusOpen])
 
   useEffect(() => {
-    function onPointer(event: MouseEvent) {
-      const target = event.target as Node
-      if (plusRef.current?.contains(target) || plusMenuRef.current?.contains(target)) return
-      setPlusOpen(false)
-    }
-    window.addEventListener('mousedown', onPointer, true)
-    return () => window.removeEventListener('mousedown', onPointer, true)
-  }, [])
-
-  useEffect(() => {
     const onMove = (event: PointerEvent) => {
       const drag = dragRef.current
       if (!drag) return
@@ -417,6 +408,7 @@ export const SessionInspector = memo(function SessionInspector({
           </button>
           {plusOpen && plusPos
             ? createPortal(
+            <HeadlessDismiss onDismiss={() => setPlusOpen(false)} insideRef={plusRef}>
             <div
               ref={plusMenuRef}
               className="inspector-add-menu is-fixed"
@@ -501,7 +493,8 @@ export const SessionInspector = memo(function SessionInspector({
                   </button>
                 ))}
               </div>
-            </div>,
+            </div>
+            </HeadlessDismiss>,
             document.body,
           )
           : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
产品里各处手写 `mousedown` / `listenOutsideDismiss` 不一致（有的关不掉，有的和 trigger 打架）。

采用业界成熟的无头组件：

- `@radix-ui/react-dismissable-layer` → `HeadlessDismiss`（已有定位的浮层）
- `@radix-ui/react-popover` → `HeadlessPopover`（trigger + 定位 + Portal）

都不带视觉样式，点层外 / Esc 关闭；日期面板、删除确认等第三方 portal 通过 ignore 选择器排除。

已接到表格单元格弹层、选择菜单、面包屑、工具栏菜单、输入框模型下拉、会话名编辑、人物菜单、检查器添加菜单、审批/Agent 菜单、连接选择器等。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

