### PR TITLE
父级和依赖显示 title，不再只显示 id

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1334,6 +1334,7 @@ export function CollectionBrowser({
             fieldKey={key}
             records={items}
             collectionPath={collectionPath}
+            labelField={schema?.labelField}
             value={readFacetFlatValue(row, key, facetSourceKey(schema))}
             onChange={
               field.writable && (kind === 'attachment' || kind === 'datetime')
@@ -1351,6 +1352,7 @@ export function CollectionBrowser({
           fieldKey={key}
           records={items}
           collectionPath={collectionPath}
+          labelField={schema?.labelField}
           value={row[key]}
           onChange={
             field.writable && (kind === 'attachment' || kind === 'datetime')
@@ -1377,11 +1379,12 @@ export function CollectionBrowser({
               field,
             )}
             records={items}
+            labelField={schema?.labelField}
             onSubmit={(next) => writeCellValue(row, key, field, next)}
           />
         )
       }
-      return <DefaultCell field={field} fieldKey={key} records={items} collectionPath={collectionPath} value={value} />
+      return <DefaultCell field={field} fieldKey={key} records={items} collectionPath={collectionPath} labelField={schema?.labelField} value={value} />
     }
     if (kind === 'facet') {
       if (field.writable) {
@@ -1430,11 +1433,12 @@ export function CollectionBrowser({
           collectionPath={collectionPath}
           options={uniqueValues(items, key, field)}
           records={items}
+          labelField={schema?.labelField}
           onSubmit={field.writable ? (next) => writeCellValue(row, key, field, next) : () => {}}
         />
       )
     }
-    return <DefaultCell field={field} fieldKey={key} records={items} collectionPath={collectionPath} value={row[key]} />
+    return <DefaultCell field={field} fieldKey={key} records={items} collectionPath={collectionPath} labelField={schema?.labelField} value={row[key]} />
   }
 
   function renderCellPop() {
@@ -1468,6 +1472,8 @@ export function CollectionBrowser({
           initial={initial}
           options={options}
           collectionPath={collectionPath}
+          seed={items}
+          labelField={schema?.labelField}
           onClose={() => setCellPop(null)}
           onSubmit={(raw) => writeCellValue(row, key, field, raw)}
         />

--- a/packages/core-file-system/src/web/cell-pop-draft.tsx
+++ b/packages/core-file-system/src/web/cell-pop-draft.tsx
@@ -160,6 +160,8 @@ export function CellPopDraft({
   initial,
   options,
   collectionPath,
+  seed,
+  labelField,
   onClose,
   onSubmit,
 }: {
@@ -169,6 +171,8 @@ export function CellPopDraft({
   initial: unknown
   options: string[]
   collectionPath: string
+  seed?: DbRecord[]
+  labelField?: string
   onClose: () => void
   onSubmit: (raw: unknown) => void
 }) {
@@ -213,6 +217,8 @@ export function CellPopDraft({
         value={raw}
         collectionPath={collectionPath}
         excludeId={record.id}
+        labelField={labelField}
+        seed={seed}
         onChange={(next) => put(next)}
         onPicked={isSingleRefField(field, fieldKey) ? onClose : undefined}
         onJump={onClose}

--- a/packages/core-file-system/src/web/field-value-pop.tsx
+++ b/packages/core-file-system/src/web/field-value-pop.tsx
@@ -16,6 +16,7 @@ export function FieldValuePop({
   collectionPath,
   options = [],
   records,
+  labelField,
   onSubmit,
 }: {
   record: DbRecord
@@ -25,6 +26,7 @@ export function FieldValuePop({
   collectionPath: string
   options?: string[]
   records?: DbRecord[]
+  labelField?: string
   onSubmit: (raw: unknown) => void
 }) {
   const hostRef = useRef<HTMLSpanElement>(null)
@@ -56,6 +58,7 @@ export function FieldValuePop({
       fieldKey={fieldKey}
       records={records}
       collectionPath={collectionPath}
+      labelField={labelField}
       value={value}
       onChange={field.writable && kind === 'attachment' ? onSubmit : undefined}
     />
@@ -88,6 +91,8 @@ export function FieldValuePop({
           initial={value}
           options={options}
           collectionPath={collectionPath}
+          seed={records}
+          labelField={labelField}
           onClose={() => setOpen(false)}
           onSubmit={onSubmit}
         />

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -37,7 +37,6 @@ import {
 import { LocalText, TokenMultiSelect } from './controls.tsx'
 import { CellDateTime } from '@biu/database-ui'
 import { AttachmentFile, MediaField, UrlHref } from './cell-media.tsx'
-import { crumbRecordLabel } from './sidebar-preview.ts'
 import { PersonFace, PersonPickPanel } from './person-cell.tsx'
 import { RecordLinkChips } from './record-link-cell.tsx'
 
@@ -309,6 +308,7 @@ export function DefaultCell({
   fieldKey,
   records,
   collectionPath,
+  labelField,
   onRun,
   onChange,
 }: {
@@ -317,6 +317,7 @@ export function DefaultCell({
   fieldKey?: string
   records?: DbRecord[]
   collectionPath?: string
+  labelField?: string
   onRun?: () => void
   onChange?: (next: unknown) => void
 }) {
@@ -331,7 +332,8 @@ export function DefaultCell({
         fieldKey={fieldKey}
         value={value}
         collectionPath={collectionPath}
-        peers={records?.map((row) => ({ id: row.id, label: crumbRecordLabel(row) }))}
+        records={records}
+        labelField={labelField}
       />
     )
   }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -241,6 +241,8 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.match(refs, /fsdb-ref-pick/)
   assert.match(refs, /showRecordInInspector/)
   assert.match(refs, /fsdb-ref-jump/)
+  assert.match(refs, /\/api\/db\/read/)
+  assert.doesNotMatch(refs, /fsdb-ref-id/)
   assert.doesNotMatch(refs, /function RefFieldPop/)
   assert.doesNotMatch(refs, /<CellPop/)
   assert.doesNotMatch(refs, /TagChip/)

--- a/packages/core-file-system/src/web/record-link-cell.test.tsx
+++ b/packages/core-file-system/src/web/record-link-cell.test.tsx
@@ -1,0 +1,58 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { render, waitFor } from '@testing-library/react'
+import { RecordLinkChips } from './record-link-cell.tsx'
+
+test('parent and depend chips show title, not the record id', () => {
+  const { container } = render(
+    <RecordLinkChips
+      field={{ type: 'ref' }}
+      fieldKey="parentId"
+      value="rec-1"
+      records={[{ id: 'rec-1', title: '封面页' }]}
+    />,
+  )
+  const title = container.querySelector('.fsdb-ref-chip-title')
+  assert.equal(title?.textContent, '封面页')
+  assert.equal(container.textContent?.includes('rec-1'), false)
+})
+
+test('depend chips resolve title from the same table when the row is off this page', async () => {
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    assert.match(url, /\/api\/db\/read/)
+    assert.match(url, /n2/)
+    return new Response(JSON.stringify({ value: { id: 'n2', title: '依赖页' } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as typeof fetch
+  try {
+    const { container } = render(
+      <RecordLinkChips
+        field={{ type: 'multi-ref' }}
+        fieldKey="dependsOn"
+        value={['n2']}
+        collectionPath="/notes"
+        records={[{ id: 'n1', title: '当前' }]}
+      />,
+    )
+    await waitFor(() => {
+      assert.equal(container.querySelector('.fsdb-ref-chip-title')?.textContent, '依赖页')
+    })
+    assert.equal(container.textContent?.includes('n2'), false)
+  } finally {
+    globalThis.fetch = original
+  }
+})
+
+test('ref picker lists titles and does not print ids beside them', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './record-link-cell.tsx'), 'utf8')
+  assert.match(src, /crumbRecordLabel/)
+  assert.match(src, /\/api\/db\/read/)
+  assert.doesNotMatch(src, /fsdb-ref-id/)
+  assert.doesNotMatch(src, /id\.slice\(0, 8\)/)
+})

--- a/packages/core-file-system/src/web/record-link-cell.tsx
+++ b/packages/core-file-system/src/web/record-link-cell.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { ArrowPathIcon, ArrowTopRightOnSquareIcon, CheckIcon } from '@heroicons/react/16/solid'
 import { ensureDbSearchStyle } from '@biu/database-ui'
 import type { DbRecord, FieldSpec } from '@biu/type-file-system'
-import { listCollection } from './db-client.ts'
+import { listCollection, readJson } from './db-client.ts'
 import { showRecordInInspector } from './inspector-db-route.ts'
 import { crumbRecordLabel } from './sidebar-preview.ts'
 import { isSingleRefField, recordLinkIds } from './fields.ts'
@@ -31,44 +31,98 @@ async function loadTablePeers(path: string, labelField?: string): Promise<Record
   return asPeers(rows, labelField ?? first.schema?.labelField)
 }
 
+async function readPeer(collectionPath: string, id: string, labelField?: string): Promise<RecordLinkPeer | null> {
+  try {
+    const body = await readJson<{ value?: DbRecord }>(
+      `/api/db/read?path=${encodeURIComponent(`${collectionPath}/${id}`)}`,
+    )
+    const row = body.value
+    if (!row?.id) return null
+    return { id: row.id, label: labelOf(row, labelField) }
+  } catch {
+    return null
+  }
+}
+
 function jumpRecord(collectionPath: string | undefined, id: string) {
   if (!collectionPath || !id) return
   showRecordInInspector(collectionPath, id)
+}
+
+function useResolvedPeerLabels(
+  ids: string[],
+  seed: RecordLinkPeer[] | undefined,
+  collectionPath: string | undefined,
+  labelField?: string,
+) {
+  const seedMap = useMemo(() => new Map((seed ?? []).map((item) => [item.id, item.label])), [seed])
+  const idKey = ids.join('\0')
+  const [extra, setExtra] = useState<Record<string, string>>({})
+  useEffect(() => {
+    const missing = ids.filter((id) => !seedMap.has(id))
+    if (!collectionPath || !missing.length) {
+      setExtra({})
+      return
+    }
+    let cancelled = false
+    void Promise.all(missing.map((id) => readPeer(collectionPath, id, labelField))).then((rows) => {
+      if (cancelled) return
+      const next: Record<string, string> = {}
+      missing.forEach((id, index) => {
+        const peer = rows[index]
+        next[id] = peer?.label || ''
+      })
+      setExtra(next)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [collectionPath, idKey, labelField, seedMap])
+  return (id: string) => {
+    const labeled = seedMap.get(id) || extra[id]
+    return labeled && labeled.trim() ? labeled : ''
+  }
 }
 
 export function RecordLinkChips({
   field,
   fieldKey,
   value,
-  peers,
+  records,
   collectionPath,
+  labelField,
 }: {
   field?: FieldSpec
   fieldKey: string
   value: unknown
-  peers?: RecordLinkPeer[]
+  records?: DbRecord[]
   collectionPath?: string
+  labelField?: string
 }) {
   const ids = recordLinkIds(field, value, fieldKey)
+  const seed = useMemo(() => asPeers(records ?? [], labelField), [labelField, records])
+  const labelOfId = useResolvedPeerLabels(ids, seed, collectionPath, labelField)
   if (!ids.length) return null
-  const byId = new Map((peers ?? []).map((item) => [item.id, item.label]))
   return (
     <span className="fsdb-ref-chips">
-      {ids.map((id) => (
-        <button
-          key={id}
-          type="button"
-          className="fsdb-ref-chip"
-          title={`在右侧打开 ${byId.get(id) ?? id}`}
-          onClick={(event) => {
-            event.stopPropagation()
-            jumpRecord(collectionPath, id)
-          }}
-        >
-          <span className="fsdb-ref-chip-title">{byId.get(id) ?? id}</span>
-          <ArrowTopRightOnSquareIcon className="size-3 shrink-0 opacity-70" aria-hidden />
-        </button>
-      ))}
+      {ids.map((id) => {
+        const label = labelOfId(id)
+        return (
+          <button
+            key={id}
+            type="button"
+            className="fsdb-ref-chip"
+            title={label ? `在右侧打开 ${label}` : '在右侧打开'}
+            onClick={(event) => {
+              event.stopPropagation()
+              jumpRecord(collectionPath, id)
+            }}
+          >
+            <span className="fsdb-ref-chip-title">{label || '…'}</span>
+            <ArrowTopRightOnSquareIcon className="size-3 shrink-0 opacity-70" aria-hidden />
+          </button>
+        )
+      })}
     </span>
   )
 }
@@ -122,6 +176,32 @@ export function RecordPickPanel({
   }, [collectionPath, labelField])
 
   const byId = useMemo(() => new Map(peers.map((item) => [item.id, item.label])), [peers])
+  const selectedKey = selected.join('\0')
+  const [extra, setExtra] = useState<Record<string, string>>({})
+  useEffect(() => {
+    const missing = selected.filter((id) => !byId.has(id))
+    if (!missing.length) {
+      setExtra({})
+      return
+    }
+    let cancelled = false
+    void Promise.all(missing.map((id) => readPeer(collectionPath, id, labelField))).then((rows) => {
+      if (cancelled) return
+      const next: Record<string, string> = {}
+      missing.forEach((id, index) => {
+        const peer = rows[index]
+        next[id] = peer?.label || ''
+      })
+      setExtra(next)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [byId, collectionPath, labelField, selectedKey])
+  const titleOf = (id: string) => {
+    const labeled = byId.get(id) || extra[id]
+    return labeled && labeled.trim() ? labeled : ''
+  }
   const q = query.trim().toLowerCase()
   const available = peers.filter(
     (item) =>
@@ -157,15 +237,14 @@ export function RecordPickPanel({
         <div className="fsdb-ref-picked">
           {selected.map((id) => (
             <div key={id} className="fsdb-ref-picked-row">
-              <button type="button" className="fsdb-ref-jump" onClick={() => jump(id)} title="在右侧打开">
-                <span className="fsdb-ref-title">{byId.get(id) ?? id}</span>
-                <span className="fsdb-ref-id">{id.slice(0, 8)}</span>
+              <button type="button" className="fsdb-ref-jump" onClick={() => jump(id)} title={titleOf(id) || '在右侧打开'}>
+                <span className="fsdb-ref-title">{titleOf(id) || '…'}</span>
                 <ArrowTopRightOnSquareIcon className="size-3 shrink-0 opacity-70" aria-hidden />
               </button>
               <button
                 type="button"
                 className="fsdb-ref-x"
-                aria-label={`取消引用 ${byId.get(id) ?? id}`}
+                aria-label={`取消引用 ${titleOf(id) || '记录'}`}
                 onClick={() => commit(selected.filter((item) => item !== id))}
               >
                 ×
@@ -202,9 +281,8 @@ export function RecordPickPanel({
               >
                 {on ? <CheckIcon className="size-3" aria-hidden /> : null}
               </button>
-              <button type="button" className="fsdb-ref-jump" onClick={() => jump(item.id)} title="在右侧打开">
+              <button type="button" className="fsdb-ref-jump" onClick={() => jump(item.id)} title={item.label}>
                 <span className="fsdb-ref-title">{item.label}</span>
-                <span className="fsdb-ref-id">{item.id.slice(0, 8)}</span>
                 <ArrowTopRightOnSquareIcon className="size-3 shrink-0 opacity-70" aria-hidden />
               </button>
             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
父级和依赖字段以前经常直接画出记录 id：当前页没有那一行时，芯片只能回退到 id；选取列表旁边还会再跟一截 id。

现在一律按文件系统默认属性 `title`（以及 labelField / name）显示名字。当前页没有时去读那条记录；选取列表也不再并排打印 id。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

