### PR TITLE
会话和聊天窗大纲横条改用二级标题长度

### DIFF
--- a/packages/core-file-system/src/web/heading-outline.test.ts
+++ b/packages/core-file-system/src/web/heading-outline.test.ts
@@ -66,8 +66,8 @@ test('session outline is one tick per user bubble, never reply headings', () => 
   assert.deepEqual(
     headingsFromRoot(root).map((item) => [item.id, item.text, item.level]),
     [
-      ['u-1', 'hello from me', 1],
-      ['u-2', 'second question', 1],
+      ['u-1', 'hello from me', 2],
+      ['u-2', 'second question', 2],
     ],
   )
 })

--- a/packages/core-file-system/src/web/heading-outline.ts
+++ b/packages/core-file-system/src/web/heading-outline.ts
@@ -40,7 +40,7 @@ function escapeId(id: string) {
   return typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(id) : id
 }
 
-/** 只读扫描。会话详情只收用户气泡；页面/任务只收 h1–h3。禁止给标题写 data-*。 */
+/** 只读扫描。会话详情只收用户气泡，刻度用二级标题长度；页面/任务只收 h1–h3。禁止给标题写 data-*。 */
 export function headingsFromRoot(root: ParentNode): HeadingOutlineItem[] {
   if (root.querySelector('[data-testid="session-record-chat"]')) {
     const items: HeadingOutlineItem[] = []
@@ -49,7 +49,7 @@ export function headingsFromRoot(root: ParentNode): HeadingOutlineItem[] {
       const id = wrap instanceof HTMLElement ? wrap.getAttribute('data-node-id')?.trim() : ''
       const text = preview(el.textContent ?? '')
       if (!id || !text) continue
-      items.push({ id, text, level: 1 })
+      items.push({ id, text, level: 2 })
     }
     return items
   }

--- a/packages/web-session-view/src/web/chat-outline.test.ts
+++ b/packages/web-session-view/src/web/chat-outline.test.ts
@@ -22,9 +22,9 @@ test('deriveChatOutline can hide robot-initiated user nodes', () => {
   assert.deepEqual(
     deriveChatOutline(nodes, 'all').map((item) => [item.id, item.robot, item.level]),
     [
-      ['u-1', false, 1],
-      ['u-2', true, 1],
-      ['u-3', false, 1],
+      ['u-1', false, 2],
+      ['u-2', true, 2],
+      ['u-3', false, 2],
     ],
   )
 })

--- a/packages/web-session-view/src/web/chat-outline.ts
+++ b/packages/web-session-view/src/web/chat-outline.ts
@@ -6,7 +6,7 @@ export type ChatOutlineItem = {
   id: string
   text: string
   robot: boolean
-  level: 1
+  level: 2
 }
 
 const OPEN_KEY = 'cordis.chatOutline.open'
@@ -75,7 +75,7 @@ export function deriveChatOutline(nodes: ChatNode[], filter: ChatOutlineFilter):
     if (node.kind !== 'user') continue
     const robot = !isHumanUserNode(node)
     if (filter === 'user' && robot) continue
-    items.push({ id: node.id, text: outlinePreview(node.text), robot, level: 1 })
+    items.push({ id: node.id, text: outlinePreview(node.text), robot, level: 2 })
   }
   return items
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
会话详情页和聊天窗左侧大纲刻度，改成跟页面二级标题一样的短横条（h2），不再用一级标题那么长。页面/任务正文里的 h1–h3 仍按标题级别。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

