### PR TITLE
详情标题下展示带文案的 action

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1669,13 +1669,12 @@ export function CollectionBrowser({
   }
 
   function RecordActions({ row, place }: { row: DbRecord; place: 'row' | 'detail' }) {
-    const actions = visibleActions(schema, row, place)
-    const [moreOpen, setMoreOpen] = useState(false)
-    const moreRef = useRef<HTMLButtonElement>(null)
+    const actions = visibleActions(schema, row, place).filter((action) => {
+      if (place !== 'detail' || !nested) return true
+      return action.id !== 'open-split' && action.id !== 'open-page'
+    })
     if (!actions.length) return null
     const Action = chrome?.Action
-    const shown = actions.filter((action) => action.id === 'open-split' || action.id === 'open-page')
-    const overflow = actions.filter((action) => action.id !== 'open-split' && action.id !== 'open-page')
     const rowShown = actions.filter(
       (action) => Action || actionIcon(action.id) || action.id === 'open-split' || action.id === 'open-page',
     )
@@ -1708,41 +1707,25 @@ export function CollectionBrowser({
       )
     }
     return (
-      <div className="tasks-row-actions" data-biu-ignore onClick={(event) => event.stopPropagation()}>
-        {shown.map(renderOne)}
-        {overflow.length ? (
-          <>
+      <div className="fsdb-detail-actions" data-testid="fsdb-detail-actions" data-biu-ignore>
+        {actions.map((action) => {
+          const run = () => void runAction(row, action)
+          if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
+          return (
             <button
-              ref={moreRef}
+              key={action.id}
               type="button"
-              className="tasks-icon-btn"
-              title="更多"
-              data-dock-tip="更多"
-              aria-label="更多操作"
-              aria-expanded={moreOpen}
+              className={`fsdb-detail-action${action.tone === 'danger' ? ' is-danger' : ''}`}
+              title={action.label}
+              aria-label={`${action.label} ${labelOf(row)}`}
               disabled={busy}
-              onClick={() => setMoreOpen((open) => !open)}
+              onClick={run}
             >
-              <EllipsisHorizontalIcon aria-hidden className="size-[14px]" />
+              {actionIcon(action.id)}
+              {action.label}
             </button>
-            {moreOpen ? (
-              <DbMenu anchor={moreRef.current} onClose={() => setMoreOpen(false)}>
-                {overflow.map((action) => (
-                  <DbSearchOption
-                    key={action.id}
-                    onClick={() => {
-                      setMoreOpen(false)
-                      void runAction(row, action)
-                    }}
-                  >
-                    {actionIcon(action.id)}
-                    {action.label}
-                  </DbSearchOption>
-                ))}
-              </DbMenu>
-            ) : null}
-          </>
-        ) : null}
+          )
+        })}
       </div>
     )
   }
@@ -2036,7 +2019,6 @@ export function CollectionBrowser({
             />
           </div>
           <div className="chat-view-header-right">
-            {selected ? <RecordActions row={selected} place="detail" /> : null}
             {activeViewId && !selected ? (
               <button
                 type="button"
@@ -2675,6 +2657,7 @@ export function CollectionBrowser({
           writeOne={writeOne}
           writePatch={writePatch}
           tableIcon={currentTable?.view?.icon}
+          toolbar={<RecordActions row={selected} place="detail" />}
           onOpenRecord={(recordId, collection) => onOpenRecord?.(recordId, activeViewId, collection)}
           onPrev={total > 1 ? () => void stepViewRecord(-1) : undefined}
           onNext={total > 1 ? () => void stepViewRecord(1) : undefined}

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -5,7 +5,9 @@ import {
   ArchiveBoxArrowDownIcon,
   ArrowPathIcon,
   Bars3BottomLeftIcon,
+  BoltIcon,
   CalendarDaysIcon,
+  ChatBubbleLeftRightIcon,
   CheckIcon,
   DocumentTextIcon,
   HashtagIcon,
@@ -49,7 +51,8 @@ export function actionIcon(id: string) {
   if (id === 'edit' || id === 'rename') return <PencilSquareIcon aria-hidden className={cls} />
   if (id === 'refresh') return <ArrowPathIcon aria-hidden className={cls} />
   if (id === 'deliver') return <PaperAirplaneIcon aria-hidden className={cls} />
-  return null
+  if (id === 'report' || id === 'progress') return <ChatBubbleLeftRightIcon aria-hidden className={cls} />
+  return <BoltIcon aria-hidden className={cls} />
 }
 
 export function ModeGlyph({ id, extra }: { id: ViewMode; extra?: CollectionViewType[] }) {

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -368,6 +368,14 @@ const CSS = `
 .fsdb-prop-val .fsdb-plain-input:focus{text-overflow:clip}
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
+.fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:10px}
+.fsdb-detail-actions{display:flex;flex-wrap:wrap;align-items:center;gap:6px;min-width:0}
+.fsdb-detail-action{display:inline-flex;align-items:center;gap:6px;height:26px;margin:0;border:0;border-radius:6px;padding:0 10px;background:transparent;color:#F0EFED;font:inherit;font-size:14px;font-weight:600;cursor:pointer}
+.fsdb-detail-action:hover{background:var(--dsw-hover)}
+.fsdb-detail-action:disabled{opacity:.45;cursor:default}
+.fsdb-detail-action.is-danger{color:var(--dsw-danger)}
+.fsdb-detail-action.is-danger:hover{background:color-mix(in srgb,var(--dsw-danger) 16%,transparent)}
+.fsdb-detail-actions .tasks-icon-btn{height:26px;width:auto;padding:0 8px}
 .fsdb-detail-title-icon-wrap{position:relative;flex:none;margin-top:2px}
 .fsdb-detail-title-icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;margin:0;border:0;border-radius:10px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:22px;line-height:1;overflow:hidden}
 button.fsdb-detail-title-icon{cursor:pointer}
@@ -378,7 +386,7 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-record-mark.is-lg{width:32px;height:32px}
 .fsdb-crumbs .fsdb-record-mark.is-sm,.fsdb-crumb-option .fsdb-record-mark.is-sm{width:14px;height:14px}
 .fsdb-record-mark .sidebar-mascot{display:block}
-.fsdb-detail-title{flex:1;min-width:0;margin:0;color:var(--dsw-label);font-size:32px;font-weight:700;line-height:1.2}
+.fsdb-detail-title{min-width:0;margin:0;color:var(--dsw-label);font-size:32px;font-weight:700;line-height:1.2}
 .fsdb-detail-title-input{display:block;width:100%;margin:0;border:0;background:transparent;color:inherit;font:inherit;font-size:inherit;font-weight:inherit;line-height:inherit;outline:none;padding:0;resize:none}
 .fsdb-detail-title-row .fsdb-detail-title-input{flex:none}
 .fsdb-page .tasks-icon-btn.is-danger:hover{background:color-mix(in srgb,var(--dsw-danger) 16%,transparent);color:var(--dsw-danger)}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -139,6 +139,15 @@ test('table title opens record from the title-side button', () => {
 test('title cell row tools skip the overflow action menu', () => {
   assert.match(browser, /if \(place === 'row'\)/)
   assert.match(browser, /rowShown\.map\(renderOne\)/)
+  assert.match(browser, /toolbar=\{<RecordActions row=\{selected\} place="detail" \/>\}/)
+  assert.match(browser, /data-testid="fsdb-detail-actions"/)
+  assert.doesNotMatch(browser, /selected \? <RecordActions row=\{selected\} place="detail" \/> : null/)
+  const detail = readFileSync(resolve(import.meta.dirname, './record-detail.tsx'), 'utf8')
+  assert.match(detail, /toolbar/)
+  assert.match(detail, /fsdb-detail-title-block/)
+  const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
+  assert.match(css, /\.fsdb-detail-action\{/)
+  assert.match(css, /\.fsdb-detail-actions\{/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -103,6 +103,7 @@ export function RecordDetail({
   canPrev,
   canNext,
   headingOutline = true,
+  toolbar,
 }: {
   selected: DbRecord
   schema: CollectionSchema
@@ -121,6 +122,7 @@ export function RecordDetail({
   canPrev?: boolean
   canNext?: boolean
   headingOutline?: boolean
+  toolbar?: ReactNode
 }) {
   useEffect(() => {
     const onTitle = () => {
@@ -168,6 +170,7 @@ export function RecordDetail({
                     })
                   }}
                 />
+                <div className="fsdb-detail-title-block">
                 {schema.labelField && schema.fields[schema.labelField]?.writable ? (
                   <h1 className="fsdb-detail-title">
                     <LocalText
@@ -195,6 +198,8 @@ export function RecordDetail({
                 ) : (
                   <h1 className="fsdb-detail-title">{labelOf(selected)}</h1>
                 )}
+                {toolbar}
+                </div>
                 </div>
                 <div className="fsdb-detail-aside">
                   <div className="fsdb-prop">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格行上的 action 是悬停图标；详情里以前要么塞在顶栏「更多」里看不见，检查器里连顶栏都没有。

现在详情标题正下方用一排 26px、14px 字重 600 的标签按钮（图标 + 文案），和属性列表同一栏内容宽度。检查器打开的详情同样显示。表格行交互不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

