### PR TITLE
fix(ui): 编辑器与聊天正文 14px，统一 ui-sans-serif

### DIFF
--- a/packages/core-chat/src/web/composer-stack.test.ts
+++ b/packages/core-chat/src/web/composer-stack.test.ts
@@ -16,7 +16,9 @@ describe('composer dock stacking above sticky user', () => {
     const thread = readFileSync(resolve(root, 'packages/core-chat/src/web/thread.tsx'), 'utf8')
 
     expect(css).toMatch(/--dsw-chat-font-size:\s*14px/)
-    expect(css).toMatch(/--dsw-chat-composer-font-size:\s*16px/)
+    expect(css).toMatch(/--dsw-chat-composer-font-size:\s*14px/)
+    expect(css).toMatch(/--font-sans:\s*ui-sans-serif/)
+    expect(css).toMatch(/\.chat-stage\s*\{[^}]*font-family:\s*var\(--font-sans\)/s)
     expect(css).toMatch(/\.composer-tiptap\.is-readonly\s*\{[^}]*font-size:\s*var\(--dsw-chat-font-size\)/s)
     expect(css).toMatch(/\.chat-stage\s*\{[^}]*isolation:\s*isolate/s)
     expect(css).toMatch(/\.chat-composer-dock\s*\{[^}]*z-index:\s*20/s)

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -79,6 +79,8 @@ test('slash suggestion uses a fixed high stacking context', async () => {
   assert.doesNotMatch(css, /\.page-slash\{[^}]*0 0 0 1px/)
   assert.match(src, /MENU_HEIGHT = 280|Math.min\(280/)
   assert.match(src, /width: Math.max\(rects.floating.width, 240\)/)
+  assert.match(css, /\.page-editor\{[^}]*font-family:var\(--font-sans\)/)
+  assert.match(css, /\.page-editor\{[^}]*font-size:14px/)
   assert.match(css, /\.page-editor \.page-block\{[^}]*isolation:isolate/)
   assert.match(css, /\.page-editor \.tiptap ul\{list-style-type:disc\}/)
   assert.match(css, /\.page-editor \.tiptap ol\{list-style-type:decimal\}/)

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,5 +1,5 @@
 export const PAGE_EDITOR_STYLE = `
-.page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;color:var(--dsw-label);font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,sans-serif,"Apple Color Emoji","Segoe UI Emoji";font-size:16px;line-height:1.7;letter-spacing:-.003em}
+.page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;color:var(--dsw-label);font-family:var(--font-sans);font-size:14px;line-height:1.7;letter-spacing:-.003em}
 .page-editor .tiptap{outline:none;min-height:240px}
 .page-editor .tiptap>:first-child{margin-top:0}
 .page-editor .tiptap p,.page-editor .tiptap h1,.page-editor .tiptap h2,.page-editor .tiptap h3,.page-editor .tiptap ul,.page-editor .tiptap ol,.page-editor .tiptap blockquote,.page-editor .tiptap pre{margin:2px 0}

--- a/web/style.css
+++ b/web/style.css
@@ -40,7 +40,7 @@
   /* 右侧对话正文字号 */
   --dsw-chat-font-size: 14px;
   --dsw-chat-line-height: 1.6;
-  --dsw-chat-composer-font-size: 16px;
+  --dsw-chat-composer-font-size: 14px;
   /* 聊天窗内控件：工具条、回合栏、排队、slash、模型、工具卡 */
   --dsw-chat-ui-font-size: 12px;
   --dsw-chat-chip-font-size: 12px;
@@ -57,8 +57,8 @@
   --dsw-sidebar-max: 360px;
   --dsw-inspector-min: 240px;
   --dsw-chat-code-bg: var(--dsw-sidebar);
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
-    "Microsoft YaHei", system-ui, sans-serif;
+  --font-sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC",
+    "Hiragino Sans GB", "Microsoft YaHei", system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Consolas, monospace;
 }
 
@@ -4233,6 +4233,7 @@ body {
   /* 把 sticky 用户消息的 z-index 关在滚动层内，避免压过底部输入栏/悬浮按钮 */
   isolation: isolate;
   align-items: center;
+  font-family: var(--font-sans);
   font-size: var(--dsw-chat-font-size);
   line-height: var(--dsw-chat-line-height);
 }
@@ -5059,6 +5060,7 @@ body {
   min-height: 28px;
   outline: none;
   color: var(--dsw-label);
+  font-family: var(--font-sans);
   font-size: var(--dsw-chat-composer-font-size);
   line-height: 28px;
   word-break: break-word;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
编辑器正文从 16px 改为 14px，与聊天气泡字号对齐。

字族统一到 `ui-sans-serif`：
- 全局 `--font-sans` 以 `ui-sans-serif` 打头（保留中文回退和 emoji）
- `.page-editor` 改用 `var(--font-sans)`，不再单独写一套栈
- `.chat-stage` / `.composer-tiptap` 同样走 `--font-sans`
- 输入框 `--dsw-chat-composer-font-size` 从 16px 收到 14px，和正文一致

代码块仍用 `--font-mono`，未改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

