### PR TITLE
未启用块：恢复插件名芯片、内缩分隔线，启用改成图标

### DIFF
--- a/packages/core-editor/src/web/page-block-meta.test.tsx
+++ b/packages/core-editor/src/web/page-block-meta.test.tsx
@@ -26,7 +26,9 @@ test('missing block shows stored source and asks to enable the stored plugin', (
   assert.doesNotMatch(text, /未运行/)
   assert.doesNotMatch(text, /源码/)
   assert.match(text, /assets\/a\.json/)
-  assert.equal(container.querySelector('[data-testid="page-block-enable"]')?.textContent?.trim(), '启用')
+  const enable = container.querySelector('[data-testid="page-block-enable"]')
+  assert.equal(enable?.getAttribute('aria-label'), '启用')
+  assert.ok(enable?.querySelector('svg'))
 })
 
 test('enable button only dispatches the stored plugin id', () => {

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper } from '@tiptap/react'
+import { PlayIcon } from '@heroicons/react/16/solid'
 import { getPageEditor, usePageEditorVersion } from './service.ts'
 import { formatPageBlockFence, requestEnablePageBlockPlugin } from './page-block-meta.ts'
 
@@ -42,13 +43,15 @@ export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin:
             type="button"
             className="page-block-missing-enable"
             data-testid="page-block-enable"
+            title="启用"
+            aria-label="启用"
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()
               requestEnablePageBlockPlugin(plugin, kind)
             }}
           >
-            启用
+            <PlayIcon aria-hidden className="page-block-missing-enable-icon" />
           </button>
         ) : null}
       </div>

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -11,13 +11,13 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .page-block{margin:12px 0;position:relative;z-index:0;isolation:isolate;overflow:hidden}
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
-.page-editor .page-block-missing{display:flex;flex-direction:column;padding:0;overflow:hidden;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
-.page-editor .page-block-missing-head{display:flex;align-items:center;justify-content:space-between;gap:12px;min-height:32px;padding:0 12px}
-.page-editor .page-block-missing-id{font-family:var(--font-mono);font-size:13px;font-weight:600;line-height:20px;color:#F0EFED}
-.page-editor .page-block-missing-state{color:#7B7B79;font-size:13px;font-weight:600;line-height:20px}
-.page-editor .page-block-missing-enable{flex:none;box-sizing:border-box;margin:0;border:1px solid var(--dsw-border);border-radius:5px;padding:0 8px;height:20px;line-height:18px;background:transparent;color:#F0EFED;font:inherit;font-size:12px;font-weight:600;cursor:pointer}
+.page-editor .page-block-missing{display:flex;flex-direction:column;gap:0;padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}
+.page-editor .page-block-missing-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:0 0 10px;margin:0 0 10px;border-bottom:1px solid var(--dsw-border)}
+.page-editor .page-block-missing-id{font-family:var(--font-mono);font-weight:600;color:#F0EFED}
+.page-editor .page-block-missing-state{color:#7B7B79;font-size:13px;font-weight:600}
+.page-editor .page-block-missing-enable{flex:none;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;width:22px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:#F0EFED;cursor:pointer}
 .page-editor .page-block-missing-enable:hover{background:var(--dsw-hover)}
-.page-editor .page-block-missing:not(:has(.page-block-missing-head)){padding:8px 12px}
+.page-editor .page-block-missing-enable-icon{display:block;width:14px;height:14px}
 .page-editor .tiptap ul,.page-editor .tiptap ol{padding-left:1.6em;list-style-position:outside}
 .page-editor .tiptap ul{list-style-type:disc}
 .page-editor .tiptap ol{list-style-type:decimal}
@@ -30,8 +30,7 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .tiptap code{display:inline;padding:.12em .35em;border-radius:4px;background:var(--dsw-hover);font-family:var(--font-mono);font-size:.9em}
 .page-editor .tiptap pre{display:block;margin:8px 0;padding:10px 12px;border:1px solid var(--dsw-border);border-radius:10px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));overflow-x:auto;white-space:pre;font-family:var(--font-mono)}
 .page-editor .tiptap pre code{display:block;padding:0;background:transparent;font-size:13px;line-height:1.6;white-space:inherit}
-.page-editor code.page-block-missing-id{padding:0;background:transparent;border-radius:0;font-size:13px;line-height:20px}
-.page-editor pre.page-block-missing-source{margin:0;max-height:220px;overflow:auto;padding:10px 12px;border:0;border-top:1px solid var(--dsw-border);border-radius:0;background:#191919;color:#ACA9A4;font-size:12px;line-height:1.55;white-space:pre-wrap;word-break:break-word}
+.page-editor pre.page-block-missing-source{margin:0;max-height:220px;overflow:auto;padding:10px 12px;border:1px solid var(--dsw-border);border-radius:8px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));color:var(--dsw-label-2);font-size:12px;line-height:1.55;white-space:pre-wrap;word-break:break-word}
 .page-editor .tiptap a{color:var(--dsw-business);text-underline-offset:2px}
 .page-editor .tiptap p.is-editor-empty:first-child::before,
 .page-editor .tiptap .is-empty::before{content:attr(data-placeholder);float:left;height:0;pointer-events:none;color:var(--dsw-placeholder)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一版把卡片做成铺满底色、分隔线拉满、插件名芯片也剥掉了，这版改回去：

- 插件 id 继续包在行内 code 芯片里
- 启用改成 Play 图标，不再用文字按钮
- 分隔线跟着内边距内缩，不再顶到虚线框两边
- 源码区回到原来的代码块底色，不再整块换成 #191919

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

