### PR TITLE
修复详情页 Maximum update depth exceeded

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -133,6 +133,18 @@ function recordsFingerprint(rows: Array<DbRecord & { path?: string }>) {
   return JSON.stringify(rows)
 }
 
+function mergeRecord(base: DbRecord, patch: DbRecord): DbRecord {
+  let changed = false
+  const next: DbRecord = { ...base }
+  for (const [key, value] of Object.entries(patch)) {
+    if (!Object.is(next[key], value)) {
+      next[key] = value
+      changed = true
+    }
+  }
+  return changed ? next : base
+}
+
 const LIST_CACHE_MAX = 8
 const listCache = new Map<string, { items: Array<DbRecord & { path?: string }>; total: number; stat: StatResult | null }>()
 
@@ -497,7 +509,7 @@ export function CollectionBrowser({
       const openId = detailIdRef.current
       if (openId) {
         const hit = listed.items.find((item) => item.id === openId)
-        if (hit) setDetailRow((prev) => (prev?.id === openId ? { ...prev, ...hit } : prev))
+        if (hit) setDetailRow((prev) => (prev?.id === openId ? mergeRecord(prev, hit) : prev))
       }
       setTotal(listed.total)
       rememberListCache(dataPath, { items: listed.items, total: listed.total, stat: { ...nextStat, schema: nextSchema } })
@@ -803,13 +815,11 @@ export function CollectionBrowser({
   const tableColSpan = Math.max(columns.length, 1)
 
   const listedSelected = detailId ? items.find((item) => item.id === detailId) : undefined
-  const selected = !detailId
-    ? null
-    : detailRow?.id === detailId
-      ? listedSelected
-        ? { ...detailRow, ...listedSelected }
-        : detailRow
-      : listedSelected ?? null
+  const selected = useMemo(() => {
+    if (!detailId) return null
+    if (detailRow?.id === detailId) return listedSelected ? mergeRecord(detailRow, listedSelected) : detailRow
+    return listedSelected ?? null
+  }, [detailId, detailRow, listedSelected])
   const viewIndex = selected ? indexOnPage(selected.id, items, page, pageSize) : null
   const stepViewRecord = async (delta: -1 | 1) => {
     if (!selected || steppingView.current) return

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -164,8 +164,10 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.doesNotMatch(detailBar, /if \(Action\)/)
   assert.match(detailBar, /rowShown\.map/)
   assert.match(browser, /listedSelected/)
-  assert.match(browser, /\.\.\.detailRow, \.\.\.listedSelected/)
-  assert.match(browser, /setDetailRow\(\(prev\) => \(prev\?\.id === openId \? \{ \.\.\.prev, \.\.\.hit \} : prev\)\)/)
+  assert.match(browser, /function mergeRecord/)
+  assert.match(browser, /useMemo\(\(\) => \{/)
+  assert.match(browser, /mergeRecord\(detailRow, listedSelected\)/)
+  assert.match(browser, /mergeRecord\(prev, hit\)/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上次为了让开始/停止跟着 `running` 更新，每帧都 `{ ...detailRow, ...listed }` 合成新对象。详情一开就会触发 crumb 刷新和受控组件的 `useLayoutEffect`，打出 Maximum update depth exceeded。

现在 `mergeRecord` 字段没变就返回原引用，`selected` 用 `useMemo`；reload 合并详情行时同样避免无意义的新对象。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

