### PR TITLE
fix(fs): Agent 的 db_stat/list/read 去掉重复 schema

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -1,0 +1,103 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { REQUIRED_RECORD_FIELDS, withBuiltinFields, type CollectionSchema } from '@biu/type-file-system'
+import { compactAgentSchema, compactAgentToolResult } from './agent-payload.ts'
+
+function notesSchema(): CollectionSchema {
+  const fields = withBuiltinFields({
+    ...REQUIRED_RECORD_FIELDS,
+    title: { type: 'string', writable: true },
+    status: { type: 'string', writable: true, enum: ['open', 'done'] },
+    pinned: { type: 'boolean' },
+  })
+  for (const [key, field] of Object.entries(fields)) {
+    fields[key] = field.computed ? { ...field, writable: false } : field
+  }
+  return {
+    labelField: 'title',
+    contentField: 'content',
+    fields,
+    records: { update: true, create: false, delete: false },
+    actions: [
+      { id: 'pin', label: '钉住', when: { pinned: false } },
+      { id: 'uiOnly', label: '仅界面', for: 'user' },
+    ],
+  }
+}
+
+test('compact schema drops identical builtins and user-only actions', () => {
+  const compact = compactAgentSchema(notesSchema())
+  assert.equal('id' in ((compact.fields as object) ?? {}), false)
+  assert.equal('createdAt' in ((compact.fields as object) ?? {}), false)
+  assert.equal('facet' in ((compact.fields as object) ?? {}), false)
+  assert.equal('title' in ((compact.fields as object) ?? {}), false)
+  assert.deepEqual((compact.fields as Record<string, unknown>).status, {
+    type: 'string',
+    enum: ['open', 'done'],
+  })
+  assert.deepEqual((compact.fields as Record<string, unknown>).pinned, { type: 'boolean' })
+  assert.equal(compact.labelField, undefined)
+  assert.equal(compact.contentField, undefined)
+  const actions = compact.actions as Array<{ id: string }>
+  assert.equal(actions.some((item) => item.id === 'pin'), true)
+  assert.equal(actions.some((item) => item.id === 'uiOnly'), false)
+})
+
+test('compact schema keeps overrides of builtin labels', () => {
+  const fields = withBuiltinFields({
+    ...REQUIRED_RECORD_FIELDS,
+    parentId: { type: 'ref', label: '父任务', writable: true },
+  })
+  const compact = compactAgentSchema({
+    labelField: 'title',
+    contentField: 'description',
+    parentField: 'parentId',
+    fields: { ...fields, description: { type: 'file', label: '描述', writable: true } },
+  })
+  assert.equal(compact.contentField, 'description')
+  assert.equal(compact.parentField, 'parentId')
+  assert.deepEqual((compact.fields as Record<string, unknown>).parentId, { type: 'ref', label: '父任务' })
+  assert.deepEqual((compact.fields as Record<string, unknown>).description, { type: 'file', label: '描述' })
+})
+
+test('compact list drops schema; compact stat keeps caps and slim schema', () => {
+  const listed = compactAgentToolResult({
+    kind: 'collection',
+    path: '/notes',
+    id: 'notes',
+    label: '笔记',
+    schema: notesSchema(),
+    total: 2,
+    offset: 0,
+    limit: 50,
+    items: [{ id: 'n1', title: '草稿' }],
+  }) as Record<string, unknown>
+  assert.equal('schema' in listed, false)
+  assert.equal(listed.total, 2)
+  assert.deepEqual(listed.items, [{ id: 'n1', title: '草稿' }])
+
+  const stat = compactAgentToolResult({
+    kind: 'collection',
+    path: '/notes',
+    id: 'notes',
+    label: '笔记',
+    caps: ['list', 'read', 'update', 'content'],
+    schema: notesSchema(),
+  }) as Record<string, unknown>
+  assert.equal(stat.id, undefined)
+  assert.equal(stat.label, '笔记')
+  assert.deepEqual(stat.caps, ['list', 'read', 'update', 'content'])
+  assert.ok(stat.schema)
+  assert.equal('records' in (stat.schema as object), false)
+})
+
+test('compact record read omits schema', () => {
+  const read = compactAgentToolResult({
+    kind: 'record',
+    path: '/notes/n1',
+    schema: notesSchema(),
+    value: { id: 'n1', title: '草稿' },
+  }) as Record<string, unknown>
+  assert.equal('schema' in read, false)
+  assert.deepEqual(read.value, { id: 'n1', title: '草稿' })
+})

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -1,0 +1,113 @@
+import {
+  withBuiltinFields,
+  type CollectionActionInfo,
+  type CollectionSchema,
+  type FieldSpec,
+} from '@biu/type-file-system'
+
+function specsMatch(field: FieldSpec, builtin: FieldSpec) {
+  const label = field.label ?? builtin.label
+  if (field.type !== builtin.type) return false
+  if (label !== (builtin.label ?? field.label)) return false
+  if (field.writable !== builtin.writable) return false
+  if (Boolean(field.sortable) !== Boolean(builtin.sortable)) return false
+  if ((field.format ?? '') !== (builtin.format ?? '')) return false
+  if (JSON.stringify(field.enum ?? null) !== JSON.stringify(builtin.enum ?? null)) return false
+  if ((field.action ?? '') !== (builtin.action ?? '')) return false
+  if (Boolean(field.computed) !== Boolean(builtin.computed)) return false
+  return true
+}
+
+function defaultFields(schema: CollectionSchema) {
+  const labelField = schema.labelField ?? 'title'
+  const contentField = schema.contentField ?? 'content'
+  const raw = withBuiltinFields({}, contentField, labelField)
+  const fields = { ...raw }
+  for (const [key, field] of Object.entries(raw)) {
+    fields[key] = field.computed ? { ...field, writable: false } : field
+  }
+  return fields
+}
+
+function compactField(key: string, field: FieldSpec) {
+  const out: Record<string, unknown> = { type: field.type }
+  if (field.label && field.label !== key) out.label = field.label
+  if (field.writable === false) out.writable = false
+  if (field.sortable) out.sortable = true
+  if (field.format) out.format = field.format
+  if (field.enum?.length) out.enum = field.enum
+  if (field.action) out.action = field.action
+  if (field.computed) out.computed = true
+  return out
+}
+
+function compactAction(action: CollectionActionInfo) {
+  if ((action.for ?? 'both') === 'user') return null
+  const out: Record<string, unknown> = { id: action.id }
+  if (action.description) out.description = action.description
+  else if (action.label && action.label !== action.id) out.label = action.label
+  if (action.when) out.when = action.when
+  if (action.parameters) out.parameters = action.parameters
+  if (action.allowMissing) out.allowMissing = true
+  if (action.confirm) out.confirm = action.confirm
+  return out
+}
+
+export function compactAgentSchema(schema: CollectionSchema) {
+  const defaults = defaultFields(schema)
+  const fields: Record<string, unknown> = {}
+  for (const [key, field] of Object.entries(schema.fields)) {
+    const builtin = defaults[key]
+    if (builtin && specsMatch(field, builtin)) continue
+    fields[key] = compactField(key, field)
+  }
+  const actions = (schema.actions ?? []).map(compactAction).filter(Boolean)
+  const out: Record<string, unknown> = {}
+  if (schema.labelField && schema.labelField !== 'title') out.labelField = schema.labelField
+  if (schema.contentField && schema.contentField !== 'content') out.contentField = schema.contentField
+  if (schema.parentField) out.parentField = schema.parentField
+  if (schema.columns?.length) out.columns = schema.columns
+  if (Object.keys(fields).length) out.fields = fields
+  if (actions.length) out.actions = actions
+  return out
+}
+
+function omitRedundantId(path: string, id: unknown) {
+  if (typeof id !== 'string' || !id) return undefined
+  return `/${id}` === path ? undefined : id
+}
+
+export function compactAgentToolResult(result: unknown) {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return result
+  const rec = result as Record<string, unknown>
+  const kind = rec.kind
+  if (kind === 'root') return result
+  if (kind === 'collection') {
+    const path = String(rec.path ?? '')
+    const next: Record<string, unknown> = { kind: 'collection', path }
+    const id = omitRedundantId(path, rec.id)
+    if (id) next.id = id
+    if (typeof rec.label === 'string' && rec.label && rec.label !== path.slice(1)) next.label = rec.label
+    if (Array.isArray(rec.caps)) next.caps = rec.caps
+    if (Array.isArray(rec.items)) {
+      if (typeof rec.total === 'number') next.total = rec.total
+      if (typeof rec.offset === 'number') next.offset = rec.offset
+      if (typeof rec.limit === 'number') next.limit = rec.limit
+      next.items = rec.items
+      return next
+    }
+    if (rec.schema && typeof rec.schema === 'object') next.schema = compactAgentSchema(rec.schema as CollectionSchema)
+    return next
+  }
+  if (kind === 'record') {
+    const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: rec.value }
+    if (rec.result !== undefined) next.result = rec.result
+    return next
+  }
+  return result
+}
+
+export const AGENT_DB_STAT_BLURB =
+  '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy、updatedBy；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
+
+

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -507,6 +507,40 @@ test('db_list columns returns only those fields plus id', async () => {
   assert.equal('status' in (row ?? {}), false)
 })
 
+test('agent db_stat omits builtin fields; service stat and list still include them', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  class HttpStub extends Service {
+    constructor(c: Context) {
+      super(c, 'http')
+    }
+    route() {}
+  }
+  new HttpStub(ctx)
+  await ctx.plugin({ inject: ['tools', 'http'], apply: applyFileSystem })
+  const db = ctx.get('database') as DatabaseService
+  db.register(notesCollection())
+  const serviceStat = await db.stat('/notes')
+  if (serviceStat.kind !== 'collection') return
+  assert.equal(serviceStat.schema.fields.id?.type, 'string')
+  assert.equal(serviceStat.schema.fields.facet?.type, 'facet')
+  const listed = await db.list('/notes')
+  assert.ok(listed.schema.fields.status)
+  const agentStat = (await ctx.tools.invoke('db_stat', { path: '/notes' })) as {
+    schema?: { fields?: Record<string, unknown>; records?: unknown }
+    caps?: string[]
+  }
+  assert.equal(agentStat.schema?.fields && 'id' in agentStat.schema.fields, false)
+  assert.equal(agentStat.schema?.fields && 'facet' in agentStat.schema.fields, false)
+  assert.ok(agentStat.schema?.fields && 'status' in agentStat.schema.fields)
+  assert.equal(agentStat.schema?.records, undefined)
+  assert.ok(agentStat.caps?.includes('list'))
+  const agentList = (await ctx.tools.invoke('db_list', { path: '/notes' })) as { schema?: unknown; items: unknown[] }
+  assert.equal(agentList.schema, undefined)
+  assert.ok(agentList.items.length)
+})
+
+
 test('db_list on a table broadcasts inspector working then done', async () => {
   const seen: Array<{ type: string; payload: unknown }> = []
   const ctx = new Context()

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -42,6 +42,7 @@ import {
 } from './content-edit.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { databaseRevealForTool, normalizeCollectionPath } from '../paths.ts'
+import { AGENT_DB_STAT_BLURB, compactAgentToolResult } from './agent-payload.ts'
 
 function publicAction(action: CollectionAction): CollectionActionInfo {
   const { run: _run, ...info } = action
@@ -1148,7 +1149,7 @@ export function apply(ctx: Context) {
   }))))
   ctx.tools.register({
     name: 'db_list',
-    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。可用 columns 只取需要的列。',
+    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。可用 columns 只取需要的列。表结构用 db_stat，列表不重复 schema。',
     parameters: {
       type: 'object',
       properties: {
@@ -1170,22 +1171,25 @@ export function apply(ctx: Context) {
     execute: (args) => {
       const path = String(args.path)
       return withInspectorReveal(ctx, path, () =>
-        db.list(path, asFilter(args.filter), {
-          q: args.q != null ? String(args.q) : '',
-          sortField: args.sortField != null ? String(args.sortField) : '',
-          sortDir: args.sortDir === 'desc' ? 'desc' : 'asc',
-          limit: args.limit != null ? Number(args.limit) : undefined,
-          offset: args.offset != null ? Number(args.offset) : undefined,
-          columns: asColumnKeys(args.columns),
-        }),
+        db
+          .list(path, asFilter(args.filter), {
+            q: args.q != null ? String(args.q) : '',
+            sortField: args.sortField != null ? String(args.sortField) : '',
+            sortDir: args.sortDir === 'desc' ? 'desc' : 'asc',
+            limit: args.limit != null ? Number(args.limit) : undefined,
+            offset: args.offset != null ? Number(args.offset) : undefined,
+            columns: asColumnKeys(args.columns),
+          })
+          .then((body) => compactAgentToolResult(body)),
       )
     },
   })
   ctx.tools.register({
     name: 'db_read',
-    description: '读取 File System 路径：表返回列表，记录返回该行 JSON（不含 content 正文，正文用 db_content）。',
+    description: '读取 File System 路径：表返回列表（不含 schema，结构用 db_stat），记录返回该行 JSON（不含 content 正文，正文用 db_content）。',
     parameters: PATH_PARAM,
-    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path))),
+    execute: (args) =>
+      withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path)).then((body) => compactAgentToolResult(body))),
   })
   ctx.tools.register({
     name: 'db_update',
@@ -1254,9 +1258,9 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_stat',
-    description: '查看路径元数据：根目录看有哪些表，表路径返回 schema。',
+    description: AGENT_DB_STAT_BLURB,
     parameters: PATH_PARAM,
-    execute: (args) => db.stat(String(args.path)),
+    execute: (args) => Promise.resolve(db.stat(String(args.path))).then((body) => compactAgentToolResult(body)),
   })
   ctx.tools.register({
     name: 'db_content',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 的 `db_stat` 只返回相对内置列的差（每张表默认的 id/title/时间/合集/父级等写在工具说明里）。`db_list` / `db_read` 表列表不再附带整份 schema。`caps` 留下，`schema.records` 和界面用的动作 placement 不进工具回包。

网页 `GET /api/db/stat|list|read` 仍是全量，UI 不受影响。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

