### PR TITLE
feat(fsdb): db_asset write 可从本地文件 from 同步

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context, Service } from 'cordis'
 import * as tools from '@biu/host-tools'
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseService, apply as applyFileSystem } from './index.ts'
@@ -479,6 +479,18 @@ test('editAsset views and writes referenced attachments with etag', async () => 
     etag: viewed.etag,
   })
   assert.equal(written.ok, true)
+  const dump = join(await mkdtemp(join(tmpdir(), 'db-asset-from-')), 'scene.json')
+  await writeFile(dump, '{"elements":[{"id":"a"}]}')
+  const fromFile = await db.editAsset('/pages/p1', {
+    command: 'write',
+    name: 'board.json',
+    from: dump,
+    etag: written.etag,
+  })
+  assert.equal(fromFile.ok, true)
+  const again = await db.editAsset('/pages/p1', { command: 'view', name: 'board.json' })
+  assert.match(String((again as { text?: string }).text), /"id":"a"/)
+  await assert.rejects(() => db.editAsset('/pages/p1', { command: 'write', name: 'board.json', etag: again.etag }), /value or from/)
   await assert.rejects(() => db.editAsset('/pages/p1', { command: 'view', name: 'nope.json' }), /not referenced/)
 })
 

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+import { isAbsolute, resolve } from 'node:path'
 import { dataPath } from '@biu/host-plugin-loader/data-dir'
 import { Service, type Context } from 'cordis'
 import {
@@ -959,7 +961,8 @@ export class DatabaseService extends Service implements Database {
       .trim()
       .replace(/^assets\//, '')
       .replace(/^.*[/\\]/, '')
-    const command = String(args.command ?? (args.value != null ? 'write' : 'view'))
+    const from = String(args.from ?? '').trim()
+    const command = String(args.command ?? (args.value != null || from ? 'write' : 'view'))
     const recPath = `${spec.path}/${record.id}`
     if (command === 'view' && !file) {
       const assets = []
@@ -990,7 +993,9 @@ export class DatabaseService extends Service implements Database {
       }
     }
     if (command !== 'write') throw new Error(`unknown asset command: ${command}`)
-    const written = await this.assets.write(file, String(args.value ?? ''), { etag: String(args.etag ?? '') })
+    const body = from ? await readLocalWriteFile(from) : String(args.value ?? '')
+    if (!from && args.value == null) throw new Error('write needs value or from')
+    const written = await this.assets.write(file, body, { etag: String(args.etag ?? '') })
     this.broadcastAsset(recPath, written.name, written.etag)
     return { kind: 'asset' as const, ok: true as const, path: recPath, name: written.name, etag: written.etag }
   }
@@ -998,6 +1003,15 @@ export class DatabaseService extends Service implements Database {
   private broadcastAsset(path: string, name: string, etag: string) {
     const http = this.ctx.get('http') as { broadcast?: (type: string, payload: unknown) => void } | undefined
     http?.broadcast?.(DATABASE_CHANNEL, { ts: Date.now(), asset: { name, etag, path } })
+  }
+}
+
+async function readLocalWriteFile(raw: string) {
+  const file = isAbsolute(raw) ? raw : resolve(process.cwd(), raw)
+  try {
+    return await readFile(file)
+  } catch {
+    throw new Error(`cannot read from: ${raw}`)
   }
 }
 
@@ -1348,6 +1362,7 @@ export function apply(ctx: Context) {
       'path 为 /<表>/<id>，name 为附件文件名（正文里的 assets/xxx 或 /api/page/file/xxx）。',
       'command=view：不传 name 列出本条引用的附件及 etag；带 name 读该文件（文本/json 带 text）和 etag。',
       'command=write：覆盖该文件，必须带 etag（等于上次 view 的 etag）。对不上返回 etag conflict，先 view 再写。',
+      '大内容不要塞进 value：先用 bash/python 写到本地文件，再 from=该路径（工作区相对或绝对，如 /tmp/board.json）。value 只适合短文本。',
       '写成功只返回 {ok, path, name, etag}。前端开着的编辑器按 etag 重载，过期 PUT 会 409。',
     ].join(' '),
     parameters: {
@@ -1358,9 +1373,13 @@ export function apply(ctx: Context) {
         command: {
           type: 'string',
           enum: ['view', 'write'],
-          description: 'view | write。省略时：有 value 则 write，否则 view。',
+          description: 'view | write。省略时：有 value 或 from 则 write，否则 view。',
         },
-        value: { type: 'string', description: 'write 的全文（json/文本）' },
+        value: { type: 'string', description: 'write 的全文（json/文本）。大文件用 from，不要把整段 JSON 贴进来。' },
+        from: {
+          type: 'string',
+          description: 'write 时读这个本地文件作为内容，代替 value。相对工作区根，或绝对路径。',
+        },
         etag: { type: 'string', description: 'write 必填，等于上次 view 的 etag' },
       },
       required: ['path'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 画 Excalidraw 会先把场景写到 `/tmp/board.json`，再想同步进附件。`db_asset write` 以前只能把整段 JSON 塞进 `value`，几万字工具参数会截断、抄错。

现在 `write` 可以带 `from`：读本地文件（工作区相对路径或绝对路径）作为附件内容。`etag` 规则不变。大文件用 `from`，短文本才用 `value`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

