### PR TITLE
fix(fsdb): 合集展开列表头用「合集名.属性名」

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -39,6 +39,7 @@ import {
   defaultColumnKeys,
   facetSourceKey,
   flattenFacetColumns,
+  facetColumnTitle,
   fieldEntries,
   flattenTree,
   formatField,
@@ -2401,7 +2402,6 @@ export function CollectionBrowser({
                   {allColumns.map((item) => {
                     const on = columns.some((col) => col.key === item.key)
                     const flat = parseFacetFlatColumnKey(item.key)
-                    const packLabel = 'packLabel' in item ? String(item.packLabel ?? '') : ''
                     const tone = flat ? schemaTagTone(flat.packId) : undefined
                     return (
                       <CheckRow
@@ -2410,7 +2410,7 @@ export function CollectionBrowser({
                         label={
                           flat ? (
                             <span style={tone ? { color: tone } : undefined}>
-                              {packLabel ? `${packLabel} · ${item.field.label ?? item.key}` : (item.field.label ?? item.key)}
+                              {facetColumnTitle(item)}
                             </span>
                           ) : (
                             item.field.label ?? item.key
@@ -2613,7 +2613,7 @@ export function CollectionBrowser({
                     {index === 0 ? <RowCheck ids={pickableIds} /> : null}
                     <span className="tasks-th">
                       <FieldGlyph kind={col.kind} />
-                      {col.field.label ?? col.key}
+                      {facetColumnTitle(col)}
                     </span>
                     <span
                       className={`fsdb-col-resizer${resizingCol === col.key ? ' is-active' : ''}`}

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS, normalizeSchemaValue } from '@biu/type-file-system'
-import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
+import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, facetColumnTitle, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
 import { placedActions, visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -141,6 +141,8 @@ test('default columns omit flattened type properties', () => {
   assert.equal(parseFacetFlatColumnKey(nested)?.fieldKey, 'dede')
   const cols = flattenFacetColumns([{ id: 'haohao', label: '好好哈', fields: [{ key: 'dede', type: 'string', label: '的的' }] }])
   assert.equal(cols[0]?.key, nested)
+  assert.equal(facetColumnTitle(cols[0]!), '好好哈.的的')
+  assert.equal(facetColumnTitle({ key: 'title', field: { label: '标题' } }), '标题')
   const row = { id: '1', facet: { tags: ['haohao'], values: { haohao: { dede: 'v' } } } }
   assert.equal(readFacetFlatValue(row, nested), 'v')
   assert.deepEqual(patchFacetFlatValue(row, nested, 'next').values.haohao?.dede, 'next')

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -201,6 +201,16 @@ export function flattenFacetColumns(catalog: CollectionSchemaPack[]) {
   )
 }
 
+export function facetColumnTitle(col: {
+  key: string
+  packLabel?: string
+  field?: { label?: string }
+}) {
+  const fieldLabel = String(col.field?.label ?? col.key).trim() || col.key
+  const pack = String(col.packLabel ?? '').trim()
+  return pack ? `${pack}.${fieldLabel}` : fieldLabel
+}
+
 export function readFacetFlatValue(row: DbRecord, columnKey: string, sourceKey = 'facet') {
   const parsed = parseFacetFlatColumnKey(columnKey)
   if (!parsed) return undefined

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -356,6 +356,7 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.doesNotMatch(browser, /if \(current\?\.builtin\) return/)
   assert.doesNotMatch(browser, /setColumnKeys\(defaultColumnKeys\(listed\.schema/)
   assert.match(browser, /flattenFacetColumns\(facetCatalog\)/)
+  assert.match(browser, /facetColumnTitle\(col\)/)
   assert.match(browser, /<SchemaFieldEditor/)
   const schemaUi = readFileSync(resolve(import.meta.dirname, './schema-field.tsx'), 'utf8')
   assert.match(schemaUi, /retagSchemaValue\(liveRef.current, resolved\)/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
合集内部属性展开成独立列时，表头与可见列菜单改为 `合集名称.属性名称`（点号分隔），不再只显示属性名，也不再用间隔号 `·`。

- 新增 `facetColumnTitle`，普通列仍只显示字段标签
- 表头与可见列勾选列表共用同一拼接规则

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

