### PR TITLE
人工放大也按检查器已有页面去重

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -113,7 +113,8 @@ import { listCollection, readJson } from './db-client.ts'
 import { findViewNeighbor, indexOnPage } from './view-adjacent.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
 import { mergeTableViews } from '../catalog-views.ts'
-import { showRecordInInspector } from './inspector-db-route.ts'
+import { databaseRecordPath } from './database-path.ts'
+import { focusInspectorIfOpen, showRecordInInspector } from './inspector-db-route.ts'
 import { SchemaChips, SchemaFieldEditor, schemaTagTone } from './schema-field.tsx'
 import { CellPop, cellUsesPop } from './cell-pop.tsx'
 import { CellPopDraft } from './cell-pop-draft.tsx'
@@ -290,6 +291,7 @@ export function CollectionBrowser({
       return
     }
     if (onOpenRow?.(row)) return
+    if (focusInspectorIfOpen(collectionPath, databaseRecordPath(collectionPath, row.id))) return
     setDetailId(row.id, row)
   }
   const [hydrated, setHydrated] = useState(false)

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'vitest'
+import { beforeEach, test } from 'vitest'
 import assert from 'node:assert/strict'
 import { databaseAllViewPath } from './database-path.ts'
 import {
@@ -6,6 +6,7 @@ import {
   isInspectorDatabasePath,
   setInspectorDbPath,
   resetInspectorDbPathMemory,
+  focusInspectorIfOpen,
   showRecordInInspector,
   showInInspector,
   applyDatabaseReveal,
@@ -13,6 +14,20 @@ import {
   isInspectorAgentWorking,
   setInspectorAgentWorking,
 } from './inspector-db-route.ts'
+
+function clearInspectorPanes() {
+  resetInspectorDbPathMemory()
+  const keys: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.startsWith('inspector.dbPath:')) keys.push(key)
+  }
+  for (const key of keys) localStorage.removeItem(key)
+}
+
+beforeEach(() => {
+  clearInspectorPanes()
+})
 
 test('inspector database path is set explicitly', () => {
   setInspectorDbPath('')
@@ -69,12 +84,12 @@ test('window reveal event opens the inspector record path', async () => {
   window.removeEventListener('biu:inspector-tab', onTab)
 })
 
-test('showRecordInInspector updates an already-open repeatable pane, not just the canonical tab id', async () => {
+test('showRecordInInspector focuses an already-open pane for the same page', () => {
   const pane = 'database:/pages::abc123'
-  setInspectorDbPath(pane, '/database/pages/view/builtin-all:/pages')
+  setInspectorDbPath(pane, '/database/pages/record/p1?view=all')
   showRecordInInspector('/pages', 'p1')
   assert.equal(getInspectorDbPath(pane), '/database/pages/record/p1')
-  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
+  assert.equal(getInspectorDbPath('database:/pages'), '')
 })
 
 test('showRecordInInspector opens the inspector on this record', async () => {
@@ -105,6 +120,14 @@ test('unique inspector reveal focuses the same page and opens a new pane for a d
     .map((key) => key.slice('inspector.dbPath:'.length))
   assert.equal(extra.length, 1)
   assert.equal(getInspectorDbPath(extra[0]!), '/database/notes/record/n2')
+})
+
+test('focusInspectorIfOpen only focuses when that page is already in the inspector', () => {
+  setInspectorDbPath('database:/pages', '/database/pages/record/p1')
+  assert.equal(focusInspectorIfOpen('/pages', '/database/pages/record/p1?view=all'), true)
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1?view=all')
+  assert.equal(focusInspectorIfOpen('/pages', '/database/pages/record/p2'), false)
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1?view=all')
 })
 
 test('showInInspector opens a collection href in the inspector', async () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -142,8 +142,27 @@ function hrefPathKey(href: string) {
   return String(href || '').split('?')[0]
 }
 
+function paneWithHref(tabId: string, href: string) {
+  const key = hrefPathKey(href)
+  return paneIdsForTab(tabId).find((id) => hrefPathKey(getInspectorDbPath(id)) === key)
+}
+
+function revealInspectorPane(paneId: string, href: string) {
+  setInspectorDbPath(paneId, href)
+  window.dispatchEvent(new Event('biu:inspector-open'))
+  window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: paneId }))
+}
+
 function nextInspectorPaneId(tabId: string) {
   return `${tabId}::${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`
+}
+
+/** 右侧已经打开同一路径时只聚焦，不新开。 */
+export function focusInspectorIfOpen(collection: string, href: string) {
+  const pane = paneWithHref(inspectorCollectionTabId(collection), href)
+  if (!pane) return false
+  revealInspectorPane(pane, href)
+  return true
 }
 
 /** 右侧检查器打开这条路径，中间主界面不动。默认同表实例一起改路径；unique 时同页只聚焦、不同页新开。 */
@@ -152,18 +171,14 @@ export function showInInspector(collection: string, href: string, opts?: { uniqu
   const unique = opts?.unique === true
   const paneIds = paneIdsForTab(tabId)
   if (unique) {
-    const same = paneIds.find((id) => hrefPathKey(getInspectorDbPath(id)) === hrefPathKey(href))
+    const same = paneWithHref(tabId, href)
     if (same) {
-      setInspectorDbPath(same, href)
-      window.dispatchEvent(new Event('biu:inspector-open'))
-      window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: same }))
+      revealInspectorPane(same, href)
       return
     }
     const live = paneIds.filter((id) => getInspectorDbPath(id))
     const target = live.length ? nextInspectorPaneId(tabId) : tabId
-    setInspectorDbPath(target, href)
-    window.dispatchEvent(new Event('biu:inspector-open'))
-    window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: target }))
+    revealInspectorPane(target, href)
     return
   }
   for (const paneId of paneIds) setInspectorDbPath(paneId, href)
@@ -171,9 +186,9 @@ export function showInInspector(collection: string, href: string, opts?: { uniqu
   window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
 }
 
-/** 右侧检查器打开这条记录，中间主界面不动。 */
+/** 右侧检查器打开这条记录。同一页已在检查器里则只聚焦。 */
 export function showRecordInInspector(collection: string, recordId: string) {
-  showInInspector(collection, databaseRecordPath(collection, recordId))
+  showInInspector(collection, databaseRecordPath(collection, recordId), { unique: true })
 }
 
 /** 工具查/改/删某张表后：打开右侧检查器并切到该表（中间主界面不动）。 */

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -110,6 +110,7 @@ test('table title opens record from the title-side button', () => {
   assert.match(browser, /const treeOn = treeable && showTree/)
   assert.match(browser, /const tree = openDetail && treeOn/)
   assert.match(browser, /openRow\(row\)/)
+  assert.match(browser, /focusInspectorIfOpen\(collectionPath, databaseRecordPath\(collectionPath, row.id\)\)/)
   assert.match(browser, /chrome\?\.openRow/)
   assert.doesNotMatch(browser, /catalogRowOpenTarget/)
   assert.doesNotMatch(browser, /tagRowOpenTarget/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索打开检查器已经会按同一页面去重。人工点标题旁放大时，如果右侧已经开着一模一样的那一页，现在也只切到现有栏，不再再开一份。

「在右侧打开」同样走 unique：同一页只聚焦。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

