### PR TITLE
feat(chat): 流式气泡边生成边渲染 Markdown

### DIFF
--- a/packages/core-chat/src/web/markdown-render.test.ts
+++ b/packages/core-chat/src/web/markdown-render.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   getCachedMarkdownHtml,
+  parseMarkdownLive,
   parseMarkdownSync,
   renderMarkdownHtml,
   resetMarkdownRenderForTests,
+  stabilizeStreamingMarkdown,
 } from './markdown-render.ts'
 
 afterEach(() => {
@@ -38,5 +40,20 @@ describe('markdown-render', () => {
     const first = parseMarkdownSync(text)
     const second = getCachedMarkdownHtml(text)
     expect(second).toBe(first)
+  })
+
+  it('live parse does not fill the LRU and still renders GFM', () => {
+    const text = 'hello **world**'
+    const html = parseMarkdownLive(text)
+    expect(html).toContain('<strong>world</strong>')
+    expect(getCachedMarkdownHtml(text)).toBeUndefined()
+  })
+
+  it('live parse closes an odd fence', () => {
+    expect(stabilizeStreamingMarkdown('```js\nconst x = 1')).toMatch(/\n```$/)
+    expect(stabilizeStreamingMarkdown('```js\nconst x = 1\n```')).toBe('```js\nconst x = 1\n```')
+    const html = parseMarkdownLive('```js\nconst x = 1')
+    expect(html).toContain('<pre>')
+    expect(html).toContain('const x = 1')
   })
 })

--- a/packages/core-chat/src/web/markdown-render.ts
+++ b/packages/core-chat/src/web/markdown-render.ts
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify'
-import { marked } from 'marked'
+import { Marked, marked } from 'marked'
 import type { MarkdownWorkerRequest, MarkdownWorkerResponse } from './markdown.worker.ts'
 import { markdownHighlight } from './markdown-highlight.ts'
 
@@ -9,6 +9,13 @@ marked.setOptions({
   async: false,
 })
 marked.use(markdownHighlight)
+
+/** 流式预览：不走 highlight.js，避免每帧高亮整段代码块。 */
+const liveMarked = new Marked({
+  gfm: true,
+  breaks: false,
+  async: false,
+})
 
 if (typeof window !== 'undefined') {
   DOMPurify.addHook('afterSanitizeAttributes', (node) => {
@@ -65,6 +72,19 @@ export function parseMarkdownSync(text: string): string {
   const html = sanitizeMarkdownHtml(dirty)
   touchCache(text, html)
   return html
+}
+
+/** 未闭合的 ``` 在流式里会把后面全吃进代码块，补一个结束围栏再 parse。 */
+export function stabilizeStreamingMarkdown(text: string): string {
+  const fences = text.match(/^ {0,3}```/gm)
+  if (fences && fences.length % 2 === 1) return `${text}\n\`\`\``
+  return text
+}
+
+/** 流式预览：不写 LRU，不定稿高亮。chunk 已按帧合并，主线程每帧 parse 一次可接受。 */
+export function parseMarkdownLive(text: string): string {
+  const dirty = liveMarked.parse(stabilizeStreamingMarkdown(text), { async: false }) as string
+  return sanitizeMarkdownHtml(dirty)
 }
 
 function getWorker(): Worker | null {

--- a/packages/core-chat/src/web/markdown.tsx
+++ b/packages/core-chat/src/web/markdown.tsx
@@ -1,13 +1,13 @@
 import { memo } from 'react'
 import 'highlight.js/styles/github-dark.css'
-import { getCachedMarkdownHtml, parseMarkdownSync } from './markdown-render.ts'
+import { getCachedMarkdownHtml, parseMarkdownLive, parseMarkdownSync } from './markdown-render.ts'
 
 /**
  * 对话气泡内的 Markdown（GFM）。
  *
  * 定稿后：渲染期同步取 LRU 缓存；未命中则同步 parse 一次并写入缓存。
  * 虚表滚走再滚回 = 同 text 必命中缓存 → 首帧就是 HTML，不再闪「加载一下」。
- * 流式仍用纯文本，避免每 token 全量解析。
+ * 流式：按当前全文做轻量 marked（不高亮、不进缓存），chunk 已按帧合并。
  */
 export const MarkdownBody = memo(function MarkdownBody({
   text,
@@ -16,16 +16,18 @@ export const MarkdownBody = memo(function MarkdownBody({
 }: {
   text: string
   className?: string
-  /** 流式中跳过解析，避免每帧全量重算 */
+  /** 流式中用轻量 parse，定稿后再高亮并写入缓存 */
   streaming?: boolean
 }) {
   if (!text) return null
 
   if (streaming) {
+    const html = parseMarkdownLive(text)
     return (
-      <div className={`chat-md chat-md-stream ${className}`.trim()}>
-        <pre className="chat-md-stream-pre">{text}</pre>
-      </div>
+      <div
+        className={`chat-md chat-md-stream ${className}`.trim()}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     )
   }
 

--- a/packages/core-chat/src/web/thread-remount.test.tsx
+++ b/packages/core-chat/src/web/thread-remount.test.tsx
@@ -131,6 +131,14 @@ describe('scroll-back remount contract', () => {
     expect(second.container.querySelector('.chat-md-stream')).toBeNull()
     expect(second.container.querySelector('strong')?.textContent).toBe('world')
   })
+
+  it('MarkdownBody streams GFM html before the message is finished', () => {
+    const { container } = render(<MarkdownBody text={'hello **world**'} streaming />)
+    expect(container.querySelector('.chat-md-stream-pre')).toBeNull()
+    expect(container.querySelector('.chat-md-stream')).toBeTruthy()
+    expect(container.querySelector('strong')?.textContent).toBe('world')
+    expect(getCachedMarkdownHtml('hello **world**')).toBeUndefined()
+  })
 })
 
 describe('markdown cache helpers', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天区原先 `streaming` 时只贴纯文本 `<pre>`，等整条 message 结束才 `marked` + highlight，所以要等很久才看到排版。

现在流式按当前全文做轻量 GFM（不高亮、不写 LRU）。chunk 已经按动画帧合并，每帧 parse 一次。定稿后仍走原来的 highlight 和缓存。未闭合的 \`\`\` 会先补结束围栏再 parse。

没有用 TipTap 挂气泡：只读预览 + 虚表不适合每条消息一个 Editor。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

