### PR TITLE
fix(fs): 标题放大/右侧打开与 action 同尺寸间隙

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1650,7 +1650,7 @@ export function CollectionBrowser({
         {!nested ? (
           <button
             type="button"
-            className="tasks-title-open"
+            className="tasks-icon-btn tasks-title-open"
             data-testid="record-title-split"
             aria-label="在右侧打开"
             title="在右侧打开"
@@ -1666,7 +1666,7 @@ export function CollectionBrowser({
           {kidCount > 0 ? <ChatCount count={kidCount} className="tasks-tree-count" title={`${kidCount} 项`} /> : null}
           <button
             type="button"
-            className="tasks-title-open"
+            className="tasks-icon-btn tasks-title-open"
             data-testid="record-title-open"
             data-biu-action="open"
             aria-label="查看详情"

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -155,11 +155,11 @@ const CSS = `
 .fsdb-page .fsdb-table-record-icon{position:relative;flex:none;display:inline-flex;align-items:center}
 .fsdb-page .fsdb-table-emoji-btn{display:inline-flex;align-items:center;justify-content:center;margin:0;border:0;padding:0;background:transparent;color:inherit;font:inherit;line-height:1;cursor:pointer}
 .fsdb-page .tasks-table.is-wrap .fsdb-title-text{white-space:normal}
-.fsdb-page .tasks-title-aside{position:relative;display:inline-flex;align-items:center;gap:0;pointer-events:none}
-.fsdb-page .tasks-title-zoom{position:relative;display:grid;place-items:center;width:24px;height:24px}
+.fsdb-page .tasks-title-aside{position:relative;display:inline-flex;align-items:center;gap:2px;pointer-events:none}
+.fsdb-page .tasks-title-zoom{position:relative;display:grid;place-items:center}
 .fsdb-page .tasks-title-zoom .tasks-tree-count,.fsdb-page .tasks-title-zoom .tasks-title-open{grid-area:1/1}
-.fsdb-page .tasks-title-open{flex:none;width:24px;height:24px;display:inline-flex;align-items:center;justify-content:center;border:0;background:transparent;color:#F0EFED;border-radius:6px;cursor:pointer;padding:0;opacity:0;z-index:1;pointer-events:none}
-.fsdb-page .tasks-row-tools-slot{position:absolute;top:50%;right:8px;z-index:2;display:inline-flex;align-items:center;gap:0;width:auto;transform:translateY(-50%);overflow:visible;pointer-events:none}
+.fsdb-page .tasks-title-open{flex:none;color:#F0EFED;opacity:0;z-index:1;pointer-events:none}
+.fsdb-page .tasks-row-tools-slot{position:absolute;top:50%;right:8px;z-index:2;display:inline-flex;align-items:center;gap:2px;width:auto;transform:translateY(-50%);overflow:visible;pointer-events:none}
 .fsdb-page .tasks-table td:has(.fsdb-title-host) .tasks-row-tools,.fsdb-page .tasks-table td:has(.fsdb-title-host) .tasks-row-actions{opacity:0;pointer-events:none}
 .fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible,.fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-row-actions,.fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-row-tools{opacity:1;pointer-events:auto}
 .fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-title-open,.fsdb-page .tasks-title-open:focus-visible,.fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-row-tools .tasks-icon-btn,.fsdb-page .tasks-table tr:hover td:has(.fsdb-title-host) .tasks-row-actions .tasks-icon-btn{background:var(--dsw-hover)}
@@ -225,6 +225,7 @@ const CSS = `
 .fsdb-page .tasks-row-tools .tasks-icon-btn:hover,.fsdb-page .tasks-row-tools .tasks-icon-btn.is-active,.fsdb-page .tasks-row-actions .tasks-icon-btn:hover,.fsdb-page .tasks-row-actions .tasks-icon-btn.is-active{color:#F0EFED}
 .fsdb-page .tasks-icon-btn.is-danger:hover{background:var(--dsw-danger-soft);color:var(--dsw-danger)}
 .fsdb-page .tasks-icon-btn:disabled{opacity:.4;cursor:default}
+.fsdb-page .tasks-icon-btn.tasks-title-open,.fsdb-page .tasks-icon-btn.tasks-title-open:hover,.fsdb-page .tasks-icon-btn.tasks-title-open.is-active{color:#F0EFED}
 .fsdb-page .tasks-queue{display:flex;flex-direction:column;gap:18px;overflow:auto;box-sizing:border-box;width:calc(100% + var(--fsdb-check-gutter));margin-left:calc(var(--fsdb-check-gutter) * -1);padding:2px 0 12px var(--fsdb-check-gutter);flex:1;min-width:0;min-height:0}
 .fsdb-page .tasks-queue-group{display:flex;flex-direction:column;gap:2px}
 .fsdb-page .tasks-queue-ghead{display:flex;align-items:center;gap:6px;padding:4px 8px;color:var(--dsw-label-2);font-size:14px;font-weight:650;letter-spacing:.01em;cursor:default}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -106,7 +106,7 @@ test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /data-testid="record-title-split"/)
   assert.match(browser, /showRecordInInspector\(collectionPath, row.id\)/)
-  assert.match(browser, /className="tasks-title-open"/)
+  assert.match(browser, /className="tasks-icon-btn tasks-title-open"/)
   assert.match(browser, /tasks-title-aside/)
   assert.match(browser, /tasks-tree-count/)
   assert.match(browser, /kidCount/)

--- a/packages/core-file-system/src/web/list-align.test.ts
+++ b/packages/core-file-system/src/web/list-align.test.ts
@@ -74,6 +74,13 @@ test('list and detail share the chat column max width with side padding', () => 
 test('title cell hover icons use F0EFED', () => {
   assert.match(css, /\.fsdb-page \.tasks-title-open\{[^}]*color:#F0EFED/)
   assert.match(css, /\.fsdb-page \.tasks-title-open:hover\{[^}]*color:#F0EFED/)
+  assert.match(css, /\.fsdb-page \.tasks-title-aside\{[^}]*gap:2px/)
+  assert.match(css, /\.fsdb-page \.tasks-row-tools-slot\{[^}]*gap:2px/)
+  assert.match(css, /\.fsdb-page \.tasks-row-actions\{[^}]*gap:2px/)
+  assert.match(css, /\.fsdb-page \.tasks-icon-btn\{[^}]*padding:3px/)
+  assert.match(css, /\.fsdb-page \.tasks-icon-btn\{[^}]*border-radius:5px/)
+  assert.doesNotMatch(css, /\.fsdb-page \.tasks-title-open\{[^}]*width:24px/)
+  assert.doesNotMatch(css, /\.fsdb-page \.tasks-title-zoom\{[^}]*width:24px/)
   assert.match(css, /\.fsdb-page \.tasks-row-tools \.tasks-icon-btn,\.fsdb-page \.tasks-row-actions \.tasks-icon-btn\{[^}]*color:#F0EFED/)
   assert.match(
     css,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
标题 cell 里「放大」和「在右侧打开」原先钉死 24px、圆角 6px、间隙 0，和 action 的 `tasks-icon-btn`（padding 3px、圆角 5px、间隙 2px）对不齐。

现在这两个按钮也用 `tasks-icon-btn`，标题工具组与 action 的 gap 都是 2px。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

