### PR TITLE
合集二级弹窗去掉重复名称

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -175,7 +175,6 @@ function FacetColumnPackRow({
       }
     >
       <div className="fsdb-col-facet-flyout" data-fsdb-col-flyout role="menu">
-        <div className="tasks-sort-head">{pack.label}</div>
         {pack.fields.length ? (
           pack.fields.map((field) => {
             const key = facetFlatColumnKey(pack.id, field.key)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -366,6 +366,8 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(browser, /function FacetColumnPackRow/)
   assert.match(browser, /data-fsdb-col-flyout/)
   assert.match(browser, /className=\{`fsdb-col-facet-dot/)
+  const facetFlyout = browser.slice(browser.indexOf('function FacetColumnPackRow'), browser.indexOf('function recordsFingerprint'))
+  assert.doesNotMatch(facetFlyout, /tasks-sort-head/)
   assert.match(browser, /<SchemaFieldEditor/)
   const schemaUi = readFileSync(resolve(import.meta.dirname, './schema-field.tsx'), 'utf8')
   assert.match(schemaUi, /retagSchemaValue\(liveRef.current, resolved\)/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
合集二级菜单只列属性勾选，顶部不再重复合集名称。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

