### PR TITLE
fix(plugins): 所有插件必须有 createdAt

### DIFF
--- a/.plugin-dev/page-algorithm/manifest.json
+++ b/.plugin-dev/page-algorithm/manifest.json
@@ -5,5 +5,6 @@
   "tags": ["page", "editor", "leetcode"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
+  "createdAt": 1788270674739,
   "headless": true
 }

--- a/.plugin-dev/page-excalidraw/manifest.json
+++ b/.plugin-dev/page-excalidraw/manifest.json
@@ -5,5 +5,6 @@
   "tags": ["page", "editor", "excalidraw"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
+  "createdAt": 1788272826621,
   "headless": true
 }

--- a/.plugin-dev/page-heading-cards/manifest.json
+++ b/.plugin-dev/page-heading-cards/manifest.json
@@ -5,5 +5,6 @@
   "tags": ["page", "editor", "theme"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/biu-harness",
+  "createdAt": 1788270674728,
   "headless": true
 }

--- a/.plugin-dev/store-heavy-ping/manifest.json
+++ b/.plugin-dev/store-heavy-ping/manifest.json
@@ -5,6 +5,7 @@
   "tags": ["demo", "host"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "createdAt": 1704067200000,
   "shell": {
     "width": 480,
     "height": 360,

--- a/.plugin/store-gomoku/manifest.json
+++ b/.plugin/store-gomoku/manifest.json
@@ -5,6 +5,7 @@
   "tags": ["game", "web"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "createdAt": 1711929600000,
   "shell": {
     "width": 360,
     "height": 520,

--- a/.plugin/store-gunfire/manifest.json
+++ b/.plugin/store-gunfire/manifest.json
@@ -5,7 +5,7 @@
   "tags": [],
   "author": "",
   "authorUrl": "",
-  "createdAt": 0,
+  "createdAt": 1722470400000,
   "shell": {
     "width": 960,
     "height": 600,

--- a/.plugin/store-heavy-ping/manifest.json
+++ b/.plugin/store-heavy-ping/manifest.json
@@ -5,6 +5,7 @@
   "tags": ["demo", "host"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "createdAt": 1704067200000,
   "shell": {
     "width": 480,
     "height": 360,

--- a/.plugin/store-hello/manifest.json
+++ b/.plugin/store-hello/manifest.json
@@ -5,6 +5,7 @@
   "tags": ["demo", "web"],
   "author": "Biu",
   "authorUrl": "https://github.com/helloooooooooooooo97/cordis-web",
+  "createdAt": 1693526400000,
   "shell": {
     "width": 360,
     "height": 320,

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -18,6 +18,48 @@ function stubHub(ctx: Context) {
   }
 }
 
+test('list writes createdAt into old manifests and does not use directory ctime', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-created-at-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const pluginDir = join(dir, '.plugin')
+    const idDir = join(pluginDir, 'store-old')
+    const { mkdir, utimes } = await import('node:fs/promises')
+    await mkdir(idDir, { recursive: true })
+    await writeFile(
+      join(idDir, 'manifest.json'),
+      `${JSON.stringify({ id: 'store-old', name: 'Old', blurb: 'x', tags: [], author: '', authorUrl: '' }, null, 2)}\n`,
+    )
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const listed = await store.list()
+    const createdAt = listed[0]?.createdAt
+    assert.ok(typeof createdAt === 'number' && createdAt > 0)
+    const onDisk = JSON.parse(await readFile(join(idDir, 'manifest.json'), 'utf8')) as { createdAt: number }
+    assert.equal(onDisk.createdAt, createdAt)
+    await utimes(idDir, 1, 1)
+    await writeFile(join(idDir, 'host.js'), 'export const name = "store-old"\n')
+    const ctx2 = new Context()
+    stubHub(ctx2)
+    const store2 = new PluginStoreService(ctx2, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const listed2 = await store2.list()
+    assert.equal(listed2[0]?.createdAt, createdAt)
+    await writeFile(
+      join(idDir, 'manifest.json'),
+      `${JSON.stringify({ id: 'store-old', name: 'Old', blurb: 'x', tags: [], author: '', authorUrl: '', createdAt: 0 }, null, 2)}\n`,
+    )
+    const ctx3 = new Context()
+    stubHub(ctx3)
+    const store3 = new PluginStoreService(ctx3, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    const listed3 = await store3.list()
+    assert.ok((listed3[0]?.createdAt ?? 0) > 0)
+    const fixed = JSON.parse(await readFile(join(idDir, 'manifest.json'), 'utf8')) as { createdAt: number }
+    assert.equal(fixed.createdAt, listed3[0]?.createdAt)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('create compiles host source straight into .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-create-small-'))
   try {

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -29,6 +29,11 @@ export type StoreManifestFields = {
   shell?: StoreShell
 }
 
+export function listingCreatedAt(createdAt: unknown) {
+  const n = Number(createdAt)
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
 export function parseTags(value: unknown): string[] {
   const list = Array.isArray(value)
     ? value
@@ -78,8 +83,22 @@ export function parseStoreManifest(raw: unknown): StoreManifestFields {
       shell: data.shell,
     },
     { createdAt },
-    Number.isFinite(createdAt) && createdAt > 0 ? createdAt : Date.now(),
+    listingCreatedAt(createdAt) || Date.now(),
   )
+}
+
+/** 缺 createdAt（含 0）时写入 manifest，之后不再用目录 ctime。 */
+export async function persistStoreManifestCreatedAt(dir: string, now = Date.now()): Promise<StoreManifestFields> {
+  const path = join(dir, 'manifest.json')
+  const raw = JSON.parse(await readFile(path, 'utf8')) as unknown
+  const data = raw && typeof raw === 'object' ? { ...(raw as Record<string, unknown>) } : {}
+  const stamped = listingCreatedAt(data.createdAt)
+  const manifest = parseStoreManifest({ ...data, createdAt: stamped || now })
+  if (!stamped) {
+    data.createdAt = manifest.createdAt
+    await writeFile(path, `${JSON.stringify(data, null, 2)}\n`)
+  }
+  return manifest
 }
 
 const HOST_ENTRIES = ['host.ts', 'host.tsx', 'host.js']
@@ -289,8 +308,7 @@ function finishBundle(code: string, kind: 'host' | 'web') {
 }
 
 export async function readSandboxManifest(dir: string) {
-  const raw = JSON.parse(await readFile(join(dir, 'manifest.json'), 'utf8')) as unknown
-  return parseStoreManifest(raw)
+  return persistStoreManifestCreatedAt(dir)
 }
 
 const CONTRACT = [

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -10,7 +10,8 @@ import {
   compileStoreModule,
   findEntry,
   HOST_ENTRIES,
-  parseStoreManifest,
+  persistStoreManifestCreatedAt,
+  listingCreatedAt,
   WEB_ENTRIES,
   type PluginCreateInput,
   type StoreManifestFields,
@@ -79,24 +80,22 @@ async function importHostFile(hostFile: string) {
   }
 }
 
-async function pluginDirStats(dir: string): Promise<Pick<StoreListing, 'bytes' | 'createdAt' | 'updatedAt' | 'hasHost' | 'hasWeb'>> {
+export { listingCreatedAt } from './plugin-create.ts'
+
+async function pluginDirStats(dir: string): Promise<Pick<StoreListing, 'bytes' | 'updatedAt' | 'hasHost' | 'hasWeb'>> {
   const names = await readdir(dir)
   let bytes = 0
-  let createdAt = Number.MAX_SAFE_INTEGER
   let updatedAt = 0
   for (const name of names) {
     const file = join(dir, name)
     const st = await stat(file)
     if (!st.isFile()) continue
     bytes += st.size
-    const born = Math.floor(st.birthtimeMs || st.ctimeMs || st.mtimeMs)
     const modified = Math.floor(st.mtimeMs)
-    if (born < createdAt) createdAt = born
     if (modified > updatedAt) updatedAt = modified
   }
   return {
     bytes,
-    createdAt: createdAt === Number.MAX_SAFE_INTEGER ? updatedAt : createdAt,
     updatedAt,
     hasHost: existsSync(join(dir, 'host.js')),
     hasWeb: existsSync(join(dir, 'web.js')),
@@ -104,9 +103,8 @@ async function pluginDirStats(dir: string): Promise<Pick<StoreListing, 'bytes' |
 }
 
 async function readManifest(dir: string): Promise<StoreManifest> {
-  const raw = JSON.parse(await readFile(join(dir, 'manifest.json'), 'utf8')) as unknown
   try {
-    return parseStoreManifest(raw)
+    return await persistStoreManifestCreatedAt(dir)
   } catch {
     throw new Error(`invalid plugin manifest in ${dir}`)
   }
@@ -254,8 +252,8 @@ export class PluginStoreService extends Service {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     const sandbox = this.sandboxPath(id)
     if (!existsSync(join(sandbox, 'manifest.json'))) throw new Error(`sandbox not found: ${sandbox}`)
+    const manifest = await persistStoreManifestCreatedAt(sandbox)
     const raw = JSON.parse(await readFile(join(sandbox, 'manifest.json'), 'utf8')) as unknown
-    const manifest = parseStoreManifest(raw)
     const hostEntry = findEntry(sandbox, HOST_ENTRIES)
     const webEntry = findEntry(sandbox, WEB_ENTRIES)
     if (!hostEntry && !webEntry) throw new Error('sandbox needs host.ts/js or web.tsx/ts/js')
@@ -311,7 +309,7 @@ export class PluginStoreService extends Service {
         hasHost: Boolean(findEntry(dir, HOST_ENTRIES)),
         hasWeb: Boolean(findEntry(dir, WEB_ENTRIES)),
         ...(manifest.headless ? { headless: true } : {}),
-        createdAt: manifest.createdAt || stats.createdAt,
+        createdAt: listingCreatedAt(manifest.createdAt),
         updatedAt: stats.updatedAt,
       })
     }
@@ -340,7 +338,7 @@ export class PluginStoreService extends Service {
         enabled,
         running: running.has(manifest.id),
         bytes: stats.bytes,
-        createdAt: manifest.createdAt || stats.createdAt,
+        createdAt: listingCreatedAt(manifest.createdAt),
         updatedAt: stats.updatedAt,
         lastRunAt: this.state.lastRunAt[manifest.id] ?? null,
         hasHost: stats.hasHost,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
插件列表按创建时间排序时，开启/关闭会打乱顺序，是因为 Linux 上目录 `ctime` 会被启停改掉。

本次改动：
- `createdAt` 只来自 `manifest.json`（必须是大于 0 的时间戳）
- 旧包或缺省/`0` 时，第一次 list/pack 会把时间写进 manifest，之后不再改
- 内置 `.plugin` / `.plugin-dev` 补上 `createdAt`
- 不再用文件系统 birthtime/ctime 当创建时间

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

