### PR TITLE
fix(fsdb): 筛选排序二级不关外层，合集浮窗去掉重名

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -143,6 +143,8 @@ function isListColumn(key: string) {
   return key !== 'description' && key !== 'notes' && key !== 'content' && key !== 'emoji'
 }
 
+const QUERY_NEST_IGNORE = `${HEADLESS_DISMISS_IGNORE}, .db-search-menu, .fsdb-cellselect-menu`
+
 function FacetColumnPackRow({
   pack,
   visibleKeys,
@@ -184,7 +186,6 @@ function FacetColumnPackRow({
       }
     >
       <div className="fsdb-col-facet-flyout" data-fsdb-col-flyout role="menu">
-        <div className="tasks-sort-head">{pack.label}</div>
         {pack.fields.length ? (
           pack.fields.map((field) => {
             const key = facetFlatColumnKey(pack.id, field.key)
@@ -2404,7 +2405,12 @@ export function CollectionBrowser({
                 {sorts.length ? <span className="tasks-sort-dot" aria-hidden /> : null}
               </button>
               {sortMenuOpen ? (
-                <HeadlessDismiss onDismiss={() => setSortMenuOpen(false)} insideRef={sortRef}>
+                <HeadlessDismiss
+                  onDismiss={() => setSortMenuOpen(false)}
+                  insideRef={sortRef}
+                  ignoreSelector={QUERY_NEST_IGNORE}
+                  inside={(node) => node instanceof Element && Boolean(node.closest('.db-search-menu, .fsdb-cellselect-menu'))}
+                >
                 <SortQueryMenu sorts={sorts} fields={sortFields} onChange={applySorts} />
                 </HeadlessDismiss>
               ) : null}
@@ -2511,7 +2517,12 @@ export function CollectionBrowser({
                 {filterActive ? <span className="tasks-filter-dot" aria-hidden /> : null}
               </button>
               {filterOpen ? (
-                <HeadlessDismiss onDismiss={() => setFilterOpen(false)} insideRef={filterRef}>
+                <HeadlessDismiss
+                  onDismiss={() => setFilterOpen(false)}
+                  insideRef={filterRef}
+                  ignoreSelector={QUERY_NEST_IGNORE}
+                  inside={(node) => node instanceof Element && Boolean(node.closest('.db-search-menu, .fsdb-cellselect-menu'))}
+                >
                 <FilterQueryMenu
                   tree={filterTree}
                   fields={filterFields}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -365,6 +365,7 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(browser, /facetColumnTitle\(col\)/)
   assert.match(browser, /function FacetColumnPackRow/)
   assert.match(browser, /data-fsdb-col-flyout/)
+  assert.doesNotMatch(browser, /data-fsdb-col-flyout[\s\S]{0,80}tasks-sort-head/)
   assert.match(browser, /className=\{`fsdb-col-facet-dot/)
   assert.match(browser, /<SchemaFieldEditor/)
   const schemaUi = readFileSync(resolve(import.meta.dirname, './schema-field.tsx'), 'utf8')
@@ -537,6 +538,8 @@ test('missing sort field falls back to title, not updatedAt', () => {
   assert.doesNotMatch(browser, /item.kind === 'datetime' \? 'desc'/)
   assert.match(browser, /<SortQueryMenu/)
   assert.match(browser, /<FilterQueryMenu/)
+  assert.match(browser, /QUERY_NEST_IGNORE/)
+  assert.match(browser, /ignoreSelector=\{QUERY_NEST_IGNORE\}/)
 })
 
 test('page collection uses a document glyph, not the table/database icon', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
一起修两处：

1. 筛选 / 排序外层弹窗：字段、运算符、方向这些二级选项是 portal 到 body 的。点进去会被当成点外面，整层关掉，没法配二级条件。现在外层忽略 `.db-search-menu` / `.fsdb-cellselect-menu`。
2. 可见列合集：二级浮窗只列属性，不再重复合集名称。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

