### PR TITLE
Fix 合集 cell popover loadFacets crash

### DIFF
--- a/packages/core-file-system/src/web/cell-pop-draft.tsx
+++ b/packages/core-file-system/src/web/cell-pop-draft.tsx
@@ -10,6 +10,7 @@ import {
 import { TagChip, TagChips } from '@biu/public-ui'
 import { DbSearchOption, ensureDbSearchStyle } from '@biu/database-ui'
 import { FieldEditor, fieldDraftValue, parseFieldValue } from './fsdb-cells.tsx'
+import { loadFacets, persistFacets, slugFacetId, subscribeFacets } from './facet-catalog.ts'
 import { PersonPickPanel } from './person-cell.tsx'
 import { RecordPickPanel } from './record-link-cell.tsx'
 import { asStringList, isParentLinkField, isRecordLinkField, parseFacetFlatColumnKey, resolveFieldType } from './fields.ts'

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -204,6 +204,7 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(browser, /if \(surface === 'table'\)/)
   assert.match(browser, /<CellPopDraft/)
   const popDraft = readFileSync(resolve(import.meta.dirname, './cell-pop-draft.tsx'), 'utf8')
+  assert.match(popDraft, /loadFacets, persistFacets, slugFacetId, subscribeFacets/)
   assert.doesNotMatch(popDraft, /提交/)
   assert.doesNotMatch(popDraft, /取消/)
   assert.match(popDraft, /fsdb-cell-pop-tags/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点合集格子会崩，是因为弹出层用了 `loadFacets` / `persistFacets` / `slugFacetId` / `subscribeFacets` 却没从 facet-catalog 引进来。补上 import。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

