### PR TITLE
检查器分页贴底，不再随表格下滚

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2041,7 +2041,7 @@ export function CollectionBrowser({
         <div className="fsdb-right-body">
         <div
           key={nested ? 'embed' : `${collectionPath}:${detailId ?? ''}`}
-          className={nested ? undefined : 'app-pane-in'}
+          className="app-pane-in"
         >
         {!detailId ? (
         <div className="tasks-main fsdb-main">

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -31,6 +31,8 @@ const CSS = `
 .fsdb-right-body:has(.fsdb-detail-stage) .app-pane-in{flex:none;width:100%;align-self:stretch;min-height:min-content;height:auto;overflow:visible}
 .fsdb-right-body:has(> * > .fsdb-workspace > .fsdb-pager){overflow:hidden}
 .fsdb-right-body:has(> * > .fsdb-workspace > .fsdb-pager)>*,.fsdb-right-body:has(> * > .fsdb-workspace > .fsdb-pager) .fsdb-main{display:flex;flex-direction:column;min-height:0;flex:1;height:100%;overflow:hidden}
+.inspector-database-page .fsdb-right-body{overflow:hidden}
+.inspector-database-page .fsdb-right-body>*,.inspector-database-page .fsdb-main{display:flex;flex-direction:column;min-height:0;flex:1;height:100%;overflow:hidden}
 .fsdb-right-body:has(.fsdb-detail-stage){overflow:auto}
 .fsdb-views{display:flex;width:100%;max-width:none;min-width:0;flex:1;flex-direction:column;min-height:0;overflow:hidden;box-sizing:border-box}
 .fsdb-page>.fsdb-views{width:var(--sidebar-col,var(--dsw-sidebar-min,160px));max-width:var(--dsw-sidebar-max,360px);flex:none}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -344,6 +344,7 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(style, /\.fsdb-fileview-img\{[^}]*max-height:none/)
   assert.match(style, /\.fsdb-right-body\{[^}]*overflow:auto/)
   assert.match(browser, /app-pane-in/)
+  assert.doesNotMatch(browser, /nested \? undefined : 'app-pane-in'/)
   assert.match(browser, /key=\{nested \? 'embed' : `\$\{collectionPath\}:\$\{detailId \?\? ''\}`\}/)
   assert.match(style, /\.fsdb-detail-split\{[^}]*overflow:visible/)
   assert.doesNotMatch(style, /\.fsdb-fileview-pre\{[^}]*overflow:auto/)

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -49,6 +49,8 @@ test('list and detail share the chat column max width with side padding', () => 
   assert.match(css, /\.fsdb-right-body:has\(> \* > \.fsdb-workspace > \.fsdb-pager\)\{[^}]*overflow:hidden/)
   assert.match(css, /\.fsdb-right-body:has\(\.fsdb-detail-stage\)\{[^}]*overflow:auto/)
   assert.doesNotMatch(css, /\.fsdb-right-body:has\(\.fsdb-pager\)\{/)
+  assert.match(css, /\.inspector-database-page \.fsdb-right-body\{[^}]*overflow:hidden/)
+  assert.match(css, /\.inspector-database-page \.fsdb-right-body>\*,\.inspector-database-page \.fsdb-main\{[^}]*overflow:hidden/)
   assert.match(css, /\.fsdb-pager\{[^}]*margin-top:auto/)
   assert.match(css, /\.fsdb-page\{[^}]*--fsdb-pager-lift:calc\(1rem \+ 44px \+ 25px \+ 25px - 30px\)/)
   assert.match(css, /\.inspector-database-page \.fsdb-pager\{[^}]*var\(--fsdb-pager-lift\)/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
检查器里的数据表分页原先会跟着表格一起往下滚。嵌套浏览跳过了 `app-pane-in`，右侧滚动容器被内容撑高，分页就掉到内容末尾。

现在检查器列表也走和中间栏相同的 flex 锁：表格自己滚，分页贴在面板底部，并继续用 `--fsdb-pager-lift` 与左侧分页对齐。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

