### PR TITLE
fix(pick): 左侧边栏内容可直接按住拖选

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -748,7 +748,7 @@ export const DataSidebar = memo(function DataSidebar({
       className="app-side-bar fsdb-views flex min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)"
       aria-label="数据"
     >
-      <div className="app-side-bar-head app-side-bar-head-brand">
+      <div className="app-side-bar-head app-side-bar-head-brand" data-biu-ignore>
         <SidebarBrandLockup />
         <button
           type="button"

--- a/packages/core-pick/src/web/overlay.test.ts
+++ b/packages/core-pick/src/web/overlay.test.ts
@@ -5,14 +5,31 @@ import assert from 'node:assert/strict'
 
 const overlay = readFileSync(resolve(import.meta.dirname, './overlay.tsx'), 'utf8')
 
-test('pick capture does not eat sidebar, inspector, or chat overlay clicks', () => {
+test('pick capture does not eat inspector chrome, chat overlay, or ignored nodes', () => {
   assert.match(overlay, /function ignorePickCapture/)
-  assert.match(overlay, /\.app-side-bar/)
+  assert.doesNotMatch(overlay, /\[data-biu-ignore\], \.app-side-bar/)
   assert.doesNotMatch(overlay, /data-os-dock/)
   assert.match(overlay, /data-biu-ignore/)
   assert.match(overlay, /chat-overlay-panel/)
   assert.doesNotMatch(overlay, /\.app-rail/)
   assert.doesNotMatch(overlay, /\.session-inspector/)
+})
+
+test('sidebar list content can start a pick drag; chrome stays ignored', async () => {
+  const { ignorePickCapture } = await import('./overlay.tsx')
+  const bar = document.createElement('aside')
+  bar.className = 'app-side-bar'
+  const row = document.createElement('div')
+  row.setAttribute('data-biu-kind', 'session')
+  row.setAttribute('data-biu-id', 's1')
+  const head = document.createElement('div')
+  head.className = 'app-side-bar-head'
+  head.setAttribute('data-biu-ignore', '')
+  bar.append(head, row)
+  document.body.append(bar)
+  assert.equal(ignorePickCapture(row), false)
+  assert.equal(ignorePickCapture(head), true)
+  bar.remove()
 })
 
 test('close button inside the chat overlay is not captured while picking', async () => {

--- a/packages/core-pick/src/web/overlay.tsx
+++ b/packages/core-pick/src/web/overlay.tsx
@@ -7,7 +7,7 @@ import { textPickFromSelection } from './types.ts'
 const DRAG_PX = 6
 
 export const PICK_NAV_GUARD =
-  '[data-biu-ignore], .app-side-bar, .brand-corner-cluster, [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"], [data-testid="chat-overlay-panel"]'
+  '[data-biu-ignore], .brand-corner-cluster, [data-testid="inspector-toggle"], [data-testid="fsdb-inspector-toggle"], [data-testid="chat-overlay-panel"]'
 
 export function ignorePickCapture(target: EventTarget | null, event?: Event) {
   const path = event && 'composedPath' in event ? event.composedPath() : []

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -86,7 +86,7 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
           }}
         />
       ) : null}
-      <div className="app-side-bar-head app-side-bar-head-brand">
+      <div className="app-side-bar-head app-side-bar-head-brand" data-biu-ignore>
         <SidebarBrandLockup />
         {!visible || narrow ? (
           <button
@@ -113,7 +113,7 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
         )}
       </div>
       {onSettings && agentHref && activeId != null ? (
-        <div className="shrink-0 px-2 pt-1">
+        <div className="shrink-0 px-2 pt-1" data-biu-ignore>
           <ShellSidePlaces
             activeId={activeId}
             agentHref={agentHref}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取 overlay 原先把整栏 `.app-side-bar` 写进 `PICK_NAV_GUARD`，侧栏上的 `pointerdown` 不会开始框选。从中间拖进侧栏能命中，是因为拖动手势已经开始。

现在禁区只剩 `data-biu-ignore` 等铬条；侧栏品牌头、场所入口仍标 ignore，列表内容可以在栏内直接按住拖。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

