### PR TITLE
展开合集时标签行高度不变

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -310,6 +310,10 @@ const CSS = `
 .fsdb-proprow-chevron{position:absolute;inset:0;opacity:0;pointer-events:none}
 .fsdb-proprow.is-facet-fold:hover .fsdb-proprow-glyph,.fsdb-proprow.is-facet-fold:focus-within .fsdb-proprow-glyph{opacity:0}
 .fsdb-proprow.is-facet-fold:hover .fsdb-proprow-chevron,.fsdb-proprow.is-facet-fold:focus-within .fsdb-proprow-chevron{opacity:1}
+.fsdb-proprow.is-facet-fold{align-items:start}
+.fsdb-proprow.is-facet-fold .fsdb-proprow-k{min-height:32px;padding-top:0}
+.fsdb-proprow.is-facet-fold .fsdb-proprow-v,.fsdb-proprow.is-facet-fold .fsdb-prop-val.is-schema{min-height:32px}
+.fsdb-proprow.is-facet-fold .fsdb-schema>:first-child{min-height:32px;display:flex;align-items:center}
 .fsdb-proprow.is-facet-fold:not(.is-open) .fsdb-schema-pack{display:none}
 .fsdb-prop-val.is-schema{overflow:visible;white-space:normal;max-width:none}
 .fsdb-schema{display:flex;flex-direction:column;gap:2px;min-width:0;width:100%}

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -83,4 +83,7 @@ test('detail facet property sits last, starts collapsed, and the glyph becomes a
   assert.match(row, /ChevronRightIcon/)
   assert.match(css, /\.fsdb-proprow\.is-facet-fold:hover \.fsdb-proprow-chevron/)
   assert.match(css, /\.fsdb-proprow\.is-facet-fold:not\(\.is-open\) \.fsdb-schema-pack\{display:none\}/)
+  assert.doesNotMatch(detail, /stacked=\{facet && facetOpen\}/)
+  assert.match(css, /\.fsdb-proprow\.is-facet-fold\{align-items:start\}/)
+  assert.match(css, /\.fsdb-proprow\.is-facet-fold \.fsdb-schema>:first-child\{[^}]*min-height:32px/)
 })

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -214,7 +214,6 @@ export function RecordDetail({
                         key={key}
                         field={field}
                         fieldKey={key}
-                        stacked={facet && facetOpen}
                         collapsible={facet}
                         expanded={facet ? facetOpen : undefined}
                         onToggle={facet ? () => setFacetOpen((open) => !open) : undefined}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
展开合集时不再切到 `is-stack` 顶对齐，合集标签那一行保持 32px 高度，多出来的字段只往下长，值不会往上跳。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

