### PR TITLE
fix(chat): 不存在的会话路由回首页

### DIFF
--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -321,9 +321,7 @@ export const ChatSidebar = memo(function ChatSidebar({
   const body = (
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="mt-2 space-y-1.5">
-          {sessions.length === 0 ? (
-            <p className="px-2 text-[11px] leading-4">No chats yet. Send a message or create one.</p>
-          ) : (
+          {sessions.length === 0 ? null : (
             sections.map((section) => {
               const sectionCollapsed = Boolean(collapsedSections[section.kind])
               return (

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -47,8 +47,9 @@ test('update button does not download when already current', () => {
 
 test('refresh does not send unfinished plugin routes home', () => {
   const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
-  assert.doesNotMatch(shell, /navigate\('\/', \{ replace: true \}\)/)
   assert.match(shell, /waitingOnNav/)
+  assert.match(shell, /biu:session-missing/)
+  assert.match(shell, /navigate\('\/', \{ replace: true \}\)/)
 })
 
 test('center stage keeps modules mounted without a page fade', () => {
@@ -84,6 +85,7 @@ test('left sidebar keeps chat and database lists mounted and folds smoothly', ()
   assert.match(shell, /id="shell-module-sidebar"/)
   assert.match(chat, /SidebarFold/)
   assert.match(chat, /embedded/)
+  assert.doesNotMatch(chat, /No chats yet/)
   assert.match(css, /\.chat-session-row::before[\s\S]*?transition:\s*background-color/)
 })
 

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -589,6 +589,18 @@ function Shell(props: SlotProps) {
   }, [location.pathname, navReady, sessionView, appModules.version()])
 
   useEffect(() => {
+    const onMissing = (event: Event) => {
+      const id = String((event as CustomEvent<{ sessionId?: string }>).detail?.sessionId ?? '')
+      if (!id) return
+      const prefix = `/s/${encodeURIComponent(id)}`
+      const path = location.pathname
+      if (path === prefix || path.startsWith(`${prefix}/`)) navigate('/', { replace: true })
+    }
+    window.addEventListener('biu:session-missing', onMissing)
+    return () => window.removeEventListener('biu:session-missing', onMissing)
+  }, [location.pathname, navigate])
+
+  useEffect(() => {
     if (activeModule === 'agent' && getChatOverlay()) closeChatOverlay()
   }, [activeModule])
 

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -400,12 +400,37 @@ export class SessionViewService extends Service {
     await this.loadMostRecentSession()
   }
 
-  private async loadMostRecentSession() {
+  private async loadMostRecentSession(skipId?: string) {
     if (!this.value.sessions.length) await this.refreshSessions()
-    const latest = mostRecentSessionId(this.value.sessions)
+    const latest = mostRecentSessionId(this.value.sessions.filter((item) => item.id !== skipId))
     if (!latest) return
     if (this.value.sessionId === latest) return
     await this.load(latest, { view: 'chat' })
+  }
+
+  /** 路由指向已删除/不存在的会话：不报 404，回首页并打开最近一条。 */
+  private async leaveMissingSession(sessionId: string) {
+    this.cache.delete(sessionId)
+    this.replace({
+      error: undefined,
+      sessionId: null,
+      events: [],
+      nodes: [],
+      trajectory: [],
+      view: 'chat',
+      focusCallId: undefined,
+      hasMoreOlder: false,
+      loadingOlder: false,
+      trajectoryHasMore: false,
+      trajectoryLoading: false,
+      totalTurns: 0,
+      switchingSession: false,
+    })
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('biu:session-missing', { detail: { sessionId } }))
+    }
+    await this.refreshSessions()
+    await this.loadMostRecentSession(sessionId)
   }
 
   ingest(sessionId: string, event: SessionEvent) {
@@ -792,20 +817,7 @@ export class SessionViewService extends Service {
       const res = await fetch(`/api/sessions/${sessionId}?turns=${SESSION_LOAD_TURNS}`)
       if (gen !== this.loadGen || this.value.sessionId !== sessionId) return
       if (!res.ok) {
-        if (res.status === 404) {
-          this.replace({
-            error: `加载 session 失败：${res.status}`,
-            sessionId: null,
-            events: [],
-            nodes: [],
-            trajectory: [],
-            view: 'chat',
-            focusCallId: undefined,
-            hasMoreOlder: false,
-            totalTurns: 0,
-            switchingSession: false,
-          })
-        }
+        if (res.status === 404) await this.leaveMissingSession(sessionId)
         return
       }
       const body = (await res.json()) as SessionPayload

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -9,15 +9,17 @@ function mockFetch(handlers: Record<string, (init?: RequestInit) => unknown>) {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input)
     calls.push({ url, init })
-    for (const [prefix, handler] of Object.entries(handlers)) {
-      if (url.includes(prefix)) {
-        const body = handler(init)
-        return {
-          ok: true,
-          status: 200,
-          json: async () => body,
-        } as Response
-      }
+    const matches = Object.entries(handlers)
+      .filter(([prefix]) => url.includes(prefix))
+      .sort((a, b) => b[0].length - a[0].length)
+    const hit = matches[0]
+    if (hit) {
+      const body = hit[1](init)
+      return {
+        ok: true,
+        status: 200,
+        json: async () => body,
+      } as Response
     }
     return { ok: false, status: 404, json: async () => ({}) } as Response
   }) as typeof fetch
@@ -753,6 +755,43 @@ test('home and module routes open the most recently updated chat', async () => {
   assert.equal(view.get().sessionId, 'new')
   await view.applyRoute({ kind: 'module', moduleId: 'database', path: '/database' })
   assert.equal(view.get().sessionId, 'new')
+})
+
+test('missing session route does not surface 404 and opens the latest chat', async () => {
+  const gone: string[] = []
+  const onMissing = (event: Event) => {
+    gone.push(String((event as CustomEvent<{ sessionId?: string }>).detail?.sessionId ?? ''))
+  }
+  window.addEventListener('biu:session-missing', onMissing)
+  mockFetch({
+    '/api/sessions': () => ({
+      sessions: [{ id: 'new', title: 'new', eventCount: 1, updatedAt: 9 }],
+    }),
+    '/api/sessions/new?turns=': () => ({
+      id: 'new',
+      events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+      hasMore: false,
+      totalTurns: 0,
+    }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const innerFetch = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input)
+    if (/\/api\/sessions\/gone(\?|$)/.test(url)) {
+      return { ok: false, status: 404, json: async () => ({}) } as Response
+    }
+    return innerFetch(input, init)
+  }) as typeof fetch
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  await view.load('gone', { view: 'chat', wait: true })
+  window.removeEventListener('biu:session-missing', onMissing)
+  assert.equal(view.get().error, undefined)
+  assert.equal(view.get().sessionId, 'new')
+  assert.deepEqual(gone, ['gone'])
 })
 
 test('sessions record routes do not switch the live session', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开不存在的 `/s/:id` 时不再显示「加载 session 失败：404」。静默回到 `/`，并打开最近一条对话。

侧栏空列表也不再显示 “No chats yet. Send a message or create one.”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

