### PR TITLE
fix(excalidraw): etag 只有真正上屏后才算已刷新

### DIFF
--- a/.plugin-dev/page-excalidraw/web.tsx
+++ b/.plugin-dev/page-excalidraw/web.tsx
@@ -1,4 +1,4 @@
-import { CaptureUpdateAction, Excalidraw } from '@excalidraw/excalidraw'
+import { Excalidraw } from '@excalidraw/excalidraw'
 import '@excalidraw/excalidraw/index.css'
 import { createPortal } from 'react-dom'
 import { createRoot, type Root } from 'react-dom/client'
@@ -131,6 +131,7 @@ type Host = {
   etag: string
   pending: ReturnType<typeof setTimeout> | null
   quietUntil: number
+  appliedEtag: string
   api: DrawApi | null
   expanded: boolean
   sync?: () => void
@@ -155,22 +156,15 @@ function sceneData(scene: Scene) {
 }
 
 function applyScene(host: Host, scene: Scene, etag: string) {
+  if (etag && host.appliedEtag === etag) return
   host.etag = etag
+  host.appliedEtag = etag
   host.lastScene = scene
   host.initialData = sceneData(scene)
   host.quietUntil = Date.now() + 1200
-  const api = host.api
-  if (api?.updateScene) {
-    api.updateScene({
-      elements: host.initialData.elements,
-      appState: host.initialData.appState,
-      captureUpdate: CaptureUpdateAction.NEVER,
-    })
-    const files = Object.values(host.initialData.files ?? {})
-    if (files.length) api.addFiles?.(files)
-    fitView(api)
-    return
-  }
+  host.api = null
+  host.root?.unmount()
+  host.root = createRoot(host.el)
   paintHost(host)
 }
 
@@ -190,7 +184,7 @@ if (typeof window !== 'undefined') {
     if (!name) return
     for (const [file, host] of hosts) {
       if (assetName(file) !== name && file !== name) continue
-      if (detail?.etag && host.etag === detail.etag) continue
+      if (detail?.etag && (host.appliedEtag === detail.etag || host.etag === detail.etag)) continue
       cancelPending(host)
       void reloadHost(file)
     }
@@ -252,6 +246,7 @@ function retainHost(file: string) {
     etag: '',
     pending: null,
     quietUntil: 0,
+    appliedEtag: '',
     api: null,
     expanded: false,
   }
@@ -259,6 +254,7 @@ function retainHost(file: string) {
     if (hosts.get(file) !== host) return host
     const scene = loaded.scene
     host.etag = loaded.etag
+    host.appliedEtag = loaded.etag
     host.quietUntil = Date.now() + 1200
     host.initialData = sceneData(scene)
     host.lastScene = scene

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -447,7 +447,7 @@ test('excalidraw board onChange does not setState', async () => {
   assert.doesNotMatch(onChange, /setScene/)
   assert.match(onChange, /saveScene/)
   assert.match(src, /function reloadHost/)
-  assert.match(src, /updateScene/)
+  assert.match(src, /appliedEtag/)
   assert.match(src, /export const inject/)
   assert.match(src, /View: Board/)
 })

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -160,7 +160,7 @@ test('page-excalidraw sandbox stores scenes as page assets', async () => {
   assert.match(src, /View: Board/)
   assert.match(src, /defaults: \(\) => \(\{ file:/)
   assert.match(src, /function reloadHost/)
-  assert.match(src, /updateScene/)
+  assert.match(src, /appliedEtag/)
   assert.match(src, /quietUntil/)
   assert.match(src, /biu:asset-changed/)
   const onChange = src.match(/const onChange = useCallback\([\s\S]*?\}, \[file\]\)/)?.[0]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一轮用 updateScene 之后仍把 `host.etag` 改成服务端新值。画布其实没重挂，下次推送发现 etag 已经一样就跳过，所以必须整页刷新才能看到新图。

现在只有 `createRoot` 重挂成功后才记下 `appliedEtag`。推送 etag 和已上屏的不一致才会卸掉再挂。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

