### PR TITLE
feat(fsdb): 选取旁增加检查器跟随开关

### DIFF
--- a/packages/core-chat/src/web/composer-stack.test.ts
+++ b/packages/core-chat/src/web/composer-stack.test.ts
@@ -130,6 +130,8 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).not.toMatch(/\.project-chip\.project-chip-pick-toggle\s*\{[^}]*border:\s*1px solid #5b9fd6/s)
     expect(css).toMatch(/\.project-chip\.project-chip-pick-toggle:hover:not\(:disabled\)/)
     expect(css).toMatch(/\.project-chip\.project-chip-pick-toggle\.is-active[\s\S]*?color:\s*#5b9fd6/)
+    expect(css).toMatch(/\.project-chip\.project-chip-follow-toggle:hover:not\(:disabled\)/)
+    expect(css).toMatch(/\.project-chip\.project-chip-follow-toggle\.is-active[\s\S]*?color:\s*#5b9fd6/)
     expect(css).toMatch(/\[data-dock-tip-at='ne'\]::after/)
     expect(approvals).toMatch(/data-dock-tip-at="ne"/)
     expect(approvals).not.toContain('待确认工具 · 先处理后再发')

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -22,6 +22,8 @@ test('database page no longer registers collection shortcuts on the dock', () =>
   assert.doesNotMatch(page, /data:\$\{item\.path\}/)
   assert.doesNotMatch(page, /databaseAllViewPath\(item.path\)/)
   assert.match(page, /applyDatabaseChannelPayload\(payload, sessionId\)/)
+  assert.match(page, /header-tools/)
+  assert.match(page, /inspector-follow/)
   assert.match(page, /sessionView/)
   assert.match(page, /builtinAllViewId\(parsed.collection\)/)
   assert.doesNotMatch(page, /isCollectionHub/)

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -10,6 +10,7 @@ import { pathForCenter, pathForCrumbTarget, type CrumbTarget } from './sidebar-n
 import { CollectionBrowser } from './browser.tsx'
 import { DatabaseInspectorBrowse, DatabaseInspectorTab, bindInspectorSnapshot, collectionTabIcon } from './inspector-database.tsx'
 import { applyDatabaseChannelPayload } from './inspector-db-route.ts'
+import { InspectorFollowToggle } from './inspector-follow.tsx'
 import { DatabaseUiService, getDatabaseUi } from './database-ui.ts'
 import {
   bootLoadCollections,
@@ -254,6 +255,10 @@ export function apply(ctx: Context) {
   }
 
   slots.place('root-overlays', RegisterErrorBanner, { key: 'fsdb-nav-errors', order: 80 })
+  slots.place('header-tools', InspectorFollowToggle, {
+    key: 'inspector-follow',
+    order: 11,
+  })
   let stopped = false
   let readyTimer = 0
   const runSync = async (rows: CollectionInfo[]) => {

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -13,6 +13,8 @@ import {
   applyDatabaseChannelPayload,
   isInspectorAgentWorking,
   setInspectorAgentWorking,
+  isInspectorAgentFollow,
+  setInspectorAgentFollow,
   clearInspectorDbPath,
   isInspectorPaneAbandoned,
 } from './inspector-db-route.ts'
@@ -29,6 +31,7 @@ function clearInspectorPanes() {
 
 beforeEach(() => {
   clearInspectorPanes()
+  setInspectorAgentFollow(false)
 })
 
 test('inspector database path is set explicitly', () => {
@@ -183,7 +186,25 @@ test('applyDatabaseChannelPayload marks the table as agent-working until done', 
     'main',
   )
   assert.equal(isInspectorAgentWorking('/tasks'), false)
+  assert.equal(getInspectorDbPath('database:/tasks'), '')
+})
+
+test('agent channel does not open inspector views unless follow is on', () => {
+  setInspectorDbPath('database:/pages', '/database/pages')
+  applyDatabaseChannelPayload(
+    { phase: 'working', sessionId: 'main', reveal: { collection: '/tasks', recordId: 't1' } },
+    'main',
+  )
+  assert.equal(getInspectorDbPath('database:/tasks'), '')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages')
+  setInspectorAgentFollow(true)
+  assert.equal(isInspectorAgentFollow(), true)
+  applyDatabaseChannelPayload(
+    { phase: 'done', sessionId: 'main', reveal: { collection: '/tasks', recordId: 't1' } },
+    'main',
+  )
   assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/record/t1')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages')
 })
 
 test('applyDatabaseChannelPayload ignores other sessions and unsigned broadcasts', () => {
@@ -225,6 +246,17 @@ test('applyDatabaseChannelPayload upserts a created view then opens it', () => {
       },
     },
   })
+  applyDatabaseChannelPayload(
+    {
+      phase: 'done',
+      sessionId: 'main',
+      reveal: { collection: '/tasks', viewId: 'board-1' },
+      savedView: { id: 'board-1', name: '看板', mode: 'board', filters: { status: 'doing' } },
+    },
+    'main',
+  )
+  assert.equal(getInspectorDbPath('database:/tasks'), '')
+  setInspectorAgentFollow(true)
   applyDatabaseChannelPayload(
     {
       phase: 'done',

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -12,6 +12,57 @@ const paths = new Map<string, string>()
 const abandonedPanes = new Set<string>()
 const working = new Set<string>()
 const workingListeners = new Set<() => void>()
+const FOLLOW_KEY = 'inspector.agentFollow'
+const followListeners = new Set<() => void>()
+let followLoaded = false
+let follow = false
+
+function bumpFollow() {
+  for (const fn of followListeners) fn()
+}
+
+function readFollow() {
+  if (followLoaded) return follow
+  followLoaded = true
+  try {
+    follow = localStorage.getItem(FOLLOW_KEY) === '1'
+  } catch {
+    follow = false
+  }
+  return follow
+}
+
+export function subscribeInspectorAgentFollow(fn: () => void) {
+  followListeners.add(fn)
+  return () => {
+    followListeners.delete(fn)
+  }
+}
+
+/** 开：Agent 改库时右侧检查器跟着打开/跳转。关：自己看，不被打断。默认关。 */
+export function isInspectorAgentFollow() {
+  return readFollow()
+}
+
+export function setInspectorAgentFollow(next: boolean) {
+  followLoaded = true
+  const value = Boolean(next)
+  if (follow === value) {
+    try {
+      localStorage.setItem(FOLLOW_KEY, follow ? '1' : '0')
+    } catch {
+      /* ignore */
+    }
+    return
+  }
+  follow = value
+  try {
+    localStorage.setItem(FOLLOW_KEY, follow ? '1' : '0')
+  } catch {
+    /* ignore */
+  }
+  bumpFollow()
+}
 
 function storageKey(paneId: string) {
   return `${STORAGE_PREFIX}${paneId}`
@@ -237,7 +288,7 @@ export function applyDatabaseChannelPayload(payload: unknown, currentSessionId?:
   const savedView = savedViewFromPayload((payload as { savedView?: unknown }).savedView, (reveal as { viewId?: unknown }).viewId)
   if (savedView) upsertSavedView(collection, savedView)
   const phase = String((payload as { phase?: unknown }).phase ?? '')
-  applyDatabaseReveal(reveal)
+  if (isInspectorAgentFollow()) applyDatabaseReveal(reveal)
   setInspectorAgentWorking(collection, phase !== 'done')
 }
 

--- a/packages/core-file-system/src/web/inspector-follow.tsx
+++ b/packages/core-file-system/src/web/inspector-follow.tsx
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react'
+import { ViewfinderCircleIcon } from '@heroicons/react/16/solid'
+import {
+  isInspectorAgentFollow,
+  setInspectorAgentFollow,
+  subscribeInspectorAgentFollow,
+} from './inspector-db-route.ts'
+
+function readFollow() {
+  return isInspectorAgentFollow()
+}
+
+export function InspectorFollowToggle() {
+  const follow = useSyncExternalStore(subscribeInspectorAgentFollow, readFollow, () => false)
+  return (
+    <button
+      type="button"
+      className={`project-chip project-chip-icon-only project-chip-pick-toggle project-chip-follow-toggle relative${follow ? ' is-active' : ''}`}
+      aria-pressed={follow}
+      aria-label="跟随"
+      data-dock-tip="跟随"
+      data-testid="inspector-follow-toggle"
+      onClick={() => setInspectorAgentFollow(!follow)}
+    >
+      <ViewfinderCircleIcon className="size-4" aria-hidden />
+    </button>
+  )
+}

--- a/web/style.css
+++ b/web/style.css
@@ -2684,7 +2684,10 @@ body {
 
 .project-chip.project-chip-pick-toggle:hover:not(:disabled),
 .project-chip.project-chip-pick-toggle.is-active,
-.project-chip.project-chip-pick-toggle.is-active:hover:not(:disabled) {
+.project-chip.project-chip-pick-toggle.is-active:hover:not(:disabled),
+.project-chip.project-chip-follow-toggle:hover:not(:disabled),
+.project-chip.project-chip-follow-toggle.is-active,
+.project-chip.project-chip-follow-toggle.is-active:hover:not(:disabled) {
   color: #5b9fd6;
 }
 
@@ -2718,7 +2721,9 @@ body {
 }
 
 .project-chip.project-chip-pick-toggle.is-active,
-.project-chip.project-chip-pick-toggle.is-active:hover:not(:disabled) {
+.project-chip.project-chip-pick-toggle.is-active:hover:not(:disabled),
+.project-chip.project-chip-follow-toggle.is-active,
+.project-chip.project-chip-follow-toggle.is-active:hover:not(:disabled) {
   border-color: var(--dsw-border);
   background: #262626;
   color: #5b9fd6;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 操作 DB 时，右侧检查器默认不再自动打开或跳转，避免打断你自己在侧栏里看东西。

- 输入栏「选取」按钮右边增加「跟随」图标
- 默认关闭；点亮后，当前 Session 的 DB 工具才会把检查器带到对应表/记录/视图
- 关掉跟随：表格数据仍会刷新，但不会帮你打开或切换检查器
- 搜索结果、自己点开检查器不受影响
- 偏好记在 `localStorage`（`inspector.agentFollow`）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

