### PR TITLE
fix(chat): 模型二级浮窗不撑高一级，边框 1px

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -5,9 +5,9 @@ import type { ChatMessage } from './chat-types.ts'
 import { isAgentToolMode, normalizeAgentMode, type AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
 import { probeLlmConnection } from '@biu/host-llm'
-import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl, inferModelCapabilities, defaultThinkingFor, defaultEffortFor, defaultContextFor } from './model-catalog.ts'
-import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, ModelCapabilities } from './model-catalog.ts'
-export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, ModelCapabilities } from './model-catalog.ts'
+import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl, inferModelCapabilities, defaultModeValues, applyModeToLlm, hasKnob } from './model-catalog.ts'
+import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, SpeedMode, ModelModeValues } from './model-catalog.ts'
+export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, SpeedMode, ModelCapabilities } from './model-catalog.ts'
 export { LLM_ENDPOINT_PRESETS, LLM_MODEL_CATALOG } from './model-catalog.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { isSessionCompactPoint, type SessionConfig, type SessionEvent } from '@biu/type-session'
@@ -62,8 +62,12 @@ interface ChatConfig {
   thinking: ThinkingMode
   reasoningEffort: ReasoningEffort
   contextWindow: ContextWindow
+  speed: SpeedMode
   /** 按「入口::模型」记住档位，切模型时带回。 */
-  modelPrefs: Record<string, { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }>
+  modelPrefs: Record<
+    string,
+    { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow; speed?: SpeedMode }
+  >
 }
 
 function configPath() {
@@ -100,6 +104,7 @@ function defaults(): ChatConfig {
     thinking: 'enabled',
     reasoningEffort: 'high',
     contextWindow: '200k',
+    speed: 'slow',
     modelPrefs: {},
   }
 }
@@ -134,6 +139,7 @@ function writePersisted(config: ChatConfig) {
         thinking: config.thinking,
         reasoningEffort: config.reasoningEffort,
         contextWindow: config.contextWindow,
+        speed: config.speed,
         modelPrefs: config.modelPrefs,
         apiKeys: config.apiKeys,
         baseUrls: config.baseUrls,
@@ -172,8 +178,8 @@ function parseContext(value: unknown): ContextWindow | undefined {
   return value === '200k' || value === '1m' ? value : undefined
 }
 
-function hasModeCaps(caps: ModelCapabilities) {
-  return Boolean(caps.thinking || caps.speed || caps.effort?.length || caps.context?.length)
+function parseSpeed(value: unknown): SpeedMode | undefined {
+  return value === 'fast' || value === 'slow' ? value : undefined
 }
 
 function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPrefs'] {
@@ -184,11 +190,13 @@ function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPr
     const thinking = parseThinking(raw.thinking)
     const reasoningEffort = parseEffort(raw.reasoningEffort)
     const contextWindow = parseContext((raw as { contextWindow?: unknown }).contextWindow)
-    if (thinking || reasoningEffort || contextWindow) {
+    const speed = parseSpeed((raw as { speed?: unknown }).speed)
+    if (thinking || reasoningEffort || contextWindow || speed) {
       out[key] = {
         ...(thinking ? { thinking } : {}),
         ...(reasoningEffort ? { reasoningEffort } : {}),
         ...(contextWindow ? { contextWindow } : {}),
+        ...(speed ? { speed } : {}),
       }
     }
   }
@@ -198,9 +206,13 @@ function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPr
 function hydrateModelMode(config: ChatConfig) {
   const caps = inferModelCapabilities(config.model, config.provider)
   const saved = config.modelPrefs[prefKey(config.endpointId, config.model)]
-  config.thinking = saved?.thinking ?? defaultThinkingFor(caps)
-  config.reasoningEffort = saved?.reasoningEffort ?? defaultEffortFor(caps)
-  config.contextWindow = saved?.contextWindow ?? defaultContextFor(caps)
+  const defaults = defaultModeValues(caps)
+  config.thinking = saved?.thinking ?? defaults.thinking
+  config.reasoningEffort = saved?.reasoningEffort ?? defaults.effort
+  config.contextWindow = saved?.contextWindow ?? defaults.context
+  config.speed =
+    saved?.speed ??
+    (hasKnob(caps, 'speed') && config.thinking === 'disabled' ? 'fast' : defaults.speed)
 }
 
 function rememberModelPrefs(config: ChatConfig) {
@@ -208,6 +220,7 @@ function rememberModelPrefs(config: ChatConfig) {
     thinking: config.thinking,
     reasoningEffort: config.reasoningEffort,
     contextWindow: config.contextWindow,
+    speed: config.speed,
   }
 }
 
@@ -348,6 +361,7 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
     thinking: parseThinking(saved.thinking) ?? base.thinking,
     reasoningEffort: parseEffort(saved.reasoningEffort) ?? base.reasoningEffort,
     contextWindow: parseContext(saved.contextWindow) ?? base.contextWindow,
+    speed: parseSpeed(saved.speed) ?? base.speed,
     modelPrefs: mergeModelPrefs(saved),
   }
   hydrateModelMode(next)
@@ -447,6 +461,7 @@ export class ChatService extends Service {
       thinking: this.config.thinking,
       reasoningEffort: this.config.reasoningEffort,
       contextWindow: this.config.contextWindow,
+      speed: this.config.speed,
       capabilities: inferModelCapabilities(this.config.model, this.config.provider),
       /** 当前默认入口是否已配置（兼容旧语义，供 banner 等使用）。 */
       configured: current ? endpointConfigured(this.config, current) : Boolean((this.config.apiKeys[this.config.provider] ?? '').trim()),
@@ -535,17 +550,18 @@ export class ChatService extends Service {
     const key = apiKey.trim() || (endpoint && isLocalEndpoint(endpoint) ? 'local' : '')
     const caps = inferModelCapabilities(effective.model, provider)
     const prefs = this.config.modelPrefs[prefKey(endpointId, effective.model)]
+    const mode: ModelModeValues = {
+      thinking: prefs?.thinking ?? this.config.thinking,
+      speed: prefs?.speed ?? this.config.speed,
+      effort: prefs?.reasoningEffort ?? this.config.reasoningEffort,
+      context: prefs?.contextWindow ?? this.config.contextWindow,
+    }
     return {
       provider,
       apiKey: key,
       model: effective.model,
       ...(endpoint ? { baseUrl: effectiveBaseUrl(this.config, endpoint) } : {}),
-      ...(hasModeCaps(caps)
-        ? {
-            thinking: prefs?.thinking ?? this.config.thinking,
-            reasoningEffort: prefs?.reasoningEffort ?? this.config.reasoningEffort,
-          }
-        : {}),
+      ...applyModeToLlm(caps, mode),
     }
   }
 
@@ -654,6 +670,7 @@ export class ChatService extends Service {
       thinking: ThinkingMode
       reasoningEffort: ReasoningEffort
       contextWindow: ContextWindow
+      speed: SpeedMode
       /** 按入口更新 key；空串 / null 清除 */
       setApiKey: Partial<Record<string, string | null>>
       /** 按入口覆盖 baseUrl；空串清除覆盖、回到 preset 默认 */
@@ -829,12 +846,20 @@ export class ChatService extends Service {
     const thinkingPatch = parseThinking(next.thinking)
     const effortPatch = parseEffort(next.reasoningEffort)
     const contextPatch = parseContext(next.contextWindow)
-    if (afterKey !== beforeKey && thinkingPatch == null && effortPatch == null && contextPatch == null) {
+    const speedPatch = parseSpeed(next.speed)
+    if (
+      afterKey !== beforeKey &&
+      thinkingPatch == null &&
+      effortPatch == null &&
+      contextPatch == null &&
+      speedPatch == null
+    ) {
       hydrateModelMode(this.config)
     }
     if (thinkingPatch) this.config.thinking = thinkingPatch
     if (effortPatch) this.config.reasoningEffort = effortPatch
     if (contextPatch) this.config.contextWindow = contextPatch
+    if (speedPatch) this.config.speed = speedPatch
     rememberModelPrefs(this.config)
     this.syncLlm()
     this.syncToolsMode()

--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -5,9 +5,9 @@ import type { ChatMessage } from './chat-types.ts'
 import { isAgentToolMode, normalizeAgentMode, type AgentToolMode } from '@biu/host-tools'
 import type { LlmConfig } from '@biu/host-llm'
 import { probeLlmConnection } from '@biu/host-llm'
-import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl, inferModelCapabilities, defaultThinkingFor, defaultEffortFor } from './model-catalog.ts'
-import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ModelCapabilities } from './model-catalog.ts'
-export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ModelCapabilities } from './model-catalog.ts'
+import { LLM_MODEL_CATALOG, LLM_ENDPOINT_PRESETS, describeProvider, defaultModelFor, CHAT_PROVIDERS, findEndpointPreset, normalizeBaseUrl, inferModelCapabilities, defaultThinkingFor, defaultEffortFor, defaultContextFor } from './model-catalog.ts'
+import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, ModelCapabilities } from './model-catalog.ts'
+export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, ModelCapabilities } from './model-catalog.ts'
 export { LLM_ENDPOINT_PRESETS, LLM_MODEL_CATALOG } from './model-catalog.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
 import { isSessionCompactPoint, type SessionConfig, type SessionEvent } from '@biu/type-session'
@@ -61,8 +61,9 @@ interface ChatConfig {
   /** 当前模型的思考开关；能思考的模型默认 enabled（对齐上游）。 */
   thinking: ThinkingMode
   reasoningEffort: ReasoningEffort
+  contextWindow: ContextWindow
   /** 按「入口::模型」记住档位，切模型时带回。 */
-  modelPrefs: Record<string, { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }>
+  modelPrefs: Record<string, { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }>
 }
 
 function configPath() {
@@ -98,6 +99,7 @@ function defaults(): ChatConfig {
     extraTools: [],
     thinking: 'enabled',
     reasoningEffort: 'high',
+    contextWindow: '200k',
     modelPrefs: {},
   }
 }
@@ -131,6 +133,7 @@ function writePersisted(config: ChatConfig) {
         extraTools: config.extraTools,
         thinking: config.thinking,
         reasoningEffort: config.reasoningEffort,
+        contextWindow: config.contextWindow,
         modelPrefs: config.modelPrefs,
         apiKeys: config.apiKeys,
         baseUrls: config.baseUrls,
@@ -165,6 +168,14 @@ function parseEffort(value: unknown): ReasoningEffort | undefined {
   return value === 'high' || value === 'max' ? value : undefined
 }
 
+function parseContext(value: unknown): ContextWindow | undefined {
+  return value === '200k' || value === '1m' ? value : undefined
+}
+
+function hasModeCaps(caps: ModelCapabilities) {
+  return Boolean(caps.thinking || caps.speed || caps.effort?.length || caps.context?.length)
+}
+
 function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPrefs'] {
   const out: ChatConfig['modelPrefs'] = {}
   if (!saved?.modelPrefs || typeof saved.modelPrefs !== 'object') return out
@@ -172,7 +183,14 @@ function mergeModelPrefs(saved: Partial<ChatConfig> | null): ChatConfig['modelPr
     if (!raw || typeof raw !== 'object') continue
     const thinking = parseThinking(raw.thinking)
     const reasoningEffort = parseEffort(raw.reasoningEffort)
-    if (thinking || reasoningEffort) out[key] = { ...(thinking ? { thinking } : {}), ...(reasoningEffort ? { reasoningEffort } : {}) }
+    const contextWindow = parseContext((raw as { contextWindow?: unknown }).contextWindow)
+    if (thinking || reasoningEffort || contextWindow) {
+      out[key] = {
+        ...(thinking ? { thinking } : {}),
+        ...(reasoningEffort ? { reasoningEffort } : {}),
+        ...(contextWindow ? { contextWindow } : {}),
+      }
+    }
   }
   return out
 }
@@ -182,12 +200,14 @@ function hydrateModelMode(config: ChatConfig) {
   const saved = config.modelPrefs[prefKey(config.endpointId, config.model)]
   config.thinking = saved?.thinking ?? defaultThinkingFor(caps)
   config.reasoningEffort = saved?.reasoningEffort ?? defaultEffortFor(caps)
+  config.contextWindow = saved?.contextWindow ?? defaultContextFor(caps)
 }
 
 function rememberModelPrefs(config: ChatConfig) {
   config.modelPrefs[prefKey(config.endpointId, config.model)] = {
     thinking: config.thinking,
     reasoningEffort: config.reasoningEffort,
+    contextWindow: config.contextWindow,
   }
 }
 
@@ -327,6 +347,7 @@ function mergePersisted(base: ChatConfig, saved: Partial<ChatConfig> | null): Ch
       : base.extraTools,
     thinking: parseThinking(saved.thinking) ?? base.thinking,
     reasoningEffort: parseEffort(saved.reasoningEffort) ?? base.reasoningEffort,
+    contextWindow: parseContext(saved.contextWindow) ?? base.contextWindow,
     modelPrefs: mergeModelPrefs(saved),
   }
   hydrateModelMode(next)
@@ -425,6 +446,7 @@ export class ChatService extends Service {
       agentMode: this.config.agentMode,
       thinking: this.config.thinking,
       reasoningEffort: this.config.reasoningEffort,
+      contextWindow: this.config.contextWindow,
       capabilities: inferModelCapabilities(this.config.model, this.config.provider),
       /** 当前默认入口是否已配置（兼容旧语义，供 banner 等使用）。 */
       configured: current ? endpointConfigured(this.config, current) : Boolean((this.config.apiKeys[this.config.provider] ?? '').trim()),
@@ -518,7 +540,7 @@ export class ChatService extends Service {
       apiKey: key,
       model: effective.model,
       ...(endpoint ? { baseUrl: effectiveBaseUrl(this.config, endpoint) } : {}),
-      ...(caps.thinking || caps.effort?.length
+      ...(hasModeCaps(caps)
         ? {
             thinking: prefs?.thinking ?? this.config.thinking,
             reasoningEffort: prefs?.reasoningEffort ?? this.config.reasoningEffort,
@@ -631,6 +653,7 @@ export class ChatService extends Service {
       extraTools: string[]
       thinking: ThinkingMode
       reasoningEffort: ReasoningEffort
+      contextWindow: ContextWindow
       /** 按入口更新 key；空串 / null 清除 */
       setApiKey: Partial<Record<string, string | null>>
       /** 按入口覆盖 baseUrl；空串清除覆盖、回到 preset 默认 */
@@ -805,11 +828,13 @@ export class ChatService extends Service {
     const afterKey = prefKey(this.config.endpointId, this.config.model)
     const thinkingPatch = parseThinking(next.thinking)
     const effortPatch = parseEffort(next.reasoningEffort)
-    if (afterKey !== beforeKey && thinkingPatch == null && effortPatch == null) {
+    const contextPatch = parseContext(next.contextWindow)
+    if (afterKey !== beforeKey && thinkingPatch == null && effortPatch == null && contextPatch == null) {
       hydrateModelMode(this.config)
     }
     if (thinkingPatch) this.config.thinking = thinkingPatch
     if (effortPatch) this.config.reasoningEffort = effortPatch
+    if (contextPatch) this.config.contextWindow = contextPatch
     rememberModelPrefs(this.config)
     this.syncLlm()
     this.syncToolsMode()

--- a/packages/core-chat/src/host/model-catalog.test.ts
+++ b/packages/core-chat/src/host/model-catalog.test.ts
@@ -10,6 +10,8 @@ import {
   normalizeBaseUrl,
   inferModelCapabilities,
   defaultThinkingFor,
+  knobIds,
+  applyModeToLlm,
 } from './model-catalog.ts'
 
 test('resolveChatCompletionsUrl uses defaults when baseUrl missing', () => {
@@ -95,47 +97,40 @@ test('normalizeBaseUrl strips trailing slash', () => {
 
 test('DeepSeek V4 can toggle thinking and High/Max', () => {
   const caps = inferModelCapabilities('deepseek-v4-flash', 'deepseek')
-  assert.equal(caps.thinking, true)
-  assert.equal(caps.speed, undefined)
-  assert.equal(caps.context, undefined)
-  assert.deepEqual(caps.effort, ['high', 'max'])
+  assert.deepEqual(knobIds(caps), ['thinking', 'effort'])
   assert.equal(defaultThinkingFor(caps), 'enabled')
 })
 
 test('Grok exposes a speed switch, not thinking', () => {
   const caps = inferModelCapabilities('grok-4', 'openai')
-  assert.equal(caps.speed, true)
-  assert.equal(caps.thinking, undefined)
-  assert.equal(caps.effort, undefined)
+  assert.deepEqual(knobIds(caps), ['speed'])
 })
 
 test('GPT-4o has no extra knobs', () => {
   const caps = inferModelCapabilities('gpt-4o', 'openai')
-  assert.equal(caps.thinking, undefined)
-  assert.equal(caps.speed, undefined)
-  assert.equal(caps.effort, undefined)
-  assert.equal(caps.context, undefined)
+  assert.deepEqual(knobIds(caps), [])
 })
 
 test('GPT-4.1 exposes context size only', () => {
   const caps = inferModelCapabilities('gpt-4.1', 'openai')
-  assert.deepEqual(caps.context, ['200k', '1m'])
-  assert.equal(caps.thinking, undefined)
-  assert.equal(caps.speed, undefined)
+  assert.deepEqual(knobIds(caps), ['context'])
 })
 
 test('GPT-5 exposes speed, effort and context', () => {
   const caps = inferModelCapabilities('gpt-5', 'openai')
-  assert.equal(caps.speed, true)
-  assert.equal(caps.thinking, undefined)
-  assert.deepEqual(caps.effort, ['high', 'max'])
-  assert.deepEqual(caps.context, ['200k', '1m'])
+  assert.deepEqual(knobIds(caps), ['speed', 'effort', 'context'])
 })
 
 test('o3 exposes speed and effort, not a thinking switch', () => {
   const caps = inferModelCapabilities('o3-mini', 'openai')
-  assert.equal(caps.thinking, undefined)
-  assert.equal(caps.speed, true)
-  assert.deepEqual(caps.effort, ['high', 'max'])
-  assert.equal(caps.context, undefined)
+  assert.deepEqual(knobIds(caps), ['speed', 'effort'])
+})
+
+test('applyModeToLlm maps speed without using thinking knobs', () => {
+  const caps = inferModelCapabilities('gpt-5', 'openai')
+  const fast = applyModeToLlm(caps, { thinking: 'enabled', speed: 'fast', effort: 'max', context: '1m' })
+  assert.deepEqual(fast, { thinking: 'disabled' })
+  const slow = applyModeToLlm(caps, { thinking: 'enabled', speed: 'slow', effort: 'max', context: '1m' })
+  assert.equal(slow.thinking, 'enabled')
+  assert.equal(slow.reasoningEffort, 'max')
 })

--- a/packages/core-chat/src/host/model-catalog.test.ts
+++ b/packages/core-chat/src/host/model-catalog.test.ts
@@ -96,8 +96,16 @@ test('normalizeBaseUrl strips trailing slash', () => {
 test('DeepSeek V4 can toggle thinking and High/Max', () => {
   const caps = inferModelCapabilities('deepseek-v4-flash', 'deepseek')
   assert.equal(caps.thinking, true)
+  assert.equal(caps.speed, undefined)
   assert.deepEqual(caps.effort, ['high', 'max'])
   assert.equal(defaultThinkingFor(caps), 'enabled')
+})
+
+test('Grok exposes a speed switch, not thinking', () => {
+  const caps = inferModelCapabilities('grok-4', 'openai')
+  assert.equal(caps.speed, true)
+  assert.equal(caps.thinking, undefined)
+  assert.equal(caps.effort, undefined)
 })
 
 test('GPT-4o has no thinking extras', () => {

--- a/packages/core-chat/src/host/model-catalog.test.ts
+++ b/packages/core-chat/src/host/model-catalog.test.ts
@@ -97,6 +97,7 @@ test('DeepSeek V4 can toggle thinking and High/Max', () => {
   const caps = inferModelCapabilities('deepseek-v4-flash', 'deepseek')
   assert.equal(caps.thinking, true)
   assert.equal(caps.speed, undefined)
+  assert.equal(caps.context, undefined)
   assert.deepEqual(caps.effort, ['high', 'max'])
   assert.equal(defaultThinkingFor(caps), 'enabled')
 })
@@ -108,14 +109,33 @@ test('Grok exposes a speed switch, not thinking', () => {
   assert.equal(caps.effort, undefined)
 })
 
-test('GPT-4o has no thinking extras', () => {
+test('GPT-4o has no extra knobs', () => {
   const caps = inferModelCapabilities('gpt-4o', 'openai')
   assert.equal(caps.thinking, undefined)
+  assert.equal(caps.speed, undefined)
   assert.equal(caps.effort, undefined)
+  assert.equal(caps.context, undefined)
 })
 
-test('o3 exposes effort but not a thinking off switch', () => {
-  const caps = inferModelCapabilities('o3-mini', 'openai')
+test('GPT-4.1 exposes context size only', () => {
+  const caps = inferModelCapabilities('gpt-4.1', 'openai')
+  assert.deepEqual(caps.context, ['200k', '1m'])
+  assert.equal(caps.thinking, undefined)
+  assert.equal(caps.speed, undefined)
+})
+
+test('GPT-5 exposes speed, effort and context', () => {
+  const caps = inferModelCapabilities('gpt-5', 'openai')
+  assert.equal(caps.speed, true)
   assert.equal(caps.thinking, undefined)
   assert.deepEqual(caps.effort, ['high', 'max'])
+  assert.deepEqual(caps.context, ['200k', '1m'])
+})
+
+test('o3 exposes speed and effort, not a thinking switch', () => {
+  const caps = inferModelCapabilities('o3-mini', 'openai')
+  assert.equal(caps.thinking, undefined)
+  assert.equal(caps.speed, true)
+  assert.deepEqual(caps.effort, ['high', 'max'])
+  assert.equal(caps.context, undefined)
 })

--- a/packages/core-chat/src/host/model-catalog.ts
+++ b/packages/core-chat/src/host/model-catalog.ts
@@ -727,8 +727,10 @@ export type ReasoningEffort = 'high' | 'max'
 export type ThinkingMode = 'enabled' | 'disabled'
 
 export interface ModelCapabilities {
-  /** 可开关思考（DeepSeek V4 / Claude 扩展思考） */
+  /** 可开关思考（DeepSeek V4 / Claude 扩展思考）。不是快/慢。 */
   thinking?: boolean
+  /** 可调快/慢（Grok 等）。开 = 快，映射为 thinking disabled。 */
+  speed?: boolean
   /** 可调推理档位 High / Max */
   effort?: Array<ReasoningEffort>
 }
@@ -744,6 +746,9 @@ export function inferModelCapabilities(model: string, provider: ChatProvider): M
   ) {
     return { thinking: true, effort: ['high', 'max'] }
   }
+  if (id.includes('grok')) {
+    return { speed: true }
+  }
   if (/(^|[^a-z])o[1-4]([^a-z]|$)|gpt-5/.test(id)) {
     return { effort: ['high', 'max'] }
   }
@@ -754,8 +759,8 @@ export function inferModelCapabilities(model: string, provider: ChatProvider): M
 }
 
 export function defaultThinkingFor(caps: ModelCapabilities): ThinkingMode {
-  // 默认同 API：能思考就开。用户可在菜单里关成「快」。
-  return caps.thinking || caps.effort?.length ? 'enabled' : 'disabled'
+  // 能思考就默认开。仅 speed 模型默认慢（思考开），用户可打成「快」。
+  return caps.thinking || caps.speed || caps.effort?.length ? 'enabled' : 'disabled'
 }
 
 export function defaultEffortFor(caps: ModelCapabilities): ReasoningEffort {

--- a/packages/core-chat/src/host/model-catalog.ts
+++ b/packages/core-chat/src/host/model-catalog.ts
@@ -725,17 +725,24 @@ export function endpointProtocolProvider(endpoint: LlmEndpointDef): ChatProvider
 
 export type ReasoningEffort = 'high' | 'max'
 export type ThinkingMode = 'enabled' | 'disabled'
+export type ContextWindow = '200k' | '1m'
 
+/**
+ * 当前模型在一级菜单里能露出的配置。切模型后整排换掉，不是全局 Fast。
+ * DeepSeek：思考 + High/Max；GPT-5：快慢 + 力度 + 上下文；各家不同。
+ */
 export interface ModelCapabilities {
-  /** 可开关思考（DeepSeek V4 / Claude 扩展思考）。不是快/慢。 */
+  /** DeepSeek / Claude：是否思考。 */
   thinking?: boolean
-  /** 可调快/慢（Grok 等）。开 = 快，映射为 thinking disabled。 */
+  /** GPT-5 / o 系列 / Grok：快（少推理）或慢。开 = thinking disabled。 */
   speed?: boolean
-  /** 可调推理档位 High / Max */
+  /** High / Max 推理档。 */
   effort?: Array<ReasoningEffort>
+  /** 上下文窗口档，如 200k / 1M。 */
+  context?: Array<ContextWindow>
 }
 
-/** 按模型 id 推断：只露出该模型真正有的 1～2 项，避免一堆无效滑杆。 */
+/** 按模型 id 推断：只露出该模型真正有的项。 */
 export function inferModelCapabilities(model: string, provider: ChatProvider): ModelCapabilities {
   const id = model.toLowerCase()
   if (
@@ -749,8 +756,14 @@ export function inferModelCapabilities(model: string, provider: ChatProvider): M
   if (id.includes('grok')) {
     return { speed: true }
   }
-  if (/(^|[^a-z])o[1-4]([^a-z]|$)|gpt-5/.test(id)) {
-    return { effort: ['high', 'max'] }
+  if (/gpt-5/.test(id)) {
+    return { speed: true, effort: ['high', 'max'], context: ['200k', '1m'] }
+  }
+  if (/(^|[^a-z])o[1-4]([^a-z]|$)/.test(id)) {
+    return { speed: true, effort: ['high', 'max'] }
+  }
+  if (/gpt-4\.1/.test(id)) {
+    return { context: ['200k', '1m'] }
   }
   if (provider === 'anthropic' && /claude-(opus|sonnet)-4|claude-4|claude-3-7/.test(id)) {
     return { thinking: true }
@@ -759,12 +772,15 @@ export function inferModelCapabilities(model: string, provider: ChatProvider): M
 }
 
 export function defaultThinkingFor(caps: ModelCapabilities): ThinkingMode {
-  // 能思考就默认开。仅 speed 模型默认慢（思考开），用户可打成「快」。
   return caps.thinking || caps.speed || caps.effort?.length ? 'enabled' : 'disabled'
 }
 
 export function defaultEffortFor(caps: ModelCapabilities): ReasoningEffort {
   return caps.effort?.includes('high') ? 'high' : 'max'
+}
+
+export function defaultContextFor(caps: ModelCapabilities): ContextWindow {
+  return caps.context?.includes('200k') ? '200k' : caps.context?.[0] ?? '200k'
 }
 
 /** 规范化用户输入的 baseUrl（去尾斜杠）。 */

--- a/packages/core-chat/src/host/model-catalog.ts
+++ b/packages/core-chat/src/host/model-catalog.ts
@@ -726,61 +726,131 @@ export function endpointProtocolProvider(endpoint: LlmEndpointDef): ChatProvider
 export type ReasoningEffort = 'high' | 'max'
 export type ThinkingMode = 'enabled' | 'disabled'
 export type ContextWindow = '200k' | '1m'
+export type SpeedMode = 'fast' | 'slow'
+export type ModelKnobId = 'thinking' | 'speed' | 'effort' | 'context'
 
-/**
- * 当前模型在一级菜单里能露出的配置。切模型后整排换掉，不是全局 Fast。
- * DeepSeek：思考 + High/Max；GPT-5：快慢 + 力度 + 上下文；各家不同。
- */
-export interface ModelCapabilities {
-  /** DeepSeek / Claude：是否思考。 */
-  thinking?: boolean
-  /** GPT-5 / o 系列 / Grok：快（少推理）或慢。开 = thinking disabled。 */
-  speed?: boolean
-  /** High / Max 推理档。 */
-  effort?: Array<ReasoningEffort>
-  /** 上下文窗口档，如 200k / 1M。 */
-  context?: Array<ContextWindow>
+export type ModelToggleKnob = {
+  id: 'thinking' | 'speed'
+  kind: 'toggle'
+  label: string
+  on: string
+  off: string
 }
 
-/** 按模型 id 推断：只露出该模型真正有的项。 */
+export type ModelChoiceKnob = {
+  id: 'effort' | 'context'
+  kind: 'choice'
+  label: string
+  options: Array<{ value: string; label: string }>
+}
+
+export type ModelKnob = ModelToggleKnob | ModelChoiceKnob
+
+/** 一级菜单只消费 knobs，不关心是哪家模型。 */
+export interface ModelCapabilities {
+  knobs: ModelKnob[]
+}
+
+export type ModelModeValues = {
+  thinking: ThinkingMode
+  speed: SpeedMode
+  effort: ReasoningEffort
+  context: ContextWindow
+}
+
+export const THINKING_KNOB: ModelToggleKnob = {
+  id: 'thinking',
+  kind: 'toggle',
+  label: '思考',
+  on: 'enabled',
+  off: 'disabled',
+}
+
+export const SPEED_KNOB: ModelToggleKnob = {
+  id: 'speed',
+  kind: 'toggle',
+  label: '快',
+  on: 'fast',
+  off: 'slow',
+}
+
+export const EFFORT_KNOB: ModelChoiceKnob = {
+  id: 'effort',
+  kind: 'choice',
+  label: '力度',
+  options: [
+    { value: 'high', label: 'High' },
+    { value: 'max', label: 'Max' },
+  ],
+}
+
+export const CONTEXT_KNOB: ModelChoiceKnob = {
+  id: 'context',
+  kind: 'choice',
+  label: '上下文',
+  options: [
+    { value: '200k', label: '200k' },
+    { value: '1m', label: '1M' },
+  ],
+}
+
+const FAMILIES: Array<{ match: (id: string, provider: ChatProvider) => boolean; knobs: ModelKnob[] }> = [
+  {
+    match: (id, provider) =>
+      provider === 'deepseek' ||
+      id.includes('deepseek-v4') ||
+      id.includes('deepseek-reasoner') ||
+      /deepseek-r1/.test(id),
+    knobs: [THINKING_KNOB, EFFORT_KNOB],
+  },
+  { match: (id) => id.includes('grok'), knobs: [SPEED_KNOB] },
+  { match: (id) => /gpt-5/.test(id), knobs: [SPEED_KNOB, EFFORT_KNOB, CONTEXT_KNOB] },
+  { match: (id) => /(^|[^a-z])o[1-4]([^a-z]|$)/.test(id), knobs: [SPEED_KNOB, EFFORT_KNOB] },
+  { match: (id) => /gpt-4\.1/.test(id), knobs: [CONTEXT_KNOB] },
+  {
+    match: (id, provider) =>
+      provider === 'anthropic' && /claude-(opus|sonnet)-4|claude-4|claude-3-7/.test(id),
+    knobs: [THINKING_KNOB],
+  },
+]
+
 export function inferModelCapabilities(model: string, provider: ChatProvider): ModelCapabilities {
   const id = model.toLowerCase()
-  if (
-    provider === 'deepseek' ||
-    id.includes('deepseek-v4') ||
-    id.includes('deepseek-reasoner') ||
-    /deepseek-r1/.test(id)
-  ) {
-    return { thinking: true, effort: ['high', 'max'] }
+  return { knobs: FAMILIES.find((family) => family.match(id, provider))?.knobs ?? [] }
+}
+
+export function hasKnob(caps: ModelCapabilities, id: ModelKnobId) {
+  return (caps.knobs ?? []).some((knob) => knob.id === id)
+}
+
+export function knobIds(caps: ModelCapabilities): ModelKnobId[] {
+  return (caps.knobs ?? []).map((knob) => knob.id)
+}
+
+export function defaultModeValues(caps: ModelCapabilities): ModelModeValues {
+  return {
+    thinking: hasKnob(caps, 'thinking') || hasKnob(caps, 'speed') || hasKnob(caps, 'effort') ? 'enabled' : 'disabled',
+    speed: 'slow',
+    effort: 'high',
+    context: '200k',
   }
-  if (id.includes('grok')) {
-    return { speed: true }
-  }
-  if (/gpt-5/.test(id)) {
-    return { speed: true, effort: ['high', 'max'], context: ['200k', '1m'] }
-  }
-  if (/(^|[^a-z])o[1-4]([^a-z]|$)/.test(id)) {
-    return { speed: true, effort: ['high', 'max'] }
-  }
-  if (/gpt-4\.1/.test(id)) {
-    return { context: ['200k', '1m'] }
-  }
-  if (provider === 'anthropic' && /claude-(opus|sonnet)-4|claude-4|claude-3-7/.test(id)) {
-    return { thinking: true }
-  }
-  return {}
 }
 
 export function defaultThinkingFor(caps: ModelCapabilities): ThinkingMode {
-  return caps.thinking || caps.speed || caps.effort?.length ? 'enabled' : 'disabled'
+  return defaultModeValues(caps).thinking
 }
 
-export function defaultEffortFor(caps: ModelCapabilities): ReasoningEffort {
-  return caps.effort?.includes('high') ? 'high' : 'max'
-}
-
-export function defaultContextFor(caps: ModelCapabilities): ContextWindow {
-  return caps.context?.includes('200k') ? '200k' : caps.context?.[0] ?? '200k'
+/** 只有发请求时才把 knobs 收成上游字段；快 ≠ 思考。 */
+export function applyModeToLlm(caps: ModelCapabilities, mode: ModelModeValues): {
+  thinking?: ThinkingMode
+  reasoningEffort?: ReasoningEffort
+} {
+  if (!(caps.knobs ?? []).length) return {}
+  if (hasKnob(caps, 'speed') && mode.speed === 'fast') return { thinking: 'disabled' }
+  return {
+    ...(hasKnob(caps, 'thinking') || hasKnob(caps, 'speed') ? { thinking: mode.thinking } : {}),
+    ...(hasKnob(caps, 'effort') ? { reasoningEffort: mode.effort } : {}),
+  }
 }
 
 /** 规范化用户输入的 baseUrl（去尾斜杠）。 */

--- a/packages/core-chat/src/web/composer-model-menu.test.ts
+++ b/packages/core-chat/src/web/composer-model-menu.test.ts
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict'
 
 const root = resolve(import.meta.dirname, '../../../..')
 
-test('composer model menu is a nested Fast / effort / model pop', () => {
+test('composer model menu is a nested thinking / speed / effort / model pop', () => {
   const menu = readFileSync(resolve(import.meta.dirname, './composer-model-menu.tsx'), 'utf8')
   const composer = readFileSync(resolve(import.meta.dirname, './composer.tsx'), 'utf8')
   const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
@@ -14,12 +14,19 @@ test('composer model menu is a nested Fast / effort / model pop', () => {
   assert.match(menu, /composer-model-panel/)
   assert.match(menu, /composer-model-flyout/)
   assert.match(menu, /composer-model-switch/)
-  assert.match(menu, />Fast</)
+  assert.match(menu, />思考</)
+  assert.match(menu, />快</)
+  assert.doesNotMatch(menu, />Fast</)
   assert.match(menu, />力度</)
   assert.match(menu, />模型</)
   assert.match(menu, /添加模型/)
   assert.match(menu, /placeholder="搜索模型"/)
-  assert.match(css, /\.composer-model-pop\s*\{/)
+  assert.match(css, /\.composer-model-pop\s*\{[^}]*align-items:\s*flex-end/)
+  assert.match(css, /\.composer-model-panel,\s*\n\.composer-model-flyout\s*\{[^}]*border:\s*1px solid/)
+  assert.doesNotMatch(
+    css,
+    /\.composer-model-panel,\s*\n\.composer-model-flyout\s*\{[^}]*--dsw-shadow-lv2/,
+  )
   assert.match(css, /\.composer-model-switch\.is-on/)
   assert.match(css, /\.composer-model-add-models/)
 })

--- a/packages/core-chat/src/web/composer-model-menu.test.ts
+++ b/packages/core-chat/src/web/composer-model-menu.test.ts
@@ -5,23 +5,23 @@ import assert from 'node:assert/strict'
 
 const root = resolve(import.meta.dirname, '../../../..')
 
-test('composer model menu shows per-model knobs plus nested model list', () => {
+test('composer model menu renders knobs from catalog, not hardcoded vendor rows', () => {
   const menu = readFileSync(resolve(import.meta.dirname, './composer-model-menu.tsx'), 'utf8')
+  const catalog = readFileSync(resolve(import.meta.dirname, '../host/model-catalog.ts'), 'utf8')
   const composer = readFileSync(resolve(import.meta.dirname, './composer.tsx'), 'utf8')
   const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
   assert.match(composer, /ComposerModelMenu/)
   assert.doesNotMatch(composer, /composer-model-modes/)
-  assert.match(menu, /composer-model-panel/)
-  assert.match(menu, /composer-model-flyout/)
-  assert.match(menu, /composer-model-switch/)
-  assert.match(menu, />思考</)
-  assert.match(menu, />快</)
-  assert.match(menu, />上下文</)
+  assert.match(menu, /modelKnobs\(capabilities\)/)
+  assert.match(menu, /knob\.kind === 'toggle'/)
   assert.doesNotMatch(menu, />Fast</)
-  assert.match(menu, />力度</)
   assert.match(menu, />模型</)
   assert.match(menu, /添加模型/)
   assert.match(menu, /placeholder="搜索模型"/)
+  assert.match(catalog, /label: '思考'/)
+  assert.match(catalog, /label: '快'/)
+  assert.match(catalog, /label: '力度'/)
+  assert.match(catalog, /label: '上下文'/)
   assert.match(css, /\.composer-model-pop\s*\{[^}]*align-items:\s*flex-end/)
   assert.match(css, /\.composer-model-panel,\s*\n\.composer-model-flyout\s*\{[^}]*border:\s*1px solid/)
   assert.doesNotMatch(

--- a/packages/core-chat/src/web/composer-model-menu.test.ts
+++ b/packages/core-chat/src/web/composer-model-menu.test.ts
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict'
 
 const root = resolve(import.meta.dirname, '../../../..')
 
-test('composer model menu is a nested thinking / speed / effort / model pop', () => {
+test('composer model menu shows per-model knobs plus nested model list', () => {
   const menu = readFileSync(resolve(import.meta.dirname, './composer-model-menu.tsx'), 'utf8')
   const composer = readFileSync(resolve(import.meta.dirname, './composer.tsx'), 'utf8')
   const css = readFileSync(resolve(root, 'web/style.css'), 'utf8')
@@ -16,6 +16,7 @@ test('composer model menu is a nested thinking / speed / effort / model pop', ()
   assert.match(menu, /composer-model-switch/)
   assert.match(menu, />思考</)
   assert.match(menu, />快</)
+  assert.match(menu, />上下文</)
   assert.doesNotMatch(menu, />Fast</)
   assert.match(menu, />力度</)
   assert.match(menu, />模型</)

--- a/packages/core-chat/src/web/composer-model-menu.tsx
+++ b/packages/core-chat/src/web/composer-model-menu.tsx
@@ -2,12 +2,11 @@ import { useMemo, useState } from 'react'
 import { CheckIcon, ChevronRightIcon, MagnifyingGlassIcon } from '@heroicons/react/16/solid'
 import {
   inferModelCapabilities,
-  type ContextWindow,
   type ModelCapabilities,
-  type ReasoningEffort,
-  type ThinkingMode,
+  type ModelKnob,
+  type ModelModeValues,
 } from '../host/model-catalog.ts'
-import { modelModeSuffix } from './model-mode.tsx'
+import { choiceKnob, knobValue, modelKnobs, modelModeSuffix, patchKnob } from './model-mode.tsx'
 
 export type ComposerModelOption = {
   id: string
@@ -18,7 +17,7 @@ export type ComposerModelOption = {
   note?: string
 }
 
-type Pane = 'root' | 'effort' | 'context' | 'model'
+type Pane = 'root' | 'model' | string
 
 function groupTitle(key: string, labels: Record<string, string>) {
   return (
@@ -30,52 +29,34 @@ function groupTitle(key: string, labels: Record<string, string>) {
 function tagFor(
   option: ComposerModelOption,
   current: ComposerModelOption,
-  thinking: ThinkingMode,
-  effort: ReasoningEffort,
-  context: ContextWindow,
+  mode: ModelModeValues,
   currentCaps: ModelCapabilities,
 ) {
-  if (option.id === current.id) return modelModeSuffix(thinking, effort, currentCaps, context)
+  if (option.id === current.id) return modelModeSuffix(mode, currentCaps)
   const caps = inferModelCapabilities(option.model, option.provider as 'deepseek' | 'openai' | 'anthropic')
-  return modelModeSuffix('enabled', 'high', caps, '200k')
+  return modelModeSuffix({ thinking: 'enabled', speed: 'slow', effort: 'high', context: '200k' }, caps)
+}
+
+function toggleOn(knob: Extract<ModelKnob, { kind: 'toggle' }>, mode: ModelModeValues) {
+  return knobValue(knob, mode) === knob.on
 }
 
 export function ComposerModelMenu(props: {
   models: ComposerModelOption[]
   current: ComposerModelOption
   endpointLabels: Record<string, string>
-  thinking: ThinkingMode
-  reasoningEffort: ReasoningEffort
-  contextWindow: ContextWindow
+  mode: ModelModeValues
   capabilities: ModelCapabilities
   disabled?: boolean
   onSelect: (option: ComposerModelOption) => void
-  onMode: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }) => void
+  onMode: (next: Partial<ModelModeValues>) => void
   onAddModels: () => void
 }) {
-  const {
-    models,
-    current,
-    endpointLabels,
-    thinking,
-    reasoningEffort,
-    contextWindow,
-    capabilities,
-    disabled,
-    onSelect,
-    onMode,
-    onAddModels,
-  } = props
+  const { models, current, endpointLabels, mode, capabilities, disabled, onSelect, onMode, onAddModels } = props
   const [pane, setPane] = useState<Pane>('root')
   const [query, setQuery] = useState('')
-  const thinkingOn = thinking === 'enabled'
-  const fast = Boolean(capabilities.speed && thinking === 'disabled')
-  const showThinking = Boolean(capabilities.thinking)
-  const showFast = Boolean(capabilities.speed)
-  const showEffort = Boolean(capabilities.effort?.length)
-  const showContext = Boolean(capabilities.context?.length)
-  const effortLabel = reasoningEffort === 'max' ? 'Max' : 'High'
-  const contextLabel = contextWindow === '1m' ? '1M' : '200k'
+  const knobs = modelKnobs(capabilities)
+  const openChoice = choiceKnob(capabilities, pane)
 
   const grouped = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -119,7 +100,7 @@ export function ComposerModelMenu(props: {
                   <div className="composer-model-group-label">{group.title}</div>
                   {group.items.map((option) => {
                     const active = option.id === current.id
-                    const tag = tagFor(option, current, thinking, reasoningEffort, contextWindow, capabilities)
+                    const tag = tagFor(option, current, mode, capabilities)
                     return (
                       <button
                         key={option.id}
@@ -147,47 +128,22 @@ export function ComposerModelMenu(props: {
         </div>
       ) : null}
 
-      {pane === 'effort' ? (
-        <div className="composer-model-flyout is-compact" role="listbox" aria-label="推理力度">
-          {(capabilities.effort ?? []).map((item) => {
-            const active = reasoningEffort === item
-            const label = item === 'max' ? 'Max' : 'High'
+      {openChoice ? (
+        <div className="composer-model-flyout is-compact" role="listbox" aria-label={openChoice.label}>
+          {openChoice.options.map((item) => {
+            const active = knobValue(openChoice, mode) === item.value
             return (
               <button
-                key={item}
+                key={item.value}
                 type="button"
                 role="option"
                 aria-selected={active}
                 className={`composer-model-item${active ? ' is-active' : ''}`}
-                data-testid={`effort-${item}`}
+                data-testid={`${openChoice.id}-${item.value}`}
                 disabled={disabled}
-                onClick={() => onMode({ reasoningEffort: item })}
+                onClick={() => onMode(patchKnob(openChoice, item.value))}
               >
-                <span className="composer-model-item-label">{label}</span>
-                {active ? <CheckIcon className="composer-model-check size-3.5" aria-hidden /> : null}
-              </button>
-            )
-          })}
-        </div>
-      ) : null}
-
-      {pane === 'context' ? (
-        <div className="composer-model-flyout is-compact" role="listbox" aria-label="上下文">
-          {(capabilities.context ?? []).map((item) => {
-            const active = contextWindow === item
-            const label = item === '1m' ? '1M' : '200k'
-            return (
-              <button
-                key={item}
-                type="button"
-                role="option"
-                aria-selected={active}
-                className={`composer-model-item${active ? ' is-active' : ''}`}
-                data-testid={`context-${item}`}
-                disabled={disabled}
-                onClick={() => onMode({ contextWindow: item })}
-              >
-                <span className="composer-model-item-label">{label}</span>
+                <span className="composer-model-item-label">{item.label}</span>
                 {active ? <CheckIcon className="composer-model-check size-3.5" aria-hidden /> : null}
               </button>
             )
@@ -196,58 +152,40 @@ export function ComposerModelMenu(props: {
       ) : null}
 
       <div className="composer-model-panel" data-testid="composer-model-panel">
-        {showThinking ? (
-          <button
-            type="button"
-            role="switch"
-            aria-checked={thinkingOn}
-            className="composer-model-row"
-            data-testid="thinking-toggle"
-            disabled={disabled}
-            onClick={() => onMode({ thinking: thinkingOn ? 'disabled' : 'enabled' })}
-          >
-            <span className="composer-model-row-label">思考</span>
-            <span className={`composer-model-switch${thinkingOn ? ' is-on' : ''}`} aria-hidden />
-          </button>
-        ) : null}
-        {showFast ? (
-          <button
-            type="button"
-            role="switch"
-            aria-checked={fast}
-            className="composer-model-row"
-            data-testid="speed-toggle"
-            disabled={disabled}
-            onClick={() => onMode({ thinking: fast ? 'enabled' : 'disabled' })}
-          >
-            <span className="composer-model-row-label">快</span>
-            <span className={`composer-model-switch${fast ? ' is-on' : ''}`} aria-hidden />
-          </button>
-        ) : null}
-        {showEffort ? (
-          <button
-            type="button"
-            className={`composer-model-row${pane === 'effort' ? ' is-open' : ''}`}
-            disabled={disabled}
-            onClick={() => setPane((p) => (p === 'effort' ? 'root' : 'effort'))}
-          >
-            <span className="composer-model-row-label">力度</span>
-            <span className="composer-model-row-val">{effortLabel}</span>
-            <ChevronRightIcon className="size-3.5 opacity-50" aria-hidden />
-          </button>
-        ) : null}
-        {showContext ? (
-          <button
-            type="button"
-            className={`composer-model-row${pane === 'context' ? ' is-open' : ''}`}
-            disabled={disabled}
-            onClick={() => setPane((p) => (p === 'context' ? 'root' : 'context'))}
-          >
-            <span className="composer-model-row-label">上下文</span>
-            <span className="composer-model-row-val">{contextLabel}</span>
-            <ChevronRightIcon className="size-3.5 opacity-50" aria-hidden />
-          </button>
-        ) : null}
+        {knobs.map((knob) => {
+          if (knob.kind === 'toggle') {
+            const on = toggleOn(knob, mode)
+            return (
+              <button
+                key={knob.id}
+                type="button"
+                role="switch"
+                aria-checked={on}
+                className="composer-model-row"
+                data-testid={`${knob.id}-toggle`}
+                disabled={disabled}
+                onClick={() => onMode(patchKnob(knob, on ? knob.off : knob.on))}
+              >
+                <span className="composer-model-row-label">{knob.label}</span>
+                <span className={`composer-model-switch${on ? ' is-on' : ''}`} aria-hidden />
+              </button>
+            )
+          }
+          const current = knob.options.find((item) => item.value === knobValue(knob, mode))?.label ?? ''
+          return (
+            <button
+              key={knob.id}
+              type="button"
+              className={`composer-model-row${pane === knob.id ? ' is-open' : ''}`}
+              disabled={disabled}
+              onClick={() => setPane((p) => (p === knob.id ? 'root' : knob.id))}
+            >
+              <span className="composer-model-row-label">{knob.label}</span>
+              <span className="composer-model-row-val">{current}</span>
+              <ChevronRightIcon className="size-3.5 opacity-50" aria-hidden />
+            </button>
+          )
+        })}
         <button
           type="button"
           className={`composer-model-row${pane === 'model' ? ' is-open' : ''}`}

--- a/packages/core-chat/src/web/composer-model-menu.tsx
+++ b/packages/core-chat/src/web/composer-model-menu.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { CheckIcon, ChevronRightIcon, MagnifyingGlassIcon } from '@heroicons/react/16/solid'
 import {
   inferModelCapabilities,
+  type ContextWindow,
   type ModelCapabilities,
   type ReasoningEffort,
   type ThinkingMode,
@@ -17,7 +18,7 @@ export type ComposerModelOption = {
   note?: string
 }
 
-type Pane = 'root' | 'effort' | 'model'
+type Pane = 'root' | 'effort' | 'context' | 'model'
 
 function groupTitle(key: string, labels: Record<string, string>) {
   return (
@@ -31,11 +32,12 @@ function tagFor(
   current: ComposerModelOption,
   thinking: ThinkingMode,
   effort: ReasoningEffort,
+  context: ContextWindow,
   currentCaps: ModelCapabilities,
 ) {
-  if (option.id === current.id) return modelModeSuffix(thinking, effort, currentCaps)
+  if (option.id === current.id) return modelModeSuffix(thinking, effort, currentCaps, context)
   const caps = inferModelCapabilities(option.model, option.provider as 'deepseek' | 'openai' | 'anthropic')
-  return modelModeSuffix('enabled', 'high', caps)
+  return modelModeSuffix('enabled', 'high', caps, '200k')
 }
 
 export function ComposerModelMenu(props: {
@@ -44,10 +46,11 @@ export function ComposerModelMenu(props: {
   endpointLabels: Record<string, string>
   thinking: ThinkingMode
   reasoningEffort: ReasoningEffort
+  contextWindow: ContextWindow
   capabilities: ModelCapabilities
   disabled?: boolean
   onSelect: (option: ComposerModelOption) => void
-  onMode: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }) => void
+  onMode: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }) => void
   onAddModels: () => void
 }) {
   const {
@@ -56,6 +59,7 @@ export function ComposerModelMenu(props: {
     endpointLabels,
     thinking,
     reasoningEffort,
+    contextWindow,
     capabilities,
     disabled,
     onSelect,
@@ -68,8 +72,10 @@ export function ComposerModelMenu(props: {
   const fast = Boolean(capabilities.speed && thinking === 'disabled')
   const showThinking = Boolean(capabilities.thinking)
   const showFast = Boolean(capabilities.speed)
-  const showEffort = Boolean(capabilities.effort?.length && (!capabilities.thinking || thinking === 'enabled'))
+  const showEffort = Boolean(capabilities.effort?.length)
+  const showContext = Boolean(capabilities.context?.length)
   const effortLabel = reasoningEffort === 'max' ? 'Max' : 'High'
+  const contextLabel = contextWindow === '1m' ? '1M' : '200k'
 
   const grouped = useMemo(() => {
     const q = query.trim().toLowerCase()
@@ -113,7 +119,7 @@ export function ComposerModelMenu(props: {
                   <div className="composer-model-group-label">{group.title}</div>
                   {group.items.map((option) => {
                     const active = option.id === current.id
-                    const tag = tagFor(option, current, thinking, reasoningEffort, capabilities)
+                    const tag = tagFor(option, current, thinking, reasoningEffort, contextWindow, capabilities)
                     return (
                       <button
                         key={option.id}
@@ -155,7 +161,31 @@ export function ComposerModelMenu(props: {
                 className={`composer-model-item${active ? ' is-active' : ''}`}
                 data-testid={`effort-${item}`}
                 disabled={disabled}
-                onClick={() => onMode({ thinking: 'enabled', reasoningEffort: item })}
+                onClick={() => onMode({ reasoningEffort: item })}
+              >
+                <span className="composer-model-item-label">{label}</span>
+                {active ? <CheckIcon className="composer-model-check size-3.5" aria-hidden /> : null}
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+
+      {pane === 'context' ? (
+        <div className="composer-model-flyout is-compact" role="listbox" aria-label="上下文">
+          {(capabilities.context ?? []).map((item) => {
+            const active = contextWindow === item
+            const label = item === '1m' ? '1M' : '200k'
+            return (
+              <button
+                key={item}
+                type="button"
+                role="option"
+                aria-selected={active}
+                className={`composer-model-item${active ? ' is-active' : ''}`}
+                data-testid={`context-${item}`}
+                disabled={disabled}
+                onClick={() => onMode({ contextWindow: item })}
               >
                 <span className="composer-model-item-label">{label}</span>
                 {active ? <CheckIcon className="composer-model-check size-3.5" aria-hidden /> : null}
@@ -203,6 +233,18 @@ export function ComposerModelMenu(props: {
           >
             <span className="composer-model-row-label">力度</span>
             <span className="composer-model-row-val">{effortLabel}</span>
+            <ChevronRightIcon className="size-3.5 opacity-50" aria-hidden />
+          </button>
+        ) : null}
+        {showContext ? (
+          <button
+            type="button"
+            className={`composer-model-row${pane === 'context' ? ' is-open' : ''}`}
+            disabled={disabled}
+            onClick={() => setPane((p) => (p === 'context' ? 'root' : 'context'))}
+          >
+            <span className="composer-model-row-label">上下文</span>
+            <span className="composer-model-row-val">{contextLabel}</span>
             <ChevronRightIcon className="size-3.5 opacity-50" aria-hidden />
           </button>
         ) : null}

--- a/packages/core-chat/src/web/composer-model-menu.tsx
+++ b/packages/core-chat/src/web/composer-model-menu.tsx
@@ -64,8 +64,10 @@ export function ComposerModelMenu(props: {
   } = props
   const [pane, setPane] = useState<Pane>('root')
   const [query, setQuery] = useState('')
-  const fast = Boolean(capabilities.thinking && thinking === 'disabled')
-  const showFast = Boolean(capabilities.thinking)
+  const thinkingOn = thinking === 'enabled'
+  const fast = Boolean(capabilities.speed && thinking === 'disabled')
+  const showThinking = Boolean(capabilities.thinking)
+  const showFast = Boolean(capabilities.speed)
   const showEffort = Boolean(capabilities.effort?.length && (!capabilities.thinking || thinking === 'enabled'))
   const effortLabel = reasoningEffort === 'max' ? 'Max' : 'High'
 
@@ -164,17 +166,31 @@ export function ComposerModelMenu(props: {
       ) : null}
 
       <div className="composer-model-panel" data-testid="composer-model-panel">
+        {showThinking ? (
+          <button
+            type="button"
+            role="switch"
+            aria-checked={thinkingOn}
+            className="composer-model-row"
+            data-testid="thinking-toggle"
+            disabled={disabled}
+            onClick={() => onMode({ thinking: thinkingOn ? 'disabled' : 'enabled' })}
+          >
+            <span className="composer-model-row-label">思考</span>
+            <span className={`composer-model-switch${thinkingOn ? ' is-on' : ''}`} aria-hidden />
+          </button>
+        ) : null}
         {showFast ? (
           <button
             type="button"
             role="switch"
             aria-checked={fast}
             className="composer-model-row"
-            data-testid="thinking-off"
+            data-testid="speed-toggle"
             disabled={disabled}
             onClick={() => onMode({ thinking: fast ? 'enabled' : 'disabled' })}
           >
-            <span className="composer-model-row-label">Fast</span>
+            <span className="composer-model-row-label">快</span>
             <span className={`composer-model-switch${fast ? ' is-on' : ''}`} aria-hidden />
           </button>
         ) : null}

--- a/packages/core-chat/src/web/composer.tsx
+++ b/packages/core-chat/src/web/composer.tsx
@@ -19,7 +19,8 @@ import {
 import { ModelConfigDialog } from './model-config-dialog.tsx'
 import { modelModeSuffix } from './model-mode.tsx'
 import { ComposerModelMenu } from './composer-model-menu.tsx'
-import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type { ContextWindow, ModelCapabilities, ModelModeValues, ReasoningEffort, SpeedMode, ThinkingMode } from '../host/model-catalog.ts'
+import { EFFORT_KNOB, THINKING_KNOB } from '../host/model-catalog.ts'
 import { ImageThumbs } from './image-thumbs.tsx'
 import { collectClipboardImages, collectImageFiles } from './clipboard-images.ts'
 import { revealOverlayThread, isComposerFocusPending } from '@biu/web-app-shell/chat-overlay'
@@ -192,7 +193,8 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const [thinking, setThinking] = useState<ThinkingMode>('enabled')
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
   const [contextWindow, setContextWindow] = useState<ContextWindow>('200k')
-  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ thinking: true, effort: ['high', 'max'] })
+  const [speed, setSpeed] = useState<SpeedMode>('slow')
+  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ knobs: [THINKING_KNOB, EFFORT_KNOB] })
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
   const [allModels, setAllModels] = useState<ModelOption[]>([])
@@ -237,6 +239,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       thinking?: ThinkingMode
       reasoningEffort?: ReasoningEffort
       contextWindow?: ContextWindow
+      speed?: SpeedMode
       capabilities?: ModelCapabilities
       providers?: Record<string, { configured?: boolean }>
       endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
@@ -271,6 +274,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
       if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
+      if (data.speed === 'fast' || data.speed === 'slow') setSpeed(data.speed)
       if (data.capabilities) setModelCaps(data.capabilities)
       const cfg: Record<string, boolean> = {}
       const labels: Record<string, string> = {
@@ -676,6 +680,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         thinking?: ThinkingMode
         reasoningEffort?: ReasoningEffort
         contextWindow?: ContextWindow
+        speed?: SpeedMode
         capabilities?: ModelCapabilities
       }
       if (data.provider && data.model) setModelOption(matchModelOption(allModels, data.provider, data.model))
@@ -683,34 +688,38 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
       if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
+      if (data.speed === 'fast' || data.speed === 'slow') setSpeed(data.speed)
       if (data.capabilities) setModelCaps(data.capabilities)
     } finally {
       setModelBusy(false)
     }
   }
 
-  async function patchModelMode(next: {
-    thinking?: ThinkingMode
-    reasoningEffort?: ReasoningEffort
-    contextWindow?: ContextWindow
-  }) {
+  async function patchModelMode(next: Partial<ModelModeValues>) {
     setModelBusy(true)
     try {
       const res = await fetch('/api/chat/config', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(next),
+        body: JSON.stringify({
+          thinking: next.thinking,
+          speed: next.speed,
+          reasoningEffort: next.effort,
+          contextWindow: next.context,
+        }),
       })
       if (!res.ok) return
       const data = (await res.json()) as {
         thinking?: ThinkingMode
         reasoningEffort?: ReasoningEffort
         contextWindow?: ContextWindow
+        speed?: SpeedMode
         capabilities?: ModelCapabilities
       }
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
       if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
+      if (data.speed === 'fast' || data.speed === 'slow') setSpeed(data.speed)
       if (data.capabilities) setModelCaps(data.capabilities)
     } finally {
       setModelBusy(false)
@@ -889,8 +898,11 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             >
               <span className="composer-model-label">
                 {modelOption.label}
-                {modelModeSuffix(thinking, reasoningEffort, modelCaps, contextWindow)
-                  ? ` · ${modelModeSuffix(thinking, reasoningEffort, modelCaps, contextWindow)}`
+                {modelModeSuffix(
+                  { thinking, speed, effort: reasoningEffort, context: contextWindow },
+                  modelCaps,
+                )
+                  ? ` · ${modelModeSuffix({ thinking, speed, effort: reasoningEffort, context: contextWindow }, modelCaps)}`
                   : ''}
               </span>
               <ChevronDownIcon className="size-3.5 opacity-70" />
@@ -901,9 +913,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   models={allModels.filter((m) => modelProviders?.[m.endpointId])}
                   current={modelOption}
                   endpointLabels={endpointLabels}
-                  thinking={thinking}
-                  reasoningEffort={reasoningEffort}
-                  contextWindow={contextWindow}
+                  mode={{ thinking, speed, effort: reasoningEffort, context: contextWindow }}
                   capabilities={modelCaps}
                   disabled={modelBusy}
                   onSelect={(option) => void selectModel(option)}

--- a/packages/core-chat/src/web/composer.tsx
+++ b/packages/core-chat/src/web/composer.tsx
@@ -19,7 +19,7 @@ import {
 import { ModelConfigDialog } from './model-config-dialog.tsx'
 import { modelModeSuffix } from './model-mode.tsx'
 import { ComposerModelMenu } from './composer-model-menu.tsx'
-import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
 import { ImageThumbs } from './image-thumbs.tsx'
 import { collectClipboardImages, collectImageFiles } from './clipboard-images.ts'
 import { revealOverlayThread, isComposerFocusPending } from '@biu/web-app-shell/chat-overlay'
@@ -191,6 +191,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
   const [configOpen, setConfigOpen] = useState(false)
   const [thinking, setThinking] = useState<ThinkingMode>('enabled')
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
+  const [contextWindow, setContextWindow] = useState<ContextWindow>('200k')
   const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ thinking: true, effort: ['high', 'max'] })
   const [pendingImages, setPendingImages] = useState<PendingImage[]>([])
   /** 全部目录模型（含未配置的），用于下拉只展示已配置入口，但当前选中可能来自任一。 */
@@ -235,6 +236,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       model?: string
       thinking?: ThinkingMode
       reasoningEffort?: ReasoningEffort
+      contextWindow?: ContextWindow
       capabilities?: ModelCapabilities
       providers?: Record<string, { configured?: boolean }>
       endpoints?: Array<{ id: string; label?: string; configured?: boolean }>
@@ -268,6 +270,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       }
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+      if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
       if (data.capabilities) setModelCaps(data.capabilities)
       const cfg: Record<string, boolean> = {}
       const labels: Record<string, string> = {
@@ -672,19 +675,25 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         model?: string
         thinking?: ThinkingMode
         reasoningEffort?: ReasoningEffort
+        contextWindow?: ContextWindow
         capabilities?: ModelCapabilities
       }
       if (data.provider && data.model) setModelOption(matchModelOption(allModels, data.provider, data.model))
       else setModelOption(option)
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+      if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
       if (data.capabilities) setModelCaps(data.capabilities)
     } finally {
       setModelBusy(false)
     }
   }
 
-  async function patchModelMode(next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }) {
+  async function patchModelMode(next: {
+    thinking?: ThinkingMode
+    reasoningEffort?: ReasoningEffort
+    contextWindow?: ContextWindow
+  }) {
     setModelBusy(true)
     try {
       const res = await fetch('/api/chat/config', {
@@ -696,10 +705,12 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
       const data = (await res.json()) as {
         thinking?: ThinkingMode
         reasoningEffort?: ReasoningEffort
+        contextWindow?: ContextWindow
         capabilities?: ModelCapabilities
       }
       if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
       if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+      if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
       if (data.capabilities) setModelCaps(data.capabilities)
     } finally {
       setModelBusy(false)
@@ -878,8 +889,8 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
             >
               <span className="composer-model-label">
                 {modelOption.label}
-                {modelModeSuffix(thinking, reasoningEffort, modelCaps)
-                  ? ` · ${modelModeSuffix(thinking, reasoningEffort, modelCaps)}`
+                {modelModeSuffix(thinking, reasoningEffort, modelCaps, contextWindow)
+                  ? ` · ${modelModeSuffix(thinking, reasoningEffort, modelCaps, contextWindow)}`
                   : ''}
               </span>
               <ChevronDownIcon className="size-3.5 opacity-70" />
@@ -892,6 +903,7 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
                   endpointLabels={endpointLabels}
                   thinking={thinking}
                   reasoningEffort={reasoningEffort}
+                  contextWindow={contextWindow}
                   capabilities={modelCaps}
                   disabled={modelBusy}
                   onSelect={(option) => void selectModel(option)}

--- a/packages/core-chat/src/web/config.tsx
+++ b/packages/core-chat/src/web/config.tsx
@@ -11,7 +11,7 @@ import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIco
 import { HeadlessDismiss } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { ModelModeControls } from './model-mode.tsx'
-import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -52,6 +52,7 @@ interface ChatPublicConfig {
   model: string
   thinking?: ThinkingMode
   reasoningEffort?: ReasoningEffort
+  contextWindow?: ContextWindow
   capabilities?: ModelCapabilities
   configured: boolean
   hint: string
@@ -86,6 +87,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
   const [defaultModel, setDefaultModel] = useState('deepseek-v4-flash')
   const [thinking, setThinking] = useState<ThinkingMode>('enabled')
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
+  const [contextWindow, setContextWindow] = useState<ContextWindow>('200k')
   const [modelCaps, setModelCaps] = useState<ModelCapabilities>({})
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
@@ -256,6 +258,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     setDefaultModel(data.model)
     if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
     if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
+    if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
     if (data.capabilities) setModelCaps(data.capabilities)
     setActiveId(eid)
 
@@ -1086,6 +1089,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                       capabilities={modelCaps}
                       thinking={thinking}
                       reasoningEffort={reasoningEffort}
+                      contextWindow={contextWindow}
                       disabled={saving}
                       onChange={(next) => {
                         void fetch('/api/chat/config', {

--- a/packages/core-chat/src/web/config.tsx
+++ b/packages/core-chat/src/web/config.tsx
@@ -11,7 +11,7 @@ import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIco
 import { HeadlessDismiss } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import { ModelModeControls } from './model-mode.tsx'
-import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type { ContextWindow, ModelCapabilities, ReasoningEffort, SpeedMode, ThinkingMode } from '../host/model-catalog.ts'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -53,6 +53,7 @@ interface ChatPublicConfig {
   thinking?: ThinkingMode
   reasoningEffort?: ReasoningEffort
   contextWindow?: ContextWindow
+  speed?: SpeedMode
   capabilities?: ModelCapabilities
   configured: boolean
   hint: string
@@ -88,7 +89,8 @@ export function ChatConfig(props?: { onClose?: () => void }) {
   const [thinking, setThinking] = useState<ThinkingMode>('enabled')
   const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
   const [contextWindow, setContextWindow] = useState<ContextWindow>('200k')
-  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({})
+  const [speed, setSpeed] = useState<SpeedMode>('slow')
+  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ knobs: [] })
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
   const [providers, setProviders] = useState<Record<string, ProviderView> | null>(null)
@@ -259,6 +261,7 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
     if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
     if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
+    if (data.speed === 'fast' || data.speed === 'slow') setSpeed(data.speed)
     if (data.capabilities) setModelCaps(data.capabilities)
     setActiveId(eid)
 
@@ -1087,15 +1090,18 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                   {isDefaultProvider ? (
                     <ModelModeControls
                       capabilities={modelCaps}
-                      thinking={thinking}
-                      reasoningEffort={reasoningEffort}
-                      contextWindow={contextWindow}
+                      mode={{ thinking, speed, effort: reasoningEffort, context: contextWindow }}
                       disabled={saving}
                       onChange={(next) => {
                         void fetch('/api/chat/config', {
                           method: 'POST',
                           headers: { 'content-type': 'application/json' },
-                          body: JSON.stringify(next),
+                          body: JSON.stringify({
+                            thinking: next.thinking,
+                            speed: next.speed,
+                            reasoningEffort: next.effort,
+                            contextWindow: next.context,
+                          }),
                         })
                           .then((res) => res.json())
                           .then((data: ChatPublicConfig) => applyPublic(data, activeId))

--- a/packages/core-chat/src/web/model-mode.tsx
+++ b/packages/core-chat/src/web/model-mode.tsx
@@ -1,4 +1,4 @@
-import type { ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
 
 const pillCls = (on: boolean) =>
   `rounded-md border px-2 py-[3px] text-[12px] leading-none transition-colors ${
@@ -11,38 +11,14 @@ export function ModelModeControls(props: {
   capabilities: ModelCapabilities
   thinking: ThinkingMode
   reasoningEffort: ReasoningEffort
+  contextWindow?: ContextWindow
   disabled?: boolean
-  onChange: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }) => void
+  onChange: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }) => void
 }) {
-  const { capabilities: caps, thinking, reasoningEffort, disabled, onChange } = props
-  if (!caps.thinking && !caps.speed && !caps.effort?.length) return null
+  const { capabilities: caps, thinking, reasoningEffort, contextWindow = '200k', disabled, onChange } = props
+  if (!caps.thinking && !caps.speed && !caps.effort?.length && !caps.context?.length) return null
   return (
     <div className="flex flex-col gap-2" data-testid="model-mode-controls">
-      {caps.speed ? (
-        <div className="flex items-center gap-2">
-          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">快</span>
-          <div className="flex gap-1">
-            <button
-              type="button"
-              className={pillCls(thinking === 'disabled')}
-              disabled={disabled}
-              data-testid="speed-on"
-              onClick={() => onChange({ thinking: 'disabled' })}
-            >
-              开
-            </button>
-            <button
-              type="button"
-              className={pillCls(thinking !== 'disabled')}
-              disabled={disabled}
-              data-testid="speed-off"
-              onClick={() => onChange({ thinking: 'enabled' })}
-            >
-              关
-            </button>
-          </div>
-        </div>
-      ) : null}
       {caps.thinking ? (
         <div className="flex items-center gap-2">
           <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">思考</span>
@@ -68,7 +44,32 @@ export function ModelModeControls(props: {
           </div>
         </div>
       ) : null}
-      {caps.effort?.length && (caps.thinking ? thinking === 'enabled' : true) ? (
+      {caps.speed ? (
+        <div className="flex items-center gap-2">
+          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">快</span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              className={pillCls(thinking === 'disabled')}
+              disabled={disabled}
+              data-testid="speed-on"
+              onClick={() => onChange({ thinking: 'disabled' })}
+            >
+              开
+            </button>
+            <button
+              type="button"
+              className={pillCls(thinking !== 'disabled')}
+              disabled={disabled}
+              data-testid="speed-off"
+              onClick={() => onChange({ thinking: 'enabled' })}
+            >
+              关
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {caps.effort?.length ? (
         <div className="flex items-center gap-2">
           <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">力度</span>
           <div className="flex gap-1">
@@ -79,9 +80,28 @@ export function ModelModeControls(props: {
                 className={pillCls(reasoningEffort === item)}
                 disabled={disabled}
                 data-testid={`effort-${item}`}
-                onClick={() => onChange({ thinking: 'enabled', reasoningEffort: item })}
+                onClick={() => onChange({ reasoningEffort: item })}
               >
                 {item === 'max' ? 'Max' : 'High'}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      {caps.context?.length ? (
+        <div className="flex items-center gap-2">
+          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">上下文</span>
+          <div className="flex gap-1">
+            {caps.context.map((item) => (
+              <button
+                key={item}
+                type="button"
+                className={pillCls(contextWindow === item)}
+                disabled={disabled}
+                data-testid={`context-${item}`}
+                onClick={() => onChange({ contextWindow: item })}
+              >
+                {item === '1m' ? '1M' : '200k'}
               </button>
             ))}
           </div>
@@ -91,9 +111,15 @@ export function ModelModeControls(props: {
   )
 }
 
-export function modelModeSuffix(thinking: ThinkingMode, effort: ReasoningEffort, caps: ModelCapabilities) {
+export function modelModeSuffix(
+  thinking: ThinkingMode,
+  effort: ReasoningEffort,
+  caps: ModelCapabilities,
+  context: ContextWindow = '200k',
+) {
   if (caps.speed && thinking === 'disabled') return '快'
   if (caps.thinking && thinking === 'disabled') return ''
+  if (caps.context?.length && context === '1m') return '1M'
   if (!caps.thinking && !caps.effort?.length) return ''
   if (effort === 'max') return 'Max'
   return caps.effort?.length ? 'High' : ''

--- a/packages/core-chat/src/web/model-mode.tsx
+++ b/packages/core-chat/src/web/model-mode.tsx
@@ -15,9 +15,34 @@ export function ModelModeControls(props: {
   onChange: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort }) => void
 }) {
   const { capabilities: caps, thinking, reasoningEffort, disabled, onChange } = props
-  if (!caps.thinking && !caps.effort?.length) return null
+  if (!caps.thinking && !caps.speed && !caps.effort?.length) return null
   return (
     <div className="flex flex-col gap-2" data-testid="model-mode-controls">
+      {caps.speed ? (
+        <div className="flex items-center gap-2">
+          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">快</span>
+          <div className="flex gap-1">
+            <button
+              type="button"
+              className={pillCls(thinking === 'disabled')}
+              disabled={disabled}
+              data-testid="speed-on"
+              onClick={() => onChange({ thinking: 'disabled' })}
+            >
+              开
+            </button>
+            <button
+              type="button"
+              className={pillCls(thinking !== 'disabled')}
+              disabled={disabled}
+              data-testid="speed-off"
+              onClick={() => onChange({ thinking: 'enabled' })}
+            >
+              关
+            </button>
+          </div>
+        </div>
+      ) : null}
       {caps.thinking ? (
         <div className="flex items-center gap-2">
           <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">思考</span>
@@ -67,8 +92,9 @@ export function ModelModeControls(props: {
 }
 
 export function modelModeSuffix(thinking: ThinkingMode, effort: ReasoningEffort, caps: ModelCapabilities) {
+  if (caps.speed && thinking === 'disabled') return '快'
+  if (caps.thinking && thinking === 'disabled') return ''
   if (!caps.thinking && !caps.effort?.length) return ''
-  if (caps.thinking && thinking === 'disabled') return '快'
   if (effort === 'max') return 'Max'
-  return 'High'
+  return caps.effort?.length ? 'High' : ''
 }

--- a/packages/core-chat/src/web/model-mode.tsx
+++ b/packages/core-chat/src/web/model-mode.tsx
@@ -1,4 +1,13 @@
-import type { ContextWindow, ModelCapabilities, ReasoningEffort, ThinkingMode } from '../host/model-catalog.ts'
+import type {
+  ContextWindow,
+  ModelCapabilities,
+  ModelChoiceKnob,
+  ModelKnob,
+  ModelModeValues,
+  ReasoningEffort,
+  SpeedMode,
+  ThinkingMode,
+} from '../host/model-catalog.ts'
 
 const pillCls = (on: boolean) =>
   `rounded-md border px-2 py-[3px] text-[12px] leading-none transition-colors ${
@@ -7,120 +16,103 @@ const pillCls = (on: boolean) =>
       : 'border-(--dsw-border) text-(--dsw-label-3) hover:bg-(--dsw-hover) hover:text-(--dsw-label)'
   }`
 
+export type ModelModePatch = Partial<ModelModeValues>
+
+function knobs(caps: ModelCapabilities): ModelKnob[] {
+  return caps.knobs ?? []
+}
+
+function valueOf(knob: ModelKnob, mode: ModelModeValues): string {
+  if (knob.id === 'thinking') return mode.thinking
+  if (knob.id === 'speed') return mode.speed
+  if (knob.id === 'effort') return mode.effort
+  return mode.context
+}
+
+function patchKnob(knob: ModelKnob, value: string): ModelModePatch {
+  if (knob.id === 'thinking') return { thinking: value as ThinkingMode }
+  if (knob.id === 'speed') return { speed: value as SpeedMode }
+  if (knob.id === 'effort') return { effort: value as ReasoningEffort }
+  return { context: value as ContextWindow }
+}
+
 export function ModelModeControls(props: {
   capabilities: ModelCapabilities
-  thinking: ThinkingMode
-  reasoningEffort: ReasoningEffort
-  contextWindow?: ContextWindow
+  mode: ModelModeValues
   disabled?: boolean
-  onChange: (next: { thinking?: ThinkingMode; reasoningEffort?: ReasoningEffort; contextWindow?: ContextWindow }) => void
+  onChange: (next: ModelModePatch) => void
 }) {
-  const { capabilities: caps, thinking, reasoningEffort, contextWindow = '200k', disabled, onChange } = props
-  if (!caps.thinking && !caps.speed && !caps.effort?.length && !caps.context?.length) return null
+  const { capabilities, mode, disabled, onChange } = props
+  const items = knobs(capabilities)
+  if (!items.length) return null
   return (
     <div className="flex flex-col gap-2" data-testid="model-mode-controls">
-      {caps.thinking ? (
-        <div className="flex items-center gap-2">
-          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">思考</span>
-          <div className="flex gap-1">
-            <button
-              type="button"
-              className={pillCls(thinking === 'disabled')}
-              disabled={disabled}
-              data-testid="thinking-off"
-              onClick={() => onChange({ thinking: 'disabled' })}
-            >
-              关
-            </button>
-            <button
-              type="button"
-              className={pillCls(thinking === 'enabled')}
-              disabled={disabled}
-              data-testid="thinking-on"
-              onClick={() => onChange({ thinking: 'enabled' })}
-            >
-              开
-            </button>
+      {items.map((knob) => {
+        const current = valueOf(knob, mode)
+        if (knob.kind === 'toggle') {
+          return (
+            <div key={knob.id} className="flex items-center gap-2">
+              <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">{knob.label}</span>
+              <div className="flex gap-1">
+                <button
+                  type="button"
+                  className={pillCls(current === knob.off)}
+                  disabled={disabled}
+                  data-testid={`${knob.id}-off`}
+                  onClick={() => onChange(patchKnob(knob, knob.off))}
+                >
+                  关
+                </button>
+                <button
+                  type="button"
+                  className={pillCls(current === knob.on)}
+                  disabled={disabled}
+                  data-testid={`${knob.id}-on`}
+                  onClick={() => onChange(patchKnob(knob, knob.on))}
+                >
+                  开
+                </button>
+              </div>
+            </div>
+          )
+        }
+        return (
+          <div key={knob.id} className="flex items-center gap-2">
+            <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">{knob.label}</span>
+            <div className="flex gap-1">
+              {knob.options.map((item) => (
+                <button
+                  key={item.value}
+                  type="button"
+                  className={pillCls(current === item.value)}
+                  disabled={disabled}
+                  data-testid={`${knob.id}-${item.value}`}
+                  onClick={() => onChange(patchKnob(knob, item.value))}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
-      ) : null}
-      {caps.speed ? (
-        <div className="flex items-center gap-2">
-          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">快</span>
-          <div className="flex gap-1">
-            <button
-              type="button"
-              className={pillCls(thinking === 'disabled')}
-              disabled={disabled}
-              data-testid="speed-on"
-              onClick={() => onChange({ thinking: 'disabled' })}
-            >
-              开
-            </button>
-            <button
-              type="button"
-              className={pillCls(thinking !== 'disabled')}
-              disabled={disabled}
-              data-testid="speed-off"
-              onClick={() => onChange({ thinking: 'enabled' })}
-            >
-              关
-            </button>
-          </div>
-        </div>
-      ) : null}
-      {caps.effort?.length ? (
-        <div className="flex items-center gap-2">
-          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">力度</span>
-          <div className="flex gap-1">
-            {caps.effort.map((item) => (
-              <button
-                key={item}
-                type="button"
-                className={pillCls(reasoningEffort === item)}
-                disabled={disabled}
-                data-testid={`effort-${item}`}
-                onClick={() => onChange({ reasoningEffort: item })}
-              >
-                {item === 'max' ? 'Max' : 'High'}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : null}
-      {caps.context?.length ? (
-        <div className="flex items-center gap-2">
-          <span className="w-10 shrink-0 text-[11px] text-(--dsw-label-3)">上下文</span>
-          <div className="flex gap-1">
-            {caps.context.map((item) => (
-              <button
-                key={item}
-                type="button"
-                className={pillCls(contextWindow === item)}
-                disabled={disabled}
-                data-testid={`context-${item}`}
-                onClick={() => onChange({ contextWindow: item })}
-              >
-                {item === '1m' ? '1M' : '200k'}
-              </button>
-            ))}
-          </div>
-        </div>
-      ) : null}
+        )
+      })}
     </div>
   )
 }
 
-export function modelModeSuffix(
-  thinking: ThinkingMode,
-  effort: ReasoningEffort,
-  caps: ModelCapabilities,
-  context: ContextWindow = '200k',
-) {
-  if (caps.speed && thinking === 'disabled') return '快'
-  if (caps.thinking && thinking === 'disabled') return ''
-  if (caps.context?.length && context === '1m') return '1M'
-  if (!caps.thinking && !caps.effort?.length) return ''
-  if (effort === 'max') return 'Max'
-  return caps.effort?.length ? 'High' : ''
+export function modelModeSuffix(mode: ModelModeValues, caps: ModelCapabilities) {
+  for (const knob of knobs(caps)) {
+    const current = valueOf(knob, mode)
+    if (knob.kind === 'toggle' && knob.id === 'speed' && current === knob.on) return '快'
+    if (knob.kind === 'toggle' && knob.id === 'thinking' && current === knob.off) return ''
+    if (knob.id === 'context' && current === '1m') return '1M'
+    if (knob.id === 'effort') return current === 'max' ? 'Max' : 'High'
+  }
+  return ''
 }
+
+export function choiceKnob(caps: ModelCapabilities, id: string): ModelChoiceKnob | undefined {
+  return knobs(caps).find((knob): knob is ModelChoiceKnob => knob.kind === 'choice' && knob.id === id)
+}
+
+export { knobs as modelKnobs, valueOf as knobValue, patchKnob }

--- a/web/style.css
+++ b/web/style.css
@@ -5162,7 +5162,7 @@ body {
   bottom: calc(100% + 8px);
   z-index: 9;
   display: flex;
-  align-items: stretch;
+  align-items: flex-end;
   gap: 6px;
 }
 
@@ -5171,7 +5171,7 @@ body {
   border: 1px solid var(--dsw-border);
   border-radius: 12px;
   background: #1c1c1c;
-  box-shadow: var(--dsw-shadow-lv2);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 }
 
 .composer-model-panel {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开模型二级列表时，一级面板保持原高度（底对齐，不再 `stretch`）。浮窗去掉 `0 0 0 1px` 阴影描边，只留 1px `border`，和其他弹层一致。

同时把「思考」和「快」拆开：DeepSeek / Claude 显示思考开关（开=思考），Grok 才显示快开关；关思考不再标成 Fast。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

