### PR TITLE
未启用块占位：去掉大标题和说明，只留 id + 启用 + 源码

### DIFF
--- a/packages/core-editor/src/web/page-block-meta.test.tsx
+++ b/packages/core-editor/src/web/page-block-meta.test.tsx
@@ -20,13 +20,13 @@ test('missing block shows stored source and asks to enable the stored plugin', (
     <PageBlockMissing kind="excalidraw" plugin="page-excalidraw" data={{ file: 'assets/a.json' }} />,
   )
   const text = container.textContent ?? ''
-  assert.match(text, /未启用「excalidraw」块/)
-  assert.match(text, /插件未启用/)
-  assert.match(text, /源码/)
+  assert.doesNotMatch(text, /未启用「/)
+  assert.doesNotMatch(text, /文档里已经存/)
   assert.match(text, /page-excalidraw/)
+  assert.match(text, /未运行/)
+  assert.match(text, /源码/)
   assert.match(text, /assets\/a\.json/)
-  assert.ok(container.querySelector('.page-block-missing-head'))
-  assert.ok(container.querySelector('[data-testid="page-block-enable"]'))
+  assert.equal(container.querySelector('[data-testid="page-block-enable"]')?.textContent?.trim(), '启用')
 })
 
 test('enable button only dispatches the stored plugin id', () => {

--- a/packages/core-editor/src/web/page-block-meta.test.tsx
+++ b/packages/core-editor/src/web/page-block-meta.test.tsx
@@ -21,8 +21,11 @@ test('missing block shows stored source and asks to enable the stored plugin', (
   )
   const text = container.textContent ?? ''
   assert.match(text, /未启用「excalidraw」块/)
+  assert.match(text, /插件未启用/)
+  assert.match(text, /源码/)
   assert.match(text, /page-excalidraw/)
   assert.match(text, /assets\/a\.json/)
+  assert.ok(container.querySelector('.page-block-missing-head'))
   assert.ok(container.querySelector('[data-testid="page-block-enable"]'))
 })
 

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -32,15 +32,16 @@ export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin:
   return (
     <div className="page-block-missing" data-testid="page-block-missing">
       <div className="page-block-missing-head">
-        <div className="page-block-missing-lead">
-          <span className="page-block-missing-kicker">插件未启用</span>
-          <div className="page-block-missing-title">未启用「{kind}」块</div>
-          {plugin ? (
-            <p className="page-block-missing-copy">文档里已经存了这块，开启 <code>{plugin}</code> 后会真正渲染。</p>
-          ) : (
-            <p className="page-block-missing-copy">文档里没有插件 id。启用对应插件后再保存，就会带上映射。</p>
-          )}
-        </div>
+        {plugin ? (
+          <div className="page-block-missing-lead">
+            <code className="page-block-missing-id">{plugin}</code>
+            <span className="page-block-missing-state">未运行</span>
+          </div>
+        ) : (
+          <div className="page-block-missing-lead">
+            <span className="page-block-missing-state">没有插件 id</span>
+          </div>
+        )}
         {plugin ? (
           <button
             type="button"
@@ -52,7 +53,7 @@ export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin:
               requestEnablePageBlockPlugin(plugin, kind)
             }}
           >
-            启用 {plugin}
+            启用
           </button>
         ) : null}
       </div>

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -31,31 +31,35 @@ export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin:
   const source = formatPageBlockFence(kind, plugin, data)
   return (
     <div className="page-block-missing" data-testid="page-block-missing">
-      <div className="page-block-missing-title">未启用「{kind}」块</div>
-      {plugin ? (
-        <p className="page-block-missing-copy">
-          这块由插件 <code>{plugin}</code> 渲染。现在没在运行，下面是文档里存下的源码。
-        </p>
-      ) : (
-        <p className="page-block-missing-copy">
-          文档里没有记下插件 id。启用对应插件后重新保存，就会带上映射。
-        </p>
-      )}
-      {plugin ? (
-        <button
-          type="button"
-          className="page-block-missing-enable"
-          data-testid="page-block-enable"
-          onClick={(event) => {
-            event.preventDefault()
-            event.stopPropagation()
-            requestEnablePageBlockPlugin(plugin, kind)
-          }}
-        >
-          启用 {plugin}
-        </button>
-      ) : null}
-      <pre className="page-block-missing-source">{source}</pre>
+      <div className="page-block-missing-head">
+        <div className="page-block-missing-lead">
+          <span className="page-block-missing-kicker">插件未启用</span>
+          <div className="page-block-missing-title">未启用「{kind}」块</div>
+          {plugin ? (
+            <p className="page-block-missing-copy">文档里已经存了这块，开启 <code>{plugin}</code> 后会真正渲染。</p>
+          ) : (
+            <p className="page-block-missing-copy">文档里没有插件 id。启用对应插件后再保存，就会带上映射。</p>
+          )}
+        </div>
+        {plugin ? (
+          <button
+            type="button"
+            className="page-block-missing-enable"
+            data-testid="page-block-enable"
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              requestEnablePageBlockPlugin(plugin, kind)
+            }}
+          >
+            启用 {plugin}
+          </button>
+        ) : null}
+      </div>
+      <div className="page-block-missing-body">
+        <div className="page-block-missing-label">源码</div>
+        <pre className="page-block-missing-source">{source}</pre>
+      </div>
     </div>
   )
 }

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -11,13 +11,18 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .page-block{margin:12px 0;position:relative;z-index:0;isolation:isolate;overflow:hidden}
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
-.page-editor .page-block-missing{display:flex;flex-direction:column;gap:8px;padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
-.page-editor .page-block-missing-title{color:var(--dsw-label);font-size:14px;font-weight:650}
-.page-editor .page-block-missing-copy{margin:0;line-height:1.5}
-.page-editor .page-block-missing-copy code{font-family:var(--font-mono);font-size:12px;color:var(--dsw-label-2)}
-.page-editor .page-block-missing-enable{align-self:flex-start;margin:0;border:1px solid var(--dsw-border);border-radius:6px;padding:5px 10px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;cursor:pointer}
+.page-editor .page-block-missing{display:flex;flex-direction:column;gap:12px;padding:14px 16px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
+.page-editor .page-block-missing-head{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:12px}
+.page-editor .page-block-missing-lead{min-width:0;display:flex;flex-direction:column;gap:4px}
+.page-editor .page-block-missing-kicker{color:#7B7B79;font-size:11px;font-weight:650;letter-spacing:.08em}
+.page-editor .page-block-missing-title{color:#F0EFED;font-size:15px;font-weight:650;line-height:1.3}
+.page-editor .page-block-missing-copy{margin:0;max-width:42em;color:#ACA9A4;font-size:13px;line-height:1.45}
+.page-editor .page-block-missing-copy code{font-family:var(--font-mono);font-size:12px;color:#F0EFED}
+.page-editor .page-block-missing-enable{flex:none;margin:2px 0 0;border:1px solid var(--dsw-border);border-radius:6px;padding:6px 10px;background:transparent;color:#F0EFED;font:inherit;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
 .page-editor .page-block-missing-enable:hover{background:var(--dsw-hover)}
-.page-editor .page-block-missing-source{margin:0;max-height:220px;overflow:auto;padding:10px 12px;border-radius:8px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));color:var(--dsw-label-2);font-family:var(--font-mono);font-size:12px;line-height:1.55;white-space:pre-wrap;word-break:break-word}
+.page-editor .page-block-missing-body{display:flex;flex-direction:column;gap:6px;min-width:0}
+.page-editor .page-block-missing-label{color:#7B7B79;font-size:11px;font-weight:650;letter-spacing:.08em}
+.page-editor .page-block-missing-source{margin:0;max-height:220px;overflow:auto;padding:10px 12px;border-radius:8px;background:#191919;color:#ACA9A4;font-family:var(--font-mono);font-size:12px;line-height:1.55;white-space:pre-wrap;word-break:break-word}
 .page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em;list-style-position:outside}
 .page-editor .tiptap ul{list-style-type:disc}
 .page-editor .tiptap ol{list-style-type:decimal}

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -12,13 +12,11 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
 .page-editor .page-block-missing{display:flex;flex-direction:column;gap:12px;padding:14px 16px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
-.page-editor .page-block-missing-head{display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:12px}
-.page-editor .page-block-missing-lead{min-width:0;display:flex;flex-direction:column;gap:4px}
-.page-editor .page-block-missing-kicker{color:#7B7B79;font-size:11px;font-weight:650;letter-spacing:.08em}
-.page-editor .page-block-missing-title{color:#F0EFED;font-size:15px;font-weight:650;line-height:1.3}
-.page-editor .page-block-missing-copy{margin:0;max-width:42em;color:#ACA9A4;font-size:13px;line-height:1.45}
-.page-editor .page-block-missing-copy code{font-family:var(--font-mono);font-size:12px;color:#F0EFED}
-.page-editor .page-block-missing-enable{flex:none;margin:2px 0 0;border:1px solid var(--dsw-border);border-radius:6px;padding:6px 10px;background:transparent;color:#F0EFED;font:inherit;font-size:13px;font-weight:600;cursor:pointer;white-space:nowrap}
+.page-editor .page-block-missing-head{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.page-editor .page-block-missing-lead{min-width:0;display:flex;align-items:baseline;gap:8px}
+.page-editor .page-block-missing-id{font-family:var(--font-mono);font-size:13px;font-weight:600;color:#F0EFED}
+.page-editor .page-block-missing-state{color:#7B7B79;font-size:13px;font-weight:600}
+.page-editor .page-block-missing-enable{flex:none;margin:0;border:1px solid var(--dsw-border);border-radius:6px;padding:5px 10px;background:transparent;color:#F0EFED;font:inherit;font-size:13px;font-weight:600;cursor:pointer}
 .page-editor .page-block-missing-enable:hover{background:var(--dsw-hover)}
 .page-editor .page-block-missing-body{display:flex;flex-direction:column;gap:6px;min-width:0}
 .page-editor .page-block-missing-label{color:#7B7B79;font-size:11px;font-weight:650;letter-spacing:.08em}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
未启用块占位再收一版：

- 去掉「未启用「excalidraw」块」大标题（和右侧启用重复）
- 去掉「文档已存下这块，开启后会渲染为画板」说明
- 第一行：左边 `page-excalidraw` + 灰色「未运行」，右边按钮只写「启用」
- 下面仍是「源码」+ fence

没有 plugin id 时只显示「没有插件 id」，没有按钮。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

