### PR TITLE
feat(fs): 集合用 chrome.Actions 自己画整组操作按钮

### DIFF
--- a/packages/core-file-system/package.json
+++ b/packages/core-file-system/package.json
@@ -6,7 +6,8 @@
   "description": "Core-File System：实现 @biu/type-file-system 契约",
   "exports": {
     "./host": "./src/host/index.ts",
-    "./web": "./src/web/index.tsx"
+    "./web": "./src/web/index.tsx",
+    "./database-ui": "./src/web/database-ui.ts"
   },
   "dependencies": {
     "@biu/type-file-system": "0.1.0",

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type PointerEvent as ReactPointerEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { Fragment, type PointerEvent as ReactPointerEvent, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode } from 'react'
 import { flushSync } from 'react-dom'
 import {
   ArrowDownIcon,
@@ -82,6 +82,7 @@ import {
   parseFieldValue,
   VIEW_MODES,
   visibleActions,
+  placedActions,
 } from './fsdb-cells.tsx'
 import { ensureFsdbStyle } from './fsdb-style.ts'
 import { RecordDetail } from './record-detail.tsx'
@@ -875,7 +876,8 @@ export function CollectionBrowser({
   useEffect(() => {
     if (!detailId || !schema) return
     if (detailRow?.id !== detailId) return
-    setDraft(draftFromRecord(schema, detailRow, bodyKey, detailBody))
+    const next = draftFromRecord(schema, detailRow, bodyKey, detailBody)
+    setDraft((prev) => (JSON.stringify(prev) === JSON.stringify(next) ? prev : next))
     hydratedDetail.current = detailId
   }, [bodyKey, detailBody, detailId, detailRow, schema])
 
@@ -1180,8 +1182,11 @@ export function CollectionBrowser({
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ path: `${dataPath}/${row.id}`, action: action.id }),
       })
-      quietUntil.current = 0
-      await reload()
+      quietUntil.current = Date.now() + 800
+      window.setTimeout(() => {
+        quietUntil.current = 0
+        void reloadRef.current()
+      }, 800)
     } catch (err) {
       setDlg({ kind: 'alert', title: `${action.label}失败`, body: String(err) })
       quietUntil.current = 0
@@ -1687,66 +1692,55 @@ export function CollectionBrowser({
   }
 
   function RecordActions({ row, place }: { row: DbRecord; place: 'row' | 'detail' }) {
+    const Actions = chrome?.Actions
+    const Action = chrome?.Action
+    const busy = actingRef.current
+    const placed = placedActions(schema, place).filter((action) => {
+      if (place !== 'detail' || !nested) return true
+      return action.id !== 'open-split' && action.id !== 'open-page'
+    })
+    const wrap = (body: ReactNode) =>
+      place === 'row' ? (
+        <div className="tasks-row-actions" data-biu-ignore onClick={(event) => event.stopPropagation()}>
+          {body}
+        </div>
+      ) : (
+        <div className="fsdb-detail-actionbar" data-testid="fsdb-detail-actions" data-biu-ignore aria-label="记录操作">
+          <div className="fsdb-detail-actions">{body}</div>
+        </div>
+      )
+    if (Actions) {
+      if (!placed.length) return null
+      return wrap(<Actions actions={placed} record={row} busy={busy} place={place} run={(action) => void runAction(row, action)} />)
+    }
     const actions = visibleActions(schema, row, place).filter((action) => {
       if (place !== 'detail' || !nested) return true
       return action.id !== 'open-split' && action.id !== 'open-page'
     })
-    if (!actions.length) return null
-    const Action = chrome?.Action
     const rowShown = actions.filter(
       (action) => Action || actionIcon(action.id) || action.id === 'open-split' || action.id === 'open-page',
     )
-    const busy = actingRef.current
-    const renderOne = (action: CollectionActionInfo) => {
-      const run = () => void runAction(row, action)
-      if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
-      const glyph = actionIcon(action.id)
-      return (
-        <button
-          key={action.id}
-          type="button"
-          className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
-          title={action.label}
-          data-dock-tip={action.label}
-          aria-label={`${action.label} ${labelOf(row)}`}
-          disabled={busy}
-          onClick={run}
-        >
-          {glyph ?? action.label}
-        </button>
-      )
-    }
-    if (place === 'row') {
-      if (!rowShown.length) return null
-      return (
-        <div className="tasks-row-actions" data-biu-ignore onClick={(event) => event.stopPropagation()}>
-          {rowShown.map(renderOne)}
-        </div>
-      )
-    }
     if (!rowShown.length) return null
-    return (
-      <div className="fsdb-detail-actionbar" data-testid="fsdb-detail-actions" data-biu-ignore aria-label="记录操作">
-        <div className="fsdb-detail-actions">
-        {rowShown.map((action) => {
-          const run = () => void runAction(row, action)
-          return (
-            <button
-              key={action.id === 'start' || action.id === 'stop' ? `${row.id}:run` : action.id}
-              type="button"
-              className="dock-icon-btn"
-              title={action.label}
-              data-dock-tip={action.label}
-              aria-label={`${action.label} ${labelOf(row)}`}
-              disabled={busy}
-              onClick={run}
-            >
-              {actionIcon(action.id, { className: 'size-4' })}
-            </button>
-          )
-        })}
-        </div>
-      </div>
+    return wrap(
+      rowShown.map((action) => {
+        const run = () => void runAction(row, action)
+        if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
+        const glyph = actionIcon(action.id)
+        return (
+          <button
+            key={action.id}
+            type="button"
+            className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
+            title={action.label}
+            data-dock-tip={action.label}
+            aria-label={`${action.label} ${labelOf(row)}`}
+            disabled={busy}
+            onClick={run}
+          >
+            {glyph ?? action.label}
+          </button>
+        )
+      }),
     )
   }
 

--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -25,6 +25,17 @@ test('decorate merges cells; later layer wins; dispose restores', () => {
   assert.equal(ui.chrome('/plugins').cells?.name, undefined)
 })
 
+test('decorate merges Actions; later layer wins', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  const First = () => null
+  const Second = () => null
+  ui.decorate('/plugins', { Actions: First })
+  assert.equal(ui.chrome('/plugins').Actions, First)
+  ui.decorate('/plugins', { Actions: Second })
+  assert.equal(ui.chrome('/plugins').Actions, Second)
+})
+
 test('decorate keeps Icon as the record mark, later layer wins', () => {
   const ctx = new Context()
   const ui = new DatabaseUiService(ctx)

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -7,6 +7,7 @@ export { normalizeCollectionPath }
 function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   const cells: CollectionChrome['cells'] = {}
   let Action: CollectionChrome['Action']
+  let Actions: CollectionChrome['Actions']
   let Icon: CollectionChrome['Icon']
   let Title: CollectionChrome['Title']
   let Board: CollectionChrome['Board']
@@ -18,6 +19,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   for (const layer of layers) {
     Object.assign(cells, layer.cells)
     if (layer.Action) Action = layer.Action
+    if (layer.Actions) Actions = layer.Actions
     if (layer.Icon) Icon = layer.Icon
     if (layer.Title) Title = layer.Title
     if (layer.Board) Board = layer.Board
@@ -33,7 +35,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
       }
     }
   }
-  return { cells, Action, Icon, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
+  return { cells, Action, Actions, Icon, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
 }
 
 function mergeViews(layers: CollectionViewType[]): CollectionViewType[] {

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
-import { visibleActions } from './fsdb-cells.tsx'
+import { placedActions, visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
   assert.equal(isViewModeId('table'), true)
@@ -92,6 +92,24 @@ test('previewActionRecord flips running from action when', () => {
   assert.equal(previewActionRecord(row, { when: { installed: true, running: false } }).running, true)
   assert.equal(previewActionRecord({ ...row, running: true }, { when: { installed: true, running: true } }).running, false)
   assert.equal(previewActionRecord(row, { when: { installed: true } }), row)
+})
+
+test('placedActions keeps start and stop so chrome.Actions can own the pair', () => {
+  const schema: CollectionSchema = {
+    fields: { ...REQUIRED_RECORD_FIELDS },
+    actions: [
+      { id: 'start', label: '运行', when: { running: false } },
+      { id: 'stop', label: '停止', when: { running: true } },
+    ],
+  }
+  assert.deepEqual(
+    placedActions(schema, 'row').map((item) => item.id),
+    ['start', 'stop'],
+  )
+  assert.deepEqual(
+    visibleActions(schema, { id: '1', running: false }, 'row').map((item) => item.id),
+    ['start'],
+  )
 })
 
 test('visibleActions hides agent-only actions from the page', () => {

--- a/packages/core-file-system/src/web/fsdb-cells.tsx
+++ b/packages/core-file-system/src/web/fsdb-cells.tsx
@@ -489,10 +489,14 @@ export function FieldEditor({
   return <LocalText className="fsdb-plain-input" value={value} title={value} placeholder="" onCommit={onChange} />
 }
 
-export function visibleActions(schema: CollectionSchema | undefined, row: DbRecord, place: 'row' | 'detail') {
+export function placedActions(schema: CollectionSchema | undefined, place: 'row' | 'detail') {
   return (schema?.actions ?? []).filter((action) => {
     if (!actionVisibleToUser(action)) return false
     const places = action.placement ?? ['row', 'detail']
-    return places.includes(place) && matchActionWhen(row, action.when)
+    return places.includes(place)
   })
+}
+
+export function visibleActions(schema: CollectionSchema | undefined, row: DbRecord, place: 'row' | 'detail') {
+  return placedActions(schema, place).filter((action) => matchActionWhen(row, action.when))
 }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -137,8 +137,9 @@ test('table title opens record from the title-side button', () => {
 })
 
 test('title cell row tools skip the overflow action menu', () => {
-  assert.match(browser, /if \(place === 'row'\)/)
-  assert.match(browser, /rowShown\.map\(renderOne\)/)
+  assert.match(browser, /const Actions = chrome\?\.Actions/)
+  assert.match(browser, /placedActions\(schema, place\)/)
+  assert.match(browser, /<Actions actions=\{placed\} record=\{row\}/)
   assert.match(browser, /toolbar=\{<RecordActions row=\{selected\} place="detail" \/>\}/)
   assert.match(browser, /data-testid="fsdb-detail-actions"/)
   assert.doesNotMatch(browser, /selected \? <RecordActions row=\{selected\} place="detail" \/> : null/)
@@ -157,19 +158,12 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*border-radius:50%/)
   assert.match(css, /\.fsdb-detail-actions\{[^}]*gap:4px/)
   assert.match(css, /\.fsdb-detail-actions\{[^}]*justify-content:center/)
-  assert.match(browser, /className="dock-icon-btn"/)
-  assert.match(browser, /data-dock-tip=\{action\.label\}/)
-  assert.match(browser, /className: 'size-4'/)
-  const detailBar = browser.slice(browser.indexOf('fsdb-detail-actionbar'), browser.indexOf('function GroupHead'))
-  assert.doesNotMatch(detailBar, /if \(Action\)/)
-  assert.match(detailBar, /rowShown\.map/)
   assert.match(browser, /listedSelected/)
   assert.match(browser, /overlayListed/)
   assert.match(browser, /overlayListed\(detailRow, listedSelected, listColumns\)/)
   assert.match(browser, /overlayListed\(prev, hit, listColumns\)/)
   assert.match(browser, /previewActionRecord/)
   assert.match(browser, /actingRef/)
-  assert.match(browser, /\$\{row\.id\}:run/)
 })
 
 test('deletable tables can pick rows and bulk-delete next to refresh', () => {

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -1,8 +1,8 @@
 import { ArchiveBoxArrowDownIcon, PlayIcon, StopIcon } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { asHttpHref } from '@biu/type-file-system'
-import type { CollectionChrome, FsActionProps, FsCellProps } from '@biu/type-file-system/ui'
-import type { DbRecord } from '@biu/type-file-system'
+import type { CollectionActionInfo, DbRecord } from '@biu/type-file-system'
+import type { CollectionChrome, FsActionProps, FsActionsProps, FsCellProps } from '@biu/type-file-system/ui'
 
 function PluginTitle({ label }: { record: DbRecord; label: string }) {
   return <span className="truncate font-medium">{label}</span>
@@ -26,13 +26,32 @@ function PluginAuthorCell({ record, fallback }: FsCellProps) {
   )
 }
 
-function PluginAction({ action, busy, run }: FsActionProps) {
+function runningOf(record: DbRecord) {
+  return record.running === true || record.running === 'true'
+}
+
+function matchWhen(record: DbRecord, when?: Record<string, unknown>) {
+  if (!when) return true
+  for (const [key, expected] of Object.entries(when)) {
+    const actual = record[key]
+    if (expected === true || expected === false) {
+      const flag = actual === true || actual === 'true'
+      if (flag !== expected) return false
+      continue
+    }
+    if (String(actual ?? '') !== String(expected)) return false
+  }
+  return true
+}
+
+function btnClass(place: 'row' | 'detail', danger?: boolean) {
+  const base = place === 'detail' ? 'dock-icon-btn' : 'tasks-icon-btn'
+  return `${base}${danger ? ' is-danger' : ''}`
+}
+
+function PluginAction({ action, busy, run, className }: FsActionProps & { className: string }) {
   const icon =
-    action.id === 'start' ? (
-      <PlayIcon aria-hidden className="size-[14px]" />
-    ) : action.id === 'stop' ? (
-      <StopIcon aria-hidden className="size-[14px]" />
-    ) : action.id === 'uninstall' ? (
+    action.id === 'uninstall' ? (
       <TrashGlyph aria-hidden className="size-[14px]" />
     ) : action.id === 'pack' ? (
       <ArchiveBoxArrowDownIcon aria-hidden className="size-[14px]" />
@@ -40,7 +59,7 @@ function PluginAction({ action, busy, run }: FsActionProps) {
   return (
     <button
       type="button"
-      className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
+      className={className}
       title={action.label}
       data-dock-tip={action.label}
       aria-label={action.label}
@@ -52,10 +71,72 @@ function PluginAction({ action, busy, run }: FsActionProps) {
   )
 }
 
+function PluginRunButton({
+  running,
+  busy,
+  className,
+  onClick,
+}: {
+  running: boolean
+  busy: boolean
+  className: string
+  onClick: () => void
+}) {
+  const label = running ? '停止' : '运行'
+  return (
+    <button
+      type="button"
+      className={className}
+      title={label}
+      data-dock-tip={label}
+      aria-label={label}
+      disabled={busy}
+      onClick={onClick}
+    >
+      {running ? <StopIcon aria-hidden className="size-[14px]" /> : <PlayIcon aria-hidden className="size-[14px]" />}
+    </button>
+  )
+}
+
+function PluginActions({ actions, record, busy, place, run }: FsActionsProps) {
+  const cls = btnClass(place)
+  const start = actions.find((action) => action.id === 'start')
+  const stop = actions.find((action) => action.id === 'stop')
+  const running = runningOf(record)
+  const current: CollectionActionInfo | undefined = running ? stop : start
+  const rest = actions.filter(
+    (action) => action.id !== 'start' && action.id !== 'stop' && matchWhen(record, action.when),
+  )
+  return (
+    <>
+      {start || stop ? (
+        <PluginRunButton
+          running={running}
+          busy={busy}
+          className={cls}
+          onClick={() => {
+            if (current) run(current)
+          }}
+        />
+      ) : null}
+      {rest.map((action) => (
+        <PluginAction
+          key={action.id}
+          action={action}
+          record={record}
+          busy={busy}
+          run={() => run(action)}
+          className={btnClass(place, action.tone === 'danger')}
+        />
+      ))}
+    </>
+  )
+}
+
 export const pluginsChrome: CollectionChrome = {
   cells: {
     author: PluginAuthorCell,
   },
   Title: PluginTitle,
-  Action: PluginAction,
+  Actions: PluginActions,
 }

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -56,7 +56,18 @@ test('plugin system web passes name/tags/action chrome into databaseUi', async (
   assert.equal(typeof ui.last?.chrome.Title, 'function')
   assert.equal(typeof ui.last?.chrome.cells?.author, 'function')
   assert.equal(ui.last?.chrome.cells?.tags, undefined)
-  assert.equal(typeof ui.last?.chrome.Action, 'function')
+  assert.equal(typeof ui.last?.chrome.Actions, 'function')
+  assert.equal(ui.last?.chrome.Action, undefined)
+})
+
+test('plugin chrome owns the whole action bar including the run toggle', async () => {
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  const chrome = readFileSync(resolve(import.meta.dirname, './chrome.tsx'), 'utf8')
+  assert.match(chrome, /function PluginActions/)
+  assert.match(chrome, /Actions: PluginActions/)
+  assert.match(chrome, /function PluginRunButton/)
+  assert.doesNotMatch(chrome, /Action: PluginAction/)
 })
 
 test('plugin title is the name only; tags stay the file-system writable column', async () => {

--- a/packages/type-file-system/src/ui.ts
+++ b/packages/type-file-system/src/ui.ts
@@ -18,6 +18,15 @@ export type FsActionProps = {
   run: () => void
 }
 
+/** 整组动作。有则宿主只挂这一次，长什么样由登记方自己决定。 */
+export type FsActionsProps = {
+  actions: CollectionActionInfo[]
+  record: DbRecord
+  busy: boolean
+  place: 'row' | 'detail'
+  run: (action: CollectionActionInfo) => void
+}
+
 export type FsDetailPaneProps = {
   record: DbRecord
   openRecord?: (recordId: string, collection?: string) => void
@@ -33,6 +42,8 @@ export type FsDetailPane = {
 export type CollectionChrome = {
   cells?: Partial<Record<string, ComponentType<FsCellProps>>>
   Action?: ComponentType<FsActionProps>
+  /** 整组动作。有则宿主不再按条 map，前端完全由登记方 decorate。 */
+  Actions?: ComponentType<FsActionsProps>
   /** 记录独立图标属性。有 emoji 用 emoji；不传则详情/侧栏/面包屑用集合 glyph。 */
   Icon?: ComponentType<{ record: DbRecord }>
   Title?: ComponentType<{ record: DbRecord; label: string }>

--- a/packages/web-app-shell/package.json
+++ b/packages/web-app-shell/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@biu/public-ui": "0.1.0",
     "@biu/public-mascot": "0.1.0",
-    "@biu/type-file-system": "0.1.0"
+    "@biu/type-file-system": "0.1.0",
+    "@biu/core-file-system": "0.1.0"
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -165,6 +165,14 @@ test('search hits never show report even if placement is row', () => {
   )
 })
 
+test('search hit actions use collection chrome.Actions when registered', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
+  assert.match(src, /getDatabaseUi\(\)\?\.chrome\(searchCollection\(hit\.kind\)\)\.Actions/)
+  assert.match(src, /placedRowActions\(hit\.actions\)/)
+  assert.match(src, /<Actions/)
+  assert.match(src, /previewRunningRecord\(record, action\.when\)/)
+})
+
 test('opening a session on the left closes search and focuses the composer', () => {
   const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
   assert.match(src, /onClose\(\)\s*if \(side === 'left' && hit\.kind === 'session'\) requestComposerFocus\(\)/)

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -20,6 +20,8 @@ import { TagChip, TagChips } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { actionVisibleToUser } from '@biu/type-file-system'
+import type { CollectionActionInfo, DbRecord } from '@biu/type-file-system'
+import { getDatabaseUi } from '@biu/core-file-system/database-ui'
 import { setChatOverlay, requestComposerFocus } from './chat-overlay.ts'
 
 export type SearchKind = 'view' | 'session' | 'task' | 'page' | 'plugin' | 'facet'
@@ -159,14 +161,25 @@ export function matchActionWhen(record: Record<string, unknown>, when?: Record<s
   return true
 }
 
+export function previewRunningRecord(record: Record<string, unknown>, when?: Record<string, unknown>) {
+  if (!when || typeof when.running !== 'boolean') return record
+  const running = when.running === false
+  if (Object.is(record.running, running)) return record
+  return { ...record, running }
+}
+
 export function visibleRowActions(actions: SearchAction[] | undefined, record: Record<string, unknown> | undefined) {
   const row = record ?? {}
+  return placedRowActions(actions).filter((action) => matchActionWhen(row, action.when))
+}
+
+export function placedRowActions(actions: SearchAction[] | undefined) {
   return (actions ?? []).filter((action) => {
     if (!actionVisibleToUser(action)) return false
     if (NAV_ACTION_IDS.has(action.id)) return false
     if (SEARCH_SKIP_ACTION_IDS.has(action.id)) return false
     const places = action.placement ?? ['row', 'detail']
-    return places.includes('row') && matchActionWhen(row, action.when)
+    return places.includes('row')
   })
 }
 
@@ -278,19 +291,18 @@ function HitRecordTags({ tags }: { tags?: string[] }) {
   )
 }
 
-function HitActions({
-  hit,
-  onRan,
-}: {
-  hit: SearchHit
-  onRan: () => void
-}) {
-  const actions = visibleRowActions(hit.actions, hit.record ?? { id: hit.id }).filter((action) => actionGlyph(action.id))
-  const [busyId, setBusyId] = useState<string | null>(null)
-  if (!actions.length) return null
+function HitActions({ hit }: { hit: SearchHit }) {
+  const [record, setRecord] = useState(hit.record ?? { id: hit.id })
+  const acting = useRef(false)
+  const Actions = getDatabaseUi()?.chrome(searchCollection(hit.kind)).Actions
+  const placed = placedRowActions(hit.actions)
+  const actions = visibleRowActions(hit.actions, record).filter((action) => actionGlyph(action.id))
   const run = async (action: SearchAction) => {
+    if (acting.current) return
     if (action.confirm && !window.confirm(action.confirm)) return
-    setBusyId(action.id)
+    acting.current = true
+    const next = previewRunningRecord(record, action.when)
+    if (next !== record) setRecord(next)
     try {
       await fetch('/api/db/action', {
         method: 'POST',
@@ -300,11 +312,26 @@ function HitActions({
           action: action.id,
         }),
       })
-      onRan()
+      window.dispatchEvent(new Event('fsdb:change'))
     } finally {
-      setBusyId(null)
+      acting.current = false
     }
   }
+  if (Actions) {
+    if (!placed.length) return null
+    return (
+      <span className="shell-search-hit-actions" data-biu-ignore onClick={(event) => event.stopPropagation()}>
+        <Actions
+          actions={placed as CollectionActionInfo[]}
+          record={record as DbRecord}
+          busy={false}
+          place="row"
+          run={(action) => void run(action)}
+        />
+      </span>
+    )
+  }
+  if (!actions.length) return null
   return (
     <span className="shell-search-hit-actions" data-biu-ignore>
       {actions.map((action) => (
@@ -315,7 +342,6 @@ function HitActions({
           title={action.label}
           data-dock-tip={action.label}
           aria-label={action.label}
-          disabled={busyId != null}
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
@@ -591,6 +617,7 @@ export function ShellSearchPanel({
                   ? item.tags
                   : undefined
                 const actions = visibleRowActions(item.actions, item.record ?? { id: item.id })
+                const hasGlyphActions = (item.actions ?? []).some((action) => actionGlyph(action.id))
                 return (
                   <div
                     role="option"
@@ -605,16 +632,14 @@ export function ShellSearchPanel({
                       <HitMark hit={item} />
                     </span>
                     <span className="shell-search-hit-title">{item.title}</span>
-                    {tags?.length || actions.length ? (
+                    {tags?.length || actions.length || hasGlyphActions ? (
                       <span className="shell-search-hit-aside">
                         {tags?.length ? (
                           <span className="shell-search-hit-tags">
                             <HitRecordTags tags={tags} />
                           </span>
                         ) : null}
-                        {actions.length ? (
-                          <HitActions hit={item} onRan={() => setReloadSeq((n) => n + 1)} />
-                        ) : null}
+                        {hasGlyphActions ? <HitActions hit={item} /> : null}
                       </span>
                     ) : null}
                   </div>

--- a/web/style.css
+++ b/web/style.css
@@ -393,9 +393,19 @@ body {
   color: var(--dsw-danger);
 }
 
-.shell-search-hit-action:disabled {
-  opacity: 0.4;
-  cursor: default;
+.shell-search-hit-actions .tasks-icon-btn {
+  border: 0;
+  border-radius: 5px;
+  padding: 3px;
+  background: transparent;
+  color: var(--dsw-label-2);
+  width: auto;
+  height: auto;
+  box-shadow: none;
+}
+
+.shell-search-hit-actions .tasks-icon-btn:hover:not(:disabled) {
+  background: var(--dsw-hover);
 }
 
 .shell-search-hit-action[data-dock-tip]::after {
@@ -2619,7 +2629,6 @@ body {
   opacity: 0;
   pointer-events: none;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-  transition: opacity 0.12s ease;
 }
 
 [data-dock-tip]:hover::after,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
宿主不再把 start/stop 当成两个独立子元素去 map。

- `CollectionChrome.Actions` 接收整组 `actions` + `record`
- 有 `Actions` 时 File System 和搜索栏都只挂这一次
- 插件自己的 `PluginActions` 决定怎么画（运行/停止是同一颗按钮只是这个集合自己的选择）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

