### PR TITLE
feat(fsdb): 新增 db_asset，附件读写走 etag

### DIFF
--- a/.plugin-dev/page-excalidraw/web.tsx
+++ b/.plugin-dev/page-excalidraw/web.tsx
@@ -67,33 +67,43 @@ function normalizeStem(raw: string, fallback: string) {
   return stem
 }
 
-async function loadScene(file: string): Promise<Scene> {
+async function loadScene(file: string): Promise<{ scene: Scene; etag: string }> {
   const name = assetName(file)
   const res = await fetch(`/api/page/file/${encodeURIComponent(name)}`)
   if (res.status === 404) {
     const scene = emptyScene()
-    await fetch(`/api/page/file/${encodeURIComponent(name)}`, {
+    const created = await fetch(`/api/page/file/${encodeURIComponent(name)}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(scene),
     })
-    return scene
+    const etag = etagFromResponse(created)
+    return { scene, etag }
   }
-  if (!res.ok) return emptyScene()
+  if (!res.ok) return { scene: emptyScene(), etag: '' }
   try {
-    return parseScene(JSON.parse(await res.text()))
+    return { scene: parseScene(JSON.parse(await res.text())), etag: etagFromResponse(res) }
   } catch {
-    return emptyScene()
+    return { scene: emptyScene(), etag: etagFromResponse(res) }
   }
 }
 
-function saveScene(file: string, scene: Scene) {
+function etagFromResponse(res: Response) {
+  return String(res.headers.get('etag') ?? '').replace(/^W\//, '').replaceAll('"', '')
+}
+
+async function saveScene(file: string, scene: Scene, etag: string) {
   const name = assetName(file)
-  void fetch(`/api/page/file/${encodeURIComponent(name)}`, {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (etag) headers['If-Match'] = `"${etag}"`
+  const res = await fetch(`/api/page/file/${encodeURIComponent(name)}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers,
     body: JSON.stringify(scene),
   })
+  if (res.status === 409) return { ok: false as const, etag: etagFromResponse(res) }
+  if (!res.ok) return { ok: false as const, etag }
+  return { ok: true as const, etag: etagFromResponse(res) || etag }
 }
 
 function fitView(api: DrawApi | null) {
@@ -112,6 +122,8 @@ type Host = {
   ready: Promise<Host>
   initialData: { elements: never; appState: Record<string, unknown>; files: never } | null
   lastScene: Scene | null
+  etag: string
+  pending: ReturnType<typeof setTimeout> | null
   expanded: boolean
   sync?: () => void
   onCollapse?: () => void
@@ -119,6 +131,43 @@ type Host = {
 
 const hosts = new Map<string, Host>()
 let syncQueued = false
+
+function cancelPending(host: Host) {
+  if (!host.pending) return
+  clearTimeout(host.pending)
+  host.pending = null
+}
+
+async function reloadHost(file: string) {
+  const host = hosts.get(file)
+  if (!host) return
+  cancelPending(host)
+  const loaded = await loadScene(file)
+  if (hosts.get(file) !== host) return
+  const scene = loaded.scene
+  host.etag = loaded.etag
+  host.lastScene = scene
+  host.initialData = {
+    elements: (scene.elements ?? []) as never,
+    appState: { ...withoutCollab(scene.appState), collaborators: new Map() },
+    files: (scene.files ?? {}) as never,
+  }
+  paintHost(host)
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('biu:asset-changed', ((event: Event) => {
+    const detail = (event as CustomEvent<{ name?: string; etag?: string }>).detail
+    const name = String(detail?.name ?? '')
+    if (!name) return
+    for (const [file, host] of hosts) {
+      if (assetName(file) !== name && file !== name) continue
+      if (detail?.etag && host.etag === detail.etag) continue
+      cancelPending(host)
+      void reloadHost(file)
+    }
+  }) as EventListener)
+}
 
 function queueHostSync() {
   if (syncQueued) return
@@ -172,10 +221,14 @@ function retainHost(file: string) {
     ready: Promise.resolve(null as unknown as Host),
     initialData: null,
     lastScene: null,
+    etag: '',
+    pending: null,
     expanded: false,
   }
-  host.ready = loadScene(file).then((scene) => {
+  host.ready = loadScene(file).then((loaded) => {
     if (hosts.get(file) !== host) return host
+    const scene = loaded.scene
+    host.etag = loaded.etag
     host.initialData = {
       elements: (scene.elements ?? []) as never,
       appState: { ...withoutCollab(scene.appState), collaborators: new Map() },
@@ -219,6 +272,7 @@ function PersistentDraw(props: {
   const file = props.file
   const pending = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSaved = useRef('')
+  const etagRef = useRef(hosts.get(file)?.etag ?? '')
   const apiRef = useRef<DrawApi | null>(null)
   const bindApi = useCallback((api: DrawApi | null) => {
     apiRef.current = api
@@ -236,7 +290,21 @@ function PersistentDraw(props: {
     const hosted = hosts.get(file)
     if (hosted) hosted.lastScene = next
     if (pending.current) clearTimeout(pending.current)
-    pending.current = setTimeout(() => saveScene(file, next), 400)
+    pending.current = setTimeout(() => {
+      const hostedNow = hosts.get(file)
+      if (hostedNow) hostedNow.pending = null
+      void saveScene(file, next, etagRef.current).then((result) => {
+        if (result.ok) {
+          etagRef.current = result.etag
+          const live = hosts.get(file)
+          if (live) live.etag = result.etag
+          return
+        }
+        void reloadHost(file)
+      })
+    }, 400)
+    const hostedPending = hosts.get(file)
+    if (hostedPending) hostedPending.pending = pending.current
   }, [file])
 
   useEffect(() => {
@@ -426,8 +494,9 @@ function Board(props: { data: Record<string, unknown>; update: (p: Record<string
 
   const onRename = (name: string) => {
     const nextFile = `assets/${name}`
-    const scene = hosts.get(file)?.lastScene
-    if (scene) saveScene(nextFile, scene)
+    const hosted = hosts.get(file)
+    const scene = hosted?.lastScene
+    if (scene) void saveScene(nextFile, scene, '')
     props.update({ file: nextFile })
   }
 

--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -191,6 +191,16 @@ test('compact root keeps view.blurb for the agent; drops route chrome', () => {
     ok: true,
   }) as Record<string, unknown>
   assert.deepEqual(written, { ok: true, path: '/notes/n1' })
+
+  const assetWrite = pack.query({
+    kind: 'asset',
+    path: '/pages/p1',
+    command: 'write',
+    ok: true,
+    name: 'board.json',
+    etag: 'abc',
+  }) as Record<string, unknown>
+  assert.deepEqual(assetWrite, { ok: true, path: '/pages/p1', name: 'board.json', etag: 'abc' })
 })
 
 

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -43,6 +43,7 @@ export class AgentDbCompact {
       return next
     }
     if (kind === 'content') return this.content(rec)
+    if (kind === 'asset') return this.asset(rec)
     return result
   }
 
@@ -96,6 +97,17 @@ export class AgentDbCompact {
     if (typeof rec.end === 'number') next.end = rec.end
     if (typeof rec.total === 'number') next.total = rec.total
     if (rec.truncated) next.truncated = true
+    return next
+  }
+
+  private asset(rec: Record<string, unknown>) {
+    if (rec.ok === true || rec.command === 'write') {
+      return { ok: true, path: rec.path, name: rec.name, etag: rec.etag }
+    }
+    if (Array.isArray(rec.assets)) return { path: rec.path, assets: rec.assets }
+    const next: Record<string, unknown> = { path: rec.path, name: rec.name, etag: rec.etag }
+    if (typeof rec.text === 'string') next.text = rec.text
+    if (typeof rec.type === 'string') next.type = rec.type
     return next
   }
 

--- a/packages/core-file-system/src/host/assets-store.test.ts
+++ b/packages/core-file-system/src/host/assets-store.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { FileSystemAssets, assetHref, isAssetFileName } from './assets-store.ts'
+import { FileSystemAssets, AssetConflictError, assetHref, collectAssetNames, isAssetFileName } from './assets-store.ts'
 
 test('shared assets live under a single directory and reject path escape', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'fs-assets-'))
@@ -17,6 +17,13 @@ test('shared assets live under a single directory and reject path escape', async
   await assert.rejects(() => store.write('../secret.png', 'nope'), /invalid asset/)
   assert.equal(isAssetFileName('ok-file_1.png'), true)
   assert.equal(isAssetFileName('../x'), false)
+  await assert.rejects(() => store.write('shot.png', 'next'), (error) => {
+    assert.equal(error instanceof AssetConflictError, true)
+    return true
+  })
+  const again = await store.write('shot.png', 'next', { etag: written.etag })
+  assert.equal(again.etag.length, 16)
+  assert.deepEqual([...collectAssetNames({ file: 'assets/画板-ab12.json' })], ['画板-ab12.json'])
 })
 
 test('asset reads fall back to a legacy folder', async () => {

--- a/packages/core-file-system/src/host/assets-store.ts
+++ b/packages/core-file-system/src/host/assets-store.ts
@@ -1,11 +1,23 @@
+import { createHash } from 'node:crypto'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { DATA_DIR_NAME, dataPath } from '@biu/host-plugin-loader/data-dir'
 
 export const FILE_SYSTEM_ASSETS = `${DATA_DIR_NAME}/assets`
 export const FILE_SYSTEM_ASSET_PREFIX = '/api/db/file/'
+export const ASSET_CHANGED_EVENT = 'biu:asset-changed'
 
 const ASSET_FILE_RE = /^[\p{L}\p{N}._-]+$/u
+const ASSET_REF_RE = /(?:(?:\.page\/)?assets\/|\/api\/(?:page|db)\/file\/)([\p{L}\p{N}._-]+)/gu
+
+export class AssetConflictError extends Error {
+  readonly etag: string
+  constructor(etag: string) {
+    super('etag conflict')
+    this.name = 'AssetConflictError'
+    this.etag = etag
+  }
+}
 
 export function isAssetFileName(name: string) {
   const file = basename(name)
@@ -29,6 +41,31 @@ export function mimeOfAsset(name: string) {
   return 'application/octet-stream'
 }
 
+export function bytesEtag(bytes: Buffer) {
+  return createHash('sha1').update(bytes).digest('hex').slice(0, 16)
+}
+
+export function parseIfMatch(raw: unknown) {
+  const text = String(raw ?? '').trim().replace(/^W\//, '').replaceAll('"', '')
+  return text && text !== '*' ? text : ''
+}
+
+export function collectAssetNames(...chunks: unknown[]): Set<string> {
+  const names = new Set<string>()
+  const eat = (text: string) => {
+    for (const match of text.matchAll(ASSET_REF_RE)) {
+      const name = basename(match[1] ?? '')
+      if (isAssetFileName(name)) names.add(name)
+    }
+  }
+  for (const chunk of chunks) {
+    if (chunk == null) continue
+    if (typeof chunk === 'string') eat(chunk)
+    else eat(JSON.stringify(chunk))
+  }
+  return names
+}
+
 export class FileSystemAssets {
   constructor(private dir = dataPath(process.cwd(), 'assets')) {}
 
@@ -36,13 +73,26 @@ export class FileSystemAssets {
     return this.dir
   }
 
-  async write(name: string, content: string | Buffer | Uint8Array) {
+  async write(name: string, content: string | Buffer | Uint8Array, opts?: { etag?: string }) {
     const file = basename(name)
     if (!file || file !== name.replace(/\\/g, '/') || !isAssetFileName(file)) throw new Error('invalid asset')
     await mkdir(this.dir, { recursive: true })
-    const bytes = typeof content === 'string' ? Buffer.from(content) : Buffer.from(content)
-    await writeFile(join(this.dir, file), bytes)
-    return { name: file, href: assetHref(file) }
+    const next = typeof content === 'string' ? Buffer.from(content) : Buffer.from(content)
+    const expected = parseIfMatch(opts?.etag)
+    let current = ''
+    try {
+      current = bytesEtag(await readFile(join(this.dir, file)))
+    } catch {
+      current = ''
+    }
+    if (current) {
+      if (!expected) throw new AssetConflictError(current)
+      if (expected !== current) throw new AssetConflictError(current)
+    } else if (expected) {
+      throw new AssetConflictError('')
+    }
+    await writeFile(join(this.dir, file), next)
+    return { name: file, href: assetHref(file), etag: bytesEtag(next) }
   }
 
   async read(name: string, fallbackDirs: string[] = []) {
@@ -53,7 +103,7 @@ export class FileSystemAssets {
     for (const dir of dirs) {
       try {
         const bytes = await readFile(join(dir, file))
-        return { bytes, type: mimeOfAsset(file) }
+        return { bytes, type: mimeOfAsset(file), etag: bytesEtag(bytes) }
       } catch (error) {
         last = error
       }

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -2,7 +2,11 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context, Service } from 'cordis'
 import * as tools from '@biu/host-tools'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { DatabaseService, apply as applyFileSystem } from './index.ts'
+import { FileSystemAssets } from './assets-store.ts'
 import type { CollectionSpec } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { facetsCollection } from './facets-collection.ts'
@@ -432,6 +436,47 @@ test('editContent view/str_replace/replace_lines/insert/write', async () => {
   assert.equal((await db.content('/docs/n1')).value, 'done')
 })
 
+test('editAsset views and writes referenced attachments with etag', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  db.assets = new FileSystemAssets(await mkdtemp(join(tmpdir(), 'db-asset-')))
+  const rows = new Map<string, Record<string, unknown>>([
+    ['p1', { id: 'p1', title: '页', notes: '{"file":"assets/board.json"}' }],
+  ])
+  db.register({
+    id: 'pages',
+    path: '/pages',
+    schema: {
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string', writable: true },
+        notes: { type: 'file', writable: true },
+      },
+    },
+    list: () => [...rows.values()] as { id: string }[],
+    get: (id) => rows.get(id) as { id: string } | undefined,
+    records: { update: true },
+  })
+  const listed = await db.editAsset('/pages/p1', { command: 'view' })
+  assert.equal(listed.command, 'view')
+  const missing = (listed as { assets: Array<{ name: string; missing?: boolean }> }).assets
+  assert.equal(missing[0]?.name, 'board.json')
+  assert.equal(missing[0]?.missing, true)
+  await db.assets.write('board.json', '{"elements":[]}')
+  const viewed = await db.editAsset('/pages/p1', { command: 'view', name: 'board.json' })
+  assert.equal(typeof viewed.etag, 'string')
+  assert.equal(String(viewed.etag).length, 16)
+  await assert.rejects(() => db.editAsset('/pages/p1', { command: 'write', name: 'board.json', value: '{}' }))
+  const written = await db.editAsset('/pages/p1', {
+    command: 'write',
+    name: 'board.json',
+    value: '{}',
+    etag: viewed.etag,
+  })
+  assert.equal(written.ok, true)
+  await assert.rejects(() => db.editAsset('/pages/p1', { command: 'view', name: 'nope.json' }), /not referenced/)
+})
+
 test('list paginates collection records and reports total', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)
@@ -497,7 +542,7 @@ test('apply registers db_* tools', async () => {
   new HttpStub(ctx)
   await ctx.plugin({ inject: ['tools', 'http'], apply: applyFileSystem })
   const names = ctx.tools.names()
-  for (const name of ['db_list', 'db_read', 'db_update', 'db_create', 'db_delete', 'db_stat', 'db_action', 'db_content']) {
+  for (const name of ['db_list', 'db_read', 'db_update', 'db_create', 'db_delete', 'db_stat', 'db_action', 'db_content', 'db_asset']) {
     assert.equal(names.includes(name), true, name)
   }
   const listed = await ctx.tools.invoke('db_list', { path: '/' })

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -456,6 +456,11 @@ test('editAsset views and writes referenced attachments with etag', async () => 
     list: () => [...rows.values()] as { id: string }[],
     get: (id) => rows.get(id) as { id: string } | undefined,
     records: { update: true },
+    update: (id, patch) => {
+      const next = { ...rows.get(id), ...patch, id }
+      rows.set(id, next)
+      return next as { id: string }
+    },
   })
   const listed = await db.editAsset('/pages/p1', { command: 'view' })
   assert.equal(listed.command, 'view')

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -29,7 +29,7 @@ import {
 } from '@biu/type-file-system'
 import { SavedViewsStore, viewsCollection, type StoredView } from './saved-views.ts'
 import { FacetStore } from './facets-store.ts'
-import { FileSystemAssets } from './assets-store.ts'
+import { AssetConflictError, FileSystemAssets, collectAssetNames, isAssetFileName, parseIfMatch } from './assets-store.ts'
 import { facetsCollection } from './facets-collection.ts'
 import {
   asContentText,
@@ -406,6 +406,7 @@ export function clampPage(limit?: number, offset?: number) {
 export class DatabaseService extends Service implements Database {
   private collections = new Map<string, CollectionSpec>()
   facets = new FacetStore()
+  assets = new FileSystemAssets()
 
   private bumpQueued = false
 
@@ -945,6 +946,59 @@ export class DatabaseService extends Service implements Database {
       ok: true as const,
     }
   }
+
+  async editAsset(path: string, args: Record<string, unknown> = {}) {
+    const parts = splitPath(path)
+    if (parts.length !== 2) throw new Error(`cannot asset: ${normalizeCollectionPath(path)}`)
+    const spec = this.collection(`/${parts[0]}`)
+    if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
+    const record = await spec.get(parts[1]!)
+    if (!record) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
+    const names = collectAssetNames(record)
+    const file = String(args.name ?? '')
+      .trim()
+      .replace(/^assets\//, '')
+      .replace(/^.*[/\\]/, '')
+    const command = String(args.command ?? (args.value != null ? 'write' : 'view'))
+    const recPath = `${spec.path}/${record.id}`
+    if (command === 'view' && !file) {
+      const assets = []
+      for (const name of [...names].sort()) {
+        try {
+          const read = await this.assets.read(name)
+          assets.push({ name, etag: read.etag, type: read.type })
+        } catch {
+          assets.push({ name, missing: true })
+        }
+      }
+      return { kind: 'asset' as const, path: recPath, command: 'view' as const, assets }
+    }
+    if (!isAssetFileName(file)) throw new Error('invalid asset')
+    if (!names.has(file)) throw new Error(`asset not referenced: ${file}`)
+    if (command === 'view') {
+      const read = await this.assets.read(file)
+      const text =
+        read.type.startsWith('text/') || read.type.includes('json') ? read.bytes.toString('utf8') : undefined
+      return {
+        kind: 'asset' as const,
+        path: recPath,
+        command: 'view' as const,
+        name: file,
+        etag: read.etag,
+        type: read.type,
+        ...(text != null ? { text } : {}),
+      }
+    }
+    if (command !== 'write') throw new Error(`unknown asset command: ${command}`)
+    const written = await this.assets.write(file, String(args.value ?? ''), { etag: String(args.etag ?? '') })
+    this.broadcastAsset(recPath, written.name, written.etag)
+    return { kind: 'asset' as const, ok: true as const, path: recPath, name: written.name, etag: written.etag }
+  }
+
+  private broadcastAsset(path: string, name: string, etag: string) {
+    const http = this.ctx.get('http') as { broadcast?: (type: string, payload: unknown) => void } | undefined
+    http?.broadcast?.(DATABASE_CHANNEL, { ts: Date.now(), asset: { name, etag, path } })
+  }
 }
 
 function parseContent(content: unknown): Record<string, unknown> {
@@ -1109,7 +1163,7 @@ export const inject = ['tools', 'http']
 export function apply(ctx: Context) {
   const db = new DatabaseService(ctx)
   db.facets.open(dataPath(process.cwd(), 'file-system.sqlite'))
-  const assets = new FileSystemAssets()
+  const assets = db.assets
   const savedViews = new SavedViewsStore()
   savedViews.open(process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'file-system.sqlite'))
   const facets = db.facets
@@ -1287,6 +1341,35 @@ export function apply(ctx: Context) {
         db.editContent(String(args.path), args).then((body) => agentDbCompact.query(body)),
       ),
   })
+  ctx.tools.register({
+    name: 'db_asset',
+    description: [
+      '读写一条记录引用的附件（画板 json、图片、文件），不是正文。正文仍用 db_content。',
+      'path 为 /<表>/<id>，name 为附件文件名（正文里的 assets/xxx 或 /api/page/file/xxx）。',
+      'command=view：不传 name 列出本条引用的附件及 etag；带 name 读该文件（文本/json 带 text）和 etag。',
+      'command=write：覆盖该文件，必须带 etag（等于上次 view 的 etag）。对不上返回 etag conflict，先 view 再写。',
+      '写成功只返回 {ok, path, name, etag}。前端开着的编辑器按 etag 重载，过期 PUT 会 409。',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        name: { type: 'string', description: '附件文件名，如 画板-ab12cd.json' },
+        command: {
+          type: 'string',
+          enum: ['view', 'write'],
+          description: 'view | write。省略时：有 value 则 write，否则 view。',
+        },
+        value: { type: 'string', description: 'write 的全文（json/文本）' },
+        etag: { type: 'string', description: 'write 必填，等于上次 view 的 etag' },
+      },
+      required: ['path'],
+    },
+    execute: (args) =>
+      withInspectorReveal(ctx, String(args.path), () =>
+        db.editAsset(String(args.path), args).then((body) => agentDbCompact.query(body)),
+      ),
+  })
 
   const send = async (route: { query: URLSearchParams; send: (status: number, body: unknown) => void }, op: () => unknown) => {
     try {
@@ -1388,8 +1471,12 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('GET', '/api/db/file/:name', async (route) => {
     try {
-      const { bytes, type } = await assets.read(route.params.name ?? '')
-      route.res.writeHead(200, { 'content-type': type, 'cache-control': 'private, max-age=60' })
+      const { bytes, type, etag } = await assets.read(route.params.name ?? '')
+      route.res.writeHead(200, {
+        'content-type': type,
+        'cache-control': 'no-store',
+        etag: `"${etag}"`,
+      })
       route.res.end(bytes)
     } catch {
       route.send(404, { error: 'not found' })
@@ -1397,9 +1484,16 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('PUT', '/api/db/file/:name', async (route) => {
     try {
-      const written = await assets.write(route.params.name ?? '', await route.bytes())
+      const written = await assets.write(route.params.name ?? '', await route.bytes(), {
+        etag: parseIfMatch(route.req.headers['if-match']),
+      })
+      ctx.http.broadcast?.(DATABASE_CHANNEL, { ts: Date.now(), asset: { name: written.name, etag: written.etag } })
       route.send(200, { ok: true, ...written })
     } catch (error) {
+      if (error instanceof AssetConflictError) {
+        route.send(409, { error: 'etag conflict', etag: error.etag })
+        return
+      }
       route.send(400, { error: String(error) })
     }
   })

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -396,6 +396,10 @@ export function apply(ctx: Context) {
     let debounce = 0
     const off = snapshot.onMessage(DATABASE_CHANNEL, (payload) => {
       window.dispatchEvent(new Event('fsdb:change'))
+      const rec = payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as { asset?: { name?: string; etag?: string } }) : null
+      if (rec?.asset?.name) {
+        window.dispatchEvent(new CustomEvent('biu:asset-changed', { detail: rec.asset }))
+      }
       const sessionId = (
         ctx.get('sessionView') as { get?: () => { sessionId?: string | null } } | undefined
       )?.get?.()?.sessionId

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -9,7 +9,7 @@ import * as tools from '@biu/host-tools'
 import * as fsPlugin from '@biu/host-fs'
 import * as page from './index.ts'
 import { dumpMarkdown, splitMarkdown } from './markdown.ts'
-import { ASSET_GC_GRACE_MS, PAGE_ASSETS, PAGE_ROOT, PagesStore, collectPageAssetNames } from './store.ts'
+import { ASSET_GC_GRACE_MS, PAGE_ASSETS, PAGE_ROOT, PageAssetConflictError, PagesStore, collectPageAssetNames } from './store.ts'
 
 test('markdown frontmatter roundtrips YAML properties and body', () => {
   const raw = dumpMarkdown({ title: '首页', tags: ['red', 'prod'] }, '正文第一段\n')
@@ -105,6 +105,9 @@ test('page plugin stores pages in SQLite under .page', async () => {
   assert.equal(shot.type, 'image/png')
   assert.deepEqual([...shot.bytes], [...png])
   await assert.rejects(() => store.writeAsset('../secret.json', '{}'), /invalid asset/)
+  await assert.rejects(() => store.writeAsset('board.json', '{}'), (error) => error instanceof PageAssetConflictError)
+  const overwritten = await store.writeAsset('board.json', '{}', { etag: asset.etag })
+  assert.equal(overwritten.etag.length, 16)
 })
 
 test('PagesStore reads existing markdown files from .page', async () => {

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -1,8 +1,8 @@
 import { dataPath } from '@biu/host-plugin-loader/data-dir'
 import type { Context } from 'cordis'
 import type { CollectionSpec } from '@biu/type-file-system'
-import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
-import { PagesStore, type WorkspaceFs } from './store.ts'
+import { DATABASE_CHANNEL, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { PagesStore, PageAssetConflictError, type WorkspaceFs } from './store.ts'
 
 export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
 
@@ -55,8 +55,12 @@ function servePageFile(ctx: Context, store: PagesStore) {
   ctx.inject(['http'], (inner) => {
     inner.http.route('GET', '/api/page/file/:name', async (route) => {
       try {
-        const { bytes, type } = await store.readAsset(route.params.name ?? '')
-        route.res.writeHead(200, { 'content-type': type, 'cache-control': 'private, max-age=60' })
+        const { bytes, type, etag } = await store.readAsset(route.params.name ?? '')
+        route.res.writeHead(200, {
+          'content-type': type,
+          'cache-control': 'no-store',
+          etag: `"${etag}"`,
+        })
         route.res.end(bytes)
       } catch {
         route.send(404, { error: 'not found' })
@@ -64,9 +68,17 @@ function servePageFile(ctx: Context, store: PagesStore) {
     })
     inner.http.route('PUT', '/api/page/file/:name', async (route) => {
       try {
-        const written = await store.writeAsset(route.params.name ?? '', await route.bytes())
+        const ifMatch = String(route.req.headers['if-match'] ?? '').trim().replace(/^W\//, '').replaceAll('"', '')
+        const written = await store.writeAsset(route.params.name ?? '', await route.bytes(), {
+          etag: ifMatch && ifMatch !== '*' ? ifMatch : '',
+        })
+        inner.http.broadcast?.(DATABASE_CHANNEL, { ts: Date.now(), asset: { name: written.name, etag: written.etag } })
         route.send(200, { ok: true, ...written })
       } catch (error) {
+        if (error instanceof PageAssetConflictError) {
+          route.send(409, { error: 'etag conflict', etag: error.etag })
+          return
+        }
         route.send(400, { error: String(error) })
       }
     })

--- a/packages/core-page/src/host/store.ts
+++ b/packages/core-page/src/host/store.ts
@@ -1,4 +1,5 @@
 import { mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 import { createRequire } from 'node:module'
 import type { DbRecord, SchemaFieldValue } from '@biu/type-file-system'
@@ -15,6 +16,24 @@ export const ASSET_GC_GRACE_MS = 24 * 60 * 60 * 1000
 const ID_RE = /^[A-Za-z0-9._-]+$/
 const ASSET_FILE_RE = /^[\p{L}\p{N}._-]+$/u
 const ASSET_REF_RE = /(?:(?:\.page\/)?assets\/|\/api\/(?:page|db)\/file\/)([\p{L}\p{N}._-]+)/gu
+
+function bytesEtag(bytes: Buffer) {
+  return createHash('sha1').update(bytes).digest('hex').slice(0, 16)
+}
+
+export class PageAssetConflictError extends Error {
+  readonly etag: string
+  constructor(etag: string) {
+    super('etag conflict')
+    this.name = 'PageAssetConflictError'
+    this.etag = etag
+  }
+}
+
+function parseIfMatch(raw: unknown) {
+  const text = String(raw ?? '').trim().replace(/^W\//, '').replaceAll('"', '')
+  return text && text !== '*' ? text : ''
+}
 
 export function isPageAssetFileName(name: string) {
   return Boolean(name) && name === basename(name) && name !== '.gitkeep' && ASSET_FILE_RE.test(name)
@@ -302,24 +321,37 @@ export class PagesStore {
     await this.gcAssets()
   }
 
-  async writeAsset(name: string, content: string | Buffer | Uint8Array) {
+  async writeAsset(name: string, content: string | Buffer | Uint8Array, opts?: { etag?: string }) {
     const file = basename(name)
     if (!file || file !== name.replace(/\\/g, '/') || !isPageAssetFileName(file)) throw new Error('invalid asset')
     await mkdir(this.assetsDir, { recursive: true })
     const bytes = typeof content === 'string' ? Buffer.from(content) : Buffer.from(content)
+    const expected = parseIfMatch(opts?.etag)
+    let current = ''
+    try {
+      current = bytesEtag(await readFile(join(this.assetsDir, file)))
+    } catch {
+      current = ''
+    }
+    if (current) {
+      if (!expected) throw new PageAssetConflictError(current)
+      if (expected !== current) throw new PageAssetConflictError(current)
+    } else if (expected) {
+      throw new PageAssetConflictError('')
+    }
     await writeFile(join(this.assetsDir, file), bytes)
-    return { name: file, href: fileUrl(file) }
+    return { name: file, href: fileUrl(file), etag: bytesEtag(bytes) }
   }
 
-  async readAsset(name: string): Promise<{ bytes: Buffer; type: string }> {
+  async readAsset(name: string): Promise<{ bytes: Buffer; type: string; etag: string }> {
     const file = basename(name)
     if (!file || file !== name.replace(/\\/g, '/')) throw new Error('invalid asset')
     try {
       const bytes = await readFile(join(this.assetsDir, file))
-      return { bytes, type: mimeOf(file) }
+      return { bytes, type: mimeOf(file), etag: bytesEtag(bytes) }
     } catch {
       const bytes = await readFile(this.fs.resolve(`${PAGE_ASSETS}/${file}`))
-      return { bytes, type: mimeOf(file) }
+      return { bytes, type: mimeOf(file), etag: bytesEtag(bytes) }
     }
   }
 

--- a/packages/host-live-sessions/src/host/index.test.ts
+++ b/packages/host-live-sessions/src/host/index.test.ts
@@ -31,6 +31,7 @@ test('live plugin no longer registers session_* tools', async () => {
     'db_stat',
     'db_action',
     'db_content',
+    'db_asset',
   ])
 })
 

--- a/packages/host-live-sessions/src/host/index.ts
+++ b/packages/host-live-sessions/src/host/index.ts
@@ -11,6 +11,7 @@ export const LIVE_TOOL_NAMES = [
   'db_stat',
   'db_action',
   'db_content',
+  'db_asset',
 ] as const
 
 export interface SessionProgressSnapshot {

--- a/packages/host-tools/src/host/index.ts
+++ b/packages/host-tools/src/host/index.ts
@@ -50,6 +50,7 @@ export const FILE_TOOL_NAMES = [
   'db_stat',
   'db_action',
   'db_content',
+  'db_asset',
 ] as const
 
 /** 本回合 slash 选中的额外工具（极简模式下临时放开）。 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
记录附件（画板 json、图片等）走共用 `db_asset`，正文仍用 `db_content`。

- `command=view`：列出本条已引用的附件及 etag，或读单个文件
- `command=write`：必须带上次 etag，对不上返回 conflict
- HTTP `GET/PUT /api/db/file` 与 `/api/page/file` 用 `ETag` / `If-Match`，冲突 409
- 写成功广播后前端 `biu:asset-changed`；画板取消未发出的防抖 PUT 并重载

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

