### PR TITLE
详情打开时也及时刷新正文

### DIFF
--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -137,3 +137,11 @@ test('page editor hydrates markdown after content fetch', async () => {
   assert.match(container.textContent ?? '', /一段正文/)
 })
 
+test('page editor applies later value when it is not focused', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const src = await readFile(resolve(import.meta.dirname, './page-editor.tsx'), 'utf8')
+  assert.match(src, /if \(editor\.isFocused\) return/)
+  assert.match(src, /md === saved\.current/)
+})
+

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -108,11 +108,17 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
-    if (value == null) return
-    if (hydratedId.current === record.id) return
     const md = asMarkdown(value)
+    if (hydratedId.current !== record.id) {
+      if (value == null) return
+      saved.current = md
+      hydratedId.current = record.id
+      editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
+      return
+    }
+    if (md === saved.current) return
+    if (editor.isFocused) return
     saved.current = md
-    hydratedId.current = record.id
     editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
   }, [editor, record.id, value])
 

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -498,6 +498,24 @@ export function CollectionBrowser({
   const reloadKey = `${dataPath}\0${page}\0${pageSize}\0${fetchQuery}\0${sortField}\0${sortDir}\0${JSON.stringify(queryFilters)}\0${activeViewId ?? ''}`
   const detailIdRef = useRef<string | null>(null)
   detailIdRef.current = detailId
+  const contentGen = useRef(0)
+  const pullDetailBody = useCallback(() => {
+    const id = detailIdRef.current
+    if (!id) {
+      setDetailBody(null)
+      return
+    }
+    const gen = ++contentGen.current
+    void readJson<{ value?: unknown }>(`/api/db/content?path=${encodeURIComponent(`${dataPath}/${id}`)}`)
+      .then((data) => {
+        if (gen !== contentGen.current) return
+        setDetailBody(data.value ?? null)
+      })
+      .catch(() => {
+        if (gen !== contentGen.current) return
+        setDetailBody(null)
+      })
+  }, [dataPath])
   const steppingView = useRef(false)
 
   useEffect(() => {
@@ -567,9 +585,11 @@ export function CollectionBrowser({
   useEffect(() => {
     let debounce = 0
     const onChange = () => {
-      if (detailIdRef.current) return
       window.clearTimeout(debounce)
-      debounce = window.setTimeout(() => void reloadRef.current(), 120)
+      debounce = window.setTimeout(() => {
+        void reloadRef.current()
+        if (detailIdRef.current) pullDetailBody()
+      }, 120)
     }
     window.addEventListener('fsdb:change', onChange)
     const timer = nested
@@ -583,7 +603,7 @@ export function CollectionBrowser({
       window.clearInterval(timer)
       window.removeEventListener('fsdb:change', onChange)
     }
-  }, [collectionPath, dataPath, nested])
+  }, [collectionPath, dataPath, nested, pullDetailBody])
 
   useEffect(() => {
     void pullFacets()
@@ -841,21 +861,12 @@ export function CollectionBrowser({
 
   useEffect(() => {
     if (!detailId) {
+      contentGen.current += 1
       setDetailBody(null)
       return
     }
-    let cancelled = false
-    void readJson<{ value?: unknown }>(`/api/db/content?path=${encodeURIComponent(`${dataPath}/${detailId}`)}`)
-      .then((data) => {
-        if (!cancelled) setDetailBody(data.value ?? null)
-      })
-      .catch(() => {
-        if (!cancelled) setDetailBody(null)
-      })
-    return () => {
-      cancelled = true
-    }
-  }, [collectionPath, dataPath, detailId])
+    pullDetailBody()
+  }, [collectionPath, dataPath, detailId, pullDetailBody])
 
   useEffect(() => {
     if (nested || !detailId) return
@@ -1158,6 +1169,7 @@ export function CollectionBrowser({
           body: JSON.stringify({ path: `${dataPath}/${row.id}`, value: content[bodyKey] }),
         })
         setDetailBody(data.value ?? content[bodyKey])
+        window.dispatchEvent(new Event('fsdb:change'))
         return
       }
       const data = await readJson<{ value?: DbRecord }>('/api/db/update', {
@@ -1169,6 +1181,7 @@ export function CollectionBrowser({
       if (next) {
         setItems((prev) => prev.map((item) => (item.id === next.id ? { ...item, ...next } : item)))
         setDetailRow((prev) => (prev?.id === next.id ? { ...prev, ...next } : prev))
+        window.dispatchEvent(new Event('fsdb:change'))
         return
       }
       quietUntil.current = 0

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -361,6 +361,11 @@ test('list polling pauses while a record is open', () => {
   assert.match(browser, /}, 20000\)/)
 })
 
+test('open detail still reloads body when the collection changes', () => {
+  assert.match(browser, /if \(detailIdRef\.current\) pullDetailBody/)
+  assert.match(browser, /window.dispatchEvent\(new Event\('fsdb:change'\)\)/)
+})
+
 test('collection reload does not follow callback identity', () => {
   assert.match(browser, /const reloadKey = /)
   assert.match(browser, /void reloadRef\.current\(\)/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开详情时列表轮询仍暂停，但 `fsdb:change` 会继续刷新当前记录的列表行和正文。未聚焦的页面编辑器会套用新内容，正在输入的那一侧不会被打断。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

