### PR TITLE
fix(settings): 插件 Active 改绿点，并列出快捷键

### DIFF
--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -107,3 +107,13 @@ test('settings and session config floats match search chrome', () => {
   assert.match(dialog, /XMarkIcon/)
   assert.doesNotMatch(dialog, />\s*Close\s*</)
 })
+
+test('settings lists search and pick shortcuts', () => {
+  const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  const chrome = readFileSync(resolve(import.meta.dirname, './shell-chrome.tsx'), 'utf8')
+  assert.match(shell, /key: 'shortcuts'/)
+  assert.match(shell, /ShellSettingsShortcuts/)
+  assert.match(chrome, /data-testid="settings-shortcuts"/)
+  assert.match(chrome, /⌘F/)
+  assert.match(chrome, /Ctrl\+Q/)
+})

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -44,7 +44,7 @@ import { SessionInspector } from './session-inspector.tsx'
 import { SessionConfigDialog } from '@biu/web-session-view/dialog'
 import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 import { OverlayChatWindow } from './overlay-window.tsx'
-import { ShellSettingsUpdate } from './shell-chrome.tsx'
+import { ShellSettingsShortcuts, ShellSettingsUpdate } from './shell-chrome.tsx'
 import { ShellSearchPanel } from './shell-search.tsx'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
@@ -835,6 +835,7 @@ function Shell(props: SlotProps) {
                   <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
                     {[
                       { key: 'plugins', label: '插件' },
+                      { key: 'shortcuts', label: '快捷键' },
                       { key: 'routes', label: '路由' },
                       { key: 'events', label: '事件' },
                       { key: 'update', label: '更新' },
@@ -855,6 +856,7 @@ function Shell(props: SlotProps) {
                   {settingsTab === 'plugins' ? (
                     <section>{props.renderSlot('sidebar')}</section>
                   ) : null}
+                  {settingsTab === 'shortcuts' ? <ShellSettingsShortcuts /> : null}
                   {settingsTab === 'routes' ? (
                     <section>{props.renderSlot('routes')}</section>
                   ) : null}

--- a/packages/web-app-shell/src/web/shell-chrome.tsx
+++ b/packages/web-app-shell/src/web/shell-chrome.tsx
@@ -11,6 +11,24 @@ import {
 import { setChatOverlay } from './chat-overlay.ts'
 import { chromeIcon } from './chrome-icon.ts'
 
+export function ShellSettingsShortcuts() {
+  return (
+    <section data-testid="settings-shortcuts">
+      <ul className="m-0 list-none p-0">
+        <li className="flex items-center justify-between gap-3 px-2 py-1.5">
+          <span>搜索</span>
+          <span className="settings-muted">⌘F</span>
+        </li>
+        <li className="flex items-center justify-between gap-3 px-2 py-1.5">
+          <span>快速选取</span>
+          <span className="settings-muted">Ctrl+Q</span>
+        </li>
+      </ul>
+      <p className="settings-muted m-0 px-2 pt-1">Windows 与 Linux 上 ⌘ 用 Ctrl。选取也可用 ⌘Q。</p>
+    </section>
+  )
+}
+
 export function ShellSettingsUpdate() {
   const [behind, setBehind] = useState(0)
   const [busy, setBusy] = useState(false)

--- a/packages/web-plugin-tree/src/web/index.test.ts
+++ b/packages/web-plugin-tree/src/web/index.test.ts
@@ -12,5 +12,8 @@ test('settings plugin tree keeps core out of capability and hides core toggles',
   assert.doesNotMatch(src, /disabled=\{!plugin\.togglable\}/)
   assert.doesNotMatch(src, /不可卸载/)
   assert.doesNotMatch(src, /plugin\.blurb/)
+  assert.doesNotMatch(src, /plugin\.id\} ·/)
+  assert.match(src, /data-testid="plugin-enabled-dot"/)
+  assert.match(src, /plugin\.state === 'active'/)
   assert.doesNotMatch(src, /text-\[1[12]px\]/)
 })

--- a/packages/web-plugin-tree/src/web/index.tsx
+++ b/packages/web-plugin-tree/src/web/index.tsx
@@ -27,24 +27,29 @@ function PluginTree(props: SlotProps) {
             <ul className="m-0 list-none p-0">
               {rows.map((plugin) => (
                 <li
-                  className="flex items-start justify-between gap-3 rounded-md px-2 py-1.5"
+                  className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5"
                   key={`${plugin.layer}:${plugin.id}`}
                 >
-                  <div className="min-w-0">
-                    <h3 className="settings-name m-0">{plugin.name}</h3>
-                    <p className="settings-muted mt-0.5 mb-0 truncate">
-                      {plugin.id} · {plugin.state}
-                    </p>
-                  </div>
-                  {plugin.togglable ? (
-                    <button
-                      className="toggle"
-                      type="button"
-                      aria-label={plugin.enabled ? `关闭 ${plugin.name}` : `打开 ${plugin.name}`}
-                      aria-checked={plugin.enabled}
-                      onClick={() => void setEnabled(plugin.id, !plugin.enabled)}
-                    />
-                  ) : null}
+                  <h3 className="settings-name m-0 min-w-0 truncate">{plugin.name}</h3>
+                  <span className="flex shrink-0 items-center gap-2">
+                    {plugin.state === 'active' ? (
+                      <span
+                        className="size-1.5 shrink-0 rounded-full bg-(--dsw-ok,#22c55e)"
+                        data-testid="plugin-enabled-dot"
+                        title="Active"
+                        aria-label="已启用"
+                      />
+                    ) : null}
+                    {plugin.togglable ? (
+                      <button
+                        className="toggle"
+                        type="button"
+                        aria-label={plugin.enabled ? `关闭 ${plugin.name}` : `打开 ${plugin.name}`}
+                        aria-checked={plugin.enabled}
+                        onClick={() => void setEnabled(plugin.id, !plugin.enabled)}
+                      />
+                    ) : null}
+                  </span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
设置插件列表只保留名字，Active 用右侧绿点，不再在下面重复 `session-store · active`。

同时加了「快捷键」一栏：搜索 ⌘F（Ctrl+F 同样可用），快速选取 Ctrl+Q（⌘Q 同样可用）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

