### PR TITLE
fix(fsdb): 打开中的表立刻展示 agent 写入的视图筛选

### DIFF
--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -29,7 +29,7 @@ import {
   type ListPage,
   type PersonValue,
 } from '@biu/type-file-system'
-import { SavedViewsStore, viewsCollection, type StoredView } from './saved-views.ts'
+import { SavedViewsStore, clientViewFromDbRow, viewsCollection, type StoredView } from './saved-views.ts'
 import { FacetStore } from './facets-store.ts'
 import { AssetConflictError, FileSystemAssets, collectAssetNames, isAssetFileName, parseIfMatch } from './assets-store.ts'
 import { facetsCollection } from './facets-collection.ts'
@@ -1113,46 +1113,30 @@ function broadcastInspectorReveal(
     reveal,
     phase,
     sessionId: currentSessionId(),
-    ...(savedViewFromCreated(result) ? { savedView: savedViewFromCreated(result) } : {}),
+    ...(savedViewFromToolResult(result) ? { savedView: savedViewFromToolResult(result) } : {}),
   })
 }
 
-function savedViewFromCreated(result: unknown) {
+function rowFromToolResult(result: unknown): Record<string, unknown> | undefined {
   if (!result || typeof result !== 'object' || Array.isArray(result)) return undefined
-  if ((result as { kind?: unknown }).kind !== 'created') return undefined
-  const items = (result as { items?: unknown }).items
-  if (!Array.isArray(items) || !items[0] || typeof items[0] !== 'object') return undefined
-  const value = (items[0] as { value?: unknown }).value
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
-  const row = value as Record<string, unknown>
-  const id = String(row.viewId ?? '').trim()
-  if (!id) return undefined
-  let filters: Record<string, string> = {}
-  if (typeof row.filters === 'string' && row.filters.trim()) {
-    try {
-      const parsed = JSON.parse(row.filters)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        filters = Object.fromEntries(Object.entries(parsed).map(([key, item]) => [key, String(item)]))
-      }
-    } catch {
-      filters = {}
-    }
+  const rec = result as { kind?: unknown; items?: unknown; value?: unknown }
+  if (rec.kind === 'created') {
+    const items = rec.items
+    if (!Array.isArray(items) || !items[0] || typeof items[0] !== 'object') return undefined
+    const value = (items[0] as { value?: unknown }).value
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    return value as Record<string, unknown>
   }
-  return {
-    id,
-    name: String(row.title ?? '新视图'),
-    mode: String(row.mode ?? 'table'),
-    sortField: String(row.sortField ?? 'title'),
-    sortDir: row.sortDir === 'desc' ? 'desc' : 'asc',
-    query: String(row.query ?? ''),
-    groupBy: String(row.groupBy ?? ''),
-    columns: Array.isArray(row.columns) ? row.columns.map((item) => String(item)) : [],
-    filters,
-    tree: row.tree !== false,
-    wrap: Boolean(row.wrap),
-    truncate: row.truncate !== false,
-    pageSize: Number(row.pageSize) || 50,
+  if (rec.kind === 'record') {
+    const value = rec.value
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+    return value as Record<string, unknown>
   }
+  return undefined
+}
+
+function savedViewFromToolResult(result: unknown) {
+  return clientViewFromDbRow(rowFromToolResult(result))
 }
 
 async function withInspectorReveal<T>(

--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { builtinAllViewId } from '../catalog-views.ts'
-import { SavedViewsStore, viewsCollection } from './saved-views.ts'
+import { SavedViewsStore, clientViewFromDbRow, viewsCollection } from './saved-views.ts'
 
 test('viewsCollection lists saved views with source table', async () => {
   const store = new SavedViewsStore()
@@ -116,4 +116,20 @@ test('saved views persist created fields and updates across reopen', async () =>
   assert.equal(hit?.groupBy, 'status')
   assert.equal(hit?.sortField, 'dueAt')
   assert.equal(hit?.filters, '{"status":"doing"}')
+})
+
+test('clientViewFromDbRow keeps flat filters and sorts for the live table', () => {
+  const view = clientViewFromDbRow({
+    viewId: 'mine',
+    title: '我的',
+    filters: '{"project":"biu"}',
+    sorts: '[{"field":"title","dir":"desc"}]',
+    sortField: 'title',
+    sortDir: 'desc',
+  })
+  assert.equal(view?.id, 'mine')
+  assert.equal(view?.filters.project, 'biu')
+  assert.equal(view?.filterTree && view.filterTree.children[0] && view.filterTree.children[0].kind === 'rule' && view.filterTree.children[0].value, 'biu')
+  assert.equal(view?.sorts[0]?.field, 'title')
+  assert.equal(view?.sorts[0]?.dir, 'desc')
 })

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -8,6 +8,7 @@ import { normalizeColumnWidths, type SavedView } from '../web/saved-view.ts'
 import { isViewModeId } from '../web/fields.ts'
 import { normalizeCollectionPath } from '../paths.ts'
 import {
+  countFilterRules,
   flatFiltersToTree,
   looksLikeFilterTree,
   normalizeFilterGroup,
@@ -313,6 +314,36 @@ function asRecord(path: string, tableName: string, view: StoredView): DbRecord {
     sorts: JSON.stringify(sorts.map((item) => ({ field: item.field, dir: item.dir }))),
     filterTree: filterTree ? JSON.stringify(filterTree) : '',
     ...recordBuiltinValues(view as Record<string, unknown>),
+  }
+}
+
+/** 工具广播给前端的视图快照（含扁平 filters / filterTree / sorts）。 */
+export function clientViewFromDbRow(row: Record<string, unknown> | undefined) {
+  if (!row) return undefined
+  const id = String(row.viewId ?? '').trim()
+  if (!id || isReadOnlyViewId(id)) return undefined
+  const parsedFilters = filtersFromPatch(row.filters)
+  const fromTree = parseJsonValue(row.filterTree)
+  const tree = looksLikeFilterTree(fromTree) ? normalizeFilterGroup(fromTree) : parsedFilters.filterTree
+  const sortsPatch = sortsFromPatch(row.sorts, row.sortField, row.sortDir)
+  return {
+    id,
+    name: String(row.title ?? row.name ?? id),
+    mode: row.mode,
+    sortField: sortsPatch.sortField,
+    sortDir: sortsPatch.sortDir,
+    sorts: sortsPatch.sorts,
+    query: String(row.query ?? ''),
+    groupBy: String(row.groupBy ?? ''),
+    columns: Array.isArray(row.columns) ? row.columns.map((item) => String(item)) : [],
+    filters: parsedFilters.filters,
+    filterTree: countFilterRules(tree) ? tree : undefined,
+    tree: row.tree !== false,
+    wrap: Boolean(row.wrap),
+    truncate: row.truncate !== false,
+    pageSize: Number(row.pageSize) || 50,
+    columnWidths: row.columnWidths,
+    builtin: false,
   }
 }
 

--- a/packages/core-file-system/src/query-logic.test.ts
+++ b/packages/core-file-system/src/query-logic.test.ts
@@ -5,6 +5,7 @@ import {
   emptyFilterGroup,
   emptyFilterRule,
   encodeListFilter,
+  filterTreeStateKey,
   flatFiltersToTree,
   matchFilterNode,
   matchListFilterRecord,
@@ -95,6 +96,16 @@ test('empty filterTree falls back to flat filters from the agent', () => {
   assert.equal(countFilterRules(tree), 1)
   assert.equal(tree.children[0] && tree.children[0].kind === 'rule' && tree.children[0].field, 'project')
   assert.equal(tree.children[0] && tree.children[0].kind === 'rule' && tree.children[0].value, 'biu')
+})
+
+test('filterTreeStateKey ignores node ids and treats empty as absent', () => {
+  const a = emptyFilterGroup()
+  const b = emptyFilterGroup()
+  assert.equal(filterTreeStateKey(a), filterTreeStateKey(b))
+  assert.equal(filterTreeStateKey(a), filterTreeStateKey(undefined))
+  a.children.push({ kind: 'rule', id: 'r1', field: 'tags', op: 'eq', value: 'test' })
+  b.children.push({ kind: 'rule', id: 'r2', field: 'tags', op: 'eq', value: 'test' })
+  assert.equal(filterTreeStateKey(a), filterTreeStateKey(b))
 })
 
 test('parseSortsInput accepts JSON strings', () => {

--- a/packages/core-file-system/src/query-logic.ts
+++ b/packages/core-file-system/src/query-logic.ts
@@ -130,6 +130,21 @@ export function countFilterRules(node: FilterNode | undefined): number {
   return node.children.reduce((sum, child) => sum + countFilterRules(child), 0)
 }
 
+function filterNodeState(node: FilterNode): unknown {
+  if (node.kind === 'rule') return { kind: 'rule', field: node.field, op: node.op, value: node.value }
+  return { kind: 'group', combinator: node.combinator, children: node.children.map(filterNodeState) }
+}
+
+/** 比较筛选树时丢掉随机 id，空树与缺省等价。 */
+export function filterTreeStateKey(tree: FilterGroup | null | undefined): string {
+  if (!tree || countFilterRules(tree) === 0) return '[]'
+  return JSON.stringify(filterNodeState(normalizeFilterGroup(tree)))
+}
+
+export function sortsStateKey(sorts: Array<Pick<SortRule, 'field' | 'dir'>> | undefined): string {
+  return JSON.stringify((sorts ?? []).map((item) => ({ field: item.field, dir: item.dir })))
+}
+
 export function opsForKind(kind: FieldType | string): Array<{ value: FilterOp; label: string }> {
   if (kind === 'datetime') {
     return [

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -110,6 +110,7 @@ import {
   isViewStarred,
   loadActiveViewId,
   loadViews,
+  pullSavedViews,
   rememberRecords,
   rememberViews,
   persistStarredViews,
@@ -142,9 +143,11 @@ import {
   countFilterRules,
   emptyFilterGroup,
   encodeListFilter,
+  filterTreeStateKey,
   moveList,
   normalizeSorts,
   resolveViewFilterTree,
+  sortsStateKey,
   type FilterGroup,
   type SortRule,
 } from '../query-logic.ts'
@@ -616,6 +619,9 @@ export function CollectionBrowser({
   const reloadGen = useRef(0)
   const hydratePath = useRef('')
   const viewsRef = useRef<SavedView[]>([])
+  const skipPersistGen = useRef(0)
+  const activeViewIdRef = useRef<string | null>(null)
+  const syncViewsRef = useRef<() => Promise<void>>(async () => {})
   const hydratedDetail = useRef('')
   const [dlg, setDlg] = useState<
     | { kind: 'rename'; view: SavedView }
@@ -898,11 +904,13 @@ export function CollectionBrowser({
 
   useEffect(() => {
     let debounce = 0
-    const onChange = () => {
+    const onChange = (event: Event) => {
       window.clearTimeout(debounce)
+      const viewsTouched = Boolean((event as CustomEvent<{ views?: boolean }>).detail?.views)
       debounce = window.setTimeout(() => {
         void reloadRef.current()
         if (detailIdRef.current) pullDetailBody()
+        if (viewsTouched) void syncViewsRef.current()
       }, 120)
     }
     window.addEventListener('fsdb:change', onChange)
@@ -1246,8 +1254,8 @@ export function CollectionBrowser({
       truncateCells === (next.truncate !== false) &&
       query === nextQuery &&
       pageSize === nextPageSize &&
-      JSON.stringify(sorts) === JSON.stringify(next.sorts ?? []) &&
-      JSON.stringify(filterTree) === JSON.stringify(next.filterTree ?? null) &&
+      sortsStateKey(sorts) === sortsStateKey(next.sorts) &&
+      filterTreeStateKey(filterTree) === filterTreeStateKey(resolveViewFilterTree(next)) &&
       JSON.stringify(filters) === JSON.stringify(next.filters) &&
       JSON.stringify(columnKeys) === JSON.stringify(nextColumns) &&
       JSON.stringify(columnWidths) === JSON.stringify(normalizeColumnWidths(next.columnWidths))
@@ -1272,6 +1280,27 @@ export function CollectionBrowser({
     setPageSize(nextPageSize)
     setPage(0)
     setViewMenuOpen(false)
+  }
+
+  viewsRef.current = views
+  activeViewIdRef.current = activeViewId
+  syncViewsRef.current = async () => {
+    if (nested || sheet) return
+    await pullSavedViews()
+    const listed = listedViews(collectionPath, loadViews(collectionPath)).map((view) =>
+      withViewDisplay(collectionPath, view),
+    )
+    const prev = viewsRef.current
+    const activeId = activeViewIdRef.current
+    rememberViews(collectionPath, listed)
+    viewsRef.current = listed
+    setViews(listed)
+    const nextView = (activeId ? listed.find((item) => item.id === activeId) : undefined) ?? listed[0]
+    const prevView = activeId ? prev.find((item) => item.id === activeId) : undefined
+    if (!nextView) return
+    if (prevView && viewStateKey(normalizeSavedView(prevView)) === viewStateKey(normalizeSavedView(nextView))) return
+    skipPersistGen.current += 1
+    applyView(nextView)
   }
 
   function selectView(view: SavedView) {
@@ -2200,7 +2229,9 @@ export function CollectionBrowser({
 
   useEffect(() => {
     if (sheet || !hydrated || !activeViewId) return
+    const persistGen = skipPersistGen.current
     const id = window.setTimeout(() => {
+      if (persistGen !== skipPersistGen.current) return
       if (hydratePath.current !== `${collectionPath}\0${dataPath}`) return
       const current = viewsRef.current.find((view) => view.id === activeViewId)
       if (!current) return

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -395,15 +395,16 @@ export function apply(ctx: Context) {
     const offSnap = snapshot.subscribe?.(fromSnap)
     let debounce = 0
     const off = snapshot.onMessage(DATABASE_CHANNEL, (payload) => {
-      window.dispatchEvent(new Event('fsdb:change'))
-      const rec = payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as { asset?: { name?: string; etag?: string } }) : null
-      if (rec?.asset?.name) {
-        window.dispatchEvent(new CustomEvent('biu:asset-changed', { detail: rec.asset }))
-      }
+      const rec = payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as { asset?: { name?: string; etag?: string }; savedView?: unknown; reveal?: { collection?: unknown } }) : null
+      const viewsTouched = Boolean(rec?.savedView) || String(rec?.reveal?.collection ?? '') === '/views'
       const sessionId = (
         ctx.get('sessionView') as { get?: () => { sessionId?: string | null } } | undefined
       )?.get?.()?.sessionId
       applyDatabaseChannelPayload(payload, sessionId)
+      window.dispatchEvent(new CustomEvent('fsdb:change', { detail: viewsTouched ? { views: true } : undefined }))
+      if (rec?.asset?.name) {
+        window.dispatchEvent(new CustomEvent('biu:asset-changed', { detail: rec.asset }))
+      }
       window.clearTimeout(debounce)
       debounce = window.setTimeout(() => void sync(), 40)
     })

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -268,8 +268,9 @@ test('applyDatabaseChannelPayload upserts a created view then opens it', () => {
   )
   assert.equal(getInspectorDbPath('database:/tasks'), '/database/tasks/view/board-1')
   assert.equal(isInspectorAgentWorking('/tasks'), false)
-  const stored = JSON.parse(mem['fsdb.views:/tasks'] ?? '[]') as Array<{ id: string; name: string; mode: string }>
+  const stored = JSON.parse(mem['fsdb.views:/tasks'] ?? '[]') as Array<{ id: string; name: string; mode: string; filters?: Record<string, string> }>
   assert.equal(stored[0]?.id, 'board-1')
   assert.equal(stored[0]?.name, '看板')
   assert.equal(stored[0]?.mode, 'table')
+  assert.equal(stored[0]?.filters?.status, 'doing')
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -2,8 +2,8 @@
 
 import { normalizeCollectionPath } from '../paths.ts'
 import { DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath, databaseViewPath } from './database-path.ts'
-import { upsertSavedView } from './view-storage.ts'
-import { normalizeSavedView, type SavedView } from './saved-view.ts'
+import { upsertSavedView, savedViewFromRecord } from './view-storage.ts'
+import { type SavedView } from './saved-view.ts'
 
 const DEFAULT_PANE = 'database'
 const STORAGE_PREFIX = 'inspector.dbPath:'
@@ -295,28 +295,25 @@ export function applyDatabaseChannelPayload(payload: unknown, currentSessionId?:
 function savedViewFromPayload(raw: unknown, revealViewId: unknown): SavedView | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
   const rec = raw as Record<string, unknown>
-  const id = String(rec.id ?? revealViewId ?? '').trim()
-  if (!id) return null
-  let filters: Record<string, string> = {}
-  if (rec.filters && typeof rec.filters === 'object' && !Array.isArray(rec.filters)) {
-    filters = Object.fromEntries(Object.entries(rec.filters).map(([key, item]) => [key, String(item)]))
-  }
-  return normalizeSavedView({
-    id,
-    name: String(rec.name ?? rec.title ?? '新视图'),
-    mode: rec.mode as SavedView['mode'],
-    sortField: String(rec.sortField ?? 'title'),
-    sortDir: rec.sortDir === 'desc' ? 'desc' : 'asc',
-    filters,
-    columns: Array.isArray(rec.columns) ? rec.columns.map((item) => String(item)) : [],
-    groupBy: String(rec.groupBy ?? ''),
-    tree: rec.tree !== false,
-    wrap: Boolean(rec.wrap),
-    truncate: rec.truncate !== false,
-    query: String(rec.query ?? ''),
+  const parsed = savedViewFromRecord({
+    viewId: rec.id ?? rec.viewId ?? revealViewId,
+    title: rec.name ?? rec.title,
+    mode: rec.mode,
+    sortField: rec.sortField,
+    sortDir: rec.sortDir,
+    sorts: rec.sorts,
+    query: rec.query,
+    groupBy: rec.groupBy,
+    columns: rec.columns,
+    filters: rec.filters,
+    filterTree: rec.filterTree,
+    tree: rec.tree,
+    wrap: rec.wrap,
+    truncate: rec.truncate,
+    pageSize: rec.pageSize,
     columnWidths: rec.columnWidths,
-    builtin: false,
   })
+  return parsed
 }
 
 export const INSPECTOR_REVEAL_EVENT = 'biu:inspector-reveal'

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -513,6 +513,16 @@ test('open detail still reloads body when the collection changes', () => {
   assert.match(browser, /window.dispatchEvent\(new Event\('fsdb:change'\)\)/)
 })
 
+test('agent view writes reload saved views without a full page refresh', () => {
+  assert.match(browser, /detail\?\.views/)
+  assert.match(browser, /void syncViewsRef\.current\(\)/)
+  assert.match(browser, /await pullSavedViews\(\)/)
+  const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  assert.match(page, /viewsTouched/)
+  assert.match(page, /applyDatabaseChannelPayload\(payload, sessionId\)/)
+  assert.match(page, /CustomEvent\('fsdb:change'/)
+})
+
 test('collection reload does not follow callback identity', () => {
   assert.match(browser, /const reloadKey = /)
   assert.match(browser, /void reloadRef\.current\(\)/)

--- a/packages/core-file-system/src/web/saved-view.test.ts
+++ b/packages/core-file-system/src/web/saved-view.test.ts
@@ -59,3 +59,15 @@ test('viewStateKey ignores name and treats missing query as empty', () => {
   assert.equal(viewStateKey(a), viewStateKey(b))
   assert.notEqual(viewStateKey(a), viewStateKey({ ...a, sortDir: 'desc' }))
 })
+
+test('viewStateKey treats filter trees with different ids as the same', () => {
+  const a = normalizeSavedView({
+    ...base,
+    filterTree: { kind: 'group', id: 'g1', combinator: 'and', children: [{ kind: 'rule', id: 'r1', field: 'tags', op: 'eq', value: 'test' }] },
+  })
+  const b = normalizeSavedView({
+    ...base,
+    filterTree: { kind: 'group', id: 'g2', combinator: 'and', children: [{ kind: 'rule', id: 'r2', field: 'tags', op: 'eq', value: 'test' }] },
+  })
+  assert.equal(viewStateKey(a), viewStateKey(b))
+})

--- a/packages/core-file-system/src/web/saved-view.ts
+++ b/packages/core-file-system/src/web/saved-view.ts
@@ -1,5 +1,5 @@
 import { isViewModeId, type ViewMode } from './fields.ts'
-import { countFilterRules, normalizeSorts, resolveViewFilterTree, type FilterGroup, type SortRule } from '../query-logic.ts'
+import { countFilterRules, filterTreeStateKey, normalizeSorts, resolveViewFilterTree, sortsStateKey, type FilterGroup, type SortRule } from '../query-logic.ts'
 
 export type SavedView = {
   id: string
@@ -96,9 +96,9 @@ export function viewStateKey(
     mode: view.mode,
     sortField: view.sortField,
     sortDir: view.sortDir,
-    sorts: (view.sorts ?? []).map((item) => ({ field: item.field, dir: item.dir })),
+    sorts: sortsStateKey(view.sorts),
     filters: view.filters,
-    filterTree: view.filterTree ?? null,
+    filterTree: filterTreeStateKey(view.filterTree),
     columns: view.columns,
     groupBy: view.groupBy ?? '',
     tree: view.tree !== false,

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -263,7 +263,6 @@ export function upsertSavedView(collectionPath: string, view: SavedView) {
   } catch {
     /* ignore */
   }
-  pushSavedViews(collectionPath, stored)
 }
 
 export function pushAllSavedViews() {
@@ -351,5 +350,6 @@ export function withViewDisplay(collectionPath: string, view: SavedView): SavedV
     name: view.name,
     builtin: view.builtin,
     filters: view.filters,
+    filterTree: view.builtin ? overlay.filterTree ?? view.filterTree : view.filterTree,
   })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 改当前视图的 `filters`/`filterTree` 时，表格要整页刷新才出现筛选芯片；排序看起来会马上有，是因为工具栏排序本来就有默认 `sorts`。

**原因**
- `fsdb:change` 只 `reload()` 行，不 `pullSavedViews` / `applyView`
- 已打开页面的 React `filterTree` 仍是空树，400ms `persistViews` 可能把空筛选写回
- 视图 `db_update` 不广播完整 `savedView`（以前只处理 `created`）

**改动**
- `/views` 创建和更新都广播 `filters` + `filterTree` + `sorts`
- 通道消息先 upsert，再 `fsdb:change`（`detail.views`），表格拉视图并对当前视图 `applyView`
- 拉视图后跳过这一轮 persist，避免空树冲掉 agent
- `applyView` / `viewStateKey` 比较筛选时忽略随机 id

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

