### PR TITLE
合集详情：属性在上，正文下添加属性，再是收集表

### DIFF
--- a/packages/core-file-system/src/web/facet-chrome.tsx
+++ b/packages/core-file-system/src/web/facet-chrome.tsx
@@ -11,5 +11,5 @@ function FacetFieldsPane({ record }: { record: { id: string } }) {
 
 export const facetsChrome: CollectionChrome = {
   Board: FacetCollectBoard,
-  panes: [{ id: 'fields', label: '字段', Pane: FacetFieldsPane }],
+  panes: [{ id: 'fields', label: '属性', Pane: FacetFieldsPane }],
 }

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -62,6 +62,8 @@ test('tag collect table lives on the record board, not as sidebar views', () => 
   assert.match(collect, /<CollectionBrowser/)
   assert.match(browser, /sheet\?: boolean/)
   assert.match(detail, /chrome\?\.Board/)
+  assert.doesNotMatch(detail, /chrome\?\.Board \? null/)
+  assert.match(chrome, /label: '属性'/)
   assert.doesNotMatch(views, /normalized === '\/views'/)
   assert.doesNotMatch(views, /normalized === '\/facets'/)
   const viewsUi = readFileSync(resolve(import.meta.dirname, './views-chrome.ts'), 'utf8')

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, type ReactNode, type Dispatch, type SetStateAction
 import type { CollectionChrome } from '@biu/type-file-system/ui'
 import type { CollectionSchema, DbRecord, FieldSpec } from '@biu/type-file-system'
 import { ChevronDownIcon, ChevronUpIcon, HashtagIcon } from '@heroicons/react/16/solid'
-import { contentFieldKey, formatField, resolveFieldType } from './fields.ts'
+import { contentFieldKey, fieldHasValue, formatField, resolveFieldType } from './fields.ts'
 import { LocalText } from './controls.tsx'
 import { FilePreview } from './fsdb-cells.tsx'
 import { PropertyRow } from './property-row.tsx'
@@ -180,6 +180,31 @@ export function RecordDetail({
                   <h1 className="fsdb-detail-title">{labelOf(selected)}</h1>
                 )}
                 </div>
+                <div className="fsdb-detail-aside">
+                  <div className="fsdb-prop">
+                    <span>
+                      <HashtagIcon aria-hidden className="size-[14px]" />
+                      ID
+                    </span>
+                    <span className="fsdb-detail-id" title={selected.id}>
+                      {selected.id}
+                    </span>
+                  </div>
+                  {Object.entries(schema.fields).map(([key, field]) => {
+                    if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return null
+                    if (chrome?.panes?.some((pane) => pane.id === key)) return null
+                    const kind = resolveFieldType(field)
+                    if (kind === 'facet' && !field.writable) return null
+                    if (field.computed && !fieldHasValue(field, selected[key])) return null
+                    return (
+                      <PropertyRow key={key} field={field} fieldKey={key} stacked={kind === 'facet'}>
+                        <div className={kind === 'facet' ? 'fsdb-prop-val is-schema' : 'fsdb-prop-val'} title={formatField(field, selected[key])}>
+                          {renderCell(selected, key, field)}
+                        </div>
+                      </PropertyRow>
+                    )
+                  })}
+                </div>
                 {contentFieldKey(schema) && schema.fields[contentFieldKey(schema)!] ? (() => {
                   const key = contentFieldKey(schema)!
                   const spec = schema.fields[key]!
@@ -231,32 +256,6 @@ export function RecordDetail({
                     </div>
                   )
                 })() : null}
-                {chrome?.Board ? <chrome.Board record={selected} openRecord={onOpenRecord} /> : null}
-                {chrome?.Board ? null : (
-                <div className="fsdb-detail-aside">
-                  <div className="fsdb-prop">
-                    <span>
-                      <HashtagIcon aria-hidden className="size-[14px]" />
-                      ID
-                    </span>
-                    <span className="fsdb-detail-id" title={selected.id}>
-                      {selected.id}
-                    </span>
-                  </div>
-                  {Object.entries(schema.fields).map(([key, field]) => {
-                    if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return null
-                    const kind = resolveFieldType(field)
-                    if (kind === 'facet' && !field.writable) return null
-                    return (
-                      <PropertyRow key={key} field={field} fieldKey={key} stacked={kind === 'facet'}>
-                        <div className={kind === 'facet' ? 'fsdb-prop-val is-schema' : 'fsdb-prop-val'} title={formatField(field, selected[key])}>
-                          {renderCell(selected, key, field)}
-                        </div>
-                      </PropertyRow>
-                    )
-                  })}
-                </div>
-                )}
                 {chrome?.panes?.length ? (
                   <div className="fsdb-detail-extras">
                     {chrome.panes.map((pane) => {
@@ -274,6 +273,7 @@ export function RecordDetail({
                     })}
                   </div>
                 ) : null}
+                {chrome?.Board ? <chrome.Board record={selected} openRecord={onOpenRecord} /> : null}
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
合集详情改成和任务一样的纵向结构：

1. 标题下的属性行（ID、收集数等）
2. 正文编辑器
3. 「添加属性」（原先藏在 Board 后面、被整段属性栏吃掉了）
4. 最下面才是合集里那张收集表

有 Board 不再隐藏属性栏。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

