### PR TITLE
主聊天输入框加上悬浮窗同款边框

### DIFF
--- a/packages/cap-chat/src/web/composer-stack.test.ts
+++ b/packages/cap-chat/src/web/composer-stack.test.ts
@@ -84,6 +84,7 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*bottom:\s*20px/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*height:\s*auto/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*padding:\s*0 16px/s)
+    expect(css).toMatch(/\.composer-pill\s*\{[^}]*border:\s*1px solid var\(--dsw-border\)/s)
     expect(css).toMatch(/\.chat-overlay-panel \.composer-pill\s*\{[^}]*border:\s*1px solid var\(--dsw-border\)/s)
     expect(css).toMatch(/\.chat-overlay-panel \.chat-pane \.chat-composer-dock\s*\{[^}]*background:\s*transparent/s)
     expect(css).toMatch(/\.chat-pane \.chat-composer-dock\s*\{[^}]*z-index:\s*10/s)

--- a/web/style.css
+++ b/web/style.css
@@ -4822,7 +4822,7 @@ body {
 .composer-pill {
   position: relative;
   width: 100%;
-  border: 0;
+  border: 1px solid var(--dsw-border);
   border-radius: 999px;
   background: #202020;
   box-shadow: 0 1px 2px rgba(15, 15, 15, 0.04), 0 10px 32px rgba(0, 0, 0, 0.28);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
主聊天区域的输入胶囊之前没有边框。现在和右下角悬浮窗输入框一样，使用 `1px solid var(--dsw-border)`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

