### PR TITLE
搜索悬浮窗：已打开插件标题左侧同样显示绿点

### DIFF
--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -10,6 +10,7 @@ import {
   searchCollection,
   searchHref,
   tagsFromRecord,
+  pluginRecordEnabled,
   visibleRowActions,
 } from './shell-search.tsx'
 
@@ -86,6 +87,17 @@ test('empty search lists every kind by updatedAt instead of skipping remotes', (
   assert.match(src, /sort: 'updatedAt'/)
   assert.match(src, /item.id === 'session' \? '\/sessions'/)
   assert.match(src, /空着时视图、会话、任务、页面、插件、合集各按更新时间列最近/)
+})
+
+test('plugin search hits show an enabled dot next to the title', () => {
+  assert.equal(pluginRecordEnabled({ enabled: true }), true)
+  assert.equal(pluginRecordEnabled({ enabled: 'true' }), true)
+  assert.equal(pluginRecordEnabled({}), false)
+  const src = readFileSync(resolve(import.meta.dirname, './shell-search.tsx'), 'utf8')
+  assert.match(src, /pluginRecordEnabled\(item\.record\)/)
+  assert.match(src, /shell-search-hit-enabled/)
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  assert.match(css, /\.shell-search-hit-enabled\s*\{[^}]*background:\s*var\(--dsw-ok/)
 })
 
 test('session task page plugin hits render tags left of actions', () => {

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -115,6 +115,10 @@ export function tagsFromRecord(row: Record<string, unknown>) {
   return [...new Set(tags)]
 }
 
+export function pluginRecordEnabled(row?: Record<string, unknown>) {
+  return row?.enabled === true || row?.enabled === 'true'
+}
+
 /** 与列表 RecordMark 相同：emoji 最多两枚。 */
 export function recordEmoji(row: Record<string, unknown>) {
   const text = String(row.emoji ?? '').trim()
@@ -631,7 +635,12 @@ export function ShellSearchPanel({
                     <span className="shell-search-hit-icon" aria-hidden>
                       <HitMark hit={item} />
                     </span>
-                    <span className="shell-search-hit-title">{item.title}</span>
+                    <span className="shell-search-hit-title">
+                      {item.kind === 'plugin' && pluginRecordEnabled(item.record) ? (
+                        <span className="shell-search-hit-enabled" data-testid="plugin-enabled-dot" aria-hidden />
+                      ) : null}
+                      <span className="shell-search-hit-title-text">{item.title}</span>
+                    </span>
                     {tags?.length || actions.length || hasGlyphActions ? (
                       <span className="shell-search-hit-aside">
                         {tags?.length ? (

--- a/web/style.css
+++ b/web/style.css
@@ -332,8 +332,24 @@ body {
 }
 
 .shell-search-hit-title {
+  display: inline-flex;
   min-width: 0;
   flex: 1;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+}
+
+.shell-search-hit-enabled {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--dsw-ok, #22c55e);
+}
+
+.shell-search-hit-title-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索悬浮窗的插件命中，已打开（`enabled`）时标题左边同样显示绿色圆点，和插件列表 Title 一致。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

