### PR TITLE
fix(fsdb): db_list 必须把表 blurb 留给 Agent

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -150,19 +150,38 @@ test('compact list drops createdAt/people unless those are the projected columns
   assert.deepEqual(times.rows, [['n1', 1]])
 })
 
-test('compact root drops view chrome; content write is ok only', () => {
+test('compact root keeps view.blurb for the agent; drops route chrome', () => {
   const root = pack.query({
     kind: 'root',
     path: '/',
     items: [
-      { id: 'notes', path: '/notes', kind: 'collection', label: '笔记', view: { moduleId: 'notes', route: '/notes', title: '笔记' } },
+      {
+        id: 'notes',
+        path: '/notes',
+        kind: 'collection',
+        label: '笔记',
+        view: { moduleId: 'notes', route: '/notes', title: '笔记', blurb: '列表 db_list /notes。本表没有 db_action。' },
+      },
       { id: 'views', path: '/views', kind: 'collection', label: 'views', view: null },
     ],
   }) as Record<string, unknown>
   assert.deepEqual(root, {
     kind: 'root',
-    items: [{ path: '/notes', label: '笔记' }, { path: '/views' }],
+    items: [
+      { path: '/notes', label: '笔记', view: { blurb: '列表 db_list /notes。本表没有 db_action。' } },
+      { path: '/views' },
+    ],
   })
+
+  const listed = pack.query({
+    kind: 'collection',
+    path: '/notes',
+    label: '笔记',
+    view: { moduleId: 'notes', route: '/notes', blurb: '列表 db_list /notes。' },
+    items: [{ id: 'n1', title: '草稿' }],
+  }) as Record<string, unknown>
+  assert.equal(listed.blurb, '列表 db_list /notes。')
+  assert.equal('view' in listed, false)
 
   const written = pack.query({
     kind: 'content',

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -66,6 +66,8 @@ export class AgentDbCompact {
     const id = this.omitRedundantId(path, rec.id)
     if (id) next.id = id
     if (typeof rec.label === 'string' && rec.label && rec.label !== path.slice(1)) next.label = rec.label
+    const blurb = this.viewBlurb(rec)
+    if (blurb) next.blurb = blurb
     if (Array.isArray(rec.caps)) next.caps = rec.caps
     if (Array.isArray(rec.items)) {
       if (typeof rec.total === 'number') next.total = rec.total
@@ -118,14 +120,25 @@ export class AgentDbCompact {
     if (!Array.isArray(entries)) return []
     return entries.flatMap((item) => {
       if (!item || typeof item !== 'object' || Array.isArray(item)) return []
-      const rec = item as { path?: unknown; label?: unknown; id?: unknown }
+      const rec = item as { path?: unknown; label?: unknown; id?: unknown; view?: unknown }
       const path = typeof rec.path === 'string' ? rec.path : typeof rec.id === 'string' ? `/${rec.id}` : ''
       if (!path) return []
       const label = typeof rec.label === 'string' ? rec.label : ''
       const next: Record<string, unknown> = { path }
       if (label && label !== path.slice(1)) next.label = label
+      const blurb = this.viewBlurb(rec)
+      if (blurb) next.view = { blurb }
       return [next]
     })
+  }
+
+  /** 表说明书必须留给 Agent：这张表是什么、用哪条 db_*。UI chrome（route/icon）仍可丢掉。 */
+  private viewBlurb(rec: { view?: unknown; blurb?: unknown }) {
+    if (typeof rec.blurb === 'string' && rec.blurb.trim()) return rec.blurb.trim()
+    const view = rec.view
+    if (!view || typeof view !== 'object' || Array.isArray(view)) return ''
+    const blurb = String((view as { blurb?: unknown }).blurb ?? '').trim()
+    return blurb
   }
 
   private recordValue(value: unknown) {

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -502,9 +502,14 @@ test('apply registers db_* tools', async () => {
   }
   const listed = await ctx.tools.invoke('db_list', { path: '/' })
   assert.equal((listed as { kind: string }).kind, 'root')
-  const paths = ((listed as { items: Array<{ path: string }> }).items ?? []).map((item) => item.path)
+  const items = ((listed as { items: Array<{ path: string; view?: { blurb?: string } }> }).items ?? [])
+  const paths = items.map((item) => item.path)
   assert.equal(paths.includes('/views'), true)
   assert.equal(paths.includes('/facets'), true)
+  const views = items.find((item) => item.path === '/views')
+  assert.match(String(views?.view?.blurb ?? ''), /db_list \/views/)
+  const facets = items.find((item) => item.path === '/facets')
+  assert.match(String(facets?.view?.blurb ?? ''), /db_list \/facets/)
 })
 
 test('db_list columns returns only those fields plus id', async () => {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -558,7 +558,7 @@ export class DatabaseService extends Service implements Database {
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     const caps = collectionCaps(spec)
     if (parts.length === 1) {
-      return { kind: 'collection' as const, path: spec.path, id: spec.id, label: spec.label ?? spec.id, schema: schemaFor(spec), caps }
+      return { kind: 'collection' as const, path: spec.path, id: spec.id, label: spec.label ?? spec.id, view: spec.view ?? null, schema: schemaFor(spec), caps }
     }
     if (parts.length === 2) {
       const record = await spec.get(parts[1]!)
@@ -604,6 +604,7 @@ export class DatabaseService extends Service implements Database {
           path: spec.path,
           id: spec.id,
           label: spec.label ?? spec.id,
+          view: spec.view ?? null,
           schema,
           total: 0,
           offset,
@@ -624,6 +625,7 @@ export class DatabaseService extends Service implements Database {
       path: spec.path,
       id: spec.id,
       label: spec.label ?? spec.id,
+      view: spec.view ?? null,
       schema,
       total,
       offset,
@@ -1150,7 +1152,7 @@ export function apply(ctx: Context) {
   }))))
   ctx.tools.register({
     name: 'db_list',
-    description: '列出 File System 路径：/ 为已登记表（path + 中文名），/<表> 为列式记录（不含 content、默认不含 createdAt/updatedAt/createdBy/updatedBy）。默认每页 50，最多 200。columns 参数只取需要的列。表结构用 db_stat。',
+    description: '列出 File System 路径：/ 为已登记表（path、中文名、view.blurb 说明书），/<表> 为列式记录（不含 content、默认不含 createdAt/updatedAt/createdBy/updatedBy）。默认每页 50，最多 200。columns 参数只取需要的列。表结构用 db_stat。',
     parameters: {
       type: 'object',
       properties: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
压 Agent 回包时丢掉了 `db_list /` 里每张表的 `view.blurb`。那是说明书（这张表是什么、用哪条 db_*、不要做什么），不能当 UI chrome 一起砍掉。

现在：
- `db_list /` 每张表保留 `view.blurb`
- `db_list /<表>` 也带表级 `blurb`
- route / icon / moduleId 仍然不给 Agent
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

