### PR TITLE
详情操作栏下移 35px，开始/停止随状态切换

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -494,6 +494,11 @@ export function CollectionBrowser({
         prev?.schema && JSON.stringify(prev.schema) === JSON.stringify(nextSchema) ? prev : { ...nextStat, schema: nextSchema },
       )
       setItems((prev) => (recordsFingerprint(prev) === recordsFingerprint(listed.items) ? prev : listed.items))
+      const openId = detailIdRef.current
+      if (openId) {
+        const hit = listed.items.find((item) => item.id === openId)
+        if (hit) setDetailRow((prev) => (prev?.id === openId ? { ...prev, ...hit } : prev))
+      }
       setTotal(listed.total)
       rememberListCache(dataPath, { items: listed.items, total: listed.total, stat: { ...nextStat, schema: nextSchema } })
       if (activeViewId) {
@@ -797,8 +802,14 @@ export function CollectionBrowser({
   }, [flattenRows, grouped, grouping, visible])
   const tableColSpan = Math.max(columns.length, 1)
 
-  const selected =
-    (detailId && (detailRow?.id === detailId ? detailRow : items.find((item) => item.id === detailId))) || null
+  const listedSelected = detailId ? items.find((item) => item.id === detailId) : undefined
+  const selected = !detailId
+    ? null
+    : detailRow?.id === detailId
+      ? listedSelected
+        ? { ...detailRow, ...listedSelected }
+        : detailRow
+      : listedSelected ?? null
   const viewIndex = selected ? indexOnPage(selected.id, items, page, pageSize) : null
   const stepViewRecord = async (delta: -1 | 1) => {
     if (!selected || steppingView.current) return
@@ -1706,10 +1717,11 @@ export function CollectionBrowser({
         </div>
       )
     }
+    if (!rowShown.length) return null
     return (
       <div className="fsdb-detail-actionbar" data-testid="fsdb-detail-actions" data-biu-ignore aria-label="记录操作">
         <div className="fsdb-detail-actions">
-        {actions.map((action) => {
+        {rowShown.map((action) => {
           const run = () => void runAction(row, action)
           return (
             <button

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -370,7 +370,7 @@ const CSS = `
 .fsdb-prop-val .fsdb-link{display:block;overflow-wrap:normal}
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
 .fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:6px}
-.fsdb-detail-actionbar{position:sticky;top:calc(100% - 95px);z-index:26;display:flex;justify-content:center;width:100%;height:0;min-height:0;overflow:visible;pointer-events:none}
+.fsdb-detail-actionbar{position:sticky;top:calc(100% - 60px);z-index:26;display:flex;justify-content:center;width:100%;height:0;min-height:0;overflow:visible;pointer-events:none}
 .fsdb-detail-actions{pointer-events:auto;display:inline-flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:4px;margin:0;padding:0;background:transparent;transform:translateY(-100%)}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn,.fsdb-page .fsdb-detail-actions .tasks-icon-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;padding:0;border:1px solid var(--dsw-border);border-radius:50%;background:#252525;color:#F0EFED;cursor:pointer;box-shadow:none}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn:hover:not(:disabled),.fsdb-page .fsdb-detail-actions .tasks-icon-btn:hover:not(:disabled){color:var(--dsw-sidebar-fg-active);background:#252525}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -149,7 +149,8 @@ test('title cell row tools skip the overflow action menu', () => {
   const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
   assert.match(css, /\.fsdb-detail-actions\{/)
   assert.match(css, /\.fsdb-detail-actionbar\{/)
-  assert.match(css, /top:calc\(100% - 95px\)/)
+  assert.match(css, /top:calc\(100% - 60px\)/)
+  assert.doesNotMatch(css, /top:calc\(100% - 95px\)/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*width:32px/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*height:32px/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*color:#F0EFED/)
@@ -161,6 +162,10 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.match(browser, /className: 'size-4'/)
   const detailBar = browser.slice(browser.indexOf('fsdb-detail-actionbar'), browser.indexOf('function GroupHead'))
   assert.doesNotMatch(detailBar, /if \(Action\)/)
+  assert.match(detailBar, /rowShown\.map/)
+  assert.match(browser, /listedSelected/)
+  assert.match(browser, /\.\.\.detailRow, \.\.\.listedSelected/)
+  assert.match(browser, /setDetailRow\(\(prev\) => \(prev\?\.id === openId \? \{ \.\.\.prev, \.\.\.hit \} : prev\)\)/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
操作栏距底从 95px 改为 **60px**（下移 35px）。

详情页之前一直用打开时缓存的 `detailRow`，列表刷新后 `running` 不跟上，所以点了「开始」还是播放键。现在和标题单元格一样：用最新列表行判断 `when`，开始/停止会互换；reload 也会把列表字段合并进详情记录。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

