### PR TITLE
合集属性沉底，默认收缩，悬停图标展开

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -305,6 +305,12 @@ const CSS = `
 .fsdb-proprow-v,.fsdb-prop-val,.fsdb-detail-id{min-width:0;color:#7C7A76}
 .fsdb-proprow.is-stack,.fsdb-prop.is-stack{align-items:flex-start;flex-wrap:wrap}
 .fsdb-proprow.is-stack .fsdb-proprow-k,.fsdb-prop.is-stack>span:first-child{padding-top:6px}
+.fsdb-proprow-fold{position:relative;display:inline-grid;place-items:center;width:14px;height:14px;flex:none;margin:0;border:0;padding:0;background:transparent;color:inherit;cursor:pointer}
+.fsdb-proprow-glyph,.fsdb-proprow-chevron{display:grid;place-items:center;width:14px;height:14px}
+.fsdb-proprow-chevron{position:absolute;inset:0;opacity:0;pointer-events:none}
+.fsdb-proprow.is-facet-fold:hover .fsdb-proprow-glyph,.fsdb-proprow.is-facet-fold:focus-within .fsdb-proprow-glyph{opacity:0}
+.fsdb-proprow.is-facet-fold:hover .fsdb-proprow-chevron,.fsdb-proprow.is-facet-fold:focus-within .fsdb-proprow-chevron{opacity:1}
+.fsdb-proprow.is-facet-fold:not(.is-open) .fsdb-schema-pack{display:none}
 .fsdb-prop-val.is-schema{overflow:visible;white-space:normal;max-width:none}
 .fsdb-schema{display:flex;flex-direction:column;gap:2px;min-width:0;width:100%}
 .fsdb-schema-pack{display:flex;flex-direction:column;gap:0;min-width:0;padding:4px 0 8px}

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -70,3 +70,17 @@ test('tag collect table lives on the record board, not as sidebar views', () => 
   assert.match(viewsUi, /openRow/)
   assert.match(viewsUi, /mergeCatalogViews/)
 })
+
+test('detail facet property sits last, starts collapsed, and the glyph becomes a fold control on hover', () => {
+  const detail = readFileSync(resolve(import.meta.dirname, './record-detail.tsx'), 'utf8')
+  const row = readFileSync(resolve(import.meta.dirname, './property-row.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
+  assert.match(detail, /resolveFieldType\(a\) === 'facet'/)
+  assert.match(detail, /useState\(false\)/)
+  assert.match(detail, /collapsible=\{facet\}/)
+  assert.match(row, /收起合集/)
+  assert.match(row, /展开合集/)
+  assert.match(row, /ChevronRightIcon/)
+  assert.match(css, /\.fsdb-proprow\.is-facet-fold:hover \.fsdb-proprow-chevron/)
+  assert.match(css, /\.fsdb-proprow\.is-facet-fold:not\(\.is-open\) \.fsdb-schema-pack\{display:none\}/)
+})

--- a/packages/core-file-system/src/web/property-row.tsx
+++ b/packages/core-file-system/src/web/property-row.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react'
 import type { FieldSpec } from '@biu/type-file-system'
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/16/solid'
 import { resolveFieldType } from './fields.ts'
 import { FieldGlyph } from './fsdb-cells.tsx'
 
@@ -7,19 +8,42 @@ export function PropertyRow({
   field,
   fieldKey,
   stacked,
+  collapsible,
+  expanded,
+  onToggle,
   children,
 }: {
   field: FieldSpec
   fieldKey?: string
   stacked?: boolean
+  collapsible?: boolean
+  expanded?: boolean
+  onToggle?: () => void
   children: ReactNode
 }) {
   const kind = resolveFieldType(field)
   const label = field.label ?? fieldKey ?? ''
   return (
-    <div className={`fsdb-proprow${stacked ? ' is-stack' : ''}`}>
+    <div className={`fsdb-proprow${stacked ? ' is-stack' : ''}${collapsible ? ' is-facet-fold' : ''}${expanded ? ' is-open' : ''}`}>
       <span className="fsdb-proprow-k" title={label}>
-        <FieldGlyph kind={kind} />
+        {collapsible ? (
+          <button
+            type="button"
+            className="fsdb-proprow-fold"
+            aria-expanded={Boolean(expanded)}
+            aria-label={expanded ? '收起合集' : '展开合集'}
+            onClick={onToggle}
+          >
+            <span className="fsdb-proprow-glyph" aria-hidden>
+              <FieldGlyph kind={kind} />
+            </span>
+            <span className="fsdb-proprow-chevron" aria-hidden>
+              {expanded ? <ChevronDownIcon className="size-[14px]" /> : <ChevronRightIcon className="size-[14px]" />}
+            </span>
+          </button>
+        ) : (
+          <FieldGlyph kind={kind} />
+        )}
         <span className="fsdb-proprow-label">{label}</span>
       </span>
       <span className="fsdb-proprow-v">{children}</span>

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -134,6 +134,22 @@ export function RecordDetail({
     return () => window.removeEventListener(FOCUS_RECORD_TITLE, onTitle)
   }, [])
 
+  const [facetOpen, setFacetOpen] = useState(false)
+  useEffect(() => {
+    setFacetOpen(false)
+  }, [selected.id])
+
+  const propertyEntries = Object.entries(schema.fields)
+    .filter(([key, field]) => {
+      if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return false
+      if (chrome?.panes?.some((pane) => pane.id === key)) return false
+      const kind = resolveFieldType(field)
+      if (kind === 'facet' && !field.writable) return false
+      if (field.computed && !fieldHasValue(field, selected[key])) return false
+      return true
+    })
+    .sort(([, a], [, b]) => Number(resolveFieldType(a) === 'facet') - Number(resolveFieldType(b) === 'facet'))
+
   return (
 <div className="fsdb-detail-stage">
           <div className="fsdb-detail-screen" role="main" aria-label="记录详情">
@@ -190,15 +206,20 @@ export function RecordDetail({
                       {selected.id}
                     </span>
                   </div>
-                  {Object.entries(schema.fields).map(([key, field]) => {
-                    if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return null
-                    if (chrome?.panes?.some((pane) => pane.id === key)) return null
+                  {propertyEntries.map(([key, field]) => {
                     const kind = resolveFieldType(field)
-                    if (kind === 'facet' && !field.writable) return null
-                    if (field.computed && !fieldHasValue(field, selected[key])) return null
+                    const facet = kind === 'facet'
                     return (
-                      <PropertyRow key={key} field={field} fieldKey={key} stacked={kind === 'facet'}>
-                        <div className={kind === 'facet' ? 'fsdb-prop-val is-schema' : 'fsdb-prop-val'} title={formatField(field, selected[key])}>
+                      <PropertyRow
+                        key={key}
+                        field={field}
+                        fieldKey={key}
+                        stacked={facet && facetOpen}
+                        collapsible={facet}
+                        expanded={facet ? facetOpen : undefined}
+                        onToggle={facet ? () => setFacetOpen((open) => !open) : undefined}
+                      >
+                        <div className={facet ? 'fsdb-prop-val is-schema' : 'fsdb-prop-val'} title={formatField(field, selected[key])}>
                           {renderCell(selected, key, field)}
                         </div>
                       </PropertyRow>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面/任务等记录详情里，合集属性固定排在其他属性最下面。默认收缩，只留合集标签；悬停该行时前面的合集图标变成展开/收起按钮。展开后才显示各合集下的字段，避免一长串把详情顶得很长。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

