### PR TITLE
fix(fs): 表名和全部视图之间也留 1px 缝

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -430,7 +430,7 @@ export const DataSidebar = memo(function DataSidebar({
       const listed = viewsFor(table.path)
       const system = isSystemCollection(table.path)
       return (
-        <div key={table.path} className="min-w-0" data-collection-kind={system ? 'system' : 'user'}>
+        <div key={table.path} className="flex min-w-0 flex-col gap-px" data-collection-kind={system ? 'system' : 'user'}>
           <div className="sidebar-group-head">
             <div
               className="flex min-h-8 min-w-0 flex-1 items-center gap-1.5 rounded-md text-left text-[14px] font-medium tracking-normal text-inherit"

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -69,6 +69,7 @@ test('table and view rows only expand from the fold column', () => {
   assert.match(sidebar, /data-testid="sidebar-system-collections"/)
   assert.match(sidebar, /className="flex min-w-0 flex-col gap-px" data-testid="sidebar-user-collections"/)
   assert.match(sidebar, /className="flex min-w-0 flex-col gap-px" data-testid="sidebar-system-collections"/)
+  assert.match(sidebar, /className="flex min-w-0 flex-col gap-px" data-collection-kind/)
   assert.match(sidebar, /className="sidebar-group-head"/)
   assert.doesNotMatch(sidebar, /sidebar-group-head mb-0\.5/)
   assert.match(sidebar, /data-collection-kind/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表名（如「绘画」）和第一层视图（「全部绘画」）之前贴在一起，视图之间却有 1px 缝。给每张表的表头和视图列表加上与搜索/通知相同的 `gap-px`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

