### PR TITLE
详情操作栏：距底 95px，按钮对齐 dock 图标

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1718,14 +1718,14 @@ export function CollectionBrowser({
             <button
               key={action.id}
               type="button"
-              className={`fsdb-detail-action${primary ? ' is-primary' : ''}${action.tone === 'danger' ? ' is-danger' : ''}`}
+              className={`dock-icon-btn${primary ? ' is-active' : ''}${action.tone === 'danger' ? ' is-danger' : ''}`}
               title={action.label}
+              data-dock-tip={action.label}
               aria-label={`${action.label} ${labelOf(row)}`}
               disabled={busy}
               onClick={run}
             >
-              {actionIcon(action.id, { fallback: false })}
-              {action.label}
+              {actionIcon(action.id, { className: 'size-4' })}
             </button>
           )
         })}

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -42,8 +42,8 @@ import { AttachmentFile, MediaField, UrlHref } from './cell-media.tsx'
 import { PersonFace, PersonPickPanel } from './person-cell.tsx'
 import { RecordLinkChips } from './record-link-cell.tsx'
 
-export function actionIcon(id: string, opts?: { fallback?: boolean }) {
-  const cls = 'size-[14px]'
+export function actionIcon(id: string, opts?: { fallback?: boolean; className?: string }) {
+  const cls = opts?.className ?? 'size-[14px]'
   if (id === 'start' || id === 'play' || id === 'run' || id === 'open') return <PlayIcon aria-hidden className={cls} />
   if (id === 'stop' || id === 'close' || id === 'pause') return <StopIcon aria-hidden className={cls} />
   if (id === 'pack') return <ArchiveBoxArrowDownIcon aria-hidden className={cls} />

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -370,17 +370,11 @@ const CSS = `
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
 .fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:6px}
-.fsdb-detail-actionbar{position:sticky;top:calc(100% - 315px);z-index:26;display:flex;justify-content:center;width:100%;height:0;min-height:0;overflow:visible;pointer-events:none}
-.fsdb-detail-actions{pointer-events:auto;display:inline-flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:6px;max-width:min(100%,var(--dsw-chat-max-width));margin:0;padding:6px 8px;border-radius:10px;background:#202020;box-shadow:0 8px 24px rgba(0,0,0,.18);transform:translateY(-100%)}
-.fsdb-detail-action{display:inline-flex;align-items:center;gap:4px;height:22px;margin:0;border:0;border-radius:11px;padding:0 9px;background:rgba(255,255,255,.08);color:#F0EFED;font:inherit;font-size:13px;font-weight:600;line-height:1;cursor:pointer}
-.fsdb-detail-action:hover{background:rgba(255,255,255,.14);color:#F0EFED}
-.fsdb-detail-action:disabled{opacity:.45;cursor:default}
-.fsdb-detail-action.is-primary{color:#fff;background:var(--dsw-business)}
-.fsdb-detail-action.is-primary:hover{background:var(--dsw-business);filter:brightness(1.08);color:#fff}
-.fsdb-detail-action.is-danger{color:#ffb4ab;background:color-mix(in srgb,var(--dsw-danger) 28%,transparent)}
-.fsdb-detail-action.is-danger:hover{background:color-mix(in srgb,var(--dsw-danger) 40%,transparent)}
-.fsdb-detail-action svg{width:13px;height:13px}
-.fsdb-detail-actions .tasks-icon-btn{height:22px;width:auto;padding:0 8px;border-radius:11px;color:#F0EFED}
+.fsdb-detail-actionbar{position:sticky;top:calc(100% - 95px);z-index:26;display:flex;justify-content:center;width:100%;height:0;min-height:0;overflow:visible;pointer-events:none}
+.fsdb-detail-actions{pointer-events:auto;display:inline-flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:4px;margin:0;padding:0;background:transparent;transform:translateY(-100%)}
+.fsdb-detail-actionbar .dock-icon-btn.is-danger{color:var(--dsw-danger)}
+.fsdb-detail-actionbar .dock-icon-btn.is-danger:hover:not(:disabled){color:var(--dsw-danger)}
+.fsdb-detail-actionbar .dock-icon-btn svg{width:16px;height:16px}
 .fsdb-detail-title-icon-wrap{position:relative;flex:none;margin-top:2px}
 .fsdb-detail-title-icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;margin:0;border:0;border-radius:10px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:22px;line-height:1;overflow:hidden}
 button.fsdb-detail-title-icon{cursor:pointer}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -147,13 +147,13 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.match(detail, /role="main" aria-label="记录详情">\s*\{toolbar\}/)
   assert.match(browser, /fsdb-detail-actionbar/)
   const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
-  assert.match(css, /\.fsdb-detail-action\{/)
   assert.match(css, /\.fsdb-detail-actions\{/)
   assert.match(css, /\.fsdb-detail-actionbar\{/)
-  assert.match(css, /top:calc\(100% - 315px\)/)
-  assert.match(css, /\.fsdb-detail-action\.is-primary\{/)
-  assert.match(browser, /is-primary/)
-  assert.match(browser, /fallback: false/)
+  assert.match(css, /top:calc\(100% - 95px\)/)
+  assert.doesNotMatch(css, /top:calc\(100% - 315px\)/)
+  assert.match(browser, /dock-icon-btn/)
+  assert.match(browser, /data-dock-tip=\{action\.label\}/)
+  assert.match(browser, /className: 'size-4'/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情操作栏改到距底 **95px**（不再是 315px）。

每个按钮改用聊天输入框上方同一套 `dock-icon-btn`：32px 圆钮、深色底、仅图标；文案走 `data-dock-tip` 悬停提示。去掉整条深色胶囊岛。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

