### PR TITLE
feat(editor): 块带上插件 id，未启用时展示源码并引导开启

### DIFF
--- a/.plugin-dev/page-algorithm/web.tsx
+++ b/.plugin-dev/page-algorithm/web.tsx
@@ -166,6 +166,7 @@ export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
       kind: string
+      plugin: string
       label: string
       hint?: string
       aliases?: string[]
@@ -176,6 +177,7 @@ export function apply(ctx: {
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'algorithm',
+    plugin: name,
     label: '算法题',
     hint: 'LeetCode 风：左题目右代码',
     aliases: ['leetcode', 'algo', '算法', 'lc'],

--- a/.plugin-dev/page-excalidraw/web.tsx
+++ b/.plugin-dev/page-excalidraw/web.tsx
@@ -8,9 +8,10 @@ export const name = 'page-excalidraw'
 export const inject = ['pageEditor']
 
 type PageEditor = {
-  registerBlock: (spec: {
-    kind: string
-    label: string
+    registerBlock: (spec: {
+      kind: string
+      plugin: string
+      label: string
     hint?: string
     aliases?: string[]
     defaults?: () => Record<string, unknown>
@@ -470,6 +471,7 @@ function Board(props: { data: Record<string, unknown>; update: (p: Record<string
 export function apply(ctx: { pageEditor: PageEditor }) {
   ctx.pageEditor.registerBlock({
     kind: 'excalidraw',
+    plugin: name,
     label: '画板',
     hint: '手绘白板，放大后编辑',
     aliases: ['excalidraw', 'draw', '白板', '画板', 'board'],

--- a/.plugin/page-algorithm/web.js
+++ b/.plugin/page-algorithm/web.js
@@ -167,6 +167,7 @@ function AlgorithmCard({
 function apply(ctx) {
   ctx.pageEditor.registerBlock({
     kind: "algorithm",
+    plugin: name,
     label: "\u7B97\u6CD5\u9898",
     hint: "LeetCode \u98CE\uFF1A\u5DE6\u9898\u76EE\u53F3\u4EE3\u7801",
     aliases: ["leetcode", "algo", "\u7B97\u6CD5", "lc"],

--- a/packages/core-editor/src/web/page-block-meta.test.tsx
+++ b/packages/core-editor/src/web/page-block-meta.test.tsx
@@ -1,0 +1,38 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { render } from '@testing-library/react'
+import { ENABLE_PAGE_BLOCK_PLUGIN, formatPageBlockFence, parsePageBlockMeta, requestEnablePageBlockPlugin } from './page-block-meta.ts'
+import { PageBlockMissing } from './page-block-view.tsx'
+
+test('page block fence keeps plugin id in the document', () => {
+  assert.deepEqual(parsePageBlockMeta('kind=excalidraw plugin=page-excalidraw'), {
+    kind: 'excalidraw',
+    plugin: 'page-excalidraw',
+  })
+  assert.match(
+    formatPageBlockFence('excalidraw', 'page-excalidraw', { file: 'assets/a.json' }),
+    /:::pageBlock \{kind=excalidraw plugin=page-excalidraw\}/,
+  )
+})
+
+test('missing block shows stored source and asks to enable the stored plugin', () => {
+  const { container } = render(
+    <PageBlockMissing kind="excalidraw" plugin="page-excalidraw" data={{ file: 'assets/a.json' }} />,
+  )
+  const text = container.textContent ?? ''
+  assert.match(text, /未启用「excalidraw」块/)
+  assert.match(text, /page-excalidraw/)
+  assert.match(text, /assets\/a\.json/)
+  assert.ok(container.querySelector('[data-testid="page-block-enable"]'))
+})
+
+test('enable button only dispatches the stored plugin id', () => {
+  const seen: string[] = []
+  const onEnable = (event: Event) => {
+    seen.push(String((event as CustomEvent<{ plugin?: string }>).detail?.plugin ?? ''))
+  }
+  window.addEventListener(ENABLE_PAGE_BLOCK_PLUGIN, onEnable)
+  requestEnablePageBlockPlugin('page-excalidraw', 'excalidraw')
+  window.removeEventListener(ENABLE_PAGE_BLOCK_PLUGIN, onEnable)
+  assert.deepEqual(seen, ['page-excalidraw'])
+})

--- a/packages/core-editor/src/web/page-block-meta.ts
+++ b/packages/core-editor/src/web/page-block-meta.ts
@@ -1,0 +1,21 @@
+/** 文档里的块只认自己写下的插件 id，编辑器不猜、不查插件表。 */
+export const ENABLE_PAGE_BLOCK_PLUGIN = 'biu:enable-page-block-plugin'
+
+export function parsePageBlockMeta(raw: string) {
+  const kind = raw.match(/\bkind=["']?([a-z0-9-]+)/i)?.[1] ?? 'card'
+  const plugin = raw.match(/\bplugin=["']?([a-z][a-z0-9-]*)/i)?.[1] ?? ''
+  return { kind, plugin }
+}
+
+export function formatPageBlockFence(kind: string, plugin: string, data: Record<string, unknown>) {
+  const body = { ...data }
+  delete body.cloneFrom
+  const meta = plugin ? `{kind=${kind} plugin=${plugin}}` : `{kind=${kind}}`
+  return `:::pageBlock ${meta}\n${JSON.stringify(body, null, 2)}\n:::`
+}
+
+export function requestEnablePageBlockPlugin(plugin: string, kind: string) {
+  const id = plugin.trim()
+  if (!id || typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent(ENABLE_PAGE_BLOCK_PLUGIN, { detail: { plugin: id, kind } }))
+}

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper } from '@tiptap/react'
 import { getPageEditor, usePageEditorVersion } from './service.ts'
+import { formatPageBlockFence, requestEnablePageBlockPlugin } from './page-block-meta.ts'
 
 function assetName(file: string) {
   return file.replace(/^assets\//, '')
@@ -26,9 +27,43 @@ async function copyPageAsset(from: string, to: string) {
   })
 }
 
+export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin: string; data: Record<string, unknown> }) {
+  const source = formatPageBlockFence(kind, plugin, data)
+  return (
+    <div className="page-block-missing" data-testid="page-block-missing">
+      <div className="page-block-missing-title">未启用「{kind}」块</div>
+      {plugin ? (
+        <p className="page-block-missing-copy">
+          这块由插件 <code>{plugin}</code> 渲染。现在没在运行，下面是文档里存下的源码。
+        </p>
+      ) : (
+        <p className="page-block-missing-copy">
+          文档里没有记下插件 id。启用对应插件后重新保存，就会带上映射。
+        </p>
+      )}
+      {plugin ? (
+        <button
+          type="button"
+          className="page-block-missing-enable"
+          data-testid="page-block-enable"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            requestEnablePageBlockPlugin(plugin, kind)
+          }}
+        >
+          启用 {plugin}
+        </button>
+      ) : null}
+      <pre className="page-block-missing-source">{source}</pre>
+    </div>
+  )
+}
+
 export function PageBlockView({ node, updateAttributes, editor }: NodeViewProps) {
   usePageEditorVersion()
   const kind = String(node.attrs.kind ?? 'card')
+  const plugin = String(node.attrs.plugin ?? '').trim()
   const data = (node.attrs.data && typeof node.attrs.data === 'object' ? node.attrs.data : {}) as Record<string, unknown>
   const spec = getPageEditor()?.block(kind)
   const cloneFrom = typeof data.cloneFrom === 'string' ? data.cloneFrom : ''
@@ -51,13 +86,13 @@ export function PageBlockView({ node, updateAttributes, editor }: NodeViewProps)
   }, [cloneFrom, file])
 
   return (
-    <NodeViewWrapper className="page-block" data-page-block={kind} data-testid={`page-block-${kind}`}>
+    <NodeViewWrapper className="page-block" data-page-block={kind} data-page-block-plugin={plugin} data-testid={`page-block-${kind}`}>
       {cloneFrom ? (
         <div className="page-block-missing">正在复制附件…</div>
       ) : View ? (
         <View data={data} update={update} writable={editor.isEditable} />
       ) : (
-        <div className="page-block-missing">未启用「{kind}」块插件</div>
+        <PageBlockMissing kind={kind} plugin={plugin} data={data} />
       )}
     </NodeViewWrapper>
   )

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -16,6 +16,7 @@ test('registerBlock adds a slash item and inserts pageBlock', async () => {
     apply(inner) {
       inner.pageEditor.registerBlock({
         kind: 'algorithm',
+        plugin: 'page-algorithm',
         label: '算法题',
         aliases: ['leetcode'],
         defaults: { title: 'Two Sum' },
@@ -36,17 +37,18 @@ test('registerBlock adds a slash item and inserts pageBlock', async () => {
   const json = editor.getJSON()
   const block = json.content?.find((node) => node.type === 'pageBlock')
   assert.equal(block?.attrs?.kind, 'algorithm')
+  assert.equal(block?.attrs?.plugin, 'page-algorithm')
   assert.equal((block?.attrs?.data as { title?: string })?.title, 'Two Sum')
   const md = editor.getMarkdown()
-  assert.match(md, /:::pageBlock \{kind=algorithm\}/)
+  assert.match(md, /:::pageBlock \{kind=algorithm plugin=page-algorithm\}/)
   assert.match(md, /Two Sum/)
   editor.destroy()
   await fiber.dispose()
   assert.equal(filterSlashItems('leetcode').some((entry) => entry.id === 'algorithm'), false)
 })
 
-test('pageBlock markdown roundtrips kind and data', () => {
-  const src = `:::pageBlock {kind=algorithm}
+test('pageBlock markdown roundtrips kind, plugin and data', () => {
+  const src = `:::pageBlock {kind=algorithm plugin=page-algorithm}
 {"title":"Two Sum","lang":"python"}
 :::
 `
@@ -58,14 +60,15 @@ test('pageBlock markdown roundtrips kind and data', () => {
   const json = editor.getJSON()
   const block = json.content?.find((node) => node.type === 'pageBlock')
   assert.equal(block?.attrs?.kind, 'algorithm')
+  assert.equal(block?.attrs?.plugin, 'page-algorithm')
   assert.equal((block?.attrs?.data as { title?: string })?.title, 'Two Sum')
   const out = editor.getMarkdown()
-  assert.match(out, /:::pageBlock \{kind=algorithm\}/)
+  assert.match(out, /:::pageBlock \{kind=algorithm plugin=page-algorithm\}/)
   assert.match(out, /Two Sum/)
   editor.destroy()
 })
 
-test('pageBlock markdown roundtrips excalidraw as a file pointer only', () => {
+test('pageBlock markdown keeps old fences without plugin id', () => {
   const src = `:::pageBlock {kind=excalidraw}
 {"file":"assets/excalidraw-demo.json"}
 :::
@@ -78,8 +81,10 @@ test('pageBlock markdown roundtrips excalidraw as a file pointer only', () => {
   const json = editor.getJSON()
   const block = json.content?.find((node) => node.type === 'pageBlock')
   assert.equal(block?.attrs?.kind, 'excalidraw')
+  assert.equal(block?.attrs?.plugin, '')
   assert.deepEqual(block?.attrs?.data, { file: 'assets/excalidraw-demo.json' })
   const out = editor.getMarkdown()
+  assert.match(out, /:::pageBlock \{kind=excalidraw\}/)
   assert.match(out, /"file": "assets\/excalidraw-demo.json"/)
   assert.doesNotMatch(out, /"elements"/)
   assert.doesNotMatch(out, /"height"/)
@@ -95,6 +100,7 @@ test('slash insert for excalidraw only puts a file pointer in the node', async (
     apply(inner) {
       inner.pageEditor.registerBlock({
         kind: 'excalidraw',
+        plugin: 'page-excalidraw',
         label: '画板',
         defaults: () => ({ file: 'assets/excalidraw-new.json' }),
         View: () => null,
@@ -111,6 +117,7 @@ test('slash insert for excalidraw only puts a file pointer in the node', async (
   const from = editor.state.selection.from - 1
   item!.command({ editor, range: { from: Math.max(1, from), to: editor.state.selection.from } })
   const block = editor.getJSON().content?.find((node) => node.type === 'pageBlock')
+  assert.equal(block?.attrs?.plugin, 'page-excalidraw')
   assert.deepEqual(block?.attrs?.data, { file: 'assets/excalidraw-new.json' })
   assert.doesNotMatch(editor.getMarkdown(), /elements/)
   editor.destroy()
@@ -145,6 +152,7 @@ test('pageBlock node view skips react update when attrs are unchanged', async ()
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-block.ts'), 'utf8')
+  assert.match(src, /oldNode\.attrs\.plugin === newNode\.attrs\.plugin/)
   assert.match(src, /oldNode\.attrs\.kind === newNode\.attrs\.kind/)
   assert.match(src, /JSON\.stringify\(oldNode\.attrs\.data\) === JSON\.stringify\(newNode\.attrs\.data\)/)
   assert.match(src, /return true/)
@@ -158,3 +166,45 @@ test('pageBlock capture includes drawing surfaces', async () => {
   assert.match(src, /\.excalidraw/)
   assert.match(src, /canvas/)
 })
+
+test('registerBlock requires plugin id', () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  assert.throws(
+    () =>
+      ctx.pageEditor.registerBlock({
+        kind: 'algorithm',
+        plugin: '',
+        label: '算法题',
+        View: () => null,
+      }),
+    /plugin id/,
+  )
+})
+
+test('saving an old fence backfills plugin from the running spec', async () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  const fiber = ctx.plugin({
+    name: 'draw',
+    inject: ['pageEditor'],
+    apply(inner) {
+      inner.pageEditor.registerBlock({
+        kind: 'excalidraw',
+        plugin: 'page-excalidraw',
+        label: '画板',
+        View: () => null,
+      })
+    },
+  })
+  await fiber
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: `:::pageBlock {kind=excalidraw}\n{"file":"assets/excalidraw-demo.json"}\n:::\n`,
+    contentType: 'markdown',
+  })
+  assert.match(editor.getMarkdown(), /plugin=page-excalidraw/)
+  editor.destroy()
+  await fiber.dispose()
+})
+

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -4,6 +4,7 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import type { Node as PmNode } from '@tiptap/pm/model'
 import { PageBlockView } from './page-block-view.tsx'
 import { getPageEditor } from './service.ts'
+import { formatPageBlockFence, parsePageBlockMeta } from './page-block-meta.ts'
 
 const metaKey = new PluginKey('page-block-meta')
 const uniqueFilesKey = new PluginKey('page-block-unique-files')
@@ -49,6 +50,7 @@ export const pageBlock = Node.create({
   addAttributes() {
     return {
       kind: { default: 'card' },
+      plugin: { default: '' },
       data: { default: {}, rendered: false },
     }
   },
@@ -61,6 +63,7 @@ export const pageBlock = Node.create({
           if (!(el instanceof HTMLElement)) return false
           return {
             kind: el.getAttribute('data-page-block') || 'card',
+            plugin: el.getAttribute('data-page-block-plugin') || '',
             data: parseData(el.getAttribute('data-page-block-data')),
           }
         },
@@ -73,6 +76,7 @@ export const pageBlock = Node.create({
       'div',
       mergeAttributes(HTMLAttributes, {
         'data-page-block': String(node.attrs.kind ?? 'card'),
+        'data-page-block-plugin': String(node.attrs.plugin ?? ''),
         'data-page-block-data': encodeURIComponent(JSON.stringify(node.attrs.data ?? {})),
       }),
     ]
@@ -80,6 +84,7 @@ export const pageBlock = Node.create({
 
   parseMarkdown: (token, helpers) => {
     const kind = String(token.attributes?.kind ?? 'card')
+    const plugin = String(token.attributes?.plugin ?? '')
     let data: Record<string, unknown> = {}
     const raw = String(token.content ?? '').trim()
     if (raw) {
@@ -89,15 +94,15 @@ export const pageBlock = Node.create({
         data = {}
       }
     }
-    return helpers.createNode('pageBlock', { kind, data })
+    return helpers.createNode('pageBlock', { kind, plugin, data })
   },
 
   renderMarkdown: (node) => {
     const kind = String(node.attrs?.kind ?? 'card')
+    const stored = String(node.attrs?.plugin ?? '').trim()
+    const plugin = stored || getPageEditor()?.block(kind)?.plugin || ''
     const data = { ...((node.attrs?.data && typeof node.attrs.data === 'object' ? node.attrs.data : {}) as Record<string, unknown>) }
-    delete data.cloneFrom
-    const body = JSON.stringify(data, null, 2)
-    return `:::pageBlock {kind=${kind}}\n${body}\n:::`
+    return formatPageBlockFence(kind, plugin, data)
   },
 
   markdownTokenizer: {
@@ -109,11 +114,11 @@ export const pageBlock = Node.create({
     tokenize(src) {
       const match = src.match(/^:::pageBlock(?:\s+\{([^}]*)\})?\s*\n([\s\S]*?)\n:::/)
       if (!match) return undefined
-      const kind = match[1]?.match(/kind=["']?([a-z0-9-]+)/i)?.[1] ?? 'card'
+      const { kind, plugin } = parsePageBlockMeta(match[1] ?? '')
       return {
         type: 'pageBlock',
         raw: match[0],
-        attributes: { kind },
+        attributes: { kind, plugin },
         content: match[2]?.trim() ?? '',
       }
     },
@@ -129,6 +134,7 @@ export const pageBlock = Node.create({
       update({ oldNode, newNode, updateProps }) {
         if (
           oldNode.attrs.kind === newNode.attrs.kind &&
+          oldNode.attrs.plugin === newNode.attrs.plugin &&
           JSON.stringify(oldNode.attrs.data) === JSON.stringify(newNode.attrs.data)
         ) {
           return true

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -59,6 +59,7 @@ test('page editor paints a registered algorithm block', async () => {
   new PageEditorService(ctx)
   ctx.pageEditor.registerBlock({
     kind: 'algorithm',
+    plugin: 'page-algorithm',
     label: '算法题',
     defaults: { title: 'Two Sum' },
     View: ({ data }) => <div data-testid="algo-view">{String(data.title ?? '')}</div>,
@@ -98,6 +99,7 @@ test('page editor hydrates markdown after content fetch', async () => {
   new PageEditorService(ctx)
   ctx.pageEditor.registerBlock({
     kind: 'algorithm',
+    plugin: 'page-algorithm',
     label: '算法题',
     defaults: { title: 'Two Sum' },
     View: ({ data }) => <div data-testid="algo-view">{String(data.title ?? '')}</div>,

--- a/packages/core-editor/src/web/service.ts
+++ b/packages/core-editor/src/web/service.ts
@@ -17,6 +17,8 @@ export type PageBlockViewProps = {
 
 export type PageBlockSpec = {
   kind: string
+  /** 写入文档的插件 id（与 export const name / manifest.id 相同）。编辑器不推断。 */
+  plugin: string
   label: string
   hint?: string
   aliases?: string[]
@@ -87,13 +89,16 @@ export class PageEditorService extends Service {
     return [...this.extras]
   }
 
-  /** 登记一种新块（atom）。斜杠菜单可插入；View 画卡片。 */
+  /** 登记一种新块（atom）。斜杠菜单可插入；View 画卡片。plugin 必须是插件自己的 id。 */
   registerBlock(spec: PageBlockSpec) {
+    const plugin = String(spec.plugin ?? '').trim()
+    if (!plugin) throw new Error('page block needs plugin id')
+    const next = { ...spec, plugin }
     return this.ctx.effect(() => {
-      this.customBlocks.set(spec.kind, spec)
+      this.customBlocks.set(spec.kind, next)
       this.bump()
       return () => {
-        if (this.customBlocks.get(spec.kind) === spec) this.customBlocks.delete(spec.kind)
+        if (this.customBlocks.get(spec.kind) === next) this.customBlocks.delete(spec.kind)
         this.bump()
       }
     })

--- a/packages/core-editor/src/web/slash.ts
+++ b/packages/core-editor/src/web/slash.ts
@@ -144,6 +144,7 @@ export function slashCatalog(): SlashItem[] {
             type: 'pageBlock',
             attrs: {
               kind: block.kind,
+              plugin: block.plugin,
               data: typeof block.defaults === 'function' ? block.defaults() : { ...(block.defaults ?? {}) },
             },
           })

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -11,7 +11,13 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .page-block{margin:12px 0;position:relative;z-index:0;isolation:isolate;overflow:hidden}
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
-.page-editor .page-block-missing{padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
+.page-editor .page-block-missing{display:flex;flex-direction:column;gap:8px;padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
+.page-editor .page-block-missing-title{color:var(--dsw-label);font-size:14px;font-weight:650}
+.page-editor .page-block-missing-copy{margin:0;line-height:1.5}
+.page-editor .page-block-missing-copy code{font-family:var(--font-mono);font-size:12px;color:var(--dsw-label-2)}
+.page-editor .page-block-missing-enable{align-self:flex-start;margin:0;border:1px solid var(--dsw-border);border-radius:6px;padding:5px 10px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;cursor:pointer}
+.page-editor .page-block-missing-enable:hover{background:var(--dsw-hover)}
+.page-editor .page-block-missing-source{margin:0;max-height:220px;overflow:auto;padding:10px 12px;border-radius:8px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));color:var(--dsw-label-2);font-family:var(--font-mono);font-size:12px;line-height:1.55;white-space:pre-wrap;word-break:break-word}
 .page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em;list-style-position:outside}
 .page-editor .tiptap ul{list-style-type:disc}
 .page-editor .tiptap ol{list-style-type:decimal}

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -314,7 +314,7 @@ export async function readSandboxManifest(dir: string) {
 const CONTRACT = [
   '契约：id 与 export const name 相同。可以 import npm，pack 会打进 host.js/web.js。不要 import react / react-dom / @biu/*：Web 用宿主 globalThis.React、ReactDOM 与 ReactJSXRuntime；宿主服务用 inject。有 npm 依赖请用 db_action /plugins/<id> action=sandbox，再用 action=pack（create 只做单文件、不解析 node_modules）。不要改 packages/ 或 cordis.plugins.json。',
   '有窗口的 Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选。运行窗口会给 extras 套操纵栏（关/缩；resizable 才有全屏），key 尽量用插件 id。',
-  '无头插件：manifest 写 headless: true。有 web 也不要 shell，不要 place plugin-store-extras，不要操纵栏。只在 apply 里登记服务（如 pageEditor）。',
+  '无头插件：manifest 写 headless: true。有 web 也不要 shell，不要 place plugin-store-extras，不要操纵栏。只在 apply 里登记服务（如 pageEditor）。pageEditor.registerBlock 必须带 plugin（与本插件 id / export const name 相同），写入文档后编辑器按这个 id 引导启用，不要让编辑器猜插件。',
   '有窗口的 web 必须在 manifest / 本动作 shell 参数里写 width 与 height。无头插件不要写 shell。',
   '/plugins 列表没有 listing.shell 对象，只有扁平字段 shellWidth、shellHeight、shellMinWidth、shellMinHeight、shellResizable、headless。有窗口时用 storeShellFromRecord 读尺寸。',
 ].join(' ')

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -40,6 +40,9 @@ test('plugin system web declares extras so store plugins can mount windows', asy
   await ctx.plugin(plugins2Ui)
   assert.equal(ctx.slots.list('root-overlays').some((item) => item.id === 'plugin-store-extras-layer'), true)
   assert.ok(ctx.slots.specOf('plugin-store-extras'))
+  const { readFileSync } = await import('node:fs')
+  const { resolve } = await import('node:path')
+  assert.match(readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8'), /listenEnablePageBlockPlugin/)
 })
 
 test('plugin system web passes name/tags/action chrome into databaseUi', async () => {
@@ -165,6 +168,7 @@ test('packed page-excalidraw plugin stores scenes as page assets', async () => {
   assert.match(src, /queueMicrotask/)
   assert.doesNotMatch(src, /expanded \? null : canvas/)
   assert.match(src, /export const inject = \['pageEditor'\]/)
+  assert.match(src, /plugin: name/)
   assert.match(src, /View: Board/)
   assert.match(src, /defaults: \(\) => \(\{ file:/)
   assert.match(src, /res\.status === 404/)

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -6,6 +6,7 @@ import type { SlotProps } from '@biu/type-slots'
 import { XMarkIcon, MinusIcon, ArrowsPointingOutIcon, ArrowsPointingInIcon, Bars2Icon } from '@heroicons/react/16/solid'
 import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { pluginsChrome } from './chrome.tsx'
+import { listenEnablePageBlockPlugin } from './page-block-plugin.ts'
 import {
   WIN_CHROME_H,
   centeredGeom,
@@ -397,6 +398,7 @@ export function apply(ctx: Context) {
   if (!slots) throw new Error('slots service required')
   const ui = ctx.get('databaseUi') as DatabaseUi
   ctx.effect(() => ui.decorate('/plugins', pluginsChrome).dispose)
+  ctx.effect(() => listenEnablePageBlockPlugin())
   slots.place('root-overlays', PluginExtrasLayer, {
     key: 'plugin-store-extras-layer',
     order: 20,

--- a/packages/core-plugin-system/src/web/page-block-plugin.test.ts
+++ b/packages/core-plugin-system/src/web/page-block-plugin.test.ts
@@ -1,0 +1,16 @@
+/** @vitest-environment jsdom */
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  ENABLE_PAGE_BLOCK_PLUGIN,
+  pageBlockPluginFromEvent,
+  pluginRecordHref,
+} from './page-block-plugin.ts'
+
+test('page block enable href is the plugin record, not guessed from kind', () => {
+  assert.equal(pluginRecordHref('page-excalidraw'), '/database/plugins/record/page-excalidraw')
+  assert.equal(
+    pageBlockPluginFromEvent(new CustomEvent(ENABLE_PAGE_BLOCK_PLUGIN, { detail: { plugin: 'page-excalidraw', kind: 'excalidraw' } })),
+    'page-excalidraw',
+  )
+})

--- a/packages/core-plugin-system/src/web/page-block-plugin.ts
+++ b/packages/core-plugin-system/src/web/page-block-plugin.ts
@@ -1,0 +1,47 @@
+import { buildAppPath } from '@biu/web-session-view'
+
+export const ENABLE_PAGE_BLOCK_PLUGIN = 'biu:enable-page-block-plugin'
+
+export function pluginRecordHref(id: string) {
+  return buildAppPath({
+    kind: 'record',
+    moduleId: 'database',
+    path: '/database',
+    collection: '/plugins',
+    recordId: id,
+  })
+}
+
+export async function startStorePlugin(id: string) {
+  const res = await fetch('/api/db/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path: `/plugins/${id}`, action: 'start' }),
+  })
+  const body = (await res.json().catch(() => ({}))) as { error?: string }
+  if (!res.ok) throw new Error(body.error || res.statusText)
+}
+
+export function pageBlockPluginFromEvent(event: Event) {
+  const detail = (event as CustomEvent<{ plugin?: unknown; kind?: unknown }>).detail
+  const plugin = typeof detail?.plugin === 'string' ? detail.plugin.trim() : ''
+  return plugin
+}
+
+export function listenEnablePageBlockPlugin() {
+  const onEnable = (event: Event) => {
+    const plugin = pageBlockPluginFromEvent(event)
+    if (!plugin) return
+    void startStorePlugin(plugin)
+      .catch(() => undefined)
+      .finally(() => {
+        const href = pluginRecordHref(plugin)
+        if (window.location.pathname !== href) {
+          window.history.pushState({}, '', href)
+          window.dispatchEvent(new PopStateEvent('popstate'))
+        }
+      })
+  }
+  window.addEventListener(ENABLE_PAGE_BLOCK_PLUGIN, onEnable)
+  return () => window.removeEventListener(ENABLE_PAGE_BLOCK_PLUGIN, onEnable)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
编辑器不再猜「哪个插件渲染这个块」。

- `registerBlock` 必须带 `plugin`（插件自己的 id）
- 存盘变成 `:::pageBlock {kind=excalidraw plugin=page-excalidraw}`
- 插件没开时：说明文案 + 文档里的源码 +「启用 {id}」
- 按钮只派发文档里的 plugin id；插件系统负责 start 并打开插件记录
- 旧文档没有 plugin 时仍能读；插件开着再保存会补上

编辑器不依赖插件系统的列表或 `page-${kind}` 推断。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

