### PR TITLE
插件：未安装不显示运行钮，已打开标题左侧加绿点

### DIFF
--- a/packages/core-plugin-system/src/web/chrome.test.tsx
+++ b/packages/core-plugin-system/src/web/chrome.test.tsx
@@ -1,0 +1,47 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { render } from '@testing-library/react'
+import type { CollectionActionInfo } from '@biu/type-file-system'
+import { pluginsChrome } from './chrome.tsx'
+
+const actions: CollectionActionInfo[] = [
+  { id: 'start', label: '运行', when: { installed: true, running: false } },
+  { id: 'stop', label: '停止', when: { installed: true, running: true } },
+  { id: 'pack', label: '打包', when: { sandbox: true } },
+]
+
+test('plugin run toggle stays hidden until the plugin is installed', () => {
+  const Actions = pluginsChrome.Actions
+  assert.ok(Actions)
+  const { container, rerender } = render(
+    <Actions actions={actions} record={{ id: 'draft', sandbox: true }} busy={false} place="row" run={() => {}} />,
+  )
+  assert.equal(container.querySelector('[aria-label="运行"]'), null)
+  assert.equal(container.querySelector('[aria-label="停止"]'), null)
+  rerender(
+    <Actions actions={actions} record={{ id: 'demo', installed: true }} busy={false} place="row" run={() => {}} />,
+  )
+  assert.ok(container.querySelector('[aria-label="运行"]'))
+  assert.equal(container.querySelector('[aria-label="停止"]'), null)
+  rerender(
+    <Actions
+      actions={actions}
+      record={{ id: 'demo', installed: true, running: true }}
+      busy={false}
+      place="row"
+      run={() => {}}
+    />,
+  )
+  assert.ok(container.querySelector('[aria-label="停止"]'))
+})
+
+test('plugin title puts a green dot left of the name when enabled', () => {
+  const Title = pluginsChrome.Title
+  assert.ok(Title)
+  const off = render(<Title record={{ id: 'draft' }} label="草稿" />)
+  assert.equal(off.container.querySelector('[data-testid="plugin-enabled-dot"]'), null)
+  const on = render(<Title record={{ id: 'demo', enabled: true }} label="画板" />)
+  const dot = on.container.querySelector('[data-testid="plugin-enabled-dot"]')
+  assert.ok(dot)
+  assert.ok(dot?.nextElementSibling?.textContent?.includes('画板'))
+})

--- a/packages/core-plugin-system/src/web/chrome.tsx
+++ b/packages/core-plugin-system/src/web/chrome.tsx
@@ -4,8 +4,20 @@ import { asHttpHref } from '@biu/type-file-system'
 import type { CollectionActionInfo, DbRecord } from '@biu/type-file-system'
 import type { CollectionChrome, FsActionProps, FsActionsProps, FsCellProps } from '@biu/type-file-system/ui'
 
-function PluginTitle({ label }: { record: DbRecord; label: string }) {
-  return <span className="truncate font-medium">{label}</span>
+function PluginTitle({ record, label }: { record: DbRecord; label: string }) {
+  const enabled = record.enabled === true || record.enabled === 'true'
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      {enabled ? (
+        <span
+          className="size-1.5 shrink-0 rounded-full bg-(--dsw-ok,#22c55e)"
+          data-testid="plugin-enabled-dot"
+          aria-hidden
+        />
+      ) : null}
+      <span className="truncate font-medium">{label}</span>
+    </span>
+  )
 }
 
 function PluginAuthorCell({ record, fallback }: FsCellProps) {
@@ -100,8 +112,8 @@ function PluginRunButton({
 
 function PluginActions({ actions, record, busy, place, run }: FsActionsProps) {
   const cls = btnClass(place)
-  const start = actions.find((action) => action.id === 'start')
-  const stop = actions.find((action) => action.id === 'stop')
+  const start = actions.find((action) => action.id === 'start' && matchWhen(record, action.when))
+  const stop = actions.find((action) => action.id === 'stop' && matchWhen(record, action.when))
   const running = runningOf(record)
   const current: CollectionActionInfo | undefined = running ? stop : start
   const rest = actions.filter(

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -79,7 +79,7 @@ test('plugin title is the name only; tags stay the file-system writable column',
   const chrome = readFileSync(resolve(import.meta.dirname, './chrome.tsx'), 'utf8')
   assert.doesNotMatch(chrome, /PluginTagsCell/)
   assert.doesNotMatch(chrome, /已装/)
-  assert.doesNotMatch(chrome, /rounded-full/)
+  assert.match(chrome, /data-testid="plugin-enabled-dot"/)
 })
 
 test('plugin window sizes from manifest.shell instead of measuring DOM', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
插件表两处调整：

- 未安装（`.plugin` 里还没有对应代码）时，不显示运行/停止按钮。只有 `installed` 满足动作 when 才出现 Play/Stop。
- 已打开（`enabled`）的插件，标题文字左边加一颗绿色圆点。放在标题左边，不跟右侧操作钮抢位置。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

