### PR TITLE
放大看图统一改用 antd Image

### DIFF
--- a/packages/cap-chat/src/web/image-thumbs.tsx
+++ b/packages/cap-chat/src/web/image-thumbs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { Image } from 'antd'
 
 export type ChatImage = {
   name: string
@@ -13,31 +13,18 @@ export function ImageThumbs({
   images: ChatImage[]
   onRemove?: (index: number) => void
 }) {
-  const [open, setOpen] = useState<number | null>(null)
-  useEffect(() => {
-    if (open == null) return
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(null)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [open])
   if (!images.length) return null
-  const current = open != null ? images[open] : null
   return (
-    <>
+    <Image.PreviewGroup>
       <div className="composer-image-row" data-testid="composer-image-thumbs">
         {images.map((image, index) => (
           <div key={`${image.name}-${index}`} className="composer-image-thumb-wrap">
-            <button
-              type="button"
+            <Image
               className="composer-image-thumb"
-              title={image.name}
-              aria-label={`查看 ${image.name}`}
-              onClick={() => setOpen(index)}
-            >
-              <img src={image.url} alt={image.name} />
-            </button>
+              src={image.url}
+              alt={image.name}
+              preview={{ mask: false }}
+            />
             {onRemove ? (
               <button
                 type="button"
@@ -52,18 +39,6 @@ export function ImageThumbs({
           </div>
         ))}
       </div>
-      {current ? (
-        <div
-          className="composer-image-lightbox"
-          role="dialog"
-          aria-modal="true"
-          aria-label={current.name}
-          data-testid="image-lightbox"
-          onClick={() => setOpen(null)}
-        >
-          <img src={current.url} alt={current.name} onClick={(event) => event.stopPropagation()} />
-        </div>
-      ) : null}
-    </>
+    </Image.PreviewGroup>
   )
 }

--- a/packages/core-file-system/package.json
+++ b/packages/core-file-system/package.json
@@ -15,7 +15,8 @@
     "@biu/database-ui": "0.1.0",
     "@biu/web-session-view": "0.1.0",
     "@biu/web-snapshot": "0.1.0",
-    "@biu/host-sessions": "0.1.0"
+    "@biu/host-sessions": "0.1.0",
+    "antd": "^6.6.1"
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1785,7 +1785,7 @@ export function CollectionBrowser({
                 onPointerDown={(event) => {
                   if (event.button !== 0) return
                   const hit = event.target as HTMLElement | null
-                  if (hit?.closest('.fsdb-row-check, .fsdb-col-resizer, .tasks-row-tools, .tasks-title-open, .fsdb-action-btn, .fsdb-boolbtn, .fsdb-thumb-btn, .fsdb-thumb')) return
+                  if (hit?.closest('.fsdb-row-check, .fsdb-col-resizer, .tasks-row-tools, .tasks-title-open, .fsdb-action-btn, .fsdb-boolbtn, .fsdb-thumb-btn, .fsdb-thumb, .ant-image')) return
                   const td = event.currentTarget
                   cellAnchorRef.current = td
                   cellPickRef.current = { id: row.id, key: col.key }

--- a/packages/core-file-system/src/web/cell-media.tsx
+++ b/packages/core-file-system/src/web/cell-media.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Image } from 'antd'
 import { PaperClipIcon, PhotoIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import { asAttachment, asHttpHref, asImageSrcList } from '@biu/type-file-system'
 import { LocalText } from './controls.tsx'
@@ -153,10 +154,11 @@ export function MediaField({
       }
     >
       {kind === 'image' && images.length ? (
+        <Image.PreviewGroup>
         <span className="fsdb-media-thumbs">
           {images.map((src, index) => (
             <span key={`${src}-${index}`} className="fsdb-media-thumb">
-              <img className="fsdb-media-preview" src={src} alt="" />
+              <Image className="fsdb-media-preview" src={src} alt="" width={18} height={18} preview={{ mask: false }} />
               <button
                 type="button"
                 className="fsdb-media-remove"
@@ -168,6 +170,7 @@ export function MediaField({
             </span>
           ))}
         </span>
+        </Image.PreviewGroup>
       ) : null}
       {kind === 'attachment' && file ? <PaperClipIcon aria-hidden className="size-[14px] shrink-0 opacity-80" /> : null}
       <button type="button" className="fsdb-media-pick" title={label} onClick={() => inputRef.current?.click()}>

--- a/packages/core-file-system/src/web/fsdb-cells.test.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.test.tsx
@@ -1,5 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { render } from '@testing-library/react'
 import { DefaultCell } from './fsdb-cells.tsx'
 
@@ -15,8 +17,8 @@ test('attachment cells render a file link, not a broken image', () => {
 
 test('image cells still render a thumbnail', () => {
   const { container } = render(<DefaultCell field={{ type: 'image' }} value="/page-covers/blue.png" />)
-  const img = container.querySelector('img.fsdb-thumb') as HTMLImageElement
-  assert.equal(img?.src.endsWith('/page-covers/blue.png'), true)
+  const img = container.querySelector('img') as HTMLImageElement
+  assert.equal(Boolean(img?.src.endsWith('/page-covers/blue.png')), true)
   assert.equal(img?.getAttribute('width'), '28')
   assert.equal(img?.getAttribute('height'), '18')
 })
@@ -25,7 +27,7 @@ test('image cells can show more than one thumbnail', () => {
   const { container } = render(
     <DefaultCell field={{ type: 'image' }} value={['/page-covers/blue.png', '/page-covers/red.png']} />,
   )
-  assert.equal(container.querySelectorAll('img.fsdb-thumb').length, 2)
+  assert.equal(container.querySelectorAll('img').length, 2)
 })
 
 test('empty cells render no placeholder copy', () => {
@@ -41,4 +43,20 @@ test('empty cells render no placeholder copy', () => {
   assert.equal(href.container.textContent, '')
   const emptyFile = render(<DefaultCell field={{ type: 'attachment' }} value={{}} />)
   assert.equal(emptyFile.container.textContent, '')
+})
+
+test('image zoom uses antd Image preview', () => {
+  const cells = readFileSync(resolve(import.meta.dirname, './fsdb-cells.tsx'), 'utf8')
+  const media = readFileSync(resolve(import.meta.dirname, './cell-media.tsx'), 'utf8')
+  const thumbs = readFileSync(resolve(import.meta.dirname, '../../../cap-chat/src/web/image-thumbs.tsx'), 'utf8')
+  const tools = readFileSync(resolve(import.meta.dirname, '../../../cap-chat/src/web/tool-card.tsx'), 'utf8')
+  assert.match(cells, /from 'antd'/)
+  assert.match(cells, /Image\.PreviewGroup/)
+  assert.doesNotMatch(cells, /fsdb-lightbox/)
+  assert.match(media, /from 'antd'/)
+  assert.match(media, /Image\.PreviewGroup/)
+  assert.match(thumbs, /from 'antd'/)
+  assert.match(thumbs, /Image\.PreviewGroup/)
+  assert.doesNotMatch(thumbs, /composer-image-lightbox/)
+  assert.match(tools, /Image\.PreviewGroup/)
 })

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { createPortal } from 'react-dom'
+import { useState } from 'react'
+import { Image } from 'antd'
 import { BoolBox, TagChip, TagChips } from '@biu/public-ui'
 import {
   ArchiveBoxArrowDownIcon,
@@ -145,47 +145,46 @@ export function BoolCell({
 }
 
 function ImageThumb({ src }: { src: string }) {
-  const [open, setOpen] = useState(false)
-  useEffect(() => {
-    if (!open) return
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false)
-    }
-    document.addEventListener('keydown', onKey)
-    return () => document.removeEventListener('keydown', onKey)
-  }, [open])
   return (
-    <>
-      <button
-        type="button"
-        className="fsdb-thumb-btn"
-        title="查看大图"
-        onPointerDown={(event) => event.stopPropagation()}
-        onClick={(event) => {
-          event.stopPropagation()
-          setOpen(true)
-        }}
-      >
-        <img className="fsdb-thumb" src={src} alt="" decoding="async" width={28} height={18} />
-      </button>
-      {open
-        ? createPortal(
-            <div
-              className="fsdb-lightbox"
-              role="dialog"
-              aria-modal="true"
-              aria-label="查看图片"
-              onMouseDown={(event) => {
-                event.stopPropagation()
-                if (event.target === event.currentTarget) setOpen(false)
-              }}
-            >
-              <img src={src} alt="" decoding="async" onClick={(event) => event.stopPropagation()} />
-            </div>,
-            document.body,
-          )
-        : null}
-    </>
+    <span className="fsdb-thumb-btn" onPointerDown={(event) => event.stopPropagation()}>
+      <Image
+        src={src}
+        alt=""
+        width={28}
+        height={18}
+        className="fsdb-thumb"
+        preview={{ mask: false }}
+      />
+    </span>
+  )
+}
+
+function ImageThumbs({ srcs, compact }: { srcs: string[]; compact?: boolean }) {
+  if (!srcs.length) return null
+  const shown = compact ? srcs.slice(0, 4) : srcs
+  return (
+    <Image.PreviewGroup>
+      {compact ? (
+        <span className="fsdb-thumbs">
+          {shown.map((src, index) => (
+            <ImageThumb key={`${src}-${index}`} src={src} />
+          ))}
+          {srcs.length > 4 ? <span className="fsdb-meta">+{srcs.length - 4}</span> : null}
+        </span>
+      ) : (
+        <div className="fsdb-fileview-imgs">
+          {shown.map((src, index) => (
+            <Image
+              key={`${src}-${index}`}
+              className="fsdb-fileview-img"
+              src={src}
+              alt=""
+              preview={{ mask: false }}
+            />
+          ))}
+        </div>
+      )}
+    </Image.PreviewGroup>
   )
 }
 
@@ -241,28 +240,12 @@ export function FilePreview({
   if (kind === 'image') {
     const list = asImageSrcList(value)
     if (!list.length) return null
-    if (compact) {
-      return (
-        <span className="fsdb-thumbs">
-          {list.slice(0, 4).map((src, index) => (
-            <ImageThumb key={`${src}-${index}`} src={src} />
-          ))}
-          {list.length > 4 ? <span className="fsdb-meta">+{list.length - 4}</span> : null}
-        </span>
-      )
-    }
-    return (
-      <div className="fsdb-fileview-imgs">
-        {list.map((src, index) => (
-          <img key={`${src}-${index}`} className="fsdb-fileview-img" src={src} alt="" decoding="async" />
-        ))}
-      </div>
-    )
+    return <ImageThumbs srcs={list} compact={compact} />
   }
   const src = previewImageSrc(kind, value)
   if (src) {
     if (compact) return <ImageThumb src={src} />
-    return <img className="fsdb-fileview-img" src={src} alt="" decoding="async" />
+    return <Image className="fsdb-fileview-img" src={src} alt="" preview={{ mask: false }} />
   }
   const file = asAttachment(value)
   if (file) {

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -125,15 +125,16 @@ const CSS = `
 .fsdb-link{color:inherit;text-underline-offset:2px;overflow-wrap:anywhere}
 .fsdb-link:hover{text-decoration:underline}
 .fsdb-thumb-btn{display:inline-flex;align-items:center;justify-content:center;line-height:0;border:0;padding:0;background:transparent;cursor:zoom-in;vertical-align:middle}
+.fsdb-thumb-btn .ant-image{display:inline-flex;line-height:0}
 .fsdb-thumb{display:block;width:28px;height:18px;object-fit:cover;border-radius:3px;background:var(--dsw-hover);flex:none;box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--dsw-border) 70%, transparent)}
-.fsdb-lightbox{position:fixed;inset:0;z-index:140;display:flex;align-items:center;justify-content:center;padding:28px;background:rgba(0,0,0,.72);cursor:zoom-out}
-.fsdb-lightbox img{max-width:min(92vw,1100px);max-height:88vh;object-fit:contain;border-radius:10px;box-shadow:0 16px 48px rgba(0,0,0,.45);cursor:default}
+.fsdb-thumb-btn .ant-image-img{display:block;width:28px;height:18px;object-fit:cover;border-radius:3px}
 .fsdb-file{display:inline-flex;align-items:center;gap:6px;min-width:0;color:inherit;text-underline-offset:2px}
 .fsdb-file:hover{text-decoration:underline}
 .fsdb-file-name{min-width:0;overflow:hidden;text-overflow:ellipsis}
 .fsdb-fileview{min-width:0;flex:none;height:auto;min-height:0;max-height:none;overflow:visible}
 .fsdb-fileview-pre{margin:0;padding:10px 12px;border-radius:8px;background:var(--dsw-input);color:var(--dsw-label);font:inherit;font-size:14px;font-family:var(--font-mono);white-space:pre-wrap;overflow:visible;height:auto;min-height:0;max-height:none}
 .fsdb-fileview-img{display:block;width:auto;max-width:100%;height:auto;max-height:none;object-fit:contain;border-radius:8px;background:var(--dsw-hover)}
+.fsdb-fileview-img .ant-image-img{display:block;width:auto;max-width:100%;height:auto;max-height:none;object-fit:contain;border-radius:8px}
 .fsdb-page .tasks-table td:has(.fsdb-title-host){position:relative}
 .fsdb-page .tasks-tree-toggle{width:20px;height:20px;flex:none;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:var(--dsw-label-3);border-radius:4px;cursor:pointer;padding:0}
 .fsdb-page .tasks-tree-toggle:hover{background:var(--dsw-hover)}
@@ -431,6 +432,7 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-cell-pop-text{box-sizing:border-box;width:100%;min-height:72px;margin:0;border:0;border-radius:6px;padding:4px 2px;background:transparent;color:var(--dsw-label);font:inherit;font-size:14px;line-height:1.45;resize:vertical;outline:none}
 .fsdb-media-field{display:flex;flex-direction:row;flex-wrap:nowrap;align-items:center;gap:6px;min-width:0;max-width:100%;height:22px}
 .fsdb-media-preview{display:block;width:18px;height:18px;flex:none;object-fit:cover;border-radius:3px;background:#111}
+.fsdb-media-thumb .ant-image-img{display:block;width:18px;height:18px;object-fit:cover;border-radius:3px}
 .fsdb-media-thumbs{display:inline-flex;align-items:center;gap:4px;min-width:0;overflow:auto}
 .fsdb-media-thumb{position:relative;flex:none;line-height:0}
 .fsdb-media-remove{position:absolute;top:-3px;right:-3px;display:grid;place-items:center;width:12px;height:12px;margin:0;border:0;border-radius:6px;padding:0;background:#202020;color:var(--dsw-label);cursor:pointer}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -194,7 +194,7 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(browser, /is-cell-ro/)
   assert.match(browser, /cellFieldWritable/)
   assert.match(browser, /<CellPop/)
-  assert.match(browser, /\.fsdb-thumb-btn, \.fsdb-thumb/)
+  assert.match(browser, /\.fsdb-thumb-btn, \.fsdb-thumb, \.ant-image/)
   assert.doesNotMatch(browser, /skipBoolean/)
 })
 

--- a/web/style.css
+++ b/web/style.css
@@ -5310,7 +5310,8 @@ body {
   height: 56px;
 }
 
-.composer-image-thumb {
+.composer-image-thumb,
+.composer-image-thumb.ant-image {
   display: block;
   width: 56px;
   height: 56px;
@@ -5322,7 +5323,8 @@ body {
   cursor: zoom-in;
 }
 
-.composer-image-thumb img {
+.composer-image-thumb img,
+.composer-image-thumb .ant-image-img {
   display: block;
   width: 100%;
   height: 100%;
@@ -5344,25 +5346,6 @@ body {
   font-size: 11px;
   line-height: 1;
   cursor: pointer;
-}
-
-.composer-image-lightbox {
-  position: fixed;
-  inset: 0;
-  z-index: 90;
-  display: grid;
-  place-items: center;
-  padding: 24px;
-  background: rgba(0, 0, 0, 0.72);
-  cursor: zoom-out;
-}
-
-.composer-image-lightbox img {
-  max-width: min(920px, 92vw);
-  max-height: 88vh;
-  border-radius: 10px;
-  box-shadow: var(--dsw-shadow-lv2);
-  object-fit: contain;
 }
 
 .user-pick-chips {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格缩略图、详情大图、单元格图片编辑、聊天输入/气泡里的图，点开放大都改用 antd `Image` / `PreviewGroup`。工具产物图本来就是这套。去掉自绘 lightbox。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

