### PR TITLE
Agent db_list 列式回包：列名只出现一次

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -1,7 +1,9 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { REQUIRED_RECORD_FIELDS, withBuiltinFields, type CollectionSchema } from '@biu/type-file-system'
-import { compactAgentSchema, compactAgentToolResult, compactAgentWriteResult } from './agent-payload.ts'
+import { AgentDbCompact } from './agent-payload.ts'
+
+const pack = new AgentDbCompact()
 
 function notesSchema(): CollectionSchema {
   const fields = withBuiltinFields({
@@ -26,7 +28,7 @@ function notesSchema(): CollectionSchema {
 }
 
 test('compact schema drops identical builtins and user-only actions', () => {
-  const compact = compactAgentSchema(notesSchema())
+  const compact = pack.schema(notesSchema())
   assert.equal('id' in ((compact.fields as object) ?? {}), false)
   assert.equal('createdAt' in ((compact.fields as object) ?? {}), false)
   assert.equal('facet' in ((compact.fields as object) ?? {}), false)
@@ -48,7 +50,7 @@ test('compact schema keeps overrides of builtin labels', () => {
     ...REQUIRED_RECORD_FIELDS,
     parentId: { type: 'ref', label: '父任务', writable: true },
   })
-  const compact = compactAgentSchema({
+  const compact = pack.schema({
     labelField: 'title',
     contentField: 'description',
     parentField: 'parentId',
@@ -61,7 +63,7 @@ test('compact schema keeps overrides of builtin labels', () => {
 })
 
 test('compact list drops schema; compact stat keeps caps and slim schema', () => {
-  const listed = compactAgentToolResult({
+  const listed = pack.query({
     kind: 'collection',
     path: '/notes',
     id: 'notes',
@@ -78,7 +80,7 @@ test('compact list drops schema; compact stat keeps caps and slim schema', () =>
   assert.deepEqual(listed.columns, ['id', 'title'])
   assert.deepEqual(listed.rows, [['n1', '草稿']])
 
-  const stat = compactAgentToolResult({
+  const stat = pack.query({
     kind: 'collection',
     path: '/notes',
     id: 'notes',
@@ -94,7 +96,7 @@ test('compact list drops schema; compact stat keeps caps and slim schema', () =>
 })
 
 test('compact record read omits schema', () => {
-  const read = compactAgentToolResult({
+  const read = pack.query({
     kind: 'record',
     path: '/notes/n1',
     schema: notesSchema(),
@@ -105,7 +107,7 @@ test('compact record read omits schema', () => {
 })
 
 test('compact list uses columns once; drops empty and path/kind', () => {
-  const listed = compactAgentToolResult({
+  const listed = pack.query({
     kind: 'collection',
     path: '/notes',
     total: 2,
@@ -122,7 +124,7 @@ test('compact list uses columns once; drops empty and path/kind', () => {
 })
 
 test('compact list drops createdAt/people unless those are the projected columns', () => {
-  const listed = compactAgentToolResult({
+  const listed = pack.query({
     kind: 'collection',
     path: '/notes',
     items: [
@@ -139,7 +141,7 @@ test('compact list drops createdAt/people unless those are the projected columns
   }) as Record<string, unknown>
   assert.deepEqual(listed.columns, ['id', 'title'])
 
-  const times = compactAgentToolResult({
+  const times = pack.query({
     kind: 'collection',
     path: '/notes',
     items: [{ id: 'n1', createdAt: 1, path: '/notes/n1', kind: 'record' }],
@@ -149,7 +151,7 @@ test('compact list drops createdAt/people unless those are the projected columns
 })
 
 test('compact root drops view chrome; content write is ok only', () => {
-  const root = compactAgentToolResult({
+  const root = pack.query({
     kind: 'root',
     path: '/',
     items: [
@@ -162,7 +164,7 @@ test('compact root drops view chrome; content write is ok only', () => {
     items: [{ path: '/notes', label: '笔记' }, { path: '/views' }],
   })
 
-  const written = compactAgentToolResult({
+  const written = pack.query({
     kind: 'content',
     path: '/notes/n1',
     field: 'content',
@@ -174,14 +176,14 @@ test('compact root drops view chrome; content write is ok only', () => {
 
 
 test('compact write drops full record; create keeps ids', () => {
-  const updated = compactAgentWriteResult({
+  const updated = pack.write({
     kind: 'record',
     path: '/notes/n1',
     value: { id: 'n1', title: '草稿', status: 'open', createdAt: 'x' },
   }) as Record<string, unknown>
   assert.deepEqual(updated, { ok: true, path: '/notes/n1' })
 
-  const acted = compactAgentWriteResult({
+  const acted = pack.write({
     kind: 'record',
     path: '/notes/n1',
     value: { id: 'n1', title: '草稿' },
@@ -189,7 +191,7 @@ test('compact write drops full record; create keeps ids', () => {
   }) as Record<string, unknown>
   assert.deepEqual(acted, { ok: true, path: '/notes/n1', result: { assigned: true } })
 
-  const created = compactAgentWriteResult({
+  const created = pack.write({
     kind: 'created',
     path: '/notes',
     items: [{ kind: 'record', path: '/notes/n3', value: { id: 'n3', title: '新' } }],

--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -73,8 +73,10 @@ test('compact list drops schema; compact stat keeps caps and slim schema', () =>
     items: [{ id: 'n1', title: '草稿' }],
   }) as Record<string, unknown>
   assert.equal('schema' in listed, false)
+  assert.equal('items' in listed, false)
   assert.equal(listed.total, 2)
-  assert.deepEqual(listed.items, [{ id: 'n1', title: '草稿' }])
+  assert.deepEqual(listed.columns, ['id', 'title'])
+  assert.deepEqual(listed.rows, [['n1', '草稿']])
 
   const stat = compactAgentToolResult({
     kind: 'collection',
@@ -100,4 +102,21 @@ test('compact record read omits schema', () => {
   }) as Record<string, unknown>
   assert.equal('schema' in read, false)
   assert.deepEqual(read.value, { id: 'n1', title: '草稿' })
+})
+
+test('compact list uses columns once; drops empty and path/kind', () => {
+  const listed = compactAgentToolResult({
+    kind: 'collection',
+    path: '/notes',
+    total: 2,
+    items: [
+      { id: 'n1', title: '草稿', tags: [], facet: {}, path: '/notes/n1', kind: 'record' },
+      { id: 'n2', title: '另一篇', tags: [], path: '/notes/n2', kind: 'record' },
+    ],
+  }) as Record<string, unknown>
+  assert.deepEqual(listed.columns, ['id', 'title'])
+  assert.deepEqual(listed.rows, [
+    ['n1', '草稿'],
+    ['n2', '另一篇'],
+  ])
 })

--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { REQUIRED_RECORD_FIELDS, withBuiltinFields, type CollectionSchema } from '@biu/type-file-system'
-import { compactAgentSchema, compactAgentToolResult } from './agent-payload.ts'
+import { compactAgentSchema, compactAgentToolResult, compactAgentWriteResult } from './agent-payload.ts'
 
 function notesSchema(): CollectionSchema {
   const fields = withBuiltinFields({
@@ -119,4 +119,28 @@ test('compact list uses columns once; drops empty and path/kind', () => {
     ['n1', '草稿'],
     ['n2', '另一篇'],
   ])
+})
+
+test('compact write drops full record; create keeps ids', () => {
+  const updated = compactAgentWriteResult({
+    kind: 'record',
+    path: '/notes/n1',
+    value: { id: 'n1', title: '草稿', status: 'open', createdAt: 'x' },
+  }) as Record<string, unknown>
+  assert.deepEqual(updated, { ok: true, path: '/notes/n1' })
+
+  const acted = compactAgentWriteResult({
+    kind: 'record',
+    path: '/notes/n1',
+    value: { id: 'n1', title: '草稿' },
+    result: { assigned: true },
+  }) as Record<string, unknown>
+  assert.deepEqual(acted, { ok: true, path: '/notes/n1', result: { assigned: true } })
+
+  const created = compactAgentWriteResult({
+    kind: 'created',
+    path: '/notes',
+    items: [{ kind: 'record', path: '/notes/n3', value: { id: 'n3', title: '新' } }],
+  }) as Record<string, unknown>
+  assert.deepEqual(created, { ok: true, path: '/notes', ids: ['n3'] })
 })

--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -121,6 +121,58 @@ test('compact list uses columns once; drops empty and path/kind', () => {
   ])
 })
 
+test('compact list drops createdAt/people unless those are the projected columns', () => {
+  const listed = compactAgentToolResult({
+    kind: 'collection',
+    path: '/notes',
+    items: [
+      {
+        id: 'n1',
+        title: '草稿',
+        createdAt: 1,
+        updatedAt: 2,
+        createdBy: { kind: 'user', name: '用户' },
+        path: '/notes/n1',
+        kind: 'record',
+      },
+    ],
+  }) as Record<string, unknown>
+  assert.deepEqual(listed.columns, ['id', 'title'])
+
+  const times = compactAgentToolResult({
+    kind: 'collection',
+    path: '/notes',
+    items: [{ id: 'n1', createdAt: 1, path: '/notes/n1', kind: 'record' }],
+  }) as Record<string, unknown>
+  assert.deepEqual(times.columns, ['id', 'createdAt'])
+  assert.deepEqual(times.rows, [['n1', 1]])
+})
+
+test('compact root drops view chrome; content write is ok only', () => {
+  const root = compactAgentToolResult({
+    kind: 'root',
+    path: '/',
+    items: [
+      { id: 'notes', path: '/notes', kind: 'collection', label: '笔记', view: { moduleId: 'notes', route: '/notes', title: '笔记' } },
+      { id: 'views', path: '/views', kind: 'collection', label: 'views', view: null },
+    ],
+  }) as Record<string, unknown>
+  assert.deepEqual(root, {
+    kind: 'root',
+    items: [{ path: '/notes', label: '笔记' }, { path: '/views' }],
+  })
+
+  const written = compactAgentToolResult({
+    kind: 'content',
+    path: '/notes/n1',
+    field: 'content',
+    command: 'write',
+    ok: true,
+  }) as Record<string, unknown>
+  assert.deepEqual(written, { ok: true, path: '/notes/n1' })
+})
+
+
 test('compact write drops full record; create keeps ids', () => {
   const updated = compactAgentWriteResult({
     kind: 'record',

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -49,7 +49,6 @@ function compactAction(action: CollectionActionInfo) {
   if (action.when) out.when = action.when
   if (action.parameters) out.parameters = action.parameters
   if (action.allowMissing) out.allowMissing = true
-  if (action.confirm) out.confirm = action.confirm
   return out
 }
 
@@ -66,7 +65,6 @@ export function compactAgentSchema(schema: CollectionSchema) {
   if (schema.labelField && schema.labelField !== 'title') out.labelField = schema.labelField
   if (schema.contentField && schema.contentField !== 'content') out.contentField = schema.contentField
   if (schema.parentField) out.parentField = schema.parentField
-  if (schema.columns?.length) out.columns = schema.columns
   if (Object.keys(fields).length) out.fields = fields
   if (actions.length) out.actions = actions
   return out
@@ -84,14 +82,27 @@ function isEmptyCell(value: unknown) {
   return false
 }
 
-/** 列名只出现一次；path/kind 可从表路径+id 推出，空列整列丢掉。 */
+const LIST_META_KEYS = new Set(['createdAt', 'updatedAt', 'createdBy', 'updatedBy'])
+
+function skipListKey(key: string, keepMeta: boolean) {
+  if (key === 'path' || key === 'kind') return true
+  if (!keepMeta && LIST_META_KEYS.has(key)) return true
+  return false
+}
+
+function listHasNonMetaFields(rows: Record<string, unknown>[]) {
+  return rows.some((row) => Object.keys(row).some((key) => key !== 'id' && !skipListKey(key, true) && !LIST_META_KEYS.has(key)))
+}
+
+/** 列名只出现一次；path/kind 可从表路径+id 推出；空列与默认时间/人员列丢掉。 */
 export function recordsToColumnar(items: unknown[]) {
   const rowsIn = items.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+  const keepMeta = !listHasNonMetaFields(rowsIn)
   const order: string[] = []
   const seen = new Set<string>()
   for (const row of rowsIn) {
     for (const key of Object.keys(row)) {
-      if (key === 'path' || key === 'kind' || seen.has(key)) continue
+      if (skipListKey(key, keepMeta) || seen.has(key)) continue
       seen.add(key)
       order.push(key)
     }
@@ -99,6 +110,21 @@ export function recordsToColumnar(items: unknown[]) {
   const columns = order.filter((key) => key === 'id' || rowsIn.some((row) => !isEmptyCell(row[key])))
   const rows = rowsIn.map((row) => columns.map((key) => (isEmptyCell(row[key]) ? null : row[key])))
   return { columns, rows }
+}
+
+function compactRootTables(entries: unknown) {
+  if (!Array.isArray(entries)) return []
+  return entries.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+    const rec = item as { path?: unknown; label?: unknown; id?: unknown }
+    const path = typeof rec.path === 'string' ? rec.path : typeof rec.id === 'string' ? `/${rec.id}` : ''
+    if (!path) return []
+    const label = typeof rec.label === 'string' ? rec.label : ''
+    const slug = path.slice(1)
+    const next: Record<string, unknown> = { path }
+    if (label && label !== slug) next.label = label
+    return [next]
+  })
 }
 
 function compactRecordValue(value: unknown) {
@@ -115,7 +141,10 @@ export function compactAgentToolResult(result: unknown) {
   if (!result || typeof result !== 'object' || Array.isArray(result)) return result
   const rec = result as Record<string, unknown>
   const kind = rec.kind
-  if (kind === 'root') return result
+  if (kind === 'root') {
+    const tables = compactRootTables(rec.items ?? rec.collections)
+    return { kind: 'root', items: tables }
+  }
   if (kind === 'collection') {
     const path = String(rec.path ?? '')
     const next: Record<string, unknown> = { kind: 'collection', path }
@@ -125,19 +154,35 @@ export function compactAgentToolResult(result: unknown) {
     if (Array.isArray(rec.caps)) next.caps = rec.caps
     if (Array.isArray(rec.items)) {
       if (typeof rec.total === 'number') next.total = rec.total
-      if (typeof rec.offset === 'number') next.offset = rec.offset
+      if (typeof rec.offset === 'number' && rec.offset) next.offset = rec.offset
       if (typeof rec.limit === 'number') next.limit = rec.limit
       const table = recordsToColumnar(rec.items)
       next.columns = table.columns
       next.rows = table.rows
       return next
     }
-    if (rec.schema && typeof rec.schema === 'object') next.schema = compactAgentSchema(rec.schema as CollectionSchema)
+    if (rec.schema && typeof rec.schema === 'object') {
+      const schema = compactAgentSchema(rec.schema as CollectionSchema)
+      if (Object.keys(schema).length) next.schema = schema
+    }
     return next
   }
   if (kind === 'record') {
     const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: compactRecordValue(rec.value) }
     if (rec.result !== undefined) next.result = rec.result
+    return next
+  }
+  if (kind === 'content') {
+    if (rec.ok === true || (typeof rec.command === 'string' && rec.command !== 'view')) {
+      const next: Record<string, unknown> = { ok: true, path: rec.path }
+      if (typeof rec.command === 'string' && rec.command !== 'write') next.command = rec.command
+      return next
+    }
+    const next: Record<string, unknown> = { path: rec.path, text: rec.text }
+    if (typeof rec.start === 'number') next.start = rec.start
+    if (typeof rec.end === 'number') next.end = rec.end
+    if (typeof rec.total === 'number') next.total = rec.total
+    if (rec.truncated) next.truncated = true
     return next
   }
   return result

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -5,150 +5,65 @@ import {
   type FieldSpec,
 } from '@biu/type-file-system'
 
-function specsMatch(field: FieldSpec, builtin: FieldSpec) {
-  const label = field.label ?? builtin.label
-  if (field.type !== builtin.type) return false
-  if (label !== (builtin.label ?? field.label)) return false
-  if (field.writable !== builtin.writable) return false
-  if (Boolean(field.sortable) !== Boolean(builtin.sortable)) return false
-  if ((field.format ?? '') !== (builtin.format ?? '')) return false
-  if (JSON.stringify(field.enum ?? null) !== JSON.stringify(builtin.enum ?? null)) return false
-  if ((field.action ?? '') !== (builtin.action ?? '')) return false
-  if (Boolean(field.computed) !== Boolean(builtin.computed)) return false
-  return true
-}
-
-function defaultFields(schema: CollectionSchema) {
-  const labelField = schema.labelField ?? 'title'
-  const contentField = schema.contentField ?? 'content'
-  const raw = withBuiltinFields({}, contentField, labelField)
-  const fields = { ...raw }
-  for (const [key, field] of Object.entries(raw)) {
-    fields[key] = field.computed ? { ...field, writable: false } : field
-  }
-  return fields
-}
-
-function compactField(key: string, field: FieldSpec) {
-  const out: Record<string, unknown> = { type: field.type }
-  if (field.label && field.label !== key) out.label = field.label
-  if (field.writable === false) out.writable = false
-  if (field.sortable) out.sortable = true
-  if (field.format) out.format = field.format
-  if (field.enum?.length) out.enum = field.enum
-  if (field.action) out.action = field.action
-  if (field.computed) out.computed = true
-  return out
-}
-
-function compactAction(action: CollectionActionInfo) {
-  if ((action.for ?? 'both') === 'user') return null
-  const out: Record<string, unknown> = { id: action.id }
-  if (action.description) out.description = action.description
-  else if (action.label && action.label !== action.id) out.label = action.label
-  if (action.when) out.when = action.when
-  if (action.parameters) out.parameters = action.parameters
-  if (action.allowMissing) out.allowMissing = true
-  return out
-}
-
-export function compactAgentSchema(schema: CollectionSchema) {
-  const defaults = defaultFields(schema)
-  const fields: Record<string, unknown> = {}
-  for (const [key, field] of Object.entries(schema.fields)) {
-    const builtin = defaults[key]
-    if (builtin && specsMatch(field, builtin)) continue
-    fields[key] = compactField(key, field)
-  }
-  const actions = (schema.actions ?? []).map(compactAction).filter(Boolean)
-  const out: Record<string, unknown> = {}
-  if (schema.labelField && schema.labelField !== 'title') out.labelField = schema.labelField
-  if (schema.contentField && schema.contentField !== 'content') out.contentField = schema.contentField
-  if (schema.parentField) out.parentField = schema.parentField
-  if (Object.keys(fields).length) out.fields = fields
-  if (actions.length) out.actions = actions
-  return out
-}
-
-function omitRedundantId(path: string, id: unknown) {
-  if (typeof id !== 'string' || !id) return undefined
-  return `/${id}` === path ? undefined : id
-}
-
-function isEmptyCell(value: unknown) {
-  if (value == null || value === '') return true
-  if (Array.isArray(value) && value.length === 0) return true
-  if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) return true
-  return false
-}
-
 const LIST_META_KEYS = new Set(['createdAt', 'updatedAt', 'createdBy', 'updatedBy'])
 
-function skipListKey(key: string, keepMeta: boolean) {
-  if (key === 'path' || key === 'kind') return true
-  if (!keepMeta && LIST_META_KEYS.has(key)) return true
-  return false
-}
+/** 把 File System 工具回包压成 Agent 用的短 JSON；网页 API 不走这里。 */
+export class AgentDbCompact {
+  readonly statBlurb =
+    '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy、updatedBy；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
 
-function listHasNonMetaFields(rows: Record<string, unknown>[]) {
-  return rows.some((row) => Object.keys(row).some((key) => key !== 'id' && !skipListKey(key, true) && !LIST_META_KEYS.has(key)))
-}
-
-/** 列名只出现一次；path/kind 可从表路径+id 推出；空列与默认时间/人员列丢掉。 */
-export function recordsToColumnar(items: unknown[]) {
-  const rowsIn = items.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
-  const keepMeta = !listHasNonMetaFields(rowsIn)
-  const order: string[] = []
-  const seen = new Set<string>()
-  for (const row of rowsIn) {
-    for (const key of Object.keys(row)) {
-      if (skipListKey(key, keepMeta) || seen.has(key)) continue
-      seen.add(key)
-      order.push(key)
+  schema(schema: CollectionSchema) {
+    const defaults = this.defaultFields(schema)
+    const fields: Record<string, unknown> = {}
+    for (const [key, field] of Object.entries(schema.fields)) {
+      const builtin = defaults[key]
+      if (builtin && this.specsMatch(field, builtin)) continue
+      fields[key] = this.field(key, field)
     }
+    const actions = (schema.actions ?? []).map((item) => this.action(item)).filter(Boolean)
+    const out: Record<string, unknown> = {}
+    if (schema.labelField && schema.labelField !== 'title') out.labelField = schema.labelField
+    if (schema.contentField && schema.contentField !== 'content') out.contentField = schema.contentField
+    if (schema.parentField) out.parentField = schema.parentField
+    if (Object.keys(fields).length) out.fields = fields
+    if (actions.length) out.actions = actions
+    return out
   }
-  const columns = order.filter((key) => key === 'id' || rowsIn.some((row) => !isEmptyCell(row[key])))
-  const rows = rowsIn.map((row) => columns.map((key) => (isEmptyCell(row[key]) ? null : row[key])))
-  return { columns, rows }
-}
 
-function compactRootTables(entries: unknown) {
-  if (!Array.isArray(entries)) return []
-  return entries.flatMap((item) => {
-    if (!item || typeof item !== 'object' || Array.isArray(item)) return []
-    const rec = item as { path?: unknown; label?: unknown; id?: unknown }
-    const path = typeof rec.path === 'string' ? rec.path : typeof rec.id === 'string' ? `/${rec.id}` : ''
-    if (!path) return []
-    const label = typeof rec.label === 'string' ? rec.label : ''
-    const slug = path.slice(1)
-    const next: Record<string, unknown> = { path }
-    if (label && label !== slug) next.label = label
-    return [next]
-  })
-}
-
-function compactRecordValue(value: unknown) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
-  const next: Record<string, unknown> = {}
-  for (const [key, cell] of Object.entries(value as Record<string, unknown>)) {
-    if (isEmptyCell(cell)) continue
-    next[key] = cell
+  /** list / read / stat / content */
+  query(result: unknown) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result
+    const rec = result as Record<string, unknown>
+    const kind = rec.kind
+    if (kind === 'root') return { kind: 'root', items: this.rootTables(rec.items ?? rec.collections) }
+    if (kind === 'collection') return this.collection(rec)
+    if (kind === 'record') {
+      const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: this.recordValue(rec.value) }
+      if (rec.result !== undefined) next.result = rec.result
+      return next
+    }
+    if (kind === 'content') return this.content(rec)
+    return result
   }
-  return next
-}
 
-export function compactAgentToolResult(result: unknown) {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) return result
-  const rec = result as Record<string, unknown>
-  const kind = rec.kind
-  if (kind === 'root') {
-    const tables = compactRootTables(rec.items ?? rec.collections)
-    return { kind: 'root', items: tables }
+  /** update / create / delete / action */
+  write(result: unknown) {
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result
+    const rec = result as Record<string, unknown>
+    if (rec.kind === 'record') {
+      const next: Record<string, unknown> = { ok: true, path: rec.path }
+      if (rec.result !== undefined) next.result = rec.result
+      return next
+    }
+    if (rec.kind === 'created') return { ok: true, path: rec.path, ids: this.createdIds(rec.items) }
+    if (rec.kind === 'deleted') return { ok: true, path: rec.path, ids: rec.ids ?? [] }
+    return result
   }
-  if (kind === 'collection') {
+
+  private collection(rec: Record<string, unknown>) {
     const path = String(rec.path ?? '')
     const next: Record<string, unknown> = { kind: 'collection', path }
-    const id = omitRedundantId(path, rec.id)
+    const id = this.omitRedundantId(path, rec.id)
     if (id) next.id = id
     if (typeof rec.label === 'string' && rec.label && rec.label !== path.slice(1)) next.label = rec.label
     if (Array.isArray(rec.caps)) next.caps = rec.caps
@@ -156,23 +71,19 @@ export function compactAgentToolResult(result: unknown) {
       if (typeof rec.total === 'number') next.total = rec.total
       if (typeof rec.offset === 'number' && rec.offset) next.offset = rec.offset
       if (typeof rec.limit === 'number') next.limit = rec.limit
-      const table = recordsToColumnar(rec.items)
+      const table = this.columnar(rec.items)
       next.columns = table.columns
       next.rows = table.rows
       return next
     }
     if (rec.schema && typeof rec.schema === 'object') {
-      const schema = compactAgentSchema(rec.schema as CollectionSchema)
+      const schema = this.schema(rec.schema as CollectionSchema)
       if (Object.keys(schema).length) next.schema = schema
     }
     return next
   }
-  if (kind === 'record') {
-    const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: compactRecordValue(rec.value) }
-    if (rec.result !== undefined) next.result = rec.result
-    return next
-  }
-  if (kind === 'content') {
+
+  private content(rec: Record<string, unknown>) {
     if (rec.ok === true || (typeof rec.command === 'string' && rec.command !== 'view')) {
       const next: Record<string, unknown> = { ok: true, path: rec.path }
       if (typeof rec.command === 'string' && rec.command !== 'write') next.command = rec.command
@@ -185,40 +96,132 @@ export function compactAgentToolResult(result: unknown) {
     if (rec.truncated) next.truncated = true
     return next
   }
-  return result
-}
 
-function createdIds(items: unknown) {
-  if (!Array.isArray(items)) return [] as string[]
-  const ids: string[] = []
-  for (const item of items) {
-    if (!item || typeof item !== 'object') continue
-    const row = item as { path?: unknown; value?: { id?: unknown } }
-    const id = typeof row.value?.id === 'string'
-      ? row.value.id
-      : typeof row.path === 'string'
-        ? row.path.slice(row.path.lastIndexOf('/') + 1)
-        : ''
-    if (id) ids.push(id)
+  private columnar(items: unknown[]) {
+    const rowsIn = items.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+    const keepMeta = !this.hasNonMetaFields(rowsIn)
+    const order: string[] = []
+    const seen = new Set<string>()
+    for (const row of rowsIn) {
+      for (const key of Object.keys(row)) {
+        if (this.skipListKey(key, keepMeta) || seen.has(key)) continue
+        seen.add(key)
+        order.push(key)
+      }
+    }
+    const columns = order.filter((key) => key === 'id' || rowsIn.some((row) => !this.empty(row[key])))
+    const rows = rowsIn.map((row) => columns.map((key) => (this.empty(row[key]) ? null : row[key])))
+    return { columns, rows }
   }
-  return ids
-}
 
-/** 写操作 Agent 已提交过字段，回包只确认路径；新建补 ids，动作补 result。 */
-export function compactAgentWriteResult(result: unknown) {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) return result
-  const rec = result as Record<string, unknown>
-  if (rec.kind === 'record') {
-    const next: Record<string, unknown> = { ok: true, path: rec.path }
-    if (rec.result !== undefined) next.result = rec.result
+  private rootTables(entries: unknown) {
+    if (!Array.isArray(entries)) return []
+    return entries.flatMap((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+      const rec = item as { path?: unknown; label?: unknown; id?: unknown }
+      const path = typeof rec.path === 'string' ? rec.path : typeof rec.id === 'string' ? `/${rec.id}` : ''
+      if (!path) return []
+      const label = typeof rec.label === 'string' ? rec.label : ''
+      const next: Record<string, unknown> = { path }
+      if (label && label !== path.slice(1)) next.label = label
+      return [next]
+    })
+  }
+
+  private recordValue(value: unknown) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+    const next: Record<string, unknown> = {}
+    for (const [key, cell] of Object.entries(value as Record<string, unknown>)) {
+      if (this.empty(cell)) continue
+      next[key] = cell
+    }
     return next
   }
-  if (rec.kind === 'created') return { ok: true, path: rec.path, ids: createdIds(rec.items) }
-  if (rec.kind === 'deleted') return { ok: true, path: rec.path, ids: rec.ids ?? [] }
-  return result
+
+  private createdIds(items: unknown) {
+    if (!Array.isArray(items)) return [] as string[]
+    const ids: string[] = []
+    for (const item of items) {
+      if (!item || typeof item !== 'object') continue
+      const row = item as { path?: unknown; value?: { id?: unknown } }
+      const id = typeof row.value?.id === 'string'
+        ? row.value.id
+        : typeof row.path === 'string'
+          ? row.path.slice(row.path.lastIndexOf('/') + 1)
+          : ''
+      if (id) ids.push(id)
+    }
+    return ids
+  }
+
+  private field(key: string, field: FieldSpec) {
+    const out: Record<string, unknown> = { type: field.type }
+    if (field.label && field.label !== key) out.label = field.label
+    if (field.writable === false) out.writable = false
+    if (field.sortable) out.sortable = true
+    if (field.format) out.format = field.format
+    if (field.enum?.length) out.enum = field.enum
+    if (field.action) out.action = field.action
+    if (field.computed) out.computed = true
+    return out
+  }
+
+  private action(action: CollectionActionInfo) {
+    if ((action.for ?? 'both') === 'user') return null
+    const out: Record<string, unknown> = { id: action.id }
+    if (action.description) out.description = action.description
+    else if (action.label && action.label !== action.id) out.label = action.label
+    if (action.when) out.when = action.when
+    if (action.parameters) out.parameters = action.parameters
+    if (action.allowMissing) out.allowMissing = true
+    return out
+  }
+
+  private defaultFields(schema: CollectionSchema) {
+    const labelField = schema.labelField ?? 'title'
+    const contentField = schema.contentField ?? 'content'
+    const raw = withBuiltinFields({}, contentField, labelField)
+    const fields = { ...raw }
+    for (const [key, field] of Object.entries(raw)) {
+      fields[key] = field.computed ? { ...field, writable: false } : field
+    }
+    return fields
+  }
+
+  private specsMatch(field: FieldSpec, builtin: FieldSpec) {
+    const label = field.label ?? builtin.label
+    if (field.type !== builtin.type) return false
+    if (label !== (builtin.label ?? field.label)) return false
+    if (field.writable !== builtin.writable) return false
+    if (Boolean(field.sortable) !== Boolean(builtin.sortable)) return false
+    if ((field.format ?? '') !== (builtin.format ?? '')) return false
+    if (JSON.stringify(field.enum ?? null) !== JSON.stringify(builtin.enum ?? null)) return false
+    if ((field.action ?? '') !== (builtin.action ?? '')) return false
+    if (Boolean(field.computed) !== Boolean(builtin.computed)) return false
+    return true
+  }
+
+  private omitRedundantId(path: string, id: unknown) {
+    if (typeof id !== 'string' || !id) return undefined
+    return `/${id}` === path ? undefined : id
+  }
+
+  private empty(value: unknown) {
+    if (value == null || value === '') return true
+    if (Array.isArray(value) && value.length === 0) return true
+    if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) return true
+    return false
+  }
+
+  private skipListKey(key: string, keepMeta: boolean) {
+    if (key === 'path' || key === 'kind') return true
+    if (!keepMeta && LIST_META_KEYS.has(key)) return true
+    return false
+  }
+
+  private hasNonMetaFields(rows: Record<string, unknown>[]) {
+    return rows.some((row) =>
+      Object.keys(row).some((key) => key !== 'id' && !this.skipListKey(key, true) && !LIST_META_KEYS.has(key)),
+    )
+  }
 }
-
-export const AGENT_DB_STAT_BLURB =
-  '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy、updatedBy；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
-
-

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -77,6 +77,40 @@ function omitRedundantId(path: string, id: unknown) {
   return `/${id}` === path ? undefined : id
 }
 
+function isEmptyCell(value: unknown) {
+  if (value == null || value === '') return true
+  if (Array.isArray(value) && value.length === 0) return true
+  if (typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length === 0) return true
+  return false
+}
+
+/** 列名只出现一次；path/kind 可从表路径+id 推出，空列整列丢掉。 */
+export function recordsToColumnar(items: unknown[]) {
+  const rowsIn = items.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object' && !Array.isArray(item))
+  const order: string[] = []
+  const seen = new Set<string>()
+  for (const row of rowsIn) {
+    for (const key of Object.keys(row)) {
+      if (key === 'path' || key === 'kind' || seen.has(key)) continue
+      seen.add(key)
+      order.push(key)
+    }
+  }
+  const columns = order.filter((key) => key === 'id' || rowsIn.some((row) => !isEmptyCell(row[key])))
+  const rows = rowsIn.map((row) => columns.map((key) => (isEmptyCell(row[key]) ? null : row[key])))
+  return { columns, rows }
+}
+
+function compactRecordValue(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return value
+  const next: Record<string, unknown> = {}
+  for (const [key, cell] of Object.entries(value as Record<string, unknown>)) {
+    if (isEmptyCell(cell)) continue
+    next[key] = cell
+  }
+  return next
+}
+
 export function compactAgentToolResult(result: unknown) {
   if (!result || typeof result !== 'object' || Array.isArray(result)) return result
   const rec = result as Record<string, unknown>
@@ -93,14 +127,16 @@ export function compactAgentToolResult(result: unknown) {
       if (typeof rec.total === 'number') next.total = rec.total
       if (typeof rec.offset === 'number') next.offset = rec.offset
       if (typeof rec.limit === 'number') next.limit = rec.limit
-      next.items = rec.items
+      const table = recordsToColumnar(rec.items)
+      next.columns = table.columns
+      next.rows = table.rows
       return next
     }
     if (rec.schema && typeof rec.schema === 'object') next.schema = compactAgentSchema(rec.schema as CollectionSchema)
     return next
   }
   if (kind === 'record') {
-    const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: rec.value }
+    const next: Record<string, unknown> = { kind: 'record', path: rec.path, value: compactRecordValue(rec.value) }
     if (rec.result !== undefined) next.result = rec.result
     return next
   }

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -143,6 +143,36 @@ export function compactAgentToolResult(result: unknown) {
   return result
 }
 
+function createdIds(items: unknown) {
+  if (!Array.isArray(items)) return [] as string[]
+  const ids: string[] = []
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue
+    const row = item as { path?: unknown; value?: { id?: unknown } }
+    const id = typeof row.value?.id === 'string'
+      ? row.value.id
+      : typeof row.path === 'string'
+        ? row.path.slice(row.path.lastIndexOf('/') + 1)
+        : ''
+    if (id) ids.push(id)
+  }
+  return ids
+}
+
+/** 写操作 Agent 已提交过字段，回包只确认路径；新建补 ids，动作补 result。 */
+export function compactAgentWriteResult(result: unknown) {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return result
+  const rec = result as Record<string, unknown>
+  if (rec.kind === 'record') {
+    const next: Record<string, unknown> = { ok: true, path: rec.path }
+    if (rec.result !== undefined) next.result = rec.result
+    return next
+  }
+  if (rec.kind === 'created') return { ok: true, path: rec.path, ids: createdIds(rec.items) }
+  if (rec.kind === 'deleted') return { ok: true, path: rec.path, ids: rec.ids ?? [] }
+  return result
+}
+
 export const AGENT_DB_STAT_BLURB =
   '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy、updatedBy；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
 

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -546,6 +546,12 @@ test('agent db_stat omits builtin fields; service stat and list still include th
   assert.ok(agentList.columns?.includes('title'))
   assert.equal(agentList.columns?.includes('path'), false)
   assert.ok((agentList.rows?.length ?? 0) >= 1)
+  const updated = (await ctx.tools.invoke('db_update', { path: '/notes/n1', content: { status: 'done' } })) as {
+    ok?: boolean
+    path?: string
+    value?: unknown
+  }
+  assert.deepEqual(updated, { ok: true, path: '/notes/n1' })
 })
 
 
@@ -604,11 +610,11 @@ test('db_create /views reveals the source table and view', async () => {
       path: '/views',
       records: [{ tablePath: '/notes', title: '看板', mode: 'graph' }],
     }),
-  )
-  const row = (created as { items: Array<{ value: { tablePath?: string; viewId?: string; title?: string } }> }).items[0]?.value
-  assert.equal(row?.tablePath, '/notes')
-  assert.equal(row?.title, '看板')
-  assert.equal(typeof row?.viewId, 'string')
+  ) as { ids?: string[] }
+  const id = created.ids?.[0]
+  assert.equal(typeof id, 'string')
+  const viewId = String(id).split('::')[1]
+  assert.equal(typeof viewId, 'string')
   const done = [...seen].reverse().find((item) => {
     const payload = item.payload as { phase?: string; reveal?: { collection?: string; viewId?: string } }
     return item.type === 'database' && payload?.phase === 'done' && payload.reveal?.collection === '/notes'
@@ -619,7 +625,7 @@ test('db_create /views reveals the source table and view', async () => {
     savedView?: { name?: string; mode?: string }
   }
   assert.equal(payload.sessionId, 's1')
-  assert.equal(payload.reveal?.viewId, row?.viewId)
+  assert.equal(payload.reveal?.viewId, viewId)
   assert.equal(payload.savedView?.name, '看板')
   assert.equal(payload.savedView?.mode, 'graph')
 })

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -499,12 +499,11 @@ test('db_list columns returns only those fields plus id', async () => {
   const db = ctx.get('database') as DatabaseService
   db.register(notesCollection())
   const listed = await ctx.tools.invoke('db_list', { path: '/notes', columns: ['label'] }) as {
-    items: Array<Record<string, unknown>>
+    columns: string[]
+    rows: unknown[][]
   }
-  const row = listed.items[0]
-  assert.equal(row?.title, '草稿')
-  assert.equal(row?.id, 'n1')
-  assert.equal('status' in (row ?? {}), false)
+  assert.deepEqual(listed.columns, ['id', 'title'])
+  assert.deepEqual(listed.rows[0], ['n1', '草稿'])
 })
 
 test('agent db_stat omits builtin fields; service stat and list still include them', async () => {
@@ -535,9 +534,18 @@ test('agent db_stat omits builtin fields; service stat and list still include th
   assert.ok(agentStat.schema?.fields && 'status' in agentStat.schema.fields)
   assert.equal(agentStat.schema?.records, undefined)
   assert.ok(agentStat.caps?.includes('list'))
-  const agentList = (await ctx.tools.invoke('db_list', { path: '/notes' })) as { schema?: unknown; items: unknown[] }
+  const agentList = (await ctx.tools.invoke('db_list', { path: '/notes' })) as {
+    schema?: unknown
+    columns?: string[]
+    rows?: unknown[][]
+    items?: unknown
+  }
   assert.equal(agentList.schema, undefined)
-  assert.ok(agentList.items.length)
+  assert.equal(agentList.items, undefined)
+  assert.ok(agentList.columns?.includes('id'))
+  assert.ok(agentList.columns?.includes('title'))
+  assert.equal(agentList.columns?.includes('path'), false)
+  assert.ok((agentList.rows?.length ?? 0) >= 1)
 })
 
 

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1149,7 +1149,7 @@ export function apply(ctx: Context) {
   }))))
   ctx.tools.register({
     name: 'db_list',
-    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。可用 columns 只取需要的列。表结构用 db_stat，列表不重复 schema。',
+    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。表记录为列式：columns 列名只出现一次，rows 为值数组；path=/<表>/<id>。可用 columns 参数只取需要的列。表结构用 db_stat，列表不重复 schema。',
     parameters: {
       type: 'object',
       properties: {
@@ -1186,7 +1186,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_read',
-    description: '读取 File System 路径：表返回列表（不含 schema，结构用 db_stat），记录返回该行 JSON（不含 content 正文，正文用 db_content）。',
+    description: '读取 File System 路径：表返回列式列表 columns/rows（不含 schema，结构用 db_stat），记录返回该行 JSON（空字段省略，不含 content 正文，正文用 db_content）。',
     parameters: PATH_PARAM,
     execute: (args) =>
       withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path)).then((body) => compactAgentToolResult(body))),

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -42,7 +42,7 @@ import {
 } from './content-edit.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { databaseRevealForTool, normalizeCollectionPath } from '../paths.ts'
-import { AGENT_DB_STAT_BLURB, compactAgentToolResult } from './agent-payload.ts'
+import { AGENT_DB_STAT_BLURB, compactAgentToolResult, compactAgentWriteResult } from './agent-payload.ts'
 
 function publicAction(action: CollectionAction): CollectionActionInfo {
   const { run: _run, ...info } = action
@@ -1193,7 +1193,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_update',
-    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。合集（facet 字段）在所有表都可写，包括 records.update 为 false 的表（如 /plugins）；其它字段仍看 caps。新建用 db_create，正文用 db_content。改合集属性用 db_update path=/facets/<id> content.fields。',
+    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。成功只返回 {ok, path}，不回整行。合集（facet 字段）在所有表都可写，包括 records.update 为 false 的表（如 /plugins）；其它字段仍看 caps。新建用 db_create，正文用 db_content。改合集属性用 db_update path=/facets/<id> content.fields。',
     parameters: {
       type: 'object',
       properties: {
@@ -1202,11 +1202,14 @@ export function apply(ctx: Context) {
       },
       required: ['path', 'content'],
     },
-    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.update(String(args.path), args.content)),
+    execute: (args) =>
+      withInspectorReveal(ctx, String(args.path), () => db.update(String(args.path), args.content)).then(
+        compactAgentWriteResult,
+      ),
   })
   ctx.tools.register({
     name: 'db_create',
-    description: '在已登记且允许新建的表中批量新增记录。路径为 /<表>，records 为对象数组。能否新建看 db_stat 的 caps 与 schema.records。新建合集用 db_create path=/facets records=[{title}]。',
+    description: '在已登记且允许新建的表中批量新增记录。路径为 /<表>，records 为对象数组。成功返回 {ok, path, ids}，不回整行。能否新建看 db_stat 的 caps。新建合集用 db_create path=/facets records=[{title}]。',
     parameters: {
       type: 'object',
       properties: {
@@ -1215,7 +1218,10 @@ export function apply(ctx: Context) {
       },
       required: ['path', 'records'],
     },
-    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.create(String(args.path), asCreateRecords(args))),
+    execute: (args) =>
+      withInspectorReveal(ctx, String(args.path), () => db.create(String(args.path), asCreateRecords(args))).then(
+        compactAgentWriteResult,
+      ),
   })
   ctx.tools.register({
     name: 'db_delete',
@@ -1230,12 +1236,15 @@ export function apply(ctx: Context) {
       },
       required: ['path'],
     },
-    execute: (args) => withInspectorReveal(ctx, String(args.path), () => db.remove(String(args.path), asDeleteQuery(args)), true),
+    execute: (args) =>
+      withInspectorReveal(ctx, String(args.path), () => db.remove(String(args.path), asDeleteQuery(args)), true).then(
+        compactAgentWriteResult,
+      ),
   })
   ctx.tools.register({
     name: 'db_action',
     description:
-      '对一条记录执行该表登记的动作。路径为 /<表>/<id>，action 为动作 id（见 db_stat 的 schema.actions）。需要参数时放在 args。任务派工/汇报、会话压缩/进度、插件创建/打包一律走这里。',
+      '对一条记录执行该表登记的动作。路径为 /<表>/<id>，action 为动作 id（见 db_stat 的 schema.actions）。成功返回 {ok, path}，有返回值时带 result，不回整行。需要参数时放在 args。任务派工/汇报、会话压缩/进度、插件创建/打包一律走这里。',
     parameters: {
       type: 'object',
       properties: {
@@ -1254,7 +1263,7 @@ export function apply(ctx: Context) {
             ? (args.args as Record<string, unknown>)
             : undefined,
         ),
-      ),
+      ).then(compactAgentWriteResult),
   })
   ctx.tools.register({
     name: 'db_stat',

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -42,7 +42,9 @@ import {
 } from './content-edit.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { databaseRevealForTool, normalizeCollectionPath } from '../paths.ts'
-import { AGENT_DB_STAT_BLURB, compactAgentToolResult, compactAgentWriteResult } from './agent-payload.ts'
+import { AgentDbCompact } from './agent-payload.ts'
+
+const agentDbCompact = new AgentDbCompact()
 
 function publicAction(action: CollectionAction): CollectionActionInfo {
   const { run: _run, ...info } = action
@@ -1180,7 +1182,7 @@ export function apply(ctx: Context) {
             offset: args.offset != null ? Number(args.offset) : undefined,
             columns: asColumnKeys(args.columns),
           })
-          .then((body) => compactAgentToolResult(body)),
+          .then((body) => agentDbCompact.query(body)),
       )
     },
   })
@@ -1189,7 +1191,7 @@ export function apply(ctx: Context) {
     description: '读取 File System 路径：表返回列式列表 columns/rows（不含 schema，结构用 db_stat），记录返回该行 JSON（空字段省略，不含 content 正文，正文用 db_content）。',
     parameters: PATH_PARAM,
     execute: (args) =>
-      withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path)).then((body) => compactAgentToolResult(body))),
+      withInspectorReveal(ctx, String(args.path), () => db.read(String(args.path)).then((body) => agentDbCompact.query(body))),
   })
   ctx.tools.register({
     name: 'db_update',
@@ -1204,7 +1206,7 @@ export function apply(ctx: Context) {
     },
     execute: (args) =>
       withInspectorReveal(ctx, String(args.path), () => db.update(String(args.path), args.content)).then(
-        compactAgentWriteResult,
+        (body) => agentDbCompact.write(body),
       ),
   })
   ctx.tools.register({
@@ -1220,7 +1222,7 @@ export function apply(ctx: Context) {
     },
     execute: (args) =>
       withInspectorReveal(ctx, String(args.path), () => db.create(String(args.path), asCreateRecords(args))).then(
-        compactAgentWriteResult,
+        (body) => agentDbCompact.write(body),
       ),
   })
   ctx.tools.register({
@@ -1238,7 +1240,7 @@ export function apply(ctx: Context) {
     },
     execute: (args) =>
       withInspectorReveal(ctx, String(args.path), () => db.remove(String(args.path), asDeleteQuery(args)), true).then(
-        compactAgentWriteResult,
+        (body) => agentDbCompact.write(body),
       ),
   })
   ctx.tools.register({
@@ -1263,13 +1265,13 @@ export function apply(ctx: Context) {
             ? (args.args as Record<string, unknown>)
             : undefined,
         ),
-      ).then(compactAgentWriteResult),
+      ).then((body) => agentDbCompact.write(body)),
   })
   ctx.tools.register({
     name: 'db_stat',
-    description: AGENT_DB_STAT_BLURB,
+    description: agentDbCompact.statBlurb,
     parameters: PATH_PARAM,
-    execute: (args) => Promise.resolve(db.stat(String(args.path))).then((body) => compactAgentToolResult(body)),
+    execute: (args) => Promise.resolve(db.stat(String(args.path))).then((body) => agentDbCompact.query(body)),
   })
   ctx.tools.register({
     name: 'db_content',
@@ -1306,7 +1308,7 @@ export function apply(ctx: Context) {
     },
     execute: (args) =>
       withInspectorReveal(ctx, String(args.path), () =>
-        db.editContent(String(args.path), args).then(compactAgentToolResult),
+        db.editContent(String(args.path), args).then((body) => agentDbCompact.query(body)),
       ),
   })
 

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1149,7 +1149,7 @@ export function apply(ctx: Context) {
   }))))
   ctx.tools.register({
     name: 'db_list',
-    description: '列出 File System 路径：/ 为已登记表，/<表> 为该表记录（不含 content 正文）。默认每页 50 条，最多 200。表记录为列式：columns 列名只出现一次，rows 为值数组；path=/<表>/<id>。可用 columns 参数只取需要的列。表结构用 db_stat，列表不重复 schema。',
+    description: '列出 File System 路径：/ 为已登记表（path + 中文名），/<表> 为列式记录（不含 content、默认不含 createdAt/updatedAt/createdBy/updatedBy）。默认每页 50，最多 200。columns 参数只取需要的列。表结构用 db_stat。',
     parameters: {
       type: 'object',
       properties: {
@@ -1225,7 +1225,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_delete',
-    description: '按条件删除记录。路径为 /<表>，必须带 ids、q 或 filter 之一，禁止无条件清空全表。能否删除看 db_stat 的 caps 与 schema.records。调用后会进入审批，用户同意才真正删。',
+    description: '按条件删除记录。路径为 /<表>，必须带 ids、q 或 filter 之一，禁止无条件清空全表。能否删除看 db_stat 的 caps。调用后会进入审批，用户同意才真正删。成功返回 {ok, path, ids}。',
     parameters: {
       type: 'object',
       properties: {
@@ -1279,7 +1279,7 @@ export function apply(ctx: Context) {
       'command=str_replace：old_str 必须在正文里唯一，替换为 new_str。',
       'command=replace_lines：按 1-based 闭区间 start_line..end_line 换成 new_str。',
       'command=insert：在 insert_line 之后插入 new_str（0 插到第一行前）。',
-      'command=write：整篇覆盖，传 value。写成功只返回 ok，不含全文。',
+      'command=write：整篇覆盖，传 value。写成功只返回 {ok, path}，不含全文。',
     ].join(' '),
     parameters: {
       type: 'object',
@@ -1305,7 +1305,9 @@ export function apply(ctx: Context) {
       required: ['path'],
     },
     execute: (args) =>
-      withInspectorReveal(ctx, String(args.path), () => db.editContent(String(args.path), args)),
+      withInspectorReveal(ctx, String(args.path), () =>
+        db.editContent(String(args.path), args).then(compactAgentToolResult),
+      ),
   })
 
   const send = async (route: { query: URLSearchParams; send: (status: number, body: unknown) => void }, op: () => unknown) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 列出表记录时，原先每条都是 `{id, title, status, ...}`，20 条就把同一批 key 重复 20 遍。

工具 `db_list` / `db_read` 表路径现在改为：

```json
{ "kind": "collection", "path": "/notes", "columns": ["id", "title", "status"], "rows": [["n1", "草稿", "open"], ...] }
```

- `path` / `kind` 可从表路径 + `id` 推出，不再每行带
- 整列都空（`[]`、`{}`、`""`）的字段丢掉
- 网页 `/api/db/*` 与 `db.list()` 仍是对象数组，UI 不变

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

