### PR TITLE
fix(fs): 插件详情 action 按钮上移 20px

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1964,7 +1964,7 @@ export function CollectionBrowser({
 
   return (
     <div
-      className={`fsdb-page tasks-root${nested ? ' inspector-database-page' : ''}${sheet ? ' is-sheet' : ''}${!sheet && pageWidth === 'full' ? ' is-full-width' : ''}`}
+      className={`fsdb-page tasks-root${nested ? ' inspector-database-page' : ''}${sheet ? ' is-sheet' : ''}${!sheet && pageWidth === 'full' ? ' is-full-width' : ''}${collectionPath === '/plugins' ? ' is-plugins' : ''}`}
       data-testid={embed ? 'inspector-database' : sheet ? 'fsdb-collect-sheet' : undefined}
     >
       {!nested ? (

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -372,6 +372,7 @@ const CSS = `
 .fsdb-detail-title-row{display:flex;align-items:flex-start;gap:12px;min-width:0;padding-bottom:16px}
 .fsdb-detail-title-block{display:flex;flex:1;min-width:0;flex-direction:column;gap:6px}
 .fsdb-detail-actionbar{position:sticky;top:calc(100% - 35px);z-index:26;display:flex;justify-content:center;width:100%;height:0;min-height:0;overflow:visible;pointer-events:none}
+.fsdb-page.is-plugins .fsdb-detail-actionbar{top:calc(100% - 55px)}
 .fsdb-detail-actions{pointer-events:auto;display:inline-flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:4px;margin:0;padding:0;background:transparent;transform:translateY(-100%)}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn,.fsdb-page .fsdb-detail-actions .tasks-icon-btn{position:relative;display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;padding:0;border:1px solid var(--dsw-border);border-radius:50%;background:#252525;color:#F0EFED;cursor:pointer;box-shadow:none}
 .fsdb-page .fsdb-detail-actions .dock-icon-btn:hover:not(:disabled),.fsdb-page .fsdb-detail-actions .tasks-icon-btn:hover:not(:disabled){color:var(--dsw-sidebar-fg-active);background:#252525}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -152,6 +152,8 @@ test('title cell row tools skip the overflow action menu', () => {
   assert.match(css, /\.fsdb-detail-actionbar\{/)
   assert.match(css, /top:calc\(100% - 35px\)/)
   assert.doesNotMatch(css, /top:calc\(100% - 60px\)/)
+  assert.match(css, /\.fsdb-page\.is-plugins \.fsdb-detail-actionbar\{[^}]*top:calc\(100% - 55px\)/)
+  assert.match(browser, /collectionPath === '\/plugins' \? ' is-plugins'/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*width:32px/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*height:32px/)
   assert.match(css, /\.fsdb-page \.fsdb-detail-actions \.dock-icon-btn,\.fsdb-page \.fsdb-detail-actions \.tasks-icon-btn\{[^}]*color:#F0EFED/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
插件详情底部 action 栏（开始/停止等）整体上移 20px：sticky 从 `100% - 35px` 改为 `100% - 55px`。只作用于 `/plugins`，其它表详情位置不变。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

