### PR TITLE
详情 action：胶囊按钮，去掉工具条感

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1706,22 +1706,24 @@ export function CollectionBrowser({
         </div>
       )
     }
+    const primaryId = actions.find((item) => item.tone !== 'danger')?.id
     return (
       <div className="fsdb-detail-actions" data-testid="fsdb-detail-actions" data-biu-ignore>
         {actions.map((action) => {
           const run = () => void runAction(row, action)
           if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
+          const primary = action.tone !== 'danger' && action.id === primaryId
           return (
             <button
               key={action.id}
               type="button"
-              className={`fsdb-detail-action${action.tone === 'danger' ? ' is-danger' : ''}`}
+              className={`fsdb-detail-action${primary ? ' is-primary' : ''}${action.tone === 'danger' ? ' is-danger' : ''}`}
               title={action.label}
               aria-label={`${action.label} ${labelOf(row)}`}
               disabled={busy}
               onClick={run}
             >
-              {actionIcon(action.id)}
+              {actionIcon(action.id, { fallback: false })}
               {action.label}
             </button>
           )

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -42,7 +42,7 @@ import { AttachmentFile, MediaField, UrlHref } from './cell-media.tsx'
 import { PersonFace, PersonPickPanel } from './person-cell.tsx'
 import { RecordLinkChips } from './record-link-cell.tsx'
 
-export function actionIcon(id: string) {
+export function actionIcon(id: string, opts?: { fallback?: boolean }) {
   const cls = 'size-[14px]'
   if (id === 'start' || id === 'play' || id === 'run' || id === 'open') return <PlayIcon aria-hidden className={cls} />
   if (id === 'stop' || id === 'close' || id === 'pause') return <StopIcon aria-hidden className={cls} />
@@ -52,6 +52,7 @@ export function actionIcon(id: string) {
   if (id === 'refresh') return <ArrowPathIcon aria-hidden className={cls} />
   if (id === 'deliver') return <PaperAirplaneIcon aria-hidden className={cls} />
   if (id === 'report' || id === 'progress') return <ChatBubbleLeftRightIcon aria-hidden className={cls} />
+  if (opts?.fallback === false) return null
   return <BoltIcon aria-hidden className={cls} />
 }
 

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -368,14 +368,17 @@ const CSS = `
 .fsdb-prop-val .fsdb-plain-input:focus{text-overflow:clip}
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
-.fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:10px}
+.fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:6px}
 .fsdb-detail-actions{display:flex;flex-wrap:wrap;align-items:center;gap:6px;min-width:0}
-.fsdb-detail-action{display:inline-flex;align-items:center;gap:6px;height:26px;margin:0;border:0;border-radius:6px;padding:0 10px;background:transparent;color:#F0EFED;font:inherit;font-size:14px;font-weight:600;cursor:pointer}
-.fsdb-detail-action:hover{background:var(--dsw-hover)}
+.fsdb-detail-action{display:inline-flex;align-items:center;gap:4px;height:22px;margin:0;border:0;border-radius:11px;padding:0 9px;background:color-mix(in srgb,var(--dsw-label) 6%,transparent);color:var(--dsw-label-2);font:inherit;font-size:13px;font-weight:600;line-height:1;cursor:pointer}
+.fsdb-detail-action:hover{background:color-mix(in srgb,var(--dsw-label) 10%,transparent);color:var(--dsw-label)}
 .fsdb-detail-action:disabled{opacity:.45;cursor:default}
-.fsdb-detail-action.is-danger{color:var(--dsw-danger)}
+.fsdb-detail-action.is-primary{color:var(--dsw-business);background:color-mix(in srgb,var(--dsw-business) 12%,transparent)}
+.fsdb-detail-action.is-primary:hover{background:color-mix(in srgb,var(--dsw-business) 18%,transparent);color:var(--dsw-business)}
+.fsdb-detail-action.is-danger{color:var(--dsw-danger);background:color-mix(in srgb,var(--dsw-danger) 10%,transparent)}
 .fsdb-detail-action.is-danger:hover{background:color-mix(in srgb,var(--dsw-danger) 16%,transparent)}
-.fsdb-detail-actions .tasks-icon-btn{height:26px;width:auto;padding:0 8px}
+.fsdb-detail-action svg{width:13px;height:13px}
+.fsdb-detail-actions .tasks-icon-btn{height:22px;width:auto;padding:0 8px;border-radius:11px}
 .fsdb-detail-title-icon-wrap{position:relative;flex:none;margin-top:2px}
 .fsdb-detail-title-icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;margin:0;border:0;border-radius:10px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:22px;line-height:1;overflow:hidden}
 button.fsdb-detail-title-icon{cursor:pointer}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -148,6 +148,9 @@ test('title cell row tools skip the overflow action menu', () => {
   const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
   assert.match(css, /\.fsdb-detail-action\{/)
   assert.match(css, /\.fsdb-detail-actions\{/)
+  assert.match(css, /\.fsdb-detail-action\.is-primary\{/)
+  assert.match(browser, /is-primary/)
+  assert.match(browser, /fallback: false/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情标题下的 action 不再用近白透明字 + 方角透明钮（看起来像硬塞的工具栏）。

改成 22px 胶囊：灰底次级文案、第一个非危险操作用业务色、危险操作用淡红底。未知 action 不再套默认闪电图标。表格行仍是悬停图标。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

