### PR TITLE
空合集也显示浅色「空」

### DIFF
--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -159,6 +159,8 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(schemaUi, /<CellMulti/)
   assert.doesNotMatch(schemaUi, /function TagPicker/)
   assert.match(schemaUi, /<FieldValuePop/)
+  assert.match(schemaUi, /!parsed.tags.length/)
+  assert.match(schemaUi, /type: 'facet'/)
   assert.doesNotMatch(schemaUi, /<FieldEditor/)
   assert.doesNotMatch(cells, /placeholder=\{fieldKey\}/)
   assert.doesNotMatch(cells, /YYYY-MM-DDTHH:mm/)

--- a/packages/core-file-system/src/web/schema-field.tsx
+++ b/packages/core-file-system/src/web/schema-field.tsx
@@ -317,6 +317,18 @@ export function SchemaFieldEditor({
   }
 
   if (!writable) return <SchemaChips value={value} tags={catalog} />
+  if (!parsed.tags.length) {
+    return (
+      <FieldValuePop
+        record={record}
+        fieldKey="facet"
+        field={{ type: 'facet', writable: true }}
+        value={value}
+        collectionPath={_collectionPath}
+        onSubmit={(next) => onChange(normalizeSchemaValue(next))}
+      />
+    )
+  }
 
   return (
     <div className="fsdb-schema" data-testid="fsdb-schema">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情里合集没有贴任何标签时，和其它空属性一样显示浅色「空」，点击再弹出选择浮窗。贴上合集后仍是原来的合集编辑器。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

