### PR TITLE
feat(chat): 流式时闭合的代码围栏立刻高亮

### DIFF
--- a/packages/core-chat/src/web/markdown-render.test.ts
+++ b/packages/core-chat/src/web/markdown-render.test.ts
@@ -5,6 +5,7 @@ import {
   parseMarkdownSync,
   renderMarkdownHtml,
   resetMarkdownRenderForTests,
+  splitStreamingMarkdown,
   stabilizeStreamingMarkdown,
 } from './markdown-render.ts'
 
@@ -55,5 +56,29 @@ describe('markdown-render', () => {
     const html = parseMarkdownLive('```js\nconst x = 1')
     expect(html).toContain('<pre>')
     expect(html).toContain('const x = 1')
+    expect(html).not.toContain('hljs')
+  })
+
+  it('splits at the last open fence so closed blocks can freeze', () => {
+    const open = 'intro\n```js\nconst x = 1'
+    expect(splitStreamingMarkdown(open)).toEqual({
+      frozen: 'intro\n',
+      live: '```js\nconst x = 1',
+    })
+    const closed = 'intro\n```js\nconst x = 1\n```\nmore **text**'
+    expect(splitStreamingMarkdown(closed)).toEqual({
+      frozen: 'intro\n```js\nconst x = 1\n```\n',
+      live: 'more **text**',
+    })
+  })
+
+  it('highlights a code block as soon as its fence closes', () => {
+    const closed = '```js\nconst n = 1\n```\nstill **streaming**'
+    const html = parseMarkdownLive(closed)
+    expect(html).toContain('hljs')
+    expect(html).toContain('language-js')
+    expect(html).toContain('<strong>streaming</strong>')
+    expect(getCachedMarkdownHtml(closed)).toBeUndefined()
+    expect(getCachedMarkdownHtml('```js\nconst n = 1\n```\n')).toBeTruthy()
   })
 })

--- a/packages/core-chat/src/web/markdown-render.ts
+++ b/packages/core-chat/src/web/markdown-render.ts
@@ -74,17 +74,58 @@ export function parseMarkdownSync(text: string): string {
   return html
 }
 
+const FENCE_RE = /^ {0,3}```/gm
+
+function fenceStarts(text: string): number[] {
+  const starts: number[] = []
+  const re = new RegExp(FENCE_RE.source, FENCE_RE.flags)
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) starts.push(m.index)
+  return starts
+}
+
+function lineEndAfter(text: string, index: number): number {
+  const nl = text.indexOf('\n', index)
+  return nl === -1 ? text.length : nl + 1
+}
+
+/**
+ * 已闭合的围栏可以定稿（含 highlight.js）；
+ * 最后一个未闭合 ``` 及之后只做轻量 parse，避免每帧高亮正在增长的代码。
+ */
+export function splitStreamingMarkdown(text: string): { frozen: string; live: string } {
+  const starts = fenceStarts(text)
+  if (starts.length === 0) return { frozen: '', live: text }
+  if (starts.length % 2 === 1) {
+    const openAt = starts[starts.length - 1]!
+    return { frozen: text.slice(0, openAt), live: text.slice(openAt) }
+  }
+  const closeAt = starts[starts.length - 1]!
+  const end = lineEndAfter(text, closeAt)
+  return { frozen: text.slice(0, end), live: text.slice(end) }
+}
+
 /** 未闭合的 ``` 在流式里会把后面全吃进代码块，补一个结束围栏再 parse。 */
 export function stabilizeStreamingMarkdown(text: string): string {
-  const fences = text.match(/^ {0,3}```/gm)
-  if (fences && fences.length % 2 === 1) return `${text}\n\`\`\``
+  const starts = fenceStarts(text)
+  if (starts.length % 2 === 1) return `${text}\n\`\`\``
   return text
 }
 
-/** 流式预览：不写 LRU，不定稿高亮。chunk 已按帧合并，主线程每帧 parse 一次可接受。 */
-export function parseMarkdownLive(text: string): string {
+function parseLiveFragment(text: string): string {
+  if (!text) return ''
   const dirty = liveMarked.parse(stabilizeStreamingMarkdown(text), { async: false }) as string
   return sanitizeMarkdownHtml(dirty)
+}
+
+/**
+ * 流式预览：闭合代码块走定稿高亮（frozen 前缀可进 LRU）；
+ * 未闭合围栏与其后正文不高亮、不把整条 message 写入 LRU。
+ */
+export function parseMarkdownLive(text: string): string {
+  const { frozen, live } = splitStreamingMarkdown(text)
+  const frozenHtml = frozen ? (getCachedMarkdownHtml(frozen) ?? parseMarkdownSync(frozen)) : ''
+  return frozenHtml + parseLiveFragment(live)
 }
 
 function getWorker(): Worker | null {

--- a/packages/core-chat/src/web/markdown.tsx
+++ b/packages/core-chat/src/web/markdown.tsx
@@ -7,7 +7,7 @@ import { getCachedMarkdownHtml, parseMarkdownLive, parseMarkdownSync } from './m
  *
  * 定稿后：渲染期同步取 LRU 缓存；未命中则同步 parse 一次并写入缓存。
  * 虚表滚走再滚回 = 同 text 必命中缓存 → 首帧就是 HTML，不再闪「加载一下」。
- * 流式：按当前全文做轻量 marked（不高亮、不进缓存），chunk 已按帧合并。
+ * 流式：已闭合的 ``` 代码块立刻定稿高亮；未闭合围栏仍轻量 parse。chunk 已按帧合并。
  */
 export const MarkdownBody = memo(function MarkdownBody({
   text,
@@ -16,7 +16,7 @@ export const MarkdownBody = memo(function MarkdownBody({
 }: {
   text: string
   className?: string
-  /** 流式中用轻量 parse，定稿后再高亮并写入缓存 */
+  /** 流式中：闭合代码块高亮，未闭合围栏轻量 parse */
   streaming?: boolean
 }) {
   if (!text) return null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
流式气泡之前整条 message 结束前都不走 highlight.js，所以即使 ``` 已经闭合，代码块也要等整段说完才变成定稿样式。

现在按围栏切开：
- 已闭合的代码块立刻定稿高亮（frozen 前缀可进 LRU）
- 最后一个未闭合 ``` 及之后仍轻量 parse，避免每帧高亮正在增长的代码

未闭合时仍会补结束围栏，所以增长中的代码也会先以 `<pre>` 出现，只是还没有语法高亮。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

