### PR TITLE
feat: 模型配置可开关思考，并选 High / Max

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -5,9 +5,9 @@ import type { ChatMessage } from './chat-types.ts'
 import { isAgentToolMode, normalizeAgentMode, type AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
 import { probeLlmConnection } from '@biu/host-llm'
-import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl } from './model-catalog.ts'
-import type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
-export type { ChatProvider, LlmModelDef, LlmEndpointDef } from './model-catalog.ts'
+import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl, inferModelCapabilities, defaultThinkingFor, defaultEffortFor } from './model-catalog.ts'
+import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ModelCapabilities } from './model-catalog.ts'
+export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ModelCapabilities } from './model-catalog.ts'
 export { LLM_ENDPOINT_PRESETS, LLM_MODEL_CATALOG } from './model-catalog.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { isSessionCompactPoint, type SessionConfig, type SessionEvent } from '@biu/type-session'
@@ -58,6 +58,11 @@ interface ChatConfig {
   agentMode: AgentToolMode
   /** 极简模式下常驻额外工具（不含 minimal 底座与 live 调度工具） */
   extraTools: string[]
+  /** 当前模型的思考开关；能思考的模型默认 enabled（对齐上游）。 */
+  thinking: ThinkingMode
+  reasoningEffort: ReasoningEffort
+  /** 按「入口::模型」记住档位，切模型时带回。 */
+  modelPrefs: Record<string, { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }>
 }
 
 function configPath() {
@@ -91,6 +96,9 @@ function defaults(): ChatConfig {
     systemPrompt: '你是控制台里的助手。需要时调用当前已注册的 tools；插件卸载后对应 tool 会消失。回答简洁。',
     agentMode: 'standard',
     extraTools: [],
+    thinking: 'enabled',
+    reasoningEffort: 'high',
+    modelPrefs: {},
   }
 }
 
@@ -121,6 +129,9 @@ function writePersisted(config: ChatConfig) {
         systemPrompt: config.systemPrompt,
         agentMode: config.agentMode,
         extraTools: config.extraTools,
+        thinking: config.thinking,
+        reasoningEffort: config.reasoningEffort,
+        modelPrefs: config.modelPrefs,
         apiKeys: config.apiKeys,
         baseUrls: config.baseUrls,
         customEndpoints: config.customEndpoints,
@@ -140,6 +151,44 @@ function parseAgentMode(value: unknown, fallback: AgentToolMode): AgentToolMode 
 
 function parseProvider(value: unknown): ChatProvider | null {
   return CHAT_PROVIDERS.includes(value as ChatProvider) ? (value as ChatProvider) : null
+}
+
+function prefKey(endpointId: string, model: string) {
+  return `${endpointId}::${model}`
+}
+
+function parseThinking(value: unknown): ThinkingMode | undefined {
+  return value === 'enabled' || value === 'disabled' ? value : undefined
+}
+
+function parseEffort(value: unknown): ReasoningEffort | undefined {
+  return value === 'high' || value === 'max' ? value : undefined
+}
+
+function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPrefs'] {
+  const out: ChatConfig['modelPrefs'] = {}
+  if (!saved?.modelPrefs || typeof saved.modelPrefs !== 'object') return out
+  for (const [key, raw] of Object.entries(saved.modelPrefs)) {
+    if (!raw || typeof raw !== 'object') continue
+    const thinking = parseThinking(raw.thinking)
+    const reasoningEffort = parseEffort(raw.reasoningEffort)
+    if (thinking || reasoningEffort) out[key] = { ...(thinking ? { thinking } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) }
+  }
+  return out
+}
+
+function hydrateModelMode(config: ChatConfig) {
+  const caps = inferModelCapabilities(config.model, config.provider)
+  const saved = config.modelPrefs[prefKey(config.endpointId, config.model)]
+  config.thinking = saved?.thinking ?? defaultThinkingFor(caps)
+  config.reasoningEffort = saved?.reasoningEffort ?? defaultEffortFor(caps)
+}
+
+function rememberModelPrefs(config: ChatConfig) {
+  config.modelPrefs[prefKey(config.endpointId, config.model)] = {
+    thinking: config.thinking,
+    reasoningEffort: config.reasoningEffort,
+  }
 }
 
 function isLocalEndpoint(endpoint: LlmEndpointDef): boolean {
@@ -260,7 +309,7 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     customEndpoints.find((e) => e.id === endpointId) ??
     findEndpointPreset(base.endpointId)
 
-  return {
+  const next: ChatConfig = {
     endpointId,
     provider: endpoint?.provider ?? parseProvider(saved.provider) ?? base.provider,
     apiKeys,
@@ -276,7 +325,12 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     extraTools: Array.isArray(saved.extraTools)
       ? [...new Set(saved.extraTools.map((name) => String(name).trim()).filter(Boolean))]
       : base.extraTools,
+    thinking: parseThinking(saved.thinking) ?? base.thinking,
+    reasoningEffort: parseEffort(saved.reasoningEffort) ?? base.reasoningEffort,
+    modelPrefs: mergeModelPrefs(saved),
   }
+  hydrateModelMode(next)
+  return next
 }
 
 function allEndpoints(config: ChatConfig): LlmEndpointDef[] {
@@ -371,6 +425,9 @@ export class ChatService extends Service {
       model: this.config.model,
       systemPrompt: this.config.systemPrompt,
       agentMode: this.config.agentMode,
+      thinking: this.config.thinking,
+      reasoningEffort: this.config.reasoningEffort,
+      capabilities: inferModelCapabilities(this.config.model, this.config.provider),
       /** 当前默认入口是否已配置（兼容旧语义，供 banner 等使用）。 */
       configured: current ? endpointConfigured(this.config, current) : Boolean((this.config.apiKeys[this.config.provider] ?? '').trim()),
       hint: hint(this.config.apiKeys[this.config.endpointId] ?? this.config.apiKeys[this.config.provider] ?? ''),
@@ -393,6 +450,7 @@ export class ChatService extends Service {
       })),
       modelCatalog: models.map((m) => ({
         ...m,
+        capabilities: inferModelCapabilities(m.model, m.provider),
         // 方便前端按入口过滤
         endpointConfigured: (() => {
           const ep = resolveEndpoint(this.config, m.endpointId)
@@ -455,11 +513,19 @@ export class ChatService extends Service {
       ''
     // 本地入口允许空 Key：上游常不校验，填占位避免部分网关拒空 Authorization
     const key = apiKey.trim() || (endpoint && isLocalEndpoint(endpoint) ? 'local' : '')
+    const caps = inferModelCapabilities(effective.model, provider)
+    const prefs = this.config.modelPrefs[prefKey(endpointId, effective.model)]
     return {
       provider,
       apiKey: key,
       model: effective.model,
       ...(endpoint ? { baseUrl: effectiveBaseUrl(this.config, endpoint) } : {}),
+      ...(caps.thinking || caps.effort?.length
+        ? {
+            thinking: prefs?.thinking ?? this.config.thinking,
+            reasoningEffort: prefs?.reasoningEffort ?? this.config.reasoningEffort,
+          }
+        : {}),
     }
   }
 
@@ -565,6 +631,8 @@ export class ChatService extends Service {
       systemPrompt: string
       agentMode: AgentToolMode
       extraTools: string[]
+      thinking: ThinkingMode
+      reasoningEffort: ReasoningEffort
       /** 按入口更新 key；空串 / null 清除 */
       setApiKey: Partial<Record<string, string | null>>
       /** 按入口覆盖 baseUrl；空串清除覆盖、回到 preset 默认 */
@@ -578,6 +646,8 @@ export class ChatService extends Service {
     }>,
     opts?: { persist?: boolean },
   ) {
+    const beforeKey = prefKey(this.config.endpointId, this.config.model)
+    rememberModelPrefs(this.config)
     if (typeof next.endpointId === 'string' && next.endpointId.trim()) {
       const id = next.endpointId.trim()
       const ep = resolveEndpoint(this.config, id)
@@ -734,6 +804,15 @@ export class ChatService extends Service {
     if (Array.isArray(next.extraTools)) {
       this.config.extraTools = [...new Set(next.extraTools.map((name) => String(name).trim()).filter(Boolean))]
     }
+    const afterKey = prefKey(this.config.endpointId, this.config.model)
+    const thinkingPatch = parseThinking(next.thinking)
+    const effortPatch = parseEffort(next.reasoningEffort)
+    if (afterKey !== beforeKey && thinkingPatch == null && effortPatch == null) {
+      hydrateModelMode(this.config)
+    }
+    if (thinkingPatch) this.config.thinking = thinkingPatch
+    if (effortPatch) this.config.reasoningEffort = effortPatch
+    rememberModelPrefs(this.config)
     this.syncLlm()
     this.syncToolsMode()
     if (opts?.persist !== false) {

--- a/packages/core-chat/src/host/model-catalog.test.ts
+++ b/packages/core-chat/src/host/model-catalog.test.ts
@@ -6,6 +6,8 @@ import {
   LLM_MODEL_CATALOG,
   findEndpointPreset,
   normalizeBaseUrl,
+  inferModelCapabilities,
+  defaultThinkingFor,
 } from './model-catalog.ts'
 
 test('resolveChatCompletionsUrl uses defaults when baseUrl missing', () => {
@@ -75,4 +77,23 @@ test('relay endpoints share a multi-model pack', () => {
 
 test('normalizeBaseUrl strips trailing slash', () => {
   assert.equal(normalizeBaseUrl(' https://a.com/v1/ '), 'https://a.com/v1')
+})
+
+test('DeepSeek V4 can toggle thinking and High/Max', () => {
+  const caps = inferModelCapabilities('deepseek-v4-flash', 'deepseek')
+  assert.equal(caps.thinking, true)
+  assert.deepEqual(caps.effort, ['high', 'max'])
+  assert.equal(defaultThinkingFor(caps), 'enabled')
+})
+
+test('GPT-4o has no thinking extras', () => {
+  const caps = inferModelCapabilities('gpt-4o', 'openai')
+  assert.equal(caps.thinking, undefined)
+  assert.equal(caps.effort, undefined)
+})
+
+test('o3 exposes effort but not a thinking off switch', () => {
+  const caps = inferModelCapabilities('o3-mini', 'openai')
+  assert.equal(caps.thinking, undefined)
+  assert.deepEqual(caps.effort, ['high', 'max'])
 })

--- a/packages/core-chat/src/host/model-catalog.ts
+++ b/packages/core-chat/src/host/model-catalog.ts
@@ -723,6 +723,45 @@ export function endpointProtocolProvider(endpoint: LlmEndpointDef): ChatProvider
   return endpoint.provider
 }
 
+export type ReasoningEffort = 'high' | 'max'
+export type ThinkingMode = 'enabled' | 'disabled'
+
+export interface ModelCapabilities {
+  /** 可开关思考（DeepSeek V4 / Claude 扩展思考） */
+  thinking?: boolean
+  /** 可调推理档位 High / Max */
+  effort?: Array<ReasoningEffort>
+}
+
+/** 按模型 id 推断：只露出该模型真正有的 1～2 项，避免一堆无效滑杆。 */
+export function inferModelCapabilities(model: string, provider: ChatProvider): ModelCapabilities {
+  const id = model.toLowerCase()
+  if (
+    provider === 'deepseek' ||
+    id.includes('deepseek-v4') ||
+    id.includes('deepseek-reasoner') ||
+    /deepseek-r1/.test(id)
+  ) {
+    return { thinking: true, effort: ['high', 'max'] }
+  }
+  if (/(^|[^a-z])o[1-4]([^a-z]|$)|gpt-5/.test(id)) {
+    return { effort: ['high', 'max'] }
+  }
+  if (provider === 'anthropic' && /claude-(opus|sonnet)-4|claude-4|claude-3-7/.test(id)) {
+    return { thinking: true }
+  }
+  return {}
+}
+
+export function defaultThinkingFor(caps: ModelCapabilities): ThinkingMode {
+  // 默认同 API：能思考就开。用户可在菜单里关成「快」。
+  return caps.thinking || caps.effort?.length ? 'enabled' : 'disabled'
+}
+
+export function defaultEffortFor(caps: ModelCapabilities): ReasoningEffort {
+  return caps.effort?.includes('high') ? 'high' : 'max'
+}
+
 /** 规范化用户输入的 baseUrl（去尾斜杠）。 */
 export function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/, '')

--- a/packages/core-chat/src/web/composer.tsx
+++ b/packages/core-chat/src/web/composer.tsx
@@ -17,6 +17,8 @@ import {
   serializeComposer,
 } from './composer-tiptap.ts'
 import { ModelConfigDialog } from './model-config-dialog.tsx'
+import { ModelModeControls, modelModeSuffix } from './model-mode.tsx'
+import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
 import { ImageThumbs } from './image-thumbs.tsx'
 import { collectClipboardImages, collectImageFiles } from './clipboard-images.ts'
 import { revealOverlayThread, isComposerFocusPending } from '@biu/web-app-shell/chat-overlay'
@@ -186,6 +188,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   })
   const [modelBusy, setModelBusy] = useState(false)
   const [configOpen, setConfigOpen] = useState(false)
+  const [thinking, setThinking] = useState<ThinkingMode>('enabled')
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
+  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ thinking: true, effort: ['high', 'max'] })
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
@@ -227,6 +232,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       provider?: string
       endpointId?: string
       model?: string
+      thinking?: ThinkingMode
+      reasoningEffort?: ReasoningEffort
+      capabilities?: ModelCapabilities
       providers?: Record<string, { configured?: boolean }>
       endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
       modelCatalog?: Array<{
@@ -257,6 +265,9 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       } else if (data.provider && data.model) {
         setModelOption(matchModelOption([], data.provider, data.model))
       }
+      if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
+      if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+      if (data.capabilities) setModelCaps(data.capabilities)
       const cfg: Record<string, boolean> = {}
       const labels: Record<string, string> = {
         deepseek: 'DeepSeek',
@@ -658,9 +669,18 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         }),
       })
       if (!res.ok) return
-      const data = (await res.json()) as { provider?: string; model?: string }
+      const data = (await res.json()) as {
+        provider?: string
+        model?: string
+        thinking?: ThinkingMode
+        reasoningEffort?: ReasoningEffort
+        capabilities?: ModelCapabilities
+      }
       if (data.provider && data.model) setModelOption(matchModelOption(allModels, data.provider, data.model))
       else setModelOption(option)
+      if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
+      if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+      if (data.capabilities) setModelCaps(data.capabilities)
       setModelOpen(false)
     } finally {
       setModelBusy(false)
@@ -837,7 +857,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
               title="选择模型"
               onClick={() => setModelOpen((open) => !open)}
             >
-              <span className="composer-model-label">{modelOption.label}</span>
+              <span className="composer-model-label">
+                {modelOption.label}
+                {modelModeSuffix(thinking, reasoningEffort, modelCaps)
+                  ? ` · ${modelModeSuffix(thinking, reasoningEffort, modelCaps)}`
+                  : ''}
+              </span>
               <ChevronDownIcon className="size-3.5 opacity-70" />
             </button>
             {modelOpen ? (
@@ -912,6 +937,39 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                     )
                   })
                 })()}
+                <div className="composer-model-modes">
+                  <ModelModeControls
+                    capabilities={modelCaps}
+                    thinking={thinking}
+                    reasoningEffort={reasoningEffort}
+                    disabled={modelBusy}
+                    onChange={(next) => {
+                      void (async () => {
+                        setModelBusy(true)
+                        try {
+                          const res = await fetch('/api/chat/config', {
+                            method: 'POST',
+                            headers: { 'content-type': 'application/json' },
+                            body: JSON.stringify(next),
+                          })
+                          if (!res.ok) return
+                          const data = (await res.json()) as {
+                            thinking?: ThinkingMode
+                            reasoningEffort?: ReasoningEffort
+                            capabilities?: ModelCapabilities
+                          }
+                          if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
+                          if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') {
+                            setReasoningEffort(data.reasoningEffort)
+                          }
+                          if (data.capabilities) setModelCaps(data.capabilities)
+                        } finally {
+                          setModelBusy(false)
+                        }
+                      })()
+                    }}
+                  />
+                </div>
               </div>
               </HeadlessDismiss>
             ) : null}

--- a/packages/core-chat/src/web/config.tsx
+++ b/packages/core-chat/src/web/config.tsx
@@ -10,6 +10,8 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIcon, SignalSlashIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import { HeadlessDismiss } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
+import { ModelModeControls } from './model-mode.tsx'
+import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -48,6 +50,9 @@ interface ChatPublicConfig {
   endpointId?: string
   provider: ChatProvider
   model: string
+  thinking?: ThinkingMode
+  reasoningEffort?: ReasoningEffort
+  capabilities?: ModelCapabilities
   configured: boolean
   hint: string
   baseUrl?: string
@@ -79,6 +84,9 @@ export function ChatConfig(props?: { onClose?: () => void }) {
   const [activeId, setActiveId] = useState('deepseek')
   const [defaultEndpointId, setDefaultEndpointId] = useState('deepseek')
   const [defaultModel, setDefaultModel] = useState('deepseek-v4-flash')
+  const [thinking, setThinking] = useState<ThinkingMode>('enabled')
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
+  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({})
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
   const [providers, setProviders] = useState<Record<string, ProviderView> | null>(null)
@@ -246,6 +254,9 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     const eid = preferActive || data.endpointId || data.provider || 'deepseek'
     setDefaultEndpointId(data.endpointId || data.provider || eid)
     setDefaultModel(data.model)
+    if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
+    if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+    if (data.capabilities) setModelCaps(data.capabilities)
     setActiveId(eid)
 
     const ep = eps.find((e) => e.id === eid)
@@ -1068,6 +1079,25 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                   ) : (
                     <p className="text-[11px] text-(--dsw-label-3)">暂无模型，在下方添加 model id</p>
                   )}
+
+                  {isDefaultProvider ? (
+                    <ModelModeControls
+                      capabilities={modelCaps}
+                      thinking={thinking}
+                      reasoningEffort={reasoningEffort}
+                      disabled={saving}
+                      onChange={(next) => {
+                        void fetch('/api/chat/config', {
+                          method: 'POST',
+                          headers: { 'content-type': 'application/json' },
+                          body: JSON.stringify(next),
+                        })
+                          .then((res) => res.json())
+                          .then((data: ChatPublicConfig) => applyPublic(data, activeId))
+                          .catch(() => setError('保存失败'))
+                      }}
+                    />
+                  ) : null}
 
                   <div className="flex gap-2">
                     <input

--- a/packages/core-chat/src/web/model-mode.tsx
+++ b/packages/core-chat/src/web/model-mode.tsx
@@ -1,0 +1,74 @@
+import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+
+const pillCls = (on: boolean) =>
+  `rounded-md border px-2 py-[3px] text-[12px] leading-none transition-colors ${
+    on
+      ? 'border-(--dsw-business) bg-(--dsw-business-soft) text-(--dsw-business)'
+      : 'border-(--dsw-border) text-(--dsw-label-3) hover:bg-(--dsw-hover) hover:text-(--dsw-label)'
+  }`
+
+export function ModelModeControls(props: {
+  capabilities: ModelCapabilities
+  thinking: ThinkingMode
+  reasoningEffort: ReasoningEffort
+  disabled?: boolean
+  onChange: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }) => void
+}) {
+  const { capabilities: caps, thinking, reasoningEffort, disabled, onChange } = props
+  if (!caps.thinking && !caps.effort?.length) return null
+  return (
+    <div className="flex flex-col gap-2" data-testid="model-mode-controls">
+      {caps.thinking ? (
+        <div className="flex items-center gap-2">
+          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">思考</span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              className={pillCls(thinking === 'disabled')}
+              disabled={disabled}
+              data-testid="thinking-off"
+              onClick={() => onChange({ thinking: 'disabled' })}
+            >
+              关
+            </button>
+            <button
+              type="button"
+              className={pillCls(thinking === 'enabled')}
+              disabled={disabled}
+              data-testid="thinking-on"
+              onClick={() => onChange({ thinking: 'enabled' })}
+            >
+              开
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {caps.effort?.length && (caps.thinking ? thinking === 'enabled' : true) ? (
+        <div className="flex items-center gap-2">
+          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">力度</span>
+          <div className="flex gap-1">
+            {caps.effort.map((item) => (
+              <button
+                key={item}
+                type="button"
+                className={pillCls(reasoningEffort === item)}
+                disabled={disabled}
+                data-testid={`effort-${item}`}
+                onClick={() => onChange({ thinking: 'enabled', reasoningEffort: item })}
+              >
+                {item === 'max' ? 'Max' : 'High'}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function modelModeSuffix(thinking: ThinkingMode, effort: ReasoningEffort, caps: ModelCapabilities) {
+  if (!caps.thinking && !caps.effort?.length) return ''
+  if (caps.thinking && thinking === 'disabled') return '快'
+  if (effort === 'max') return 'Max'
+  return 'High'
+}

--- a/packages/host-llm/src/host/index.ts
+++ b/packages/host-llm/src/host/index.ts
@@ -12,6 +12,34 @@ export interface LlmConfig {
    * 也可直接传入已含后缀的完整 URL。
    */
   baseUrl?: string
+  /** DeepSeek V4 / Claude 扩展思考：显式开关，避免上游默认开思考把页面卡死。 */
+  thinking?: 'enabled' | 'disabled'
+  reasoningEffort?: 'high' | 'max'
+}
+
+export function attachProviderOptions(
+  body: Record<string, unknown>,
+  config: LlmConfig,
+  protocol: 'openai-compat' | 'anthropic',
+) {
+  if (protocol === 'anthropic') {
+    if (config.thinking === 'enabled') {
+      body.thinking = { type: 'enabled', budget_tokens: 10_000 }
+    } else if (config.thinking === 'disabled') {
+      body.thinking = { type: 'disabled' }
+    }
+    return
+  }
+  if (config.thinking === 'disabled') {
+    body.thinking = { type: 'disabled' }
+    return
+  }
+  if (config.thinking === 'enabled') {
+    body.thinking = { type: 'enabled' }
+  }
+  if (config.reasoningEffort === 'high' || config.reasoningEffort === 'max') {
+    body.reasoning_effort = config.reasoningEffort
+  }
 }
 
 /** 把用户配置的 baseUrl 解析成 chat.completions 完整地址。 */
@@ -398,6 +426,7 @@ export class OpenAiCompatLlm implements LlmClient {
       body.tools = tools
       body.tool_choice = 'auto'
     }
+    attachProviderOptions(body, this.config, 'openai-compat')
     const res = await fetch(url, {
       method: 'POST',
       headers: {
@@ -485,6 +514,7 @@ export class AnthropicLlm implements LlmClient {
         }
       })
     }
+    attachProviderOptions(body, this.config, 'anthropic')
     const res = await fetch(endpoint, {
       method: 'POST',
       headers: {

--- a/packages/host-llm/src/host/llm.stream.test.ts
+++ b/packages/host-llm/src/host/llm.stream.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'vitest'
-import { consumeChatCompletionSse } from '@biu/host-llm'
+import { consumeChatCompletionSse, attachProviderOptions } from '@biu/host-llm'
 
 function sseBody(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder()
@@ -75,4 +75,29 @@ test('consumeChatCompletionSse aborts with signal', async () => {
     },
   })
   await assert.rejects(() => consumeChatCompletionSse(stream, { signal: abort.signal }), /cancelled/)
+})
+
+test('attachProviderOptions disables DeepSeek thinking', () => {
+  const body: Record<string, unknown> = {}
+  attachProviderOptions(body, {
+    provider: 'deepseek',
+    apiKey: 'k',
+    model: 'deepseek-v4-flash',
+    thinking: 'disabled',
+  }, 'openai-compat')
+  assert.deepEqual(body.thinking, { type: 'disabled' })
+  assert.equal(body.reasoning_effort, undefined)
+})
+
+test('attachProviderOptions sends enabled thinking plus Max effort', () => {
+  const body: Record<string, unknown> = {}
+  attachProviderOptions(body, {
+    provider: 'deepseek',
+    apiKey: 'k',
+    model: 'deepseek-v4-flash',
+    thinking: 'enabled',
+    reasoningEffort: 'max',
+  }, 'openai-compat')
+  assert.deepEqual(body.thinking, { type: 'enabled' })
+  assert.equal(body.reasoning_effort, 'max')
 })

--- a/web/style.css
+++ b/web/style.css
@@ -5199,6 +5199,11 @@ body {
   line-height: 1.5;
 }
 
+.composer-model-modes {
+  padding: 8px 12px 10px;
+  border-top: 1px solid var(--dsw-border);
+}
+
 .composer-model-config-head {
   position: sticky;
   top: 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 怎么做（竞品）

ChatGPT / Cursor / DeepSeek 网页都不是把温度、top_p 全堆出来，而是：

1. 先选模型
2. **只显示这个模型有的 1～2 项**：思考开/关，力度 High / Max（Cursor 的 Max Mode 也是这个思路）

关思考 ≈ 他们说的 Ultra Fast；High / Max 是开思考后的档位。

## 改动

- 输入框模型菜单底部：思考 **关 / 开**，开了再出现 **High / Max**
- 齿轮里的模型配置同样有这两项
- 触发器显示 `Flash · 快` / `· High` / `· Max`
- 请求里显式带 `thinking` / `reasoning_effort`（关思考会发 `disabled`，不再吃上游默认）
- 按「入口::模型」记住档位

GPT-4o 这类没有思考参数的模型不会出现这些按钮。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

