### PR TITLE
详情操作钮：去掉点击后的闪烁

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -49,6 +49,7 @@ import {
   isRecordLinkField,
   listProjectionKeys,
   overlayListed,
+  previewActionRecord,
   parentFieldKey,
   parseFacetFlatColumnKey,
   patchFacetFlatValue,
@@ -220,7 +221,7 @@ export function CollectionBrowser({
   const [detailRow, setDetailRow] = useState<DbRecord | null>(null)
   const [detailBody, setDetailBody] = useState<unknown>(null)
   const [draft, setDraft] = useState<Record<string, string>>({})
-  const [busyKey, setBusyKey] = useState<string | null>(null)
+  const actingRef = useRef(false)
   const initialView = viewForPath(collectionPath, routeViewId)
   const dbUi = getDatabaseUi()
   const extraViews = useSyncExternalStore(
@@ -1166,8 +1167,13 @@ export function CollectionBrowser({
   }
 
   async function executeAction(row: DbRecord, action: CollectionActionInfo) {
-    const key = `${action.id}:${row.id}`
-    setBusyKey(key)
+    if (actingRef.current) return
+    const preview = previewActionRecord(row, action)
+    actingRef.current = true
+    if (preview !== row) {
+      setItems((prev) => prev.map((item) => (item.id === row.id ? overlayListed(item, preview, listColumns) : item)))
+      setDetailRow((prev) => (prev?.id === row.id ? overlayListed(prev, preview, listColumns) : prev))
+    }
     try {
       await readJson('/api/db/action', {
         method: 'POST',
@@ -1178,8 +1184,10 @@ export function CollectionBrowser({
       await reload()
     } catch (err) {
       setDlg({ kind: 'alert', title: `${action.label}失败`, body: String(err) })
+      quietUntil.current = 0
+      await reload()
     } finally {
-      setBusyKey(null)
+      actingRef.current = false
     }
   }
 
@@ -1688,7 +1696,7 @@ export function CollectionBrowser({
     const rowShown = actions.filter(
       (action) => Action || actionIcon(action.id) || action.id === 'open-split' || action.id === 'open-page',
     )
-    const busy = Boolean(busyKey?.endsWith(`:${row.id}`))
+    const busy = actingRef.current
     const renderOne = (action: CollectionActionInfo) => {
       const run = () => void runAction(row, action)
       if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
@@ -1724,7 +1732,7 @@ export function CollectionBrowser({
           const run = () => void runAction(row, action)
           return (
             <button
-              key={action.id}
+              key={action.id === 'start' || action.id === 'stop' ? `${row.id}:run` : action.id}
               type="button"
               className="dock-icon-btn"
               title={action.label}

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
-import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
+import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
 import { visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -85,6 +85,13 @@ test('overlayListed clears omitted false flags from sparse list rows', () => {
   assert.equal(matchActionWhen(next, { installed: true, running: true }), false)
   assert.equal(overlayListed(next, listed), next)
   assert.equal(overlayListed(base, { ...listed, running: true }).running, true)
+})
+
+test('previewActionRecord flips running from action when', () => {
+  const row = { id: '1', installed: true, running: false }
+  assert.equal(previewActionRecord(row, { when: { installed: true, running: false } }).running, true)
+  assert.equal(previewActionRecord({ ...row, running: true }, { when: { installed: true, running: true } }).running, false)
+  assert.equal(previewActionRecord(row, { when: { installed: true } }), row)
 })
 
 test('visibleActions hides agent-only actions from the page', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -460,6 +460,14 @@ export function groupRecords(rows: DbRecord[], schema: CollectionSchema | undefi
   return listed
 }
 
+export function previewActionRecord(row: DbRecord, action: { when?: Record<string, unknown> }): DbRecord {
+  const when = action.when
+  if (!when || !('running' in when) || typeof when.running !== 'boolean') return row
+  const running = when.running === false
+  if (Object.is(row.running, running)) return row
+  return { ...row, running }
+}
+
 export function overlayListed(base: DbRecord, listed: DbRecord, projected?: string[] | null): DbRecord {
   let changed = false
   const next: DbRecord = { ...base }

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -374,7 +374,7 @@ const CSS = `
 .fsdb-detail-actions{pointer-events:auto;display:inline-flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:4px;margin:0;padding:0;background:transparent;transform:translateY(-100%)}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn,.fsdb-page .fsdb-detail-actions .tasks-icon-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;padding:0;border:1px solid var(--dsw-border);border-radius:50%;background:#252525;color:#F0EFED;cursor:pointer;box-shadow:none}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn:hover:not(:disabled),.fsdb-page .fsdb-detail-actions .tasks-icon-btn:hover:not(:disabled){color:var(--dsw-sidebar-fg-active);background:#252525}
-.fsdb-page .fsdb-detail-actions .dock-icon-btn:disabled,.fsdb-page .fsdb-detail-actions .tasks-icon-btn:disabled{opacity:.45;cursor:default}
+.fsdb-page .fsdb-detail-actions .dock-icon-btn:disabled,.fsdb-page .fsdb-detail-actions .tasks-icon-btn:disabled{opacity:1;cursor:default}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn svg,.fsdb-page .fsdb-detail-actions .tasks-icon-btn svg{width:16px;height:16px}
 .fsdb-detail-title-icon-wrap{position:relative;flex:none;margin-top:2px}
 .fsdb-detail-title-icon{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;margin:0;border:0;border-radius:10px;padding:0;background:transparent;color:var(--dsw-label-2);font-size:22px;line-height:1;overflow:hidden}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -167,6 +167,9 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.match(browser, /overlayListed/)
   assert.match(browser, /overlayListed\(detailRow, listedSelected, listColumns\)/)
   assert.match(browser, /overlayListed\(prev, hit, listColumns\)/)
+  assert.match(browser, /previewActionRecord/)
+  assert.match(browser, /actingRef/)
+  assert.match(browser, /\$\{row\.id\}:run/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点击会先 `busy` 半透明、开始/停止又是两颗不同 key 的按钮，等 reload 再换图标，所以会闪一次。

现在先乐观改 `running`（图标立刻换），开始/停止共用同一颗按钮；不再用 busy 变灰。reload 只做确认。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

