### PR TITLE
切到页面时不再自动弹出添加合集

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1338,7 +1338,6 @@ export function CollectionBrowser({
             value={fieldDraftValue(field, value)}
             source={value}
             collectionPath={collectionPath}
-            autoOpen
             options={uniqueValues(
               items.map((item) => ({ ...item, [key]: readFacetFlatValue(item, key, source) })),
               key,
@@ -1359,7 +1358,6 @@ export function CollectionBrowser({
             record={row}
             value={row[key]}
             writable
-            autoOpen
             onChange={(next) => void writePatch(row, { [key]: next })}
           />
         )

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -242,6 +242,7 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.doesNotMatch(browser, /setColumnKeys\(defaultColumnKeys\(listed\.schema/)
   assert.match(browser, /flattenFacetColumns\(facetCatalog\)/)
   assert.match(browser, /<SchemaFieldEditor/)
+  assert.doesNotMatch(browser, /<SchemaFieldEditor[\s\S]{0,240}autoOpen/)
   assert.match(readFileSync(resolve(import.meta.dirname, './cell-pop-draft.tsx'), 'utf8'), /autoOpen/)
   assert.match(browser, /schemaTagTone\(flat\.packId\)/)
   assert.match(css, /\.tasks-table\.is-wrap\{[^}]*white-space:normal/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开页面详情时，合集属性把 `autoOpen` 传给了「添加合集」，所以一切到页面悬浮窗就会自己弹出来。属性行改为点了再开；表格格子里点开编辑弹层仍会直接出选择器。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

