### PR TITLE
feat(fs): db_list 可选 columns 投影

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -70,6 +70,22 @@ test('root lists registered collections; record read/update follows schema', asy
   assert.equal(listed.items.length, 2)
   assert.equal(listed.items[0]?.title, '草稿')
 
+  const slim = await db.list('/notes', undefined, { columns: ['title'] })
+  assert.equal(slim.kind, 'collection')
+  if (slim.kind !== 'collection') return
+  const row = slim.items[0]
+  assert.equal(row?.id, 'n1')
+  assert.equal(row?.title, '草稿')
+  assert.equal(row?.path, '/notes/n1')
+  assert.equal(row?.kind, 'record')
+  assert.equal('status' in (row ?? {}), false)
+  assert.equal('pinned' in (row ?? {}), false)
+  const labeled = await db.list('/notes', undefined, { columns: ['label'] })
+  assert.equal(labeled.kind, 'collection')
+  if (labeled.kind !== 'collection') return
+  assert.equal(labeled.items[0]?.title, '草稿')
+  assert.equal('status' in (labeled.items[0] ?? {}), false)
+
   const read = await db.read('/notes/n1')
   assert.equal(read.kind, 'record')
   if (read.kind !== 'record') return
@@ -467,6 +483,28 @@ test('apply registers db_* tools', async () => {
   const paths = ((listed as { items: Array<{ path: string }> }).items ?? []).map((item) => item.path)
   assert.equal(paths.includes('/views'), true)
   assert.equal(paths.includes('/facets'), true)
+})
+
+test('db_list columns returns only those fields plus id', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  class HttpStub extends Service {
+    constructor(c: Context) {
+      super(c, 'http')
+    }
+    route() {}
+  }
+  new HttpStub(ctx)
+  await ctx.plugin({ inject: ['tools', 'http'], apply: applyFileSystem })
+  const db = ctx.get('database') as DatabaseService
+  db.register(notesCollection())
+  const listed = await ctx.tools.invoke('db_list', { path: '/notes', columns: ['label'] }) as {
+    items: Array<Record<string, unknown>>
+  }
+  const row = listed.items[0]
+  assert.equal(row?.title, '草稿')
+  assert.equal(row?.id, 'n1')
+  assert.equal('status' in (row ?? {}), false)
 })
 
 test('db_list on a table broadcasts inspector working then done', async () => {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -150,6 +150,34 @@ function withoutContent(spec: CollectionSpec, row: DbRecord): DbRecord {
   return next
 }
 
+function listedColumnKeys(requested: unknown, labelField: string): string[] | null {
+  if (!Array.isArray(requested) || !requested.length) return null
+  const keys: string[] = []
+  const seen = new Set<string>()
+  const add = (key: string) => {
+    const next = key.trim()
+    if (!next || seen.has(next)) return
+    seen.add(next)
+    keys.push(next)
+  }
+  add('id')
+  for (const item of requested) {
+    const raw = String(item ?? '').trim()
+    if (!raw) continue
+    add(raw === 'label' ? labelField : raw)
+  }
+  return keys
+}
+
+function pickListedFields(row: DbRecord, keys: string[]): DbRecord {
+  const next: DbRecord = { id: row.id }
+  for (const key of keys) {
+    if (key === 'path' || key === 'kind') continue
+    if (Object.prototype.hasOwnProperty.call(row, key)) next[key] = row[key]
+  }
+  return next
+}
+
 export function matchActionWhen(record: DbRecord, when?: Record<string, unknown>) {
   if (!when) return true
   for (const [key, expected] of Object.entries(when)) {
@@ -564,6 +592,7 @@ export class DatabaseService extends Service implements Database {
     const sortField = page?.sortField ?? ''
     const sortDir = page?.sortDir === 'desc' ? 'desc' : 'asc'
     const schemaFilter = filter?.facet != null && filter.facet !== '' ? String(filter.facet) : ''
+    const columnKeys = listedColumnKeys(page?.columns, schema.labelField ?? 'title')
     const query: CollectionListQuery = { q, filter }
     if (schemaFilter && schema.fields.facet && spec.path !== '/facets') {
       const stamped = this.facets.stampedIds(spec.path, schemaFilter)
@@ -597,11 +626,15 @@ export class DatabaseService extends Service implements Database {
       total,
       offset,
       limit,
-      items: slice.map((row): DbRecord & { path: string; kind: 'record' } => ({
-        ...withoutContent(spec, row),
-        path: `${spec.path}/${row.id}`,
-        kind: 'record',
-      })),
+      items: slice.map((row): DbRecord & { path: string; kind: 'record' } => {
+        const value = withoutContent(spec, row)
+        const picked = columnKeys ? pickListedFields(value, columnKeys) : value
+        return {
+          ...picked,
+          path: `${spec.path}/${row.id}`,
+          kind: 'record',
+        }
+      }),
     }
   }
 
@@ -976,6 +1009,12 @@ function parseRecords(content: unknown): Record<string, unknown>[] {
 
 const PATH_PARAM = { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] } as const
 
+function asColumnKeys(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const keys = value.map((item) => String(item).trim()).filter(Boolean)
+  return keys.length ? keys : undefined
+}
+
 function asFilter(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
   return value as Record<string, unknown>
@@ -1095,7 +1134,7 @@ export function apply(ctx: Context) {
   }))))
   ctx.tools.register({
     name: 'db_list',
-    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。',
+    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。可用 columns 只取需要的列。',
     parameters: {
       type: 'object',
       properties: {
@@ -1106,6 +1145,11 @@ export function apply(ctx: Context) {
         sortDir: { type: 'string', enum: ['asc', 'desc'] },
         limit: { type: 'number', description: '每页条数，默认 50，最大 200' },
         offset: { type: 'number' },
+        columns: {
+          type: 'array',
+          items: { type: 'string' },
+          description: '可选，只返回这些列。始终带 id。label 等于标题列（默认 title）。不传则除 content 外全返回。',
+        },
       },
       required: ['path'],
     },
@@ -1118,6 +1162,7 @@ export function apply(ctx: Context) {
           sortDir: args.sortDir === 'desc' ? 'desc' : 'asc',
           limit: args.limit != null ? Number(args.limit) : undefined,
           offset: args.offset != null ? Number(args.offset) : undefined,
+          columns: asColumnKeys(args.columns),
         }),
       )
     },

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -595,6 +595,8 @@ export type ListPage = {
   /** 缺省 50，最大 200；列表接口不会一次返回整表。 */
   limit?: number
   offset?: number
+  /** 只返回这些列；空或不传则除 content 外全返回。id 始终带上。 */
+  columns?: string[]
 }
 
 /** File System 实现必须满足的服务面。换实现时只要还叫 ctx.database 并遵守这套方法。 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 调 `db_list` 时可传 `columns`，只返回 `id` + 指定列，避免每次把整行字段都带回来。

- `columns: ["title"]`：只带 `id` + `title`
- `columns: ["label"]`：`label` 映射到 schema 的 `labelField`（默认 `title`）
- 不传 `columns`：行为不变（仍去掉 content 正文）
- 界面 `/api/db/list` 不投影，表格仍拿全列

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

