### PR TITLE
fix(chat): 模型配置页不再放思考和力度

### DIFF
--- a/packages/core-chat/src/web/config.tsx
+++ b/packages/core-chat/src/web/config.tsx
@@ -10,8 +10,6 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { CheckIcon, ChevronDownIcon, ArrowPathIcon, PlusIcon, MagnifyingGlassIcon, SignalSlashIcon, XMarkIcon } from '@heroicons/react/16/solid'
 import { HeadlessDismiss } from '@biu/public-ui'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
-import { ModelModeControls } from './model-mode.tsx'
-import type { ContextWindow, ModelCapabilities, ReasoningEffort, SpeedMode, ThinkingMode } from '../host/model-catalog.ts'
 
 type ChatProvider = 'deepseek' | 'openai' | 'anthropic'
 
@@ -50,11 +48,6 @@ interface ChatPublicConfig {
   endpointId?: string
   provider: ChatProvider
   model: string
-  thinking?: ThinkingMode
-  reasoningEffort?: ReasoningEffort
-  contextWindow?: ContextWindow
-  speed?: SpeedMode
-  capabilities?: ModelCapabilities
   configured: boolean
   hint: string
   baseUrl?: string
@@ -86,11 +79,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
   const [activeId, setActiveId] = useState('deepseek')
   const [defaultEndpointId, setDefaultEndpointId] = useState('deepseek')
   const [defaultModel, setDefaultModel] = useState('deepseek-v4-flash')
-  const [thinking, setThinking] = useState<ThinkingMode>('enabled')
-  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>('high')
-  const [contextWindow, setContextWindow] = useState<ContextWindow>('200k')
-  const [speed, setSpeed] = useState<SpeedMode>('slow')
-  const [modelCaps, setModelCaps] = useState<ModelCapabilities>({ knobs: [] })
   const [endpoints, setEndpoints] = useState<EndpointView[]>([])
   const [modelCatalog, setModelCatalog] = useState<ModelDef[]>([])
   const [providers, setProviders] = useState<Record<string, ProviderView> | null>(null)
@@ -258,11 +246,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
     const eid = preferActive || data.endpointId || data.provider || 'deepseek'
     setDefaultEndpointId(data.endpointId || data.provider || eid)
     setDefaultModel(data.model)
-    if (data.thinking === 'enabled' || data.thinking === 'disabled') setThinking(data.thinking)
-    if (data.reasoningEffort === 'high' || data.reasoningEffort === 'max') setReasoningEffort(data.reasoningEffort)
-    if (data.contextWindow === '200k' || data.contextWindow === '1m') setContextWindow(data.contextWindow)
-    if (data.speed === 'fast' || data.speed === 'slow') setSpeed(data.speed)
-    if (data.capabilities) setModelCaps(data.capabilities)
     setActiveId(eid)
 
     const ep = eps.find((e) => e.id === eid)
@@ -1086,29 +1069,6 @@ export function ChatConfig(props?: { onClose?: () => void }) {
                   ) : (
                     <p className="text-[11px] text-(--dsw-label-3)">暂无模型，在下方添加 model id</p>
                   )}
-
-                  {isDefaultProvider ? (
-                    <ModelModeControls
-                      capabilities={modelCaps}
-                      mode={{ thinking, speed, effort: reasoningEffort, context: contextWindow }}
-                      disabled={saving}
-                      onChange={(next) => {
-                        void fetch('/api/chat/config', {
-                          method: 'POST',
-                          headers: { 'content-type': 'application/json' },
-                          body: JSON.stringify({
-                            thinking: next.thinking,
-                            speed: next.speed,
-                            reasoningEffort: next.effort,
-                            contextWindow: next.context,
-                          }),
-                        })
-                          .then((res) => res.json())
-                          .then((data: ChatPublicConfig) => applyPublic(data, activeId))
-                          .catch(() => setError('保存失败'))
-                      }}
-                    />
-                  ) : null}
 
                   <div className="flex gap-2">
                     <input

--- a/packages/core-chat/src/web/model-config-dialog.test.ts
+++ b/packages/core-chat/src/web/model-config-dialog.test.ts
@@ -10,4 +10,11 @@ describe('model config dialog stacking', () => {
     expect(src).toMatch(/z-\[240\]/)
     expect(src).not.toMatch(/z-30/)
   })
+
+  it('does not repeat thinking or effort knobs already on the composer', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './config.tsx'), 'utf8')
+    expect(src).not.toMatch(/ModelModeControls/)
+    expect(src).not.toMatch(/thinking:/)
+    expect(src).not.toMatch(/reasoningEffort/)
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
模型配置页去掉思考 / 力度（以及同组的速度、上下文 knobs）。这些已经在输入框的模型菜单里配置，配置页只保留连接、密钥和模型列表。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

