### PR TITLE
fix: Agent 长任务卡在 step/start 时流式推送工具参数

### DIFF
--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -91,6 +91,40 @@ export class AgentLoop implements AgentRunner {
     let chunkBuf = ''
     let chunkFlush: Promise<void> = Promise.resolve()
     let chunkTimer: ReturnType<typeof setTimeout> | null = null
+    let toolBuf = new Map<string, { id: string; name: string; arguments: string }>()
+    let toolFlush: Promise<void> = Promise.resolve()
+    let toolTimer: ReturnType<typeof setTimeout> | null = null
+
+    const flushTools = () => {
+      if (toolTimer != null) {
+        clearTimeout(toolTimer)
+        toolTimer = null
+      }
+      if (!toolBuf.size) return toolFlush
+      const pending = [...toolBuf.values()]
+      toolBuf = new Map()
+      toolFlush = toolFlush.then(async () => {
+        for (const call of pending) {
+          await session.append(this.sessionId, {
+            type: 'tool/call',
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments,
+          })
+        }
+      })
+      return toolFlush
+    }
+
+    const queueTool = (call: { id: string; name: string; arguments: string }) => {
+      if (!call.id || !call.name) return
+      toolBuf.set(call.id, call)
+      if (toolTimer != null) return
+      toolTimer = setTimeout(() => {
+        toolTimer = null
+        void flushTools()
+      }, 48)
+    }
 
     const flushChunks = () => {
       if (chunkTimer != null) {
@@ -119,11 +153,14 @@ export class AgentLoop implements AgentRunner {
     for (let step = 0; ; step++) {
       if (this.signal.aborted) {
         await flushChunks()
+        await flushTools()
         await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
         throw new Error('cancelled')
       }
       this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'running', step })
       await session.append(this.sessionId, { type: 'step/start', turn, step })
+      // 让 step/start 先从 WS 出去，再去做可能很重的 derive / 等首 token
+      await new Promise<void>((resolve) => setImmediate(resolve))
 
       const rawMessages = session.deriveMessages(this.sessionId)
       const inputComp = session.statInputComposition(this.sessionId)
@@ -141,10 +178,15 @@ export class AgentLoop implements AgentRunner {
           onDelta: async (text) => {
             queueChunk(text)
           },
+          onToolDelta: (call) => {
+            queueTool(call)
+          },
         })
         await flushChunks()
+        await flushTools()
       } catch (error) {
         await flushChunks()
+        await flushTools()
         if (this.signal.aborted) {
           await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'cancelled' })
           this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle' })

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -210,6 +210,8 @@ export interface AssistantReply {
 export interface ChatOptions {
   /** 文本 delta；agent-loop 用来即时 append `assistant/chunk`。 */
   onDelta?: (text: string) => void | Promise<void>
+  /** 工具调用增量（name 出现后就开始推，长参数不必等整段生成完）。 */
+  onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>
 }
 
 export interface LlmClient {
@@ -261,6 +263,7 @@ export async function consumeChatCompletionSse(
   stream: ReadableStream<Uint8Array>,
   options: {
     onDelta?: (text: string) => void | Promise<void>
+    onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>
     signal?: AbortSignal
   } = {},
 ): Promise<AssistantReply> {
@@ -325,6 +328,7 @@ export async function consumeChatCompletionSse(
           if (call.function?.name) acc.name = call.function.name
           if (typeof call.function?.arguments === 'string') acc.arguments += call.function.arguments
           tools.set(index, acc)
+          if (acc.id && acc.name) await options.onToolDelta?.({ id: acc.id, name: acc.name, arguments: acc.arguments })
         }
         const nextUsage = parseProviderUsage(chunk.usage)
         if (nextUsage) usage = nextUsage
@@ -406,7 +410,7 @@ export class OpenAiCompatLlm implements LlmClient {
       throw new Error(detail)
     }
     if (!res.body) throw new Error('llm stream missing body')
-    return consumeChatCompletionSse(res.body, { onDelta: options?.onDelta, signal })
+    return consumeChatCompletionSse(res.body, { onDelta: options?.onDelta, onToolDelta: options?.onToolDelta, signal })
   }
 }
 
@@ -494,7 +498,7 @@ export class AnthropicLlm implements LlmClient {
       throw new Error(detail)
     }
     if (!res.body) throw new Error('llm stream missing body')
-    return consumeMessagesSse(res.body, { onDelta: options?.onDelta, signal })
+    return consumeMessagesSse(res.body, { onDelta: options?.onDelta, onToolDelta: options?.onToolDelta, signal })
   }
 }
 
@@ -510,7 +514,7 @@ function parseToolJson(text: string): unknown {
 /** 解析 Anthropic Messages SSE：text（text_delta）+ 工具参数（input_json_delta）累积。 */
 async function consumeMessagesSse(
   stream: ReadableStream<Uint8Array>,
-  options: { onDelta?: (text: string) => void | Promise<void>; signal?: AbortSignal } = {},
+  options: { onDelta?: (text: string) => void | Promise<void>; onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>; signal?: AbortSignal } = {},
 ): Promise<AssistantReply> {
   const reader = stream.getReader()
   const decoder = new TextDecoder()
@@ -557,6 +561,9 @@ async function consumeMessagesSse(
             const block = evt.content_block as { type?: string; id?: string; name?: string } | undefined
             if (block?.type === 'tool_use') {
               toolBlocks.push({ id: block.id, name: block.name, input: '' })
+              if (block.id && block.name) {
+                await options.onToolDelta?.({ id: block.id, name: block.name, arguments: '' })
+              }
             }
             break
           }
@@ -567,7 +574,12 @@ async function consumeMessagesSse(
               await options.onDelta?.(delta.text)
             } else if (delta?.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
               const last = toolBlocks[toolBlocks.length - 1]
-              if (last) last.input += delta.partial_json
+              if (last) {
+                last.input += delta.partial_json
+                if (last.id && last.name) {
+                  await options.onToolDelta?.({ id: last.id, name: last.name, arguments: last.input })
+                }
+              }
             }
             break
           }
@@ -619,6 +631,7 @@ export class LlmService extends Service {
             ctx.emit('llm/stream', { text })
             await options?.onDelta?.(text)
           },
+          onToolDelta: options?.onToolDelta,
         })
         return reply
       },

--- a/packages/host-llm/src/host/llm.stream.test.ts
+++ b/packages/host-llm/src/host/llm.stream.test.ts
@@ -29,7 +29,8 @@ test('consumeChatCompletionSse yields text deltas and usage', async () => {
   assert.deepEqual(reply.usage, { inputTokens: 3, outputTokens: 2, totalTokens: 5 })
 })
 
-test('consumeChatCompletionSse accumulates tool_calls by index', async () => {
+test('consumeChatCompletionSse streams tool_calls before the stream ends', async () => {
+  const tools: Array<{ id: string; name: string; arguments: string }> = []
   const reply = await consumeChatCompletionSse(
     sseBody([
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1","function":{"name":"clock_now","arguments":""}}]}}]}\n\n',
@@ -37,9 +38,12 @@ test('consumeChatCompletionSse accumulates tool_calls by index', async () => {
       'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]}}]}\n\n',
       'data: [DONE]\n\n',
     ]),
+    { onToolDelta: (call) => { tools.push({ ...call }) } },
   )
-  assert.equal(reply.content, null)
-  assert.deepEqual(reply.toolCalls, [{ id: 'c1', name: 'clock_now', arguments: '{}' }])
+  assert.equal(reply.toolCalls[0]?.name, 'clock_now')
+  assert.ok(tools.length >= 2)
+  assert.equal(tools[0]?.name, 'clock_now')
+  assert.equal(tools.at(-1)?.arguments, '{}')
 })
 
 test('consumeChatCompletionSse aborts with signal', async () => {

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -416,8 +416,20 @@ export class SessionsService extends Service {
     const event: SessionEvent = { ...body, seq: record.events.length, ts: Date.now() }
     record.events.push(event)
     this.cache.set(id, record)
-    // chunk 极高频：先内存追加并广播，落盘合并到下一帧/定时器，避免每 token 全量 JSON 写盘
+    // chunk / 进行中的 tool/call：先内存追加并广播，落盘合并到下一帧，避免把事件循环卡死
     if (body.type === 'assistant/chunk') {
+      this.schedulePersist(id)
+    } else if (body.type === 'tool/call') {
+      const existing = record.events.slice(0, -1).findLast((item) => item.type === 'tool/call' && item.id === body.id)
+      if (existing && existing.type === 'tool/call') {
+        existing.name = body.name || existing.name
+        existing.arguments = body.arguments
+        existing.ts = event.ts
+        record.events.pop()
+        this.schedulePersist(id)
+        this.ctx.emit('session/event', { sessionId: id, event: existing })
+        return existing
+      }
       this.schedulePersist(id)
     } else {
       this.clearPersistTimer(id)

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -500,6 +500,30 @@ test('statInputComposition: idle with multiple turns -> latest turn is "this", e
   assert.ok(out.histPct < 0.5) // curPct=1-histPct > 0.5
 })
 
+test('append coalesces live tool/call arguments for the same id', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create()
+  const first = await ctx.sessions.append(record.id, {
+    type: 'tool/call',
+    id: 'c1',
+    name: 'db_update',
+    arguments: '{',
+  })
+  const second = await ctx.sessions.append(record.id, {
+    type: 'tool/call',
+    id: 'c1',
+    name: 'db_update',
+    arguments: '{"title":"hi"}',
+  })
+  const events = (await ctx.sessions.require(record.id)).events
+  const calls = events.filter((event) => event.type === 'tool/call')
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]?.arguments, '{"title":"hi"}')
+  assert.equal(second.seq, first.seq)
+})
+
 test('statInputComposition: honors compact point (starts counting after it)', () => {
   const events = [
     ev({ type: 'turn/start', turn: 1, seq: 0 }),

--- a/packages/host-sessions/src/host/trajectory-index.ts
+++ b/packages/host-sessions/src/host/trajectory-index.ts
@@ -63,6 +63,12 @@ export function projectTrajectoryRows(events: SessionEvent[]): TrajectoryRow[] {
     } else if (event.type === 'tool/call') {
       callId = event.id
       summary = `${event.name}(${event.arguments.slice(0, 80)})`
+      const prev = rows.findLast((row) => row.type === 'tool/call' && row.callId === event.id)
+      if (prev) {
+        prev.summary = summary
+        prev.seq = event.seq
+        continue
+      }
     } else if (event.type === 'tool/result') {
       callId = event.id
       summary = `${event.name} → ${event.ok ? 'ok' : 'fail'}: ${event.detail.slice(0, 80)}`

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1408,7 +1408,27 @@ export class SessionViewService extends Service {
 }
 
 function upsertEvent(events: SessionEvent[], event: SessionEvent) {
-  if (events.some((item) => item.seq === event.seq)) return events
+  if (event.type === 'tool/call') {
+    const idx = events.findLastIndex((item) => item.type === 'tool/call' && item.id === event.id)
+    if (idx >= 0) {
+      const prev = events[idx]
+      if (prev?.type === 'tool/call') {
+        const next = [...events]
+        next[idx] = { ...prev, name: event.name || prev.name, arguments: event.arguments, ts: event.ts, seq: prev.seq }
+        return next
+      }
+    }
+  }
+  if (events.some((item) => item.seq === event.seq)) {
+    if (event.type === 'tool/call') {
+      return events.map((item) =>
+        item.seq === event.seq && item.type === 'tool/call'
+          ? { ...item, name: event.name || item.name, arguments: event.arguments, ts: event.ts }
+          : item,
+      )
+    }
+    return events
+  }
   if (event.type === 'assistant/chunk') {
     const last = events.at(-1)
     if (last?.type === 'assistant/chunk') {

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -245,6 +245,27 @@ test('ingest coalesces consecutive chunks and skips trajectory on chat view', as
   assert.equal(view.get().trajectory.length, 0)
 })
 
+test('ingest updates live tool/call arguments without duplicating the card', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.ingest('s1', { type: 'turn/start', turn: 1, seq: 1, ts: 2 })
+  view.ingest('s1', { type: 'step/start', turn: 1, step: 0, seq: 2, ts: 3 })
+  view.ingest('s1', { type: 'tool/call', id: 'c1', name: 'db_update', arguments: '{', seq: 3, ts: 4 })
+  view.ingest('s1', { type: 'tool/call', id: 'c1', name: 'db_update', arguments: '{"title":"hi"}', seq: 3, ts: 5 })
+  view.ingest('s1', { type: 'tool/call', id: 'c1', name: 'db_update', arguments: '{"title":"hello"}', seq: 9, ts: 6 })
+  const reply = view.get().nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind === 'reply' && reply.parts.filter((part) => part.kind === 'tool').length, 1)
+  const tool = reply?.kind === 'reply' ? reply.parts.find((part) => part.kind === 'tool') : undefined
+  assert.equal(tool?.kind === 'tool' && tool.name, 'db_update')
+  assert.equal(tool?.kind === 'tool' && tool.arguments, '{"title":"hello"}')
+})
+
 test('load fetches full session turns and skips trajectory until ensureTrajectory', async () => {
   const calls: string[] = []
   globalThis.fetch = (async (input: RequestInfo | URL) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

长任务里下一步经常是 `db_*` 等工具调用。模型会先吐很长的 JSON 参数。

原先只有 **文本** 走 `assistant/chunk`；**tool_calls 的 arguments 只在 SSE 里累积**，等 `chat()` 整段结束后才 `append(tool/call)`。所以你会看到：

1. `step/start` 出现
2. 页面长时间没新消息
3. 过一会儿整段工具卡片一起出来

这不是「流式完全没做」，而是 **工具参数那条路没接到 UI**。另外 `step/start` 之后立刻 `deriveMessages` + 等首 token，也可能把事件循环堵住，WS 看起来更卡。

## 改动

- LLM SSE：`id + name` 出现后就开始 `onToolDelta`（全量 arguments 快照）
- Agent loop：48ms 批处理写入 `tool/call`；`step/start` 后 `setImmediate` 再 derive / 调模型
- sessions：同一 `id` 的 `tool/call` 就地更新，不重复卡片
- 前端 ingest：同 id 更新 arguments

## 验证

- `llm.stream` / `sessions` / `session-view` 相关测试
- 未在浏览器里跑真模型长任务（环境无 API）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

