### PR TITLE
fix: 把 DeepSeek 思考内容流式显示到聊天里

### DIFF
--- a/packages/core-chat/src/web/thread.tsx
+++ b/packages/core-chat/src/web/thread.tsx
@@ -178,7 +178,27 @@ function renderReplyPartList({
       lastStep = step
     }
 
-    if (part.kind === 'assistant') {
+    if (part.kind === 'think') {
+      const partStreaming = Boolean(part.streaming)
+      elements.push(
+        <div
+          key={part.id}
+          className="chat-think-body text-[13px] leading-5 text-(--dsw-label-3)"
+          data-testid="chat-think"
+          {...pickDomAttrs('message', part.id, pickPreview(part.text) || 'think')}
+        >
+          <div className="mb-1 text-[12px] font-medium tracking-wide">思考</div>
+          {part.text ? (
+            <div className="whitespace-pre-wrap">{part.text}</div>
+          ) : partStreaming ? (
+            '…'
+          ) : null}
+          {partStreaming ? (
+            <span className="ml-1 inline-block animate-pulse">▍</span>
+          ) : null}
+        </div>,
+      )
+    } else if (part.kind === 'assistant') {
       const partStreaming = Boolean(part.streaming)
       elements.push(
         <div

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -89,6 +89,7 @@ export class AgentLoop implements AgentRunner {
     const steps: AgentTurn['steps'] = []
     let final = '（空回复）'
     let chunkBuf = ''
+    let chunkChannel: 'text' | 'reasoning' = 'text'
     let chunkFlush: Promise<void> = Promise.resolve()
     let chunkTimer: ReturnType<typeof setTimeout> | null = null
     let toolBuf = new Map<string, { id: string; name: string; arguments: string }>()
@@ -133,15 +134,22 @@ export class AgentLoop implements AgentRunner {
       }
       if (!chunkBuf) return chunkFlush
       const text = chunkBuf
+      const channel = chunkChannel
       chunkBuf = ''
       chunkFlush = chunkFlush.then(async () => {
-        await session.append(this.sessionId, { type: 'assistant/chunk', text })
+        await session.append(this.sessionId, {
+          type: 'assistant/chunk',
+          text,
+          ...(channel === 'reasoning' ? { channel: 'reasoning' as const } : {}),
+        })
       })
       return chunkFlush
     }
 
-    const queueChunk = (text: string) => {
+    const queueChunk = (text: string, channel: 'text' | 'reasoning' = 'text') => {
       if (!text) return
+      if (chunkBuf && chunkChannel !== channel) void flushChunks()
+      chunkChannel = channel
       chunkBuf += text
       if (chunkTimer != null) return
       chunkTimer = setTimeout(() => {
@@ -177,6 +185,9 @@ export class AgentLoop implements AgentRunner {
         reply = await this.llm.chat(messages, this.ctx.tools.schemas(), this.signal, {
           onDelta: async (text) => {
             queueChunk(text)
+          },
+          onReasoningDelta: (text) => {
+            queueChunk(text, 'reasoning')
           },
           onToolDelta: (call) => {
             queueTool(call)

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -210,6 +210,8 @@ export interface AssistantReply {
 export interface ChatOptions {
   /** 文本 delta；agent-loop 用来即时 append `assistant/chunk`。 */
   onDelta?: (text: string) => void | Promise<void>
+  /** 思考/reasoning delta（DeepSeek V4 `reasoning_content` 等）；不进最终 message。 */
+  onReasoningDelta?: (text: string) => void | Promise<void>
   /** 工具调用增量（name 出现后就开始推，长参数不必等整段生成完）。 */
   onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>
 }
@@ -263,6 +265,7 @@ export async function consumeChatCompletionSse(
   stream: ReadableStream<Uint8Array>,
   options: {
     onDelta?: (text: string) => void | Promise<void>
+    onReasoningDelta?: (text: string) => void | Promise<void>
     onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>
     signal?: AbortSignal
   } = {},
@@ -299,6 +302,8 @@ export async function consumeChatCompletionSse(
           choices?: Array<{
             delta?: {
               content?: string | null
+              reasoning_content?: string | null
+              reasoning?: string | null
               tool_calls?: Array<{
                 index?: number
                 id?: string
@@ -316,6 +321,10 @@ export async function consumeChatCompletionSse(
         }
         if (chunk.error?.message) throw new Error(chunk.error.message)
         const delta = chunk.choices?.[0]?.delta
+        const reasoning = delta?.reasoning_content ?? delta?.reasoning
+        if (typeof reasoning === 'string' && reasoning.length) {
+          await options.onReasoningDelta?.(reasoning)
+        }
         const text = delta?.content
         if (typeof text === 'string' && text.length) {
           content += text
@@ -410,7 +419,7 @@ export class OpenAiCompatLlm implements LlmClient {
       throw new Error(detail)
     }
     if (!res.body) throw new Error('llm stream missing body')
-    return consumeChatCompletionSse(res.body, { onDelta: options?.onDelta, onToolDelta: options?.onToolDelta, signal })
+    return consumeChatCompletionSse(res.body, { onDelta: options?.onDelta, onReasoningDelta: options?.onReasoningDelta, onToolDelta: options?.onToolDelta, signal })
   }
 }
 
@@ -498,7 +507,7 @@ export class AnthropicLlm implements LlmClient {
       throw new Error(detail)
     }
     if (!res.body) throw new Error('llm stream missing body')
-    return consumeMessagesSse(res.body, { onDelta: options?.onDelta, onToolDelta: options?.onToolDelta, signal })
+    return consumeMessagesSse(res.body, { onDelta: options?.onDelta, onReasoningDelta: options?.onReasoningDelta, onToolDelta: options?.onToolDelta, signal })
   }
 }
 
@@ -514,7 +523,7 @@ function parseToolJson(text: string): unknown {
 /** 解析 Anthropic Messages SSE：text（text_delta）+ 工具参数（input_json_delta）累积。 */
 async function consumeMessagesSse(
   stream: ReadableStream<Uint8Array>,
-  options: { onDelta?: (text: string) => void | Promise<void>; onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>; signal?: AbortSignal } = {},
+  options: { onDelta?: (text: string) => void | Promise<void>; onReasoningDelta?: (text: string) => void | Promise<void>; onToolDelta?: (call: { id: string; name: string; arguments: string }) => void | Promise<void>; signal?: AbortSignal } = {},
 ): Promise<AssistantReply> {
   const reader = stream.getReader()
   const decoder = new TextDecoder()
@@ -568,10 +577,12 @@ async function consumeMessagesSse(
             break
           }
           case 'content_block_delta': {
-            const delta = evt.delta as { type?: string; text?: string; partial_json?: string } | undefined
+            const delta = evt.delta as { type?: string; text?: string; partial_json?: string; thinking?: string } | undefined
             if (delta?.type === 'text_delta' && typeof delta.text === 'string' && delta.text.length) {
               content += delta.text
               await options.onDelta?.(delta.text)
+            } else if (delta?.type === 'thinking_delta' && typeof delta.thinking === 'string' && delta.thinking.length) {
+              await options.onReasoningDelta?.(delta.thinking)
             } else if (delta?.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
               const last = toolBlocks[toolBlocks.length - 1]
               if (last) {
@@ -631,6 +642,7 @@ export class LlmService extends Service {
             ctx.emit('llm/stream', { text })
             await options?.onDelta?.(text)
           },
+          onReasoningDelta: options?.onReasoningDelta,
           onToolDelta: options?.onToolDelta,
         })
         return reply

--- a/packages/host-llm/src/host/llm.stream.test.ts
+++ b/packages/host-llm/src/host/llm.stream.test.ts
@@ -29,6 +29,26 @@ test('consumeChatCompletionSse yields text deltas and usage', async () => {
   assert.deepEqual(reply.usage, { inputTokens: 3, outputTokens: 2, totalTokens: 5 })
 })
 
+test('consumeChatCompletionSse streams DeepSeek reasoning_content separately from the answer', async () => {
+  const reasoning: string[] = []
+  const deltas: string[] = []
+  const reply = await consumeChatCompletionSse(
+    sseBody([
+      'data: {"choices":[{"delta":{"reasoning_content":"先"}}]}\n\n',
+      'data: {"choices":[{"delta":{"reasoning_content":"想"}}]}\n\n',
+      'data: {"choices":[{"delta":{"content":"短"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+    {
+      onDelta: (text) => { deltas.push(text) },
+      onReasoningDelta: (text) => { reasoning.push(text) },
+    },
+  )
+  assert.deepEqual(reasoning, ['先', '想'])
+  assert.deepEqual(deltas, ['短'])
+  assert.equal(reply.content, '短')
+})
+
 test('consumeChatCompletionSse streams tool_calls before the stream ends', async () => {
   const tools: Array<{ id: string; name: string; arguments: string }> = []
   const reply = await consumeChatCompletionSse(

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -39,7 +39,7 @@ export type SessionEventBody =
         histPct?: number
       }
     }
-  | { type: 'assistant/chunk'; text: string }
+  | { type: 'assistant/chunk'; text: string; channel?: 'reasoning' }
   | { type: 'tool/call'; id: string; name: string; arguments: string }
   | { type: 'tool/result'; id: string; name: string; ok: boolean; detail: string }
 

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -35,6 +35,8 @@ export {
   sumTrajectoryRowUsage,
   sumUsageParts,
   type ChatNode,
+  type ChatAssistantPart,
+  type ChatThinkPart,
   type ChatReplyPart,
   type ChatStepStat,
   type ChatToolPart,
@@ -1431,7 +1433,7 @@ function upsertEvent(events: SessionEvent[], event: SessionEvent) {
   }
   if (event.type === 'assistant/chunk') {
     const last = events.at(-1)
-    if (last?.type === 'assistant/chunk') {
+    if (last?.type === 'assistant/chunk' && (last.channel === 'reasoning') === (event.channel === 'reasoning')) {
       return [
         ...events.slice(0, -1),
         { ...last, text: last.text + event.text, ts: event.ts },
@@ -1440,7 +1442,7 @@ function upsertEvent(events: SessionEvent[], event: SessionEvent) {
   }
   if (event.type === 'assistant/message') {
     const last = events.at(-1)
-    if (last?.type === 'assistant/chunk') {
+    if (last?.type === 'assistant/chunk' && last.channel !== 'reasoning') {
       return [...events.slice(0, -1), event]
     }
   }
@@ -1455,11 +1457,19 @@ function patchStreamingNodes(
   if (last?.kind === 'reply') {
     const parts = [...last.parts]
     const lastPart = parts.at(-1)
-    if (lastPart?.kind === 'assistant' && lastPart.streaming) {
+    const isThink = chunk.channel === 'reasoning'
+    if (lastPart?.kind === (isThink ? 'think' : 'assistant') && lastPart.streaming) {
       if (lastPart.text === chunk.text) return nodes
       parts[parts.length - 1] = { ...lastPart, text: chunk.text, streaming: true }
     } else {
-      parts.push({ id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true })
+      if (isThink) {
+        parts.push({ id: `think-${chunk.seq}`, kind: 'think', text: chunk.text, streaming: true })
+      } else {
+        if (lastPart?.kind === 'think' && lastPart.streaming) {
+          parts[parts.length - 1] = { ...lastPart, streaming: false }
+        }
+        parts.push({ id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true })
+      }
     }
     const copyText = parts
       .filter((part) => part.kind === 'assistant')
@@ -1473,8 +1483,8 @@ function patchStreamingNodes(
     {
       id: `r-${chunk.seq}`,
       kind: 'reply',
-      parts: [{ id: `a-${chunk.seq}`, kind: 'assistant', text: chunk.text, streaming: true }],
-      copyText: chunk.text,
+      parts: [{ id: `a-${chunk.seq}`, kind: chunk.channel === 'reasoning' ? 'think' : 'assistant', text: chunk.text, streaming: true }],
+      copyText: chunk.channel === 'reasoning' ? '' : chunk.text,
       streaming: true,
       finished: false,
     },

--- a/packages/web-session-view/src/web/session-project.test.ts
+++ b/packages/web-session-view/src/web/session-project.test.ts
@@ -43,6 +43,27 @@ test('projects user, streaming assistant, tool call/result from session events',
   if (user?.kind === 'user') assert.equal(user.ts, 2)
 })
 
+test('projectNodes keeps streamed DeepSeek reasoning as a think part', () => {
+  const nodes = projectNodes([
+    { type: 'turn/start', turn: 1, seq: 1, ts: 1 },
+    { type: 'step/start', turn: 1, step: 0, seq: 2, ts: 2 },
+    { type: 'assistant/chunk', text: '先想', channel: 'reasoning', seq: 3, ts: 3 },
+    { type: 'assistant/chunk', text: '清楚', channel: 'reasoning', seq: 4, ts: 4 },
+    { type: 'assistant/chunk', text: '短答', seq: 5, ts: 5 },
+    { type: 'assistant/message', text: '短答', seq: 6, ts: 6 },
+  ])
+  const reply = nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  assert.deepEqual(
+    reply.parts.map((part) => part.kind),
+    ['think', 'assistant'],
+  )
+  assert.equal(reply.parts[0]?.kind === 'think' && reply.parts[0].text, '先想清楚')
+  assert.equal(reply.parts[1]?.kind === 'assistant' && reply.parts[1].text, '短答')
+  assert.equal(reply.copyText, '短答')
+})
+
 test('projects live sender onto user nodes', () => {
   const nodes = projectNodes([
     { type: 'session/open', version: 1, seq: 0, ts: 1 },
@@ -275,6 +296,21 @@ test('compactSessionEvents coalesces chunks and drops ones superseded by message
     ['user/message', 'assistant/message', 'assistant/chunk'],
   )
   assert.equal(compacted[2]?.type === 'assistant/chunk' && compacted[2].text, 'partial')
+})
+
+test('compactSessionEvents keeps reasoning chunks when the answer message arrives', () => {
+  const compacted = compactSessionEvents([
+    { type: 'assistant/chunk', text: '想', channel: 'reasoning', seq: 1, ts: 1 },
+    { type: 'assistant/chunk', text: '一下', channel: 'reasoning', seq: 2, ts: 2 },
+    { type: 'assistant/chunk', text: '答', seq: 3, ts: 3 },
+    { type: 'assistant/message', text: '答', seq: 4, ts: 4 },
+  ])
+  assert.deepEqual(
+    compacted.map((event) => event.type),
+    ['assistant/chunk', 'assistant/message'],
+  )
+  assert.equal(compacted[0]?.type === 'assistant/chunk' && compacted[0].channel, 'reasoning')
+  assert.equal(compacted[0]?.type === 'assistant/chunk' && compacted[0].text, '想一下')
 })
 
 test('projectTrajectory keeps seq ledger and tool callIds for inspect', () => {

--- a/packages/web-session-view/src/web/session-project.ts
+++ b/packages/web-session-view/src/web/session-project.ts
@@ -29,7 +29,7 @@ export type SessionEvent = {
         histPct?: number
       }
     }
-  | { type: 'assistant/chunk'; text: string }
+  | { type: 'assistant/chunk'; text: string; channel?: 'reasoning' }
   | { type: 'tool/call'; id: string; name: string; arguments: string }
   | { type: 'tool/result'; id: string; name: string; ok: boolean; detail: string }
 )
@@ -62,7 +62,15 @@ export type ChatAssistantPart = {
   step?: number
 }
 
-export type ChatReplyPart = ChatAssistantPart | ChatToolPart
+export type ChatThinkPart = {
+  id: string
+  kind: 'think'
+  text: string
+  streaming?: boolean
+  step?: number
+}
+
+export type ChatReplyPart = ChatAssistantPart | ChatToolPart | ChatThinkPart
 
 /** 单步摘要：横条展示用。 */
 export type ChatStepStat = {
@@ -165,6 +173,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
     id: string
     parts: ChatReplyPart[]
     streamingId: string | null
+    streamingThinkId: string | null
     tools: Map<string, ChatToolPart>
     usage: { input: number; output: number; total: number; cache: number; hit: boolean }
     /** 历史占比加权累加器：Σ(histPct × inputTokens) / Σ(inputTokens)。 */
@@ -183,6 +192,7 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
         id: `r-${seq}`,
         parts: [],
         streamingId: null,
+        streamingThinkId: null,
         tools: new Map(),
         usage: { input: 0, output: 0, total: 0, cache: 0, hit: false },
         histSum: 0,
@@ -335,26 +345,56 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
       })
     } else if (event.type === 'assistant/chunk') {
       const r = ensureReply(event.seq)
-      if (r.streamingId) {
-        const idx = r.parts.findIndex((part) => part.id === r.streamingId)
-        const current = idx >= 0 ? r.parts[idx] : undefined
-        if (current?.kind === 'assistant') {
-          r.parts[idx] = {
-            ...current,
-            text: current.text + event.text,
+      if (event.channel === 'reasoning') {
+        if (r.streamingThinkId) {
+          const idx = r.parts.findIndex((part) => part.id === r.streamingThinkId)
+          const current = idx >= 0 ? r.parts[idx] : undefined
+          if (current?.kind === 'think') {
+            r.parts[idx] = {
+              ...current,
+              text: current.text + event.text,
+              streaming: true,
+              ...(currentStep != null ? { step: currentStep } : {}),
+            }
+          }
+        } else {
+          r.streamingThinkId = `think-${event.seq}`
+          r.parts.push({
+            id: r.streamingThinkId,
+            kind: 'think',
+            text: event.text,
             streaming: true,
             ...(currentStep != null ? { step: currentStep } : {}),
-          }
+          })
         }
       } else {
-        r.streamingId = `a-${event.seq}`
-        r.parts.push({
-          id: r.streamingId,
-          kind: 'assistant',
-          text: event.text,
-          streaming: true,
-          ...(currentStep != null ? { step: currentStep } : {}),
-        })
+        if (r.streamingThinkId) {
+          const idx = r.parts.findIndex((part) => part.id === r.streamingThinkId)
+          const current = idx >= 0 ? r.parts[idx] : undefined
+          if (current?.kind === 'think') r.parts[idx] = { ...current, streaming: false }
+          r.streamingThinkId = null
+        }
+        if (r.streamingId) {
+          const idx = r.parts.findIndex((part) => part.id === r.streamingId)
+          const current = idx >= 0 ? r.parts[idx] : undefined
+          if (current?.kind === 'assistant') {
+            r.parts[idx] = {
+              ...current,
+              text: current.text + event.text,
+              streaming: true,
+              ...(currentStep != null ? { step: currentStep } : {}),
+            }
+          }
+        } else {
+          r.streamingId = `a-${event.seq}`
+          r.parts.push({
+            id: r.streamingId,
+            kind: 'assistant',
+            text: event.text,
+            streaming: true,
+            ...(currentStep != null ? { step: currentStep } : {}),
+          })
+        }
       }
       r.streaming = true
     } else if (event.type === 'assistant/message') {
@@ -384,10 +424,22 @@ export function projectNodes(events: SessionEvent[]): ChatNode[] {
           ...(currentStep != null ? { step: currentStep } : {}),
         })
       }
+      if (r.streamingThinkId) {
+        const idx = r.parts.findIndex((part) => part.id === r.streamingThinkId)
+        const current = idx >= 0 ? r.parts[idx] : undefined
+        if (current?.kind === 'think') r.parts[idx] = { ...current, streaming: false }
+        r.streamingThinkId = null
+      }
       if (currentTurn != null) r.streaming = true
     } else if (event.type === 'tool/call') {
       const r = ensureReply(event.seq)
       r.streamingId = null
+      if (r.streamingThinkId) {
+        const idx = r.parts.findIndex((part) => part.id === r.streamingThinkId)
+        const current = idx >= 0 ? r.parts[idx] : undefined
+        if (current?.kind === 'think') r.parts[idx] = { ...current, streaming: false }
+        r.streamingThinkId = null
+      }
       if (currentTurn != null) r.streaming = true
       const existing = r.tools.get(event.id)
       if (existing) {
@@ -614,7 +666,7 @@ export function compactSessionEvents(events: SessionEvent[]): SessionEvent[] {
   for (const event of events) {
     if (event.type === 'assistant/chunk') {
       const prev = coalesced.at(-1)
-      if (prev?.type === 'assistant/chunk') {
+      if (prev?.type === 'assistant/chunk' && (prev.channel === 'reasoning') === (event.channel === 'reasoning')) {
         coalesced[coalesced.length - 1] = {
           ...prev,
           text: prev.text + event.text,
@@ -629,7 +681,7 @@ export function compactSessionEvents(events: SessionEvent[]): SessionEvent[] {
   for (let i = 0; i < coalesced.length; i++) {
     const event = coalesced[i]!
     const next = coalesced[i + 1]
-    if (event.type === 'assistant/chunk' && next?.type === 'assistant/message') continue
+    if (event.type === 'assistant/chunk' && event.channel !== 'reasoning' && next?.type === 'assistant/message') continue
     out.push(event)
   }
   return out

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -245,6 +245,24 @@ test('ingest coalesces consecutive chunks and skips trajectory on chat view', as
   assert.equal(view.get().trajectory.length, 0)
 })
 
+test('ingest keeps reasoning chunks separate from the answer', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.ingest('s1', { type: 'assistant/chunk', text: '想', channel: 'reasoning', seq: 1, ts: 2 })
+  view.ingest('s1', { type: 'assistant/chunk', text: '答', seq: 2, ts: 3 })
+  const chunks = view.get().events.filter((event) => event.type === 'assistant/chunk')
+  assert.equal(chunks.length, 2)
+  const reply = view.get().nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind === 'reply' && reply.parts[0]?.kind, 'think')
+  assert.equal(reply?.kind === 'reply' && reply.parts[1]?.kind, 'assistant')
+})
+
 test('ingest updates live tool/call arguments without duplicating the card', async () => {
   mockFetch({
     '/api/sessions': () => ({ sessions: [] }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

DeepSeek V4 Flash **默认开思考**。思考走 SSE 的 `delta.reasoning_content`，真正回复才走 `delta.content`。

我们以前只订了 `content`，思考阶段页面没有任何 `assistant/chunk`，于是卡在 `step/start` 后面一两分钟，最后只冒出很短的答案。

## 改动

- 解析 `reasoning_content` / `reasoning`（以及 Anthropic `thinking_delta`）
- 写成 `assistant/chunk` + `channel: reasoning`
- 聊天里单独一块「思考」，流式出来
- **不**并进最终 `assistant/message`，**不**进下一轮 `deriveMessages`

轨迹面板逻辑没动。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

