### PR TITLE
fix(chat): 模型二级浮窗弹在一级右侧

### DIFF
--- a/packages/core-chat/src/web/composer-model-menu.test.ts
+++ b/packages/core-chat/src/web/composer-model-menu.test.ts
@@ -22,7 +22,8 @@ test('composer model menu renders knobs from catalog, not hardcoded vendor rows'
   assert.match(catalog, /label: '快'/)
   assert.match(catalog, /label: '力度'/)
   assert.match(catalog, /label: '上下文'/)
-  assert.match(css, /\.composer-model-pop\s*\{[^}]*align-items:\s*flex-end/)
+  assert.match(css, /\.composer-model-pop\s*\{/)
+  assert.match(css, /\.composer-model-flyout\s*\{[^}]*left:\s*calc\(100% \+ 6px\)/)
   assert.match(css, /\.composer-model-panel,\s*\n\.composer-model-flyout\s*\{[^}]*border:\s*1px solid/)
   assert.doesNotMatch(
     css,

--- a/web/style.css
+++ b/web/style.css
@@ -5161,9 +5161,6 @@ body {
   right: 0;
   bottom: calc(100% + 8px);
   z-index: 9;
-  display: flex;
-  align-items: flex-end;
-  gap: 6px;
 }
 
 .composer-model-panel,
@@ -5244,6 +5241,9 @@ body {
 }
 
 .composer-model-flyout {
+  position: absolute;
+  left: calc(100% + 6px);
+  bottom: 0;
   display: flex;
   width: 260px;
   max-height: min(380px, 56vh);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
模型选择的二级浮窗（模型列表 / 力度 / 上下文）贴在一级面板右侧弹出，一级位置不再被挤到左边。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

