### PR TITLE
fix(chat): 空闲发消息立刻入队，不再卡到整段生成完

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -1239,7 +1239,8 @@ export function apply(ctx: Context) {
       : []
     const sendOpts = {
       ...(extraTools.length ? { extraTools } : {}),
-      ...(payload.wait === false ? { wait: false as const } : {}),
+      // 默认不等待整回合：聊天要靠 WS 推 chunk。显式 wait:true 才阻塞 HTTP。
+      wait: payload.wait === true,
       ...(images.length ? { images } : {}),
     }
     if (payload.kind === 'inject') {

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1272,7 +1272,9 @@ export class SessionViewService extends Service {
     const tools = [...new Set(extraTools.map((name) => name.trim()).filter(Boolean))]
     const busy = this.value.pending || this.value.agentStatus === 'running'
     const hasWake = this.value.inbox.some((item) => item.kind === 'wake')
-    // 忙碌且已有 wake：再发 → inject；否则 wake。忙碌时 wait:false 立刻返回。
+    // 忙碌且已有 wake：再发 → inject；否则 wake。
+    // 空闲 wake 也必须 wait:false：否则 POST 会卡到整段生成完（背长文会空等七八秒，
+    // 轨迹里也没有 assistant/chunk），HTTP/1 还可能堵住同域 WS。
     const effectiveKind: 'wake' | 'inject' =
       kind === 'inject' || (kind === 'wake' && busy && hasWake) ? 'inject' : 'wake'
     const imagePayload = pics.length ? { images: pics } : {}
@@ -1281,7 +1283,7 @@ export class SessionViewService extends Service {
         ? { text: content || '（图片）', kind: 'inject', ...(tools.length ? { extraTools: tools } : {}), ...imagePayload }
         : {
             text: content || '（图片）',
-            ...(busy ? { wait: false } : {}),
+            wait: false,
             ...(tools.length ? { extraTools: tools } : {}),
             ...imagePayload,
           }
@@ -1318,15 +1320,7 @@ export class SessionViewService extends Service {
       }
       if (!res.ok) throw new Error(data.error || `发送失败：${res.status}`)
       if (Array.isArray(data.inbox)) this.setInbox(data.inbox, data.sessionId ?? sessionId)
-      if (data.queued) {
-        // 已入队：不阻塞等回合结束，状态交给 WS
-        return
-      }
-      if (data.sessionId && data.sessionId !== sessionId) {
-        await this.load(data.sessionId, { view: 'chat', wait: true })
-      } else {
-        await this.load(sessionId, { view: this.value.view, wait: true })
-      }
+      // wait:false：HTTP 立刻返回，token / 状态走 WS。不要 GET 整页，会和首包 chunk 抢，看起来像先卡再整段弹出。
       if (typeof data.text === 'string' && data.text.startsWith('模型调用失败：')) {
         this.replace({ error: data.text })
       }

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -112,7 +112,7 @@ test('send inject posts kind without clearing running state', async () => {
 })
 
 test('send wake keeps running after HTTP so WS agent/status owns idle', async () => {
-  mockFetch({
+  const calls = mockFetch({
     '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', eventCount: 1, updatedAt: 1 }] }),
     '/api/sessions/s1?turns=': () => ({
       id: 's1',
@@ -121,13 +121,16 @@ test('send wake keeps running after HTTP so WS agent/status owns idle', async ()
       totalTurns: 0,
     }),
     '/api/approvals': () => ({ mode: 'auto', pending: [] }),
-    '/api/sessions/s1/messages': () => ({ sessionId: 's1', text: 'ok' }),
+    '/api/sessions/s1/messages': () => ({ sessionId: 's1', text: 'ok', queued: true }),
   })
   const ctx = new Context()
   await ctx.plugin(sessionView)
   const view = ctx.sessionView as SessionViewService
   view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
   await view.send('hi')
+  const post = calls.find((call) => call.url.includes('/messages'))
+  assert.ok(post)
+  assert.match(String(post!.init?.body), /"wait":false/)
   assert.equal(view.get().agentStatus, 'running')
   assert.equal(view.get().pending, true)
   assert.equal(view.get().busySessions.s1, true)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

空闲时第一次发消息（例如「背诵岳阳楼记」）会先空等大约 8–9 秒，界面和轨迹都没有任何数据，然后整段回复一起出现。

这不是上次 abort/agent loop 修不好取消的那条路径。原因是：

- 忙碌续发已经带 `wait: false`，HTTP 立刻返回，token 走 WebSocket `assistant/chunk`
- **空闲 wake 不传 wait**，host 默认 `wait !== false` → POST `/api/sessions/:id/messages` 一直等到模型把整段生成完才 200
- 输入框 `await sessionView.send()`，composer 卡在这次请求上；返回后还可能 GET 整页，和首包 chunk 抢，看起来像「先卡再整段弹出」

长文生成大约要七八秒，所以体感就是固定空窗，轨迹里这段是空的。

## 改动

- 空闲 wake 也始终 `wait: false`
- 发送成功后不再 GET 会话；状态和正文交给 WS
- POST handler 默认不等待整回合，只有显式 `wait: true` 才阻塞 HTTP

## 测试

`vitest`：`session-view` / `host-agents` / `host-agent-loop` 相关用例通过。空闲 `send('hi')` 断言 body 含 `"wait":false`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

