### PR TITLE
详情操作：停止后能切回开始

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -48,6 +48,7 @@ import {
   hasTreeLinks,
   isRecordLinkField,
   listProjectionKeys,
+  overlayListed,
   parentFieldKey,
   parseFacetFlatColumnKey,
   patchFacetFlatValue,
@@ -131,18 +132,6 @@ function isListColumn(key: string) {
 
 function recordsFingerprint(rows: Array<DbRecord & { path?: string }>) {
   return JSON.stringify(rows)
-}
-
-function mergeRecord(base: DbRecord, patch: DbRecord): DbRecord {
-  let changed = false
-  const next: DbRecord = { ...base }
-  for (const [key, value] of Object.entries(patch)) {
-    if (!Object.is(next[key], value)) {
-      next[key] = value
-      changed = true
-    }
-  }
-  return changed ? next : base
 }
 
 const LIST_CACHE_MAX = 8
@@ -509,7 +498,7 @@ export function CollectionBrowser({
       const openId = detailIdRef.current
       if (openId) {
         const hit = listed.items.find((item) => item.id === openId)
-        if (hit) setDetailRow((prev) => (prev?.id === openId ? mergeRecord(prev, hit) : prev))
+        if (hit) setDetailRow((prev) => (prev?.id === openId ? overlayListed(prev, hit, listColumns) : prev))
       }
       setTotal(listed.total)
       rememberListCache(dataPath, { items: listed.items, total: listed.total, stat: { ...nextStat, schema: nextSchema } })
@@ -817,9 +806,9 @@ export function CollectionBrowser({
   const listedSelected = detailId ? items.find((item) => item.id === detailId) : undefined
   const selected = useMemo(() => {
     if (!detailId) return null
-    if (detailRow?.id === detailId) return listedSelected ? mergeRecord(detailRow, listedSelected) : detailRow
+    if (detailRow?.id === detailId) return listedSelected ? overlayListed(detailRow, listedSelected, listColumns) : detailRow
     return listedSelected ?? null
-  }, [detailId, detailRow, listedSelected])
+  }, [detailId, detailRow, listColumns, listedSelected])
   const viewIndex = selected ? indexOnPage(selected.id, items, page, pageSize) : null
   const stepViewRecord = async (delta: -1 | 1) => {
     if (!selected || steppingView.current) return

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
-import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
+import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
 import { visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -75,9 +75,16 @@ test('formatField renders datetime tags and media', () => {
   assert.equal(inferPackFieldType({ kind: 'user', name: '用户' }), 'person')
 })
 
-test('matchActionWhen uses field equality including booleans', () => {
-  assert.equal(matchActionWhen({ id: '1', enabled: false }, { enabled: false }), true)
-  assert.equal(matchActionWhen({ id: '1', enabled: true }, { enabled: false }), false)
+test('overlayListed clears omitted false flags from sparse list rows', () => {
+  const base = { id: '1', running: true, installed: true, name: '插件' }
+  const listed = { id: '1', installed: true, name: '插件' }
+  const next = overlayListed(base, listed)
+  assert.equal(next.running, false)
+  assert.equal(next.installed, true)
+  assert.equal(matchActionWhen(next, { installed: true, running: false }), true)
+  assert.equal(matchActionWhen(next, { installed: true, running: true }), false)
+  assert.equal(overlayListed(next, listed), next)
+  assert.equal(overlayListed(base, { ...listed, running: true }).running, true)
 })
 
 test('visibleActions hides agent-only actions from the page', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -460,6 +460,26 @@ export function groupRecords(rows: DbRecord[], schema: CollectionSchema | undefi
   return listed
 }
 
+export function overlayListed(base: DbRecord, listed: DbRecord, projected?: string[] | null): DbRecord {
+  let changed = false
+  const next: DbRecord = { ...base }
+  for (const [key, value] of Object.entries(listed)) {
+    if (!Object.is(next[key], value)) {
+      next[key] = value
+      changed = true
+    }
+  }
+  const keys = projected?.length ? projected : Object.keys(base)
+  for (const key of keys) {
+    if (key === 'id') continue
+    if (Object.prototype.hasOwnProperty.call(listed, key)) continue
+    if (next[key] !== true) continue
+    next[key] = false
+    changed = true
+  }
+  return changed ? next : base
+}
+
 export function matchActionWhen(record: DbRecord, when?: Record<string, unknown>) {
   if (!when) return true
   for (const [key, expected] of Object.entries(when)) {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -164,10 +164,9 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.doesNotMatch(detailBar, /if \(Action\)/)
   assert.match(detailBar, /rowShown\.map/)
   assert.match(browser, /listedSelected/)
-  assert.match(browser, /function mergeRecord/)
-  assert.match(browser, /useMemo\(\(\) => \{/)
-  assert.match(browser, /mergeRecord\(detailRow, listedSelected\)/)
-  assert.match(browser, /mergeRecord\(prev, hit\)/)
+  assert.match(browser, /overlayListed/)
+  assert.match(browser, /overlayListed\(detailRow, listedSelected, listColumns\)/)
+  assert.match(browser, /overlayListed\(prev, hit, listColumns\)/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
插件列表会 `omitEmpty`，`running: false` 不会出现在行上。详情把列表叠到缓存记录上时，缺字段仍留着 `running: true`，所以开始能变成停止，停止变不回开始。

叠列表时：投影里有、列表行却没带的 `true` 布尔字段改回 `false`，和标题单元格用列表行判断 `when` 一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

