### PR TITLE
fix(ui): 图标选窗统一并润色

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1602,7 +1602,6 @@ export function CollectionBrowser({
   function TableRecordIcon({ row }: { row: DbRecord }) {
     const emoji = recordPreviewEmoji(row)
     const [open, setOpen] = useState(false)
-    const [draft, setDraft] = useState(emoji)
     const [anchor, setAnchor] = useState<HTMLElement | null>(null)
     return (
       <span className="fsdb-table-record-icon">
@@ -1619,7 +1618,6 @@ export function CollectionBrowser({
                 setAnchor(null)
                 return false
               }
-              setDraft(emoji)
               setAnchor(btn)
               return true
             })
@@ -1635,8 +1633,6 @@ export function CollectionBrowser({
         {open && anchor ? (
           <RecordEmojiBoard
             anchor={anchor}
-            draft={draft}
-            onDraft={setDraft}
             onPick={(next) => {
               void writePatch(row, { emoji: normalizeRecordEmoji(next) })
               setOpen(false)

--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -89,7 +89,6 @@ function ViewRecordPreview({
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({})
   const [pickerId, setPickerId] = useState<string | null>(null)
   const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null)
-  const [emojiDraft, setEmojiDraft] = useState('')
   const chromeIcon = getDatabaseUi()?.chrome(path).Icon
 
   useEffect(() => {
@@ -185,7 +184,6 @@ function ViewRecordPreview({
                     setPickerAnchor(btn)
                     return row.id
                   })
-                  setEmojiDraft(emoji)
                 }}
               >
                 {emoji ? (
@@ -197,8 +195,6 @@ function ViewRecordPreview({
               {pickerId === row.id && pickerAnchor ? (
                 <RecordEmojiBoard
                   anchor={pickerAnchor}
-                  draft={emojiDraft}
-                  onDraft={setEmojiDraft}
                   onPick={(next) => void saveEmoji(row, next)}
                   onClear={() => void saveEmoji(row, '')}
                   onClose={() => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -97,9 +97,15 @@ test('sidebar records paint detail immediately without reloading the view', () =
   const emoji = readFileSync(resolve(import.meta.dirname, '../../../public-ui/src/emoji-board.tsx'), 'utf8')
   assert.match(emoji, /function RecordEmojiBoard/)
   assert.match(emoji, /className="fsdb-emoji-picker is-fixed"/)
+  assert.doesNotMatch(emoji, /fsdb-emoji-picker-input/)
+  assert.doesNotMatch(emoji, />恢复默认</)
+  assert.match(emoji, /aria-label="恢复默认"/)
   assert.match(sidebar, /fsdb-record-emoji/)
-  assert.match(css, /\.fsdb-emoji-picker \{[^}]*border:\s*0/s)
-  assert.match(css, /\.fsdb-emoji-picker \{[^}]*background:\s*#191919/s)
+  assert.match(css, /\.fsdb-emoji-picker \{[^}]*border-radius:\s*12px/s)
+  assert.match(css, /\.fsdb-emoji-picker \{[^}]*background:\s*#1c1c1c/s)
+  assert.match(css, /\.fsdb-emoji-picker-presets \{[^}]*grid-template-columns:\s*repeat\(8/)
+  assert.match(detail, /key === 'emoji'/)
+  assert.match(detail, /<RecordEmojiBoard/)
 })
 
 test('table title opens record from the title-side button', () => {

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -28,7 +28,6 @@ function DetailTitleIcon({
   onChange: (next: string) => void
 }) {
   const [open, setOpen] = useState(false)
-  const [draft, setDraft] = useState(emoji)
   const [anchor, setAnchor] = useState<HTMLElement | null>(null)
   return (
     <span className="fsdb-detail-title-icon-wrap">
@@ -44,7 +43,6 @@ function DetailTitleIcon({
               setAnchor(null)
               return false
             }
-            setDraft(emoji)
             setAnchor(btn)
             return true
           })
@@ -63,8 +61,6 @@ function DetailTitleIcon({
       {open && anchor ? (
         <RecordEmojiBoard
           anchor={anchor}
-          draft={draft}
-          onDraft={setDraft}
           onPick={(next) => {
             onChange(normalizeRecordEmoji(next))
             setOpen(false)
@@ -143,7 +139,7 @@ export function RecordDetail({
 
   const propertyEntries = Object.entries(schema.fields)
     .filter(([key, field]) => {
-      if (key === 'id' || key === schema.labelField || key === contentFieldKey(schema)) return false
+      if (key === 'id' || key === 'emoji' || key === schema.labelField || key === contentFieldKey(schema)) return false
       if (chrome?.panes?.some((pane) => pane.id === key)) return false
       const kind = resolveFieldType(field)
       if (kind === 'facet' && !field.writable) return false

--- a/packages/public-ui/src/emoji-board.tsx
+++ b/packages/public-ui/src/emoji-board.tsx
@@ -2,19 +2,32 @@ import { useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { HeadlessDismiss } from './headless-dismiss.tsx'
 
-const RECORD_EMOJI_PRESETS = ['⭐', '🔥', '✅', '📌', '💡', '🎯', '📦', '🧩', '📄', '⚡']
+const RECORD_EMOJI_PRESETS = [
+  '📄', '📝', '📚', '🗂️', '📁', '📦', '🔖', '🧩',
+  '⭐', '🔥', '✅', '📌', '💡', '🎯', '⚡', '🚀',
+  '💻', '🛠️', '🧪', '📊', '📈', '🧠', '🔍', '💬',
+  '🏠', '🌍', '🎨', '🎵', '🎬', '📷', '🎮', '🧱',
+  '❤️', '😊', '🎉', '🌈', '☕', '🌙', '☀️', '🍀',
+  '🐛', '🔒', '⚠️', '✨', '🏆', '🧬', '🪄', '🌱',
+]
+
+const PICKER_WIDTH = 272
+
+function RestoreIcon() {
+  return (
+    <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden fill="currentColor">
+      <path d="M8 1.5a6.5 6.5 0 1 0 6.32 8.12.75.75 0 0 0-1.46-.32A5 5 0 1 1 8 3a4.9 4.9 0 0 1 3.45 1.4H9.75a.75.75 0 0 0 0 1.5h3.5A.75.75 0 0 0 14 5.15V1.75a.75.75 0 0 0-1.5 0v1.36A6.47 6.47 0 0 0 8 1.5Z" />
+    </svg>
+  )
+}
 
 export function RecordEmojiBoard({
   anchor,
-  draft,
-  onDraft,
   onPick,
   onClear,
   onClose,
 }: {
   anchor: HTMLElement
-  draft: string
-  onDraft: (next: string) => void
   onPick: (emoji: string) => void
   onClear: () => void
   onClose: () => void
@@ -23,11 +36,11 @@ export function RecordEmojiBoard({
   useLayoutEffect(() => {
     const place = () => {
       const box = anchor.getBoundingClientRect()
-      const width = 168
-      setPos({
-        left: Math.min(box.left, Math.max(8, window.innerWidth - width - 8)),
-        top: box.bottom + 4,
-      })
+      const height = 268
+      const left = Math.min(box.left, Math.max(8, window.innerWidth - PICKER_WIDTH - 8))
+      const below = box.bottom + 6
+      const top = below + height > window.innerHeight - 8 ? Math.max(8, box.top - height - 6) : below
+      setPos({ left, top })
     }
     place()
     window.addEventListener('resize', place)
@@ -56,23 +69,11 @@ export function RecordEmojiBoard({
           </button>
         ))}
       </div>
-      <input
-        className="fsdb-emoji-picker-input"
-        value={draft}
-        placeholder="输入 emoji"
-        maxLength={8}
-        onChange={(event) => onDraft(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter') {
-            event.preventDefault()
-            onPick(draft)
-          }
-          if (event.key === 'Escape') onClose()
-        }}
-      />
-      <button type="button" className="fsdb-emoji-picker-clear" onClick={onClear}>
-        恢复默认
-      </button>
+      <div className="fsdb-emoji-picker-foot">
+        <button type="button" className="fsdb-emoji-picker-clear" title="恢复默认" aria-label="恢复默认" onClick={onClear}>
+          <RestoreIcon />
+        </button>
+      </div>
     </div>
     </HeadlessDismiss>,
     document.body,

--- a/web/style.css
+++ b/web/style.css
@@ -2279,35 +2279,37 @@ body {
 
 .fsdb-emoji-picker {
   position: absolute;
-  top: calc(100% + 4px);
+  top: calc(100% + 6px);
   left: 0;
   z-index: 30;
-  width: 168px;
-  padding: 8px;
-  border: 0;
-  border-radius: 10px;
-  background: #191919;
-  box-shadow: none;
+  width: 272px;
+  padding: 10px 10px 8px;
+  border: 1px solid color-mix(in srgb, var(--dsw-border) 70%, transparent);
+  border-radius: 12px;
+  background: #1c1c1c;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.42);
 }
 
 .fsdb-emoji-picker.is-fixed {
   position: fixed;
-  z-index: 140;
+  z-index: 240;
 }
 
 .fsdb-emoji-picker-presets {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 2px;
 }
 
 .fsdb-emoji-picker-item {
-  width: 28px;
-  height: 28px;
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1;
   border: 0;
-  border-radius: 6px;
+  border-radius: 8px;
   background: transparent;
-  font-size: 16px;
+  font-size: 18px;
   line-height: 1;
   cursor: pointer;
 }
@@ -2316,33 +2318,31 @@ body {
   background: var(--dsw-hover);
 }
 
-.fsdb-emoji-picker-input {
-  box-sizing: border-box;
-  width: 100%;
-  margin-top: 8px;
-  padding: 6px 8px;
-  border: 1px solid var(--dsw-border);
-  border-radius: 6px;
-  background: transparent;
-  color: inherit;
-  font-size: 14px;
+.fsdb-emoji-picker-foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, var(--dsw-border) 55%, transparent);
 }
 
 .fsdb-emoji-picker-clear {
-  display: block;
-  width: 100%;
-  margin-top: 6px;
-  padding: 4px 0;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: 0;
+  padding: 0;
   border: 0;
+  border-radius: 8px;
   background: transparent;
   color: var(--dsw-label-3);
-  font-size: 14px;
-  text-align: left;
   cursor: pointer;
 }
 
 .fsdb-emoji-picker-clear:hover {
   color: var(--dsw-sidebar-fg-active);
+  background: var(--dsw-hover);
 }
 
 /* 不推整行背景，只给会话内容加约 2/3 图标宽的左内边距 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
图标选择悬浮窗侧栏、表格、详情标题共用同一套：

- 去掉输入框，只能点预设
- 「恢复默认」改成底部重置图标
- 预设从 10 个加到 48 个（8 列网格）
- 详情属性里不再出现可输入的 emoji 字段，改点标题旁图标打开同一选窗

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

