### PR TITLE
fix(shell): 左侧浮出栏贴窗口边时不要闪一下收起

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -116,7 +116,11 @@ test('shell columns stay three tracks without animating on window resize', () =>
   assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*top:\s*60px/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed:hover \.sidebar-edge-hot\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*z-index:\s*81/s)
-  assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*none/s)
+  assert.match(
+    css,
+    /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*transform 0s linear 180ms, opacity 0s linear 180ms/s,
+  )
+  assert.match(css, /\.sidebar-flyout-host\.is-collapsed:hover \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*none/s)
   assert.doesNotMatch(css, /\.sidebar-flyout-host\.is-collapsed:focus-within/)
   assert.doesNotMatch(css, /\.sidebar-flyout-host\.is-collapsed:hover\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/)
   assert.match(css, /\.app-side-bar\s*\{[^}]*min-width:\s*0/s)

--- a/web/style.css
+++ b/web/style.css
@@ -1454,7 +1454,8 @@ body {
   transform: translateX(calc(-100% - 8px));
   opacity: 0;
   pointer-events: none;
-  transition: none;
+  /* 贴窗口左缘时 :hover 会闪断；收起延迟一帧以上，避免消失又弹出 */
+  transition: transform 0s linear 180ms, opacity 0s linear 180ms;
   z-index: 81;
 }
 
@@ -1471,6 +1472,7 @@ body {
   transform: none;
   opacity: 1;
   pointer-events: auto;
+  transition: none;
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
指针贴着浏览器左缘（还没真正离开窗口）时，浏览器会短暂清掉 `:hover`。浮出栏当时是立刻收起，热区又马上接到指针，看起来就是消失再弹出。

收起改成延迟 180ms（transform / opacity），再次悬停仍然立刻展开。真正滑出栏外后仍会收起，只是带一点缓冲。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

