### PR TITLE
db_content 支持按行读和局部替换

### DIFF
--- a/packages/core-file-system/src/host/content-edit.test.ts
+++ b/packages/core-file-system/src/host/content-edit.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  asContentText,
+  insertText,
+  replaceLinesText,
+  resolveContentCommand,
+  strReplaceText,
+  viewContent,
+} from './content-edit.ts'
+
+test('view numbers lines and defaults to an 80-line window', () => {
+  const text = Array.from({ length: 100 }, (_, i) => `L${i + 1}`).join('\n')
+  const viewed = viewContent(text, undefined)
+  assert.equal(viewed.start, 1)
+  assert.equal(viewed.end, 80)
+  assert.equal(viewed.total, 100)
+  assert.equal(viewed.truncated, true)
+  assert.match(viewed.text, /^  1\tL1/)
+  assert.match(viewed.text, /80\tL80$/)
+  const ranged = viewContent(text, [90, -1])
+  assert.equal(ranged.start, 90)
+  assert.equal(ranged.end, 100)
+  assert.equal(ranged.truncated, true)
+})
+
+test('str_replace requires a unique old_str', () => {
+  assert.equal(strReplaceText('aa\nbb\n', 'bb', 'cc'), 'aa\ncc\n')
+  assert.throws(() => strReplaceText('aa\naa\n', 'aa', 'x'), /not unique/)
+  assert.throws(() => strReplaceText('aa\n', 'zz', 'x'), /not found/)
+})
+
+test('insert and replace_lines edit by 1-based line numbers', () => {
+  assert.equal(insertText('a\nb\nc', 1, 'x'), 'a\nx\nb\nc')
+  assert.equal(insertText('a\nb', 0, 'x'), 'x\na\nb')
+  assert.equal(replaceLinesText('a\nb\nc', 2, 3, 'x\ny'), 'a\nx\ny')
+  assert.equal(replaceLinesText('a\nb\nc', 2, 2, ''), 'a\nc')
+})
+
+test('command defaults to view, or write when value is passed', () => {
+  assert.equal(resolveContentCommand({}), 'view')
+  assert.equal(resolveContentCommand({ value: 'x' }), 'write')
+  assert.equal(resolveContentCommand({ command: 'str_replace' }), 'str_replace')
+  assert.equal(asContentText({ a: 1 }), '{\n  "a": 1\n}')
+})

--- a/packages/core-file-system/src/host/content-edit.ts
+++ b/packages/core-file-system/src/host/content-edit.ts
@@ -1,0 +1,102 @@
+export const DEFAULT_VIEW_WINDOW = 80
+
+export type ContentCommand = 'view' | 'str_replace' | 'replace_lines' | 'insert' | 'write'
+
+export function asContentText(value: unknown) {
+  if (value == null) return ''
+  if (typeof value === 'string') return value
+  return JSON.stringify(value, null, 2)
+}
+
+export function resolveContentCommand(args: Record<string, unknown>): ContentCommand {
+  const raw = String(args.command ?? '').trim()
+  if (raw) {
+    if (raw === 'view' || raw === 'str_replace' || raw === 'replace_lines' || raw === 'insert' || raw === 'write') return raw
+    throw new Error(`unsupported command: ${raw}`)
+  }
+  return args.value !== undefined ? 'write' : 'view'
+}
+
+export function numberLines(text: string) {
+  const lines = text.split('\n')
+  const width = String(Math.max(lines.length, 1)).length
+  return lines.map((line, index) => `${String(index + 1).padStart(width)}\t${line}`)
+}
+
+export function viewContent(text: string, viewRange: unknown) {
+  const lines = text.split('\n')
+  const total = lines.length
+  const numbered = numberLines(text)
+  const range = parseViewRange(viewRange, total)
+  const truncated = range.start > 1 || range.end < total
+  return {
+    start: range.start,
+    end: range.end,
+    total,
+    truncated,
+    text: numbered.slice(range.start - 1, range.end).join('\n'),
+  }
+}
+
+function parseViewRange(viewRange: unknown, lineCount: number) {
+  if (!Array.isArray(viewRange) || viewRange.length === 0) {
+    return { start: 1, end: Math.min(DEFAULT_VIEW_WINDOW, Math.max(lineCount, 1)) }
+  }
+  const start = Number(viewRange[0])
+  const endRaw = viewRange.length > 1 ? Number(viewRange[1]) : start
+  if (!Number.isInteger(start) || start < 1) throw new Error('view_range start must be a positive integer')
+  const end = endRaw === -1 ? lineCount : endRaw
+  if (!Number.isInteger(end) || end < start) throw new Error('invalid view_range')
+  return { start, end: Math.min(end, Math.max(lineCount, 1)) }
+}
+
+export function strReplaceText(text: string, oldStr: unknown, newStr: unknown) {
+  if (typeof oldStr !== 'string' || !oldStr) throw new Error('old_str is required for str_replace')
+  const nextNew = typeof newStr === 'string' ? newStr : ''
+  const occurrences = countOccurrences(text, oldStr)
+  if (occurrences === 0) throw new Error('old_str not found')
+  if (occurrences > 1) throw new Error(`old_str is not unique (${occurrences} matches)`)
+  return text.replace(oldStr, nextNew)
+}
+
+export function insertText(text: string, insertLine: unknown, newStr: unknown) {
+  if (typeof newStr !== 'string') throw new Error('new_str is required for insert')
+  const line = Number(insertLine)
+  if (!Number.isInteger(line) || line < 0) throw new Error('insert_line must be a non-negative integer')
+  const lines = text.split('\n')
+  if (line > lines.length) throw new Error(`insert_line ${line} is beyond end of content (${lines.length} lines)`)
+  lines.splice(line, 0, newStr)
+  return lines.join('\n')
+}
+
+export function replaceLinesText(text: string, startLine: unknown, endLine: unknown, newStr: unknown) {
+  if (typeof newStr !== 'string') throw new Error('new_str is required for replace_lines')
+  const start = Number(startLine)
+  const end = Number(endLine)
+  if (!Number.isInteger(start) || !Number.isInteger(end) || start < 1 || end < start) {
+    throw new Error('replace_lines needs 1-based start_line and end_line')
+  }
+  const lines = text.split('\n')
+  if (start > lines.length) throw new Error(`start_line ${start} is beyond end of content (${lines.length} lines)`)
+  const last = Math.min(end, lines.length)
+  const parts = newStr === '' ? [] : newStr.split('\n')
+  lines.splice(start - 1, last - start + 1, ...parts)
+  return lines.join('\n')
+}
+
+function countOccurrences(haystack: string, needle: string) {
+  let count = 0
+  let from = 0
+  while (true) {
+    const idx = haystack.indexOf(needle, from)
+    if (idx === -1) break
+    count += 1
+    from = idx + needle.length
+  }
+  return count
+}
+
+export function writeContentText(value: unknown) {
+  if (typeof value !== 'string') throw new Error('write needs string value')
+  return value
+}

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -232,6 +232,48 @@ test('content is omitted from list/read and served on its own path', async () =>
   assert.deepEqual(written.value, { kind: 'note', body: { a: 2 } })
 })
 
+test('editContent view/str_replace/replace_lines/insert/write', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  const rows = new Map<string, Record<string, unknown>>([
+    ['n1', { id: 'n1', title: 'a', content: 'one\ntwo\nthree\nfour' }],
+  ])
+  db.register({
+    id: 'docs',
+    path: '/docs',
+    schema: {
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string', writable: true },
+        content: { type: 'file', writable: true },
+      },
+    },
+    list: () => [...rows.values()] as { id: string }[],
+    get: (id) => rows.get(id) as { id: string } | undefined,
+    records: { update: true },
+    update: (id, patch) => {
+      const next = { ...rows.get(id), ...patch, id }
+      rows.set(id, next)
+      return next as { id: string }
+    },
+  })
+  const viewed = await db.editContent('/docs/n1', { command: 'view', view_range: [2, 3] })
+  assert.equal(viewed.command, 'view')
+  assert.equal(viewed.truncated, true)
+  assert.match(String(viewed.text), /2\ttwo/)
+  assert.equal('value' in viewed, false)
+  const replaced = await db.editContent('/docs/n1', { command: 'str_replace', old_str: 'two', new_str: 'TWO' })
+  assert.equal(replaced.ok, true)
+  assert.equal('value' in replaced, false)
+  assert.equal((await db.content('/docs/n1')).value, 'one\nTWO\nthree\nfour')
+  await db.editContent('/docs/n1', { command: 'replace_lines', start_line: 3, end_line: 4, new_str: 'C\nD' })
+  assert.equal((await db.content('/docs/n1')).value, 'one\nTWO\nC\nD')
+  await db.editContent('/docs/n1', { command: 'insert', insert_line: 1, new_str: 'mid' })
+  assert.equal((await db.content('/docs/n1')).value, 'one\nmid\nTWO\nC\nD')
+  await db.editContent('/docs/n1', { command: 'write', value: 'done' })
+  assert.equal((await db.content('/docs/n1')).value, 'done')
+})
+
 test('list paginates collection records and reports total', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -28,6 +28,15 @@ import {
 import { SavedViewsStore, viewsCollection, type StoredView } from './saved-views.ts'
 import { FacetStore, FILE_SYSTEM_SQLITE } from './facets-store.ts'
 import { facetsCollection } from './facets-collection.ts'
+import {
+  asContentText,
+  insertText,
+  replaceLinesText,
+  resolveContentCommand,
+  strReplaceText,
+  viewContent,
+  writeContentText,
+} from './content-edit.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { databaseRevealForTool, normalizeCollectionPath } from '../paths.ts'
 
@@ -760,6 +769,42 @@ export class DatabaseService extends Service implements Database {
       value: record[field] ?? null,
     }
   }
+
+  async editContent(path: string, args: Record<string, unknown> = {}) {
+    const command = resolveContentCommand(args)
+    const current = await this.content(path)
+    const text = asContentText(current.value)
+    if (command === 'view') {
+      const viewed = viewContent(text, args.view_range)
+      return {
+        kind: 'content' as const,
+        path: current.path,
+        field: current.field,
+        command,
+        start: viewed.start,
+        end: viewed.end,
+        total: viewed.total,
+        truncated: viewed.truncated,
+        text: viewed.text,
+      }
+    }
+    const next =
+      command === 'write'
+        ? writeContentText(args.value ?? args.new_str)
+        : command === 'str_replace'
+          ? strReplaceText(text, args.old_str, args.new_str)
+          : command === 'insert'
+            ? insertText(text, args.insert_line, args.new_str)
+            : replaceLinesText(text, args.start_line, args.end_line, args.new_str)
+    await this.writeContent(path, next)
+    return {
+      kind: 'content' as const,
+      path: current.path,
+      field: current.field,
+      command,
+      ok: true as const,
+    }
+  }
 }
 
 function parseContent(content: unknown): Record<string, unknown> {
@@ -1009,19 +1054,39 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_content',
-    description: '读写一条记录的正文（content 字段）。list/read 不含正文。path 为 /<表>/<id>，写时传 value。',
+    description: [
+      '读写一条记录的正文。list/read 不含正文。path 为 /<表>/<id>。',
+      'command=view：带行号读一段正文，默认前 80 行，可用 view_range=[start,end]（1-based，end=-1 到末尾）；truncated 表示还有未读行。',
+      'command=str_replace：old_str 必须在正文里唯一，替换为 new_str。',
+      'command=replace_lines：按 1-based 闭区间 start_line..end_line 换成 new_str。',
+      'command=insert：在 insert_line 之后插入 new_str（0 插到第一行前）。',
+      'command=write：整篇覆盖，传 value。写成功只返回 ok，不含全文。',
+    ].join(' '),
     parameters: {
       type: 'object',
       properties: {
         path: { type: 'string' },
-        value: { description: '要写入的正文；不传则只读' },
+        command: {
+          type: 'string',
+          enum: ['view', 'str_replace', 'replace_lines', 'insert', 'write'],
+          description: 'view | str_replace | replace_lines | insert | write。省略时：有 value 则 write，否则 view。',
+        },
+        value: { type: 'string', description: 'write 的全文' },
+        old_str: { type: 'string', description: 'str_replace 要替换的原文，必须唯一' },
+        new_str: { type: 'string', description: 'str_replace / insert / replace_lines 的新文本' },
+        insert_line: { type: 'integer', description: 'insert：在该行之后插入' },
+        start_line: { type: 'integer', description: 'replace_lines 起始行（含）' },
+        end_line: { type: 'integer', description: 'replace_lines 结束行（含）' },
+        view_range: {
+          type: 'array',
+          items: { type: 'integer' },
+          description: 'view 的行区间，如 [11, 20] 或 [80, -1]',
+        },
       },
       required: ['path'],
     },
     execute: (args) =>
-      withInspectorReveal(ctx, String(args.path), () =>
-        args.value !== undefined ? db.writeContent(String(args.path), args.value) : db.content(String(args.path)),
-      ),
+      withInspectorReveal(ctx, String(args.path), () => db.editContent(String(args.path), args)),
   })
 
   const send = async (route: { query: URLSearchParams; send: (status: number, body: unknown) => void }, op: () => unknown) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`db_content` 不再只能整篇读写。Agent 用 `command` 操作正文：

- **view**：带行号读窗口，默认前 80 行；`view_range=[start,end]`（`end=-1` 到末尾）；`truncated` 表示还有未读行
- **str_replace**：`old_str` 必须唯一，换成 `new_str`
- **replace_lines**：1-based 闭区间 `start_line`..`end_line` 换成 `new_str`
- **insert**：在 `insert_line` 之后插入（0 插到第一行前）
- **write**：整篇覆盖（`value`）

写成功只返回 `ok`，不把全文塞回 tool result。HTTP `/api/db/content` 仍给 UI 整篇读写。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

