### PR TITLE
feat(agent): 文件模式只开 db 工具，默认标准

### DIFF
--- a/packages/core-chat/src/host/inspector.test.ts
+++ b/packages/core-chat/src/host/inspector.test.ts
@@ -62,6 +62,30 @@ test('minimal unlocks extras; standard includes store tools', () => {
     }),
     false,
   )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'db_list',
+      mode: 'file',
+      pinnedExtras: [],
+    }),
+    true,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'bash',
+      mode: 'file',
+      pinnedExtras: ['bash'],
+    }),
+    false,
+  )
+  assert.equal(
+    isToolActiveForSession({
+      name: 'fs_read',
+      mode: 'file',
+      pinnedExtras: ['fs_read'],
+    }),
+    false,
+  )
 })
 
 test('buildInspectorTools marks configurable plugin tools in minimal mode', () => {
@@ -88,8 +112,12 @@ test('inspector tool sources do not use a live type', async () => {
   const { resolve } = await import('node:path')
   const src = readFileSync(resolve(import.meta.dirname, './inspector.ts'), 'utf8')
   const dialog = readFileSync(resolve(import.meta.dirname, '../../../web-session-view/src/web/session-config-dialog.tsx'), 'utf8')
+  const approvals = readFileSync(resolve(import.meta.dirname, '../web/approvals.tsx'), 'utf8')
   assert.doesNotMatch(src, /Live 调度/)
   assert.doesNotMatch(src, /id: 'live'/)
   assert.match(src, /id: 'db'/)
   assert.doesNotMatch(dialog, /'live'/)
+  assert.match(approvals, /id: 'file'/)
+  assert.match(approvals, /id: 'minimal'/)
+  assert.match(approvals, /id: 'standard'/)
 })

--- a/packages/core-chat/src/host/inspector.ts
+++ b/packages/core-chat/src/host/inspector.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'cordis'
-import { MINIMAL_TOOL_NAMES, type AgentToolMode } from '@biu/host-tools'
-import { LIVE_TOOL_NAMES } from '@biu/host-live-sessions'
+import { FILE_TOOL_NAMES, MINIMAL_TOOL_NAMES, normalizeAgentMode, type AgentToolMode } from '@biu/host-tools'
 import {
   collectLiveDispatchedTasks,
   type DispatchedTask,
@@ -33,7 +32,7 @@ const SOURCE_INFO: InspectorSourceInfo[] = [
   {
     id: 'db',
     label: '数据库',
-    description: '数据库读写与动作工具。',
+    description: 'agentMode=file 时仅开放这些 db_* 工具（Biu 文件系统）。',
   },
   {
     id: 'plugin',
@@ -49,7 +48,7 @@ const SOURCE_INFO: InspectorSourceInfo[] = [
 
 export function toolSourceOf(name: string, origin?: 'core' | 'store'): ToolSourceId {
   if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return 'minimal'
-  if ((LIVE_TOOL_NAMES as readonly string[]).includes(name)) return 'db'
+  if ((FILE_TOOL_NAMES as readonly string[]).includes(name)) return 'db'
   if (origin === 'store') return 'store'
   return 'plugin'
 }
@@ -62,6 +61,7 @@ export function isToolActiveForSession(opts: {
 }): boolean {
   if (opts.mode === 'standard') return true
   if (opts.origin === 'store' || toolSourceOf(opts.name, opts.origin) === 'store') return false
+  if (opts.mode === 'file') return (FILE_TOOL_NAMES as readonly string[]).includes(opts.name)
   if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(opts.name)) return true
   return opts.pinnedExtras.includes(opts.name)
 }
@@ -99,8 +99,7 @@ export function registerChatInspectorRoutes(ctx: Context) {
     const record = await ctx.sessions.get(id)
     if (!record) return route.send(404, { error: 'unknown session' })
     const resolved = ctx.chat.resolveEffective(id)
-    const rawMode = resolved.effective.agentMode
-    const mode: AgentToolMode = rawMode === 'minimal' ? 'minimal' : 'standard'
+    const mode: AgentToolMode = normalizeAgentMode(resolved.effective.agentMode)
     const pinnedExtras = Array.isArray(resolved.effective.extraTools) ? resolved.effective.extraTools : []
     const tools = buildInspectorTools(ctx.tools.catalog(), { mode, pinnedExtras })
     const title =

--- a/packages/core-chat/src/web/approvals.tsx
+++ b/packages/core-chat/src/web/approvals.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircleIcon,
   CommandLineIcon,
   ExclamationCircleIcon,
+  FolderIcon,
   PaintBrushIcon,
   PauseIcon,
   Squares2X2Icon,
@@ -15,10 +16,11 @@ import { HeadlessDismiss } from '@biu/public-ui'
 import { ChatSidebar } from '@biu/web-app-shell/chat-sidebar'
 import { SessionProjectPanel } from './project-panel.tsx'
 
-type AgentMode = 'minimal' | 'standard'
+type AgentMode = 'minimal' | 'file' | 'standard'
 
 function parseAgentMode(value: unknown): AgentMode {
-  return value === 'minimal' ? 'minimal' : 'standard'
+  if (value === 'minimal' || value === 'file') return value
+  return 'standard'
 }
 
 /** 最新一条回复里，上下文（更早 turn）占发给模型的输入文字的比例（0..1）。 */
@@ -375,6 +377,12 @@ export function ApprovalsRail(props: SlotProps) {
                 label: '极简',
                 icon: <CommandLineIcon className="size-4" aria-hidden />,
                 hint: '只开放 bash 和文件编辑。上下文更省，适合改一小段、少打扰。',
+              },
+              {
+                id: 'file',
+                label: '文件',
+                icon: <FolderIcon className="size-4" aria-hidden />,
+                hint: '只开放 Biu 文件系统的 db 工具，用来查表、改记录。',
               },
               {
                 id: 'standard',

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -41,10 +41,11 @@ export class AgentLoop implements AgentRunner {
         if (!extras.includes(name)) extras.push(name)
       }
     }
-    // 极简是底座；Slash 增量放开。商店插件跟标准模式一起可见。
+    // 极简是底座；Slash 增量放开。文件模式只开放 db_*。商店插件跟标准模式一起可见。
     if (mode === 'minimal') {
       extras = extras.filter((name) => this.ctx.tools.originOf(name) !== 'store')
     }
+    if (mode === 'file') extras = []
     return runWithSession(this.sessionId, () =>
       runWithToolPolicy({ mode, extras }, () => this.runInSession(claimed)),
     )

--- a/packages/host-live-sessions/src/host/index.ts
+++ b/packages/host-live-sessions/src/host/index.ts
@@ -1,6 +1,7 @@
 import type { Context } from 'cordis'
 import type { SessionEvent } from '@biu/type-session'
 
+/** 与 @biu/host-tools FILE_TOOL_NAMES 一致：Biu 文件系统 db_*。 */
 export const LIVE_TOOL_NAMES = [
   'db_list',
   'db_read',

--- a/packages/host-sessions/src/host/session-config.test.ts
+++ b/packages/host-sessions/src/host/session-config.test.ts
@@ -19,6 +19,9 @@ test('session config title overrides derived title', async () => {
   const again = await ctx.sessions.require(record.id)
   assert.equal(again.config?.model, 'deepseek-reasoner')
   assert.equal(again.config?.agentMode, 'minimal')
+  await ctx.sessions.patchConfig(record.id, { agentMode: 'file' })
+  const filed = await ctx.sessions.require(record.id)
+  assert.equal(filed.config?.agentMode, 'file')
   assert.equal(again.config?.title, '指挥台-A')
 })
 

--- a/packages/host-sessions/src/host/sessions-collection.ts
+++ b/packages/host-sessions/src/host/sessions-collection.ts
@@ -152,7 +152,7 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
         model: { type: 'string', label: '模型', writable: true },
         provider: { type: 'select', label: '服务商', enum: ['deepseek', 'openai', 'anthropic'], writable: true },
         systemPrompt: { type: 'string', label: '系统提示', writable: true },
-        agentMode: { type: 'select', label: '模式', enum: ['standard', 'minimal'], writable: true },
+        agentMode: { type: 'select', label: '模式', enum: ['standard', 'file', 'minimal'], writable: true },
         extraTools: { type: 'multi-select', label: '额外工具', writable: true },
         updatedAt: { type: 'datetime', label: '更新时间', sortable: true },
         mascotName: { type: 'string', label: '形象', computed: true },
@@ -176,7 +176,7 @@ export function sessionsCollection(sessions: SessionsLike): CollectionSpec {
         config.provider = patch.provider
       }
       if (typeof patch.systemPrompt === 'string') config.systemPrompt = patch.systemPrompt
-      if (patch.agentMode === 'minimal') config.agentMode = 'minimal'
+      if (patch.agentMode === 'minimal' || patch.agentMode === 'file') config.agentMode = patch.agentMode
       if (patch.agentMode === 'standard' || patch.agentMode === 'create') config.agentMode = 'standard'
       if (Array.isArray(patch.extraTools)) config.extraTools = patch.extraTools.map((item) => String(item))
       if (Object.keys(config).length) await sessions.patchConfig(id, config)

--- a/packages/host-tools/src/host/index.test.ts
+++ b/packages/host-tools/src/host/index.test.ts
@@ -124,6 +124,28 @@ test('store tools appear in standard mode', async () => {
   await assert.rejects(() => ctx.tools.invoke('store_ping'), /not available in minimal mode/)
 })
 
+test('file mode only exposes filesystem db tools', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  for (const name of ['bash', 'str_replace_editor', 'db_list', 'db_read', 'fs_read']) {
+    ctx.tools.register({
+      name,
+      description: name,
+      parameters: { type: 'object', properties: {} },
+      execute: () => name,
+    })
+  }
+  ctx.tools.setMode('file')
+  assert.equal(ctx.tools.getMode(), 'file')
+  assert.deepEqual(ctx.tools.names().sort(), ['db_list', 'db_read'])
+  assert.equal(await ctx.tools.invoke('db_list'), 'db_list')
+  await assert.rejects(() => ctx.tools.invoke('bash'), /not available in file mode/)
+  await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in file mode/)
+  await tools.runWithExtraTools(['fs_read'], async () => {
+    await assert.rejects(() => ctx.tools.invoke('fs_read'), /not available in file mode/)
+  })
+})
+
 test('invoke rejects promptly when aborted during a hung execute', async () => {
   const ctx = new Context()
   await ctx.plugin(tools)

--- a/packages/host-tools/src/host/index.ts
+++ b/packages/host-tools/src/host/index.ts
@@ -24,21 +24,33 @@ export interface ToolRequest {
 
 export type ToolGuard = (req: ToolRequest) => ToolRequest | Promise<ToolRequest>
 
-/** 极简=底座；标准=内置 + 商店插件。旧创造配置并入标准。 */
-export const AGENT_TOOL_MODES = ['minimal', 'standard'] as const
+/** 极简=底座两工具；文件=文件系统 db_*；标准=全部。旧创造配置并入标准。 */
+export const AGENT_TOOL_MODES = ['minimal', 'file', 'standard'] as const
 export type AgentToolMode = (typeof AGENT_TOOL_MODES)[number]
 
 export function isAgentToolMode(value: unknown): value is AgentToolMode {
-  return value === 'minimal' || value === 'standard'
+  return value === 'minimal' || value === 'file' || value === 'standard'
 }
 
 export function normalizeAgentMode(value: unknown, fallback: AgentToolMode = 'standard'): AgentToolMode {
-  if (value === 'minimal') return 'minimal'
+  if (value === 'minimal' || value === 'file') return value
   if (value === 'standard' || value === 'create') return 'standard'
   return fallback
 }
 
 export const MINIMAL_TOOL_NAMES = ['bash', 'str_replace_editor'] as const
+
+/** Biu 文件系统 DB 工具；文件模式下只开放这些。 */
+export const FILE_TOOL_NAMES = [
+  'db_list',
+  'db_read',
+  'db_update',
+  'db_create',
+  'db_delete',
+  'db_stat',
+  'db_action',
+  'db_content',
+] as const
 
 /** 本回合 slash 选中的额外工具（极简模式下临时放开）。 */
 const extraToolsStorage = new AsyncLocalStorage<ReadonlySet<string>>()
@@ -103,23 +115,13 @@ export class ToolsService extends Service {
   }
 
   setPinnedExtras(names: readonly string[]) {
-    const dbTools = new Set<string>([
-      'db_list',
-      'db_read',
-      'db_update',
-      'db_create',
-      'db_delete',
-      'db_stat',
-      'db_action',
-      'db_content',
-    ])
     const cleaned = [
       ...new Set(
         names
           .map((name) => name.trim())
           .filter(Boolean)
           .filter((name) => !(MINIMAL_TOOL_NAMES as readonly string[]).includes(name))
-          .filter((name) => !dbTools.has(name)),
+          .filter((name) => !(FILE_TOOL_NAMES as readonly string[]).includes(name)),
       ),
     ]
     const same =
@@ -134,6 +136,7 @@ export class ToolsService extends Service {
     const mode = policy?.mode ?? this.mode
     if (mode === 'standard') return true
     if (this.originOf(name) === 'store') return false
+    if (mode === 'file') return (FILE_TOOL_NAMES as readonly string[]).includes(name)
     if ((MINIMAL_TOOL_NAMES as readonly string[]).includes(name)) return true
     if ((policy?.extras ?? new Set()).has(name)) return true
     if (!policy && this.pinnedExtras.includes(name)) return true

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -70,7 +70,7 @@ export interface SessionConfig {
   provider?: 'deepseek' | 'openai' | 'anthropic'
   model?: string
   systemPrompt?: string
-  agentMode?: 'standard' | 'minimal'
+  agentMode?: 'standard' | 'minimal' | 'file'
   /** 极简模式下常驻额外工具 */
   extraTools?: string[]
   /** 侧栏标签；一条会话可属于多个标签组 */
@@ -92,7 +92,7 @@ export function normalizeSessionConfig(value: unknown): SessionConfig | undefine
   if (raw.provider === 'deepseek' || raw.provider === 'openai' || raw.provider === 'anthropic') next.provider = raw.provider
   if (typeof raw.model === 'string' && raw.model.trim()) next.model = raw.model.trim()
   if (typeof raw.systemPrompt === 'string') next.systemPrompt = raw.systemPrompt
-  if (raw.agentMode === 'minimal') next.agentMode = 'minimal'
+  if (raw.agentMode === 'minimal' || raw.agentMode === 'file') next.agentMode = raw.agentMode
   if (raw.agentMode === 'standard' || raw.agentMode === 'create') next.agentMode = 'standard'
   if (Array.isArray(raw.extraTools)) {
     next.extraTools = [...new Set(raw.extraTools.map((name) => String(name).trim()).filter(Boolean))]
@@ -135,7 +135,7 @@ export function mergeSessionConfig(
     if (patch.systemPrompt == null) delete next.systemPrompt
     else next.systemPrompt = String(patch.systemPrompt)
   }
-  if (patch.agentMode === 'minimal') next.agentMode = 'minimal'
+  if (patch.agentMode === 'minimal' || patch.agentMode === 'file') next.agentMode = patch.agentMode
   if (patch.agentMode === 'standard' || patch.agentMode === 'create') next.agentMode = 'standard'
   if (Array.isArray(patch.extraTools)) {
     next.extraTools = [...new Set(patch.extraTools.map((name) => String(name).trim()).filter(Boolean))]

--- a/packages/web-session-view/src/web/session-config-dialog.tsx
+++ b/packages/web-session-view/src/web/session-config-dialog.tsx
@@ -7,7 +7,7 @@ import {
 import { ChatOutlineFilterFields } from './chat-outline-fields.tsx'
 
 type ToolSourceId = 'minimal' | 'db' | 'plugin' | 'store'
-type AgentMode = 'standard' | 'minimal'
+type AgentMode = 'standard' | 'file' | 'minimal'
 type ChatProvider = 'deepseek' | 'openai'
 
 interface InspectorTool {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 工具模式三档，默认标准：

- **极简**：只开放 `bash` 和 `str_replace_editor`
- **文件**：只开放 Biu 文件系统 `db_*`（list/read/update/create/delete/stat/action/content）
- **标准**：全部工具（含商店插件）

未设置或旧配置仍回落到标准。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

