### PR TITLE
fix(fsdb): db_update 视图立刻套到来源表当前视图

### DIFF
--- a/packages/core-file-system/src/host/saved-views.test.ts
+++ b/packages/core-file-system/src/host/saved-views.test.ts
@@ -121,6 +121,7 @@ test('saved views persist created fields and updates across reopen', async () =>
 test('clientViewFromDbRow keeps flat filters and sorts for the live table', () => {
   const view = clientViewFromDbRow({
     viewId: 'mine',
+    tablePath: '/pages',
     title: '我的',
     filters: '{"project":"biu"}',
     sorts: '[{"field":"title","dir":"desc"}]',
@@ -128,6 +129,7 @@ test('clientViewFromDbRow keeps flat filters and sorts for the live table', () =
     sortDir: 'desc',
   })
   assert.equal(view?.id, 'mine')
+  assert.equal(view?.tablePath, '/pages')
   assert.equal(view?.filters.project, 'biu')
   assert.equal(view?.filterTree && view.filterTree.children[0] && view.filterTree.children[0].kind === 'rule' && view.filterTree.children[0].value, 'biu')
   assert.equal(view?.sorts[0]?.field, 'title')

--- a/packages/core-file-system/src/host/saved-views.ts
+++ b/packages/core-file-system/src/host/saved-views.ts
@@ -328,6 +328,7 @@ export function clientViewFromDbRow(row: Record<string, unknown> | undefined) {
   const sortsPatch = sortsFromPatch(row.sorts, row.sortField, row.sortDir)
   return {
     id,
+    tablePath: normalizeCollectionPath(String(row.tablePath ?? '')),
     name: String(row.title ?? row.name ?? id),
     mode: row.mode,
     sortField: sortsPatch.sortField,

--- a/packages/core-file-system/src/paths.test.ts
+++ b/packages/core-file-system/src/paths.test.ts
@@ -46,3 +46,17 @@ test('databaseRevealForTool opens the source table view after creating a saved v
     { collection: '/views' },
   )
 })
+
+test('databaseRevealForTool maps view db_update onto the source table', () => {
+  assert.deepEqual(
+    databaseRevealForTool({
+      path: '/views/pages::mine',
+      result: {
+        kind: 'record',
+        path: '/views/pages::mine',
+        value: { tablePath: '/pages', viewId: 'mine', filters: '{"project":"biu"}' },
+      },
+    }),
+    { collection: '/pages', viewId: 'mine' },
+  )
+})

--- a/packages/core-file-system/src/paths.ts
+++ b/packages/core-file-system/src/paths.ts
@@ -39,23 +39,37 @@ export function databaseRevealForTool(opts: {
     const fromPath = databaseRevealFromPath(opts.path)
     return fromPath ? { collection: fromPath.collection } : null
   }
-  const created = revealFromCreatedView(opts.result)
-  if (created) return created
+  const fromView = revealFromSavedViewRow(opts.result)
+  if (fromView) return fromView
   return databaseRevealFromPath(resultPathOf(opts.result) || opts.path)
 }
 
-function revealFromCreatedView(result: unknown): DatabaseReveal | null {
+function viewRowFromResult(result: unknown): { tablePath?: unknown; viewId?: unknown } | null {
   if (!result || typeof result !== 'object' || Array.isArray(result)) return null
-  if ((result as { kind?: unknown }).kind !== 'created') return null
-  const items = (result as { items?: unknown }).items
-  if (!Array.isArray(items) || !items.length) return null
-  const first = items[0]
-  if (!first || typeof first !== 'object' || Array.isArray(first)) return null
-  const value = (first as { value?: unknown }).value
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
-  const row = value as { tablePath?: unknown; viewId?: unknown }
+  const rec = result as { kind?: unknown; items?: unknown; value?: unknown }
+  if (rec.kind === 'created') {
+    const items = rec.items
+    if (!Array.isArray(items) || !items.length) return null
+    const first = items[0]
+    if (!first || typeof first !== 'object' || Array.isArray(first)) return null
+    const value = (first as { value?: unknown }).value
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+    return value as { tablePath?: unknown; viewId?: unknown }
+  }
+  if (rec.kind === 'record') {
+    const value = rec.value
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+    return value as { tablePath?: unknown; viewId?: unknown }
+  }
+  return null
+}
+
+/** /views 行属于来源表；通知 tablePath 上的那条视图，而不是 /views 自己。 */
+function revealFromSavedViewRow(result: unknown): DatabaseReveal | null {
+  const row = viewRowFromResult(result)
+  if (!row) return null
   const collection = normalizeCollectionPath(String(row.tablePath ?? ''))
   const viewId = String(row.viewId ?? '').trim()
-  if (!collection || collection === '/' || !viewId) return null
+  if (!collection || collection === '/' || collection === '/views' || !viewId) return null
   return { collection, viewId }
 }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -132,7 +132,7 @@ import { listCollection, readJson } from './db-client.ts'
 import { findViewNeighbor, indexOnPage } from './view-adjacent.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
 import { mergeTableViews } from '../catalog-views.ts'
-import { showRecordInInspector } from './inspector-db-route.ts'
+import { SAVED_VIEW_EVENT, showRecordInInspector } from './inspector-db-route.ts'
 import { SchemaChips, SchemaFieldEditor, schemaTagTone } from './schema-field.tsx'
 import { CellPop, cellUsesPop } from './cell-pop.tsx'
 import { CellPopDraft } from './cell-pop-draft.tsx'
@@ -622,6 +622,7 @@ export function CollectionBrowser({
   const skipPersistGen = useRef(0)
   const activeViewIdRef = useRef<string | null>(null)
   const syncViewsRef = useRef<() => Promise<void>>(async () => {})
+  const adoptViewRef = useRef<(view: SavedView) => void>(() => undefined)
   const hydratedDetail = useRef('')
   const [dlg, setDlg] = useState<
     | { kind: 'rename'; view: SavedView }
@@ -904,10 +905,13 @@ export function CollectionBrowser({
 
   useEffect(() => {
     let debounce = 0
+    let pendingViews = false
     const onChange = (event: Event) => {
+      if ((event as CustomEvent<{ views?: boolean }>).detail?.views) pendingViews = true
       window.clearTimeout(debounce)
-      const viewsTouched = Boolean((event as CustomEvent<{ views?: boolean }>).detail?.views)
       debounce = window.setTimeout(() => {
+        const viewsTouched = pendingViews
+        pendingViews = false
         void reloadRef.current()
         if (detailIdRef.current) pullDetailBody()
         if (viewsTouched) void syncViewsRef.current()
@@ -1284,8 +1288,21 @@ export function CollectionBrowser({
 
   viewsRef.current = views
   activeViewIdRef.current = activeViewId
+  adoptViewRef.current = (view: SavedView) => {
+    if (sheet) return
+    const listed = listedViews(collectionPath, loadViews(collectionPath)).map((item) =>
+      withViewDisplay(collectionPath, item),
+    )
+    rememberViews(collectionPath, listed)
+    viewsRef.current = listed
+    setViews(listed)
+    if (view.id === activeViewIdRef.current) {
+      skipPersistGen.current += 1
+      applyView(view)
+    }
+  }
   syncViewsRef.current = async () => {
-    if (nested || sheet) return
+    if (sheet) return
     await pullSavedViews()
     const listed = listedViews(collectionPath, loadViews(collectionPath)).map((view) =>
       withViewDisplay(collectionPath, view),
@@ -1307,6 +1324,16 @@ export function CollectionBrowser({
     applyView(view)
     onOpenView?.(view.id)
   }
+
+  useEffect(() => {
+    const onSaved = (event: Event) => {
+      const detail = (event as CustomEvent<{ collection?: string; view?: SavedView }>).detail
+      if (String(detail?.collection ?? '') !== collectionPath) return
+      if (detail?.view) adoptViewRef.current(detail.view)
+    }
+    window.addEventListener(SAVED_VIEW_EVENT, onSaved)
+    return () => window.removeEventListener(SAVED_VIEW_EVENT, onSaved)
+  }, [collectionPath])
 
   useEffect(() => {
     if (!routeViewId) return

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -395,8 +395,11 @@ export function apply(ctx: Context) {
     const offSnap = snapshot.subscribe?.(fromSnap)
     let debounce = 0
     const off = snapshot.onMessage(DATABASE_CHANNEL, (payload) => {
-      const rec = payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as { asset?: { name?: string; etag?: string }; savedView?: unknown; reveal?: { collection?: unknown } }) : null
-      const viewsTouched = Boolean(rec?.savedView) || String(rec?.reveal?.collection ?? '') === '/views'
+      const rec = payload && typeof payload === 'object' && !Array.isArray(payload) ? (payload as { asset?: { name?: string; etag?: string }; savedView?: unknown; reveal?: { collection?: unknown; viewId?: unknown } }) : null
+      const viewsTouched =
+        Boolean(rec?.savedView) ||
+        Boolean(rec?.reveal?.viewId) ||
+        String(rec?.reveal?.collection ?? '') === '/views'
       const sessionId = (
         ctx.get('sessionView') as { get?: () => { sessionId?: string | null } } | undefined
       )?.get?.()?.sessionId

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -274,3 +274,45 @@ test('applyDatabaseChannelPayload upserts a created view then opens it', () => {
   assert.equal(stored[0]?.mode, 'table')
   assert.equal(stored[0]?.filters?.status, 'doing')
 })
+
+test('view db_update writes the source table view, not /views', () => {
+  const mem: Record<string, string> = {}
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => mem[key] ?? null,
+      setItem: (key: string, value: string) => {
+        mem[key] = value
+      },
+      removeItem: (key: string) => {
+        delete mem[key]
+      },
+      key: (index: number) => Object.keys(mem)[index] ?? null,
+      get length() {
+        return Object.keys(mem).length
+      },
+    },
+  })
+  const seen: Array<{ collection?: string; view?: { id?: string } }> = []
+  const onSaved = (event: Event) => {
+    seen.push((event as CustomEvent<{ collection?: string; view?: { id?: string } }>).detail)
+  }
+  window.addEventListener('fsdb:saved-view', onSaved)
+  applyDatabaseChannelPayload(
+    {
+      phase: 'done',
+      sessionId: 'other',
+      reveal: { collection: '/views', recordId: 'pages::mine' },
+      savedView: { id: 'mine', tablePath: '/pages', name: '我的', filters: { project: 'biu' } },
+    },
+    'main',
+  )
+  window.removeEventListener('fsdb:saved-view', onSaved)
+  assert.equal(mem['fsdb.views:/views'], undefined)
+  const stored = JSON.parse(mem['fsdb.views:/pages'] ?? '[]') as Array<{ id: string; filters?: Record<string, string> }>
+  assert.equal(stored[0]?.id, 'mine')
+  assert.equal(stored[0]?.filters?.project, 'biu')
+  assert.equal(seen[0]?.collection, '/pages')
+  assert.equal(seen[0]?.view?.id, 'mine')
+  assert.equal(getInspectorDbPath('database:/pages'), '')
+})

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -276,17 +276,22 @@ export function applyDatabaseReveal(reveal: unknown) {
   showInInspector(collection, databaseAllViewPath(collection), { unique })
 }
 
-/** Agent 工具推送：只跟当前主 Session。表格刷新仍走 fsdb:change。 */
+/** 视图表写入立刻套到来源表；检查器跟随仍只跟当前主 Session。 */
 export function applyDatabaseChannelPayload(payload: unknown, currentSessionId?: string | null) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return
+  const reveal = (payload as { reveal?: unknown }).reveal
+  const revealRec = reveal && typeof reveal === 'object' && !Array.isArray(reveal) ? (reveal as { collection?: unknown; viewId?: unknown }) : null
+  const collection = normalizeCollectionPath(String(revealRec?.collection ?? ''))
+  const savedRaw = (payload as { savedView?: unknown }).savedView
+  const savedView = savedViewFromPayload(savedRaw, revealRec?.viewId)
+  const tablePath = savedViewTablePath(savedRaw, collection)
+  if (savedView && tablePath) {
+    upsertSavedView(tablePath, savedView)
+    window.dispatchEvent(new CustomEvent(SAVED_VIEW_EVENT, { detail: { collection: tablePath, view: savedView } }))
+  }
   const sessionId = String((payload as { sessionId?: unknown }).sessionId ?? '').trim()
   if (!sessionId || !currentSessionId || sessionId !== String(currentSessionId)) return
-  const reveal = (payload as { reveal?: unknown }).reveal
-  if (!reveal || typeof reveal !== 'object' || Array.isArray(reveal)) return
-  const collection = normalizeCollectionPath(String((reveal as { collection?: unknown }).collection ?? ''))
   if (!collection || collection === '/') return
-  const savedView = savedViewFromPayload((payload as { savedView?: unknown }).savedView, (reveal as { viewId?: unknown }).viewId)
-  if (savedView) upsertSavedView(collection, savedView)
   const phase = String((payload as { phase?: unknown }).phase ?? '')
   if (isInspectorAgentFollow()) applyDatabaseReveal(reveal)
   setInspectorAgentWorking(collection, phase !== 'done')
@@ -316,6 +321,18 @@ function savedViewFromPayload(raw: unknown, revealViewId: unknown): SavedView | 
   return parsed
 }
 
+function savedViewTablePath(raw: unknown, revealCollection: string) {
+  const fromRow =
+    raw && typeof raw === 'object' && !Array.isArray(raw)
+      ? normalizeCollectionPath(String((raw as { tablePath?: unknown }).tablePath ?? ''))
+      : '/'
+  const fromReveal = revealCollection === '/views' ? '/' : revealCollection
+  const path = fromRow && fromRow !== '/' && fromRow !== '/views' ? fromRow : fromReveal
+  if (!path || path === '/' || path === '/views') return ''
+  return path
+}
+
+export const SAVED_VIEW_EVENT = 'fsdb:saved-view'
 export const INSPECTOR_REVEAL_EVENT = 'biu:inspector-reveal'
 export const INSPECTOR_PANE_CLOSED_EVENT = 'biu:inspector-pane-closed'
 

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -514,11 +514,14 @@ test('open detail still reloads body when the collection changes', () => {
 })
 
 test('agent view writes reload saved views without a full page refresh', () => {
-  assert.match(browser, /detail\?\.views/)
+  assert.match(browser, /pendingViews/)
+  assert.match(browser, /SAVED_VIEW_EVENT/)
+  assert.match(browser, /adoptViewRef/)
   assert.match(browser, /void syncViewsRef\.current\(\)/)
   assert.match(browser, /await pullSavedViews\(\)/)
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.match(page, /viewsTouched/)
+  assert.match(page, /reveal\?\.viewId/)
   assert.match(page, /applyDatabaseChannelPayload\(payload, sessionId\)/)
   assert.match(page, /CustomEvent\('fsdb:change'/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`db_update /views/<id>` 只改了视图表行。中间打开的 `/pages`（等）当前视图不会套上新的 filters。

原因：更新结果的 reveal 落在 `/views`，upsert 也写到错误的 collection。

改动：
- 用行上的 `tablePath` + `viewId` 通知来源表
- 立刻 `applyView` 到当前打开的那条视图
- 后续无 `views` 标记的 `fsdb:change` 不再把这次视图同步冲掉

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

