### PR TITLE
fix(chat): 默认只露出 DeepSeek / Anthropic / OpenAI

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -358,12 +358,10 @@ function effectiveBaseUrl(config: ChatConfig, endpoint: LlmEndpointDef): string 
   return override?.trim() ? normalizeBaseUrl(override) : endpoint.baseUrl
 }
 
-/** 入口是否已配置：有 Key（或本地入口），且未被探测失败拉黑。 */
+/** 入口是否已配置：有 Key，且未被探测失败拉黑。本地入口不自动算已接入。 */
 function endpointConfigured(config: ChatConfig, endpoint: LlmEndpointDef): boolean {
   if (config.blockedEndpoints.includes(endpoint.id)) return false
-  const key = (config.apiKeys[endpoint.id] ?? '').trim()
-  if (key) return true
-  return isLocalEndpoint(endpoint)
+  return Boolean((config.apiKeys[endpoint.id] ?? '').trim())
 }
 
 function unblockEndpoint(config: ChatConfig, id: string) {

--- a/packages/core-chat/src/host/model-catalog.test.ts
+++ b/packages/core-chat/src/host/model-catalog.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { test } from 'vitest'
 import { resolveChatCompletionsUrl, resolveAnthropicMessagesUrl } from '@biu/host-llm'
 import {
@@ -44,6 +46,18 @@ test('endpoint presets cover official + relay + local groups', () => {
   assert.ok(findEndpointPreset('openrouter'))
   assert.ok(findEndpointPreset('closeai'))
   assert.ok(findEndpointPreset('ollama'))
+})
+
+test('local runtimes stay as addable presets, not default providers', () => {
+  assert.equal(findEndpointPreset('vllm')?.group, 'local')
+  assert.equal(findEndpointPreset('ollama')?.group, 'local')
+  assert.equal(findEndpointPreset('lmstudio')?.group, 'local')
+  const host = readFileSync(resolve(import.meta.dirname, './index.ts'), 'utf8')
+  assert.match(host, /return Boolean\(\(config\.apiKeys\[endpoint\.id\] \?\? ''\)\.trim\(\)\)/)
+  assert.doesNotMatch(host, /return isLocalEndpoint\(endpoint\)/)
+  const composer = readFileSync(resolve(import.meta.dirname, '../web/composer.tsx'), 'utf8')
+  assert.match(composer, /allModels\.filter\(\(m\) => modelProviders\?\.\[m\.endpointId\]\)/)
+  assert.doesNotMatch(composer, /modelProviders\?\.\[m\.provider\]/)
 })
 
 test('builtin models reference known endpoints', () => {

--- a/packages/core-chat/src/host/model-catalog.ts
+++ b/packages/core-chat/src/host/model-catalog.ts
@@ -52,7 +52,7 @@ export interface LlmModelDef {
   builtin?: boolean
 }
 
-/** 内置入口：官方 + 常见中转站 / 聚合 + 本地。越全越好，URL 可按需在 UI 覆盖。 */
+/** 内置入口：默认侧栏只有 DeepSeek / Anthropic / OpenAI；其余进「添加」预设，不自动标已接入。 */
 export const LLM_ENDPOINT_PRESETS: LlmEndpointDef[] = [
   // ── 官方 ──
   {

--- a/packages/core-chat/src/web/composer.tsx
+++ b/packages/core-chat/src/web/composer.tsx
@@ -882,9 +882,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   </button>
                 </div>
                 {(() => {
-                  const visible = allModels.filter(
-                    (m) => modelProviders?.[m.endpointId] || modelProviders?.[m.provider],
-                  )
+                  const visible = allModels.filter((m) => modelProviders?.[m.endpointId])
                   if (!visible.length) {
                     return (
                       <div className="composer-model-empty">

--- a/packages/core-chat/src/web/config.tsx
+++ b/packages/core-chat/src/web/config.tsx
@@ -455,6 +455,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     if (fromPreset && !newLabel.trim()) {
       const body: Record<string, unknown> = { endpointId: fromPreset.id }
       if (newKey.trim()) body.setApiKey = { [fromPreset.id]: newKey.trim() }
+      else if (fromPreset.group === 'local') body.setApiKey = { [fromPreset.id]: 'local' }
       if (newUrl.trim() && newUrl.trim() !== fromPreset.defaultBaseUrl) {
         body.setBaseUrl = { [fromPreset.id]: newUrl.trim() }
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
模型设置和输入栏下拉默认只认官方三家：DeepSeek、Anthropic、OpenAI。

之前 vLLM / Ollama / LM Studio 因为本地免 Key 被当成「已接入」，再叠加按 `openai` 协议过滤，菜单里会把它们一起带出来。

改动：
- 没有 Key 就不算已配置（本地也不再自动亮）
- 模型列表只按入口 id 过滤，不再把所有 OpenAI 兼容模型混进 GPT 组
- 仍可在配置里「添加」这三家本地运行时；加 Ollama 等时会写占位 Key，之后就能用
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

