### PR TITLE
fix(fsdb): 单元格写合集属性时自动贴合集

### DIFF
--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { REQUIRED_RECORD_FIELDS, normalizeSchemaValue } from '@biu/type-file-system'
 import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
 import { placedActions, visibleActions } from './fsdb-cells.tsx'
 
@@ -144,6 +144,11 @@ test('default columns omit flattened type properties', () => {
   const row = { id: '1', facet: { tags: ['haohao'], values: { haohao: { dede: 'v' } } } }
   assert.equal(readFacetFlatValue(row, nested), 'v')
   assert.deepEqual(patchFacetFlatValue(row, nested, 'next').values.haohao?.dede, 'next')
+  const untagged = { id: '2', facet: { tags: [], values: {} } }
+  const stamped = patchFacetFlatValue(untagged, nested, 'next')
+  assert.deepEqual(stamped.tags, ['haohao'])
+  assert.equal(stamped.values.haohao?.dede, 'next')
+  assert.equal(normalizeSchemaValue(stamped).values.haohao?.dede, 'next')
 })
 
 test('list projection keeps visible columns plus title, emoji, and parent', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -211,8 +211,9 @@ export function patchFacetFlatValue(row: DbRecord, columnKey: string, next: unkn
   const parsed = parseFacetFlatColumnKey(columnKey)
   const current = normalizeSchemaValue(row[sourceKey])
   if (!parsed) return current
+  const tags = current.tags.includes(parsed.packId) ? current.tags : [...current.tags, parsed.packId]
   return {
-    tags: current.tags,
+    tags,
     values: {
       ...current.values,
       [parsed.packId]: { ...(current.values[parsed.packId] ?? {}), [parsed.fieldKey]: next },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格里改合集展开列的单元格时，如果这条记录还没贴上对应合集，会把该合集打到 `facet` 上再写入属性。不再因为没贴合集就把值丢掉、看起来像不能编辑。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

