### PR TITLE
fix(fsdb): 创建人唯一、编辑人追加，均不可手改

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -10,7 +10,7 @@ const LIST_META_KEYS = new Set(['createdAt', 'updatedAt', 'createdBy', 'updatedB
 /** 把 File System 工具回包压成 Agent 用的短 JSON；网页 API 不走这里。 */
 export class AgentDbCompact {
   readonly statBlurb =
-    '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy、updatedBy；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
+    '查看路径元数据。根目录列出表。表路径返回相对默认的 schema：每张表都有 id、title（标题）、createdAt、updatedAt、emoji、tags、facet、parentId（父级）、dependsOn、createdBy（唯一创建人，系统自记不可写）、updatedBy（编辑人列表，系统自记不可写，多人先后编辑会追加）；正文默认字段 content（file，用 db_content）。fields 只含本表多出来的列，或覆盖了这些默认的列。caps 表示能否 list/read/update/create/delete/action/content。'
 
   schema(schema: CollectionSchema) {
     const defaults = this.defaultFields(schema)
@@ -224,6 +224,7 @@ export class AgentDbCompact {
     if (JSON.stringify(field.enum ?? null) !== JSON.stringify(builtin.enum ?? null)) return false
     if ((field.action ?? '') !== (builtin.action ?? '')) return false
     if (Boolean(field.computed) !== Boolean(builtin.computed)) return false
+    if (Boolean(field.multiple) !== Boolean(builtin.multiple)) return false
     return true
   }
 

--- a/packages/core-file-system/src/host/facets-store.ts
+++ b/packages/core-file-system/src/host/facets-store.ts
@@ -4,6 +4,7 @@ import { dirname } from 'node:path'
 import { createRequire } from 'node:module'
 import {
   asPerson,
+  asPersonList,
   normalizeSchemaPack,
   normalizeSchemaValue,
   type CollectionSchemaPack,
@@ -321,7 +322,7 @@ export class FacetStore {
     emoji: string | null
     tags: string[] | null
     createdBy: PersonValue | null
-    updatedBy: PersonValue | null
+    updatedBy: PersonValue[]
   } | null {
     const row = this.ensure()
       .prepare('SELECT emoji, tags_json, created_by_json, updated_by_json FROM record_meta WHERE collection = ? AND record_id = ?')
@@ -351,19 +352,27 @@ export class FacetStore {
         return asPerson(raw)
       }
     }
+    const parsePeople = (raw: string | null | undefined) => {
+      if (raw == null || raw === '') return []
+      try {
+        return asPersonList(JSON.parse(raw))
+      } catch {
+        return asPersonList(raw)
+      }
+    }
     return {
       emoji: row.emoji != null ? String(row.emoji) : null,
       tags,
       createdBy: parsePerson(row.created_by_json),
-      updatedBy: parsePerson(row.updated_by_json),
+      updatedBy: parsePeople(row.updated_by_json),
     }
   }
 
   writeRecordMeta(
     collection: string,
     recordId: string,
-    patch: { emoji?: string; tags?: string[]; createdBy?: PersonValue | null; updatedBy?: PersonValue | null },
-  ): { emoji: string | null; tags: string[] | null; createdBy: PersonValue | null; updatedBy: PersonValue | null } {
+    patch: { emoji?: string; tags?: string[]; createdBy?: PersonValue | null; updatedBy?: PersonValue[] | PersonValue | null },
+  ): { emoji: string | null; tags: string[] | null; createdBy: PersonValue | null; updatedBy: PersonValue[] } {
     this.ensure()
       .prepare(
         `INSERT INTO record_meta (collection, record_id, emoji, tags_json, created_by_json, updated_by_json)
@@ -382,9 +391,9 @@ export class FacetStore {
           ? JSON.stringify([...new Set(patch.tags.map((item) => String(item).trim()).filter(Boolean))])
           : null,
         patch.createdBy !== undefined ? JSON.stringify(patch.createdBy) : null,
-        patch.updatedBy !== undefined ? JSON.stringify(patch.updatedBy) : null,
+        patch.updatedBy !== undefined ? JSON.stringify(asPersonList(patch.updatedBy)) : null,
       )
-    return this.recordMeta(collection, recordId) ?? { emoji: null, tags: null, createdBy: null, updatedBy: null }
+    return this.recordMeta(collection, recordId) ?? { emoji: null, tags: null, createdBy: null, updatedBy: [] }
   }
 
   removeRecord(collection: string, recordId: string) {

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -172,6 +172,7 @@ test('every collection schema includes id, title, createdAt and updatedAt', asyn
   assert.equal(stat.schema.fields.createdBy?.label, '创建人')
   assert.equal(stat.schema.fields.updatedBy?.type, 'person')
   assert.equal(stat.schema.fields.updatedBy?.writable, false)
+  assert.equal(stat.schema.fields.updatedBy?.multiple, true)
   assert.equal(stat.schema.fields.updatedBy?.label, '编辑人')
   assert.equal(stat.schema.contentField, 'content')
   const tagged = await db.update('/notes/n1', { facet: { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } } })
@@ -256,7 +257,7 @@ test('stamps agent createdBy with the session title from /sessions', async () =>
   })
   const written = await runWithSession('sess-agent-1', () => db.update('/notes/n1', { status: 'done' }))
   assert.deepEqual(written.value.createdBy, { kind: 'agent', name: '蓝团爱', sessionId: 'sess-agent-1' })
-  assert.deepEqual(written.value.updatedBy, { kind: 'agent', name: '蓝团爱', sessionId: 'sess-agent-1' })
+  assert.deepEqual(written.value.updatedBy, [{ kind: 'agent', name: '蓝团爱', sessionId: 'sess-agent-1' }])
 })
 
 test('updates stamp createdBy and updatedBy from the current actor', async () => {
@@ -265,11 +266,37 @@ test('updates stamp createdBy and updatedBy from the current actor', async () =>
   db.register(notesCollection())
   const written = await db.update('/notes/n1', { status: 'done' })
   assert.deepEqual(written.value.createdBy, { kind: 'user', name: '用户' })
-  assert.deepEqual(written.value.updatedBy, { kind: 'user', name: '用户' })
+  assert.deepEqual(written.value.updatedBy, [{ kind: 'user', name: '用户' }])
   await assert.rejects(() => db.update('/notes/n1', { updatedBy: { kind: 'system', name: '系统' } }), /not writable/)
   const again = await db.update('/notes/n1', { status: 'open' })
   assert.deepEqual(again.value.createdBy, { kind: 'user', name: '用户' })
-  assert.deepEqual(again.value.updatedBy, { kind: 'user', name: '用户' })
+  assert.deepEqual(again.value.updatedBy, [{ kind: 'user', name: '用户' }])
+})
+
+test('later editors append to updatedBy and leave createdBy alone', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  db.register(notesCollection())
+  db.register({
+    id: 'sessions',
+    path: '/sessions',
+    schema: {
+      labelField: 'title',
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string', writable: true },
+      },
+    },
+    list: () => [{ id: 'sess-a', title: '甲' }],
+    get: (id) => (id === 'sess-a' ? { id: 'sess-a', title: '甲' } : null),
+  })
+  await db.update('/notes/n1', { status: 'done' })
+  const second = await runWithSession('sess-a', () => db.update('/notes/n1', { status: 'open' }))
+  assert.deepEqual(second.value.createdBy, { kind: 'user', name: '用户' })
+  assert.deepEqual(second.value.updatedBy, [
+    { kind: 'user', name: '用户' },
+    { kind: 'agent', name: '甲', sessionId: 'sess-a' },
+  ])
 })
 
 test('person fields accept user system and agent values', async () => {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -6,6 +6,8 @@ import {
   DATABASE_CHANNEL,
   asAttachmentList,
   asPerson,
+  asPersonList,
+  appendPerson,
   asHttpHref,
   asImageSrc,
   asImageSrcList,
@@ -624,11 +626,21 @@ export class DatabaseService extends Service implements Database {
   private applyPersonOverlay(spec: CollectionSpec, row: DbRecord): DbRecord {
     const meta = this.facets.recordMeta(spec.path, row.id)
     if (!meta) return row
+    const editors = asPersonList(meta.updatedBy).map((item) => this.namedPerson(item))
     return {
       ...row,
       ...(meta.createdBy ? { createdBy: this.namedPerson(meta.createdBy) } : {}),
-      ...(meta.updatedBy ? { updatedBy: this.namedPerson(meta.updatedBy) } : {}),
+      ...(editors.length ? { updatedBy: editors } : {}),
     }
+  }
+
+  private async stampActor(collection: string, recordId: string) {
+    const actor = await this.currentPerson()
+    const existing = this.facets.recordMeta(collection, recordId)
+    this.facets.writeRecordMeta(collection, recordId, {
+      ...(existing?.createdBy ? {} : { createdBy: actor }),
+      updatedBy: appendPerson(existing?.updatedBy, actor),
+    })
   }
 
   private async currentPerson(): Promise<PersonValue> {
@@ -758,6 +770,7 @@ export class DatabaseService extends Service implements Database {
           ...(meta.tags !== null ? { tags: meta.tags } : {}),
         }
       }
+      await this.stampActor(spec.path, current.id)
       this.bump()
       return {
         kind: 'record' as const,
@@ -767,13 +780,8 @@ export class DatabaseService extends Service implements Database {
     }
     const patch = pickWritablePatch(schema, raw)
     await assertSameTableLinks(spec, patch, parts[1])
-    const actor = await this.currentPerson()
     let record = await spec.update(parts[1]!, patch)
-    const existing = this.facets.recordMeta(spec.path, record.id)
-    this.facets.writeRecordMeta(spec.path, record.id, {
-      ...(existing?.createdBy ? {} : { createdBy: actor }),
-      updatedBy: actor,
-    })
+    await this.stampActor(spec.path, record.id)
     if (spec.path === '/facets' && schema.fields.facet && 'facet' in patch) {
       const nextFacet = coerce(schema.fields.facet, patch.facet)
       const labelKey = schema.labelField ?? 'title'
@@ -797,7 +805,6 @@ export class DatabaseService extends Service implements Database {
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     if (!spec.records?.create || !spec.create) throw new Error(`collection cannot create: ${spec.path}`)
     const schema = schemaFor(spec)
-    const actor = await this.currentPerson()
     const rows = parseRecords(content)
     const records: Record<string, unknown>[] = []
     for (const row of rows) {
@@ -807,10 +814,7 @@ export class DatabaseService extends Service implements Database {
     }
     const created = await spec.create(records)
     for (const record of created) {
-      this.facets.writeRecordMeta(spec.path, record.id, {
-        createdBy: actor,
-        updatedBy: actor,
-      })
+      await this.stampActor(spec.path, record.id)
       this.indexFacetRecord(spec, record)
     }
     this.bump()
@@ -904,6 +908,7 @@ export class DatabaseService extends Service implements Database {
       ? pickWritablePatch(schema, { [field]: value })
       : { [field]: value }
     const record = await spec.update(parts[1]!, patch)
+    await this.stampActor(spec.path, record.id)
     this.bump()
     return {
       kind: 'content' as const,

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -1,5 +1,5 @@
 import type { AtomicFieldType, CollectionSchema, CollectionSchemaPack, DbRecord, FieldSpec, FieldType, SchemaFieldValue } from '@biu/type-file-system'
-import { asAttachment, asAttachmentList, asHttpHref, asImageSrc, asImageSrcList, asPerson, BUILTIN_FIELD_KEYS, isFacetFieldType, isRefFieldType, isReservedSchemaFieldKey, normalizeSchemaValue } from '@biu/type-file-system'
+import { asAttachment, asAttachmentList, asHttpHref, asImageSrc, asImageSrcList, asPerson, asPersonList, BUILTIN_FIELD_KEYS, isFacetFieldType, isRefFieldType, isReservedSchemaFieldKey, normalizeSchemaValue } from '@biu/type-file-system'
 
 export const BUILTIN_VIEW_MODES = ['table'] as const
 export type BuiltinViewMode = (typeof BUILTIN_VIEW_MODES)[number]
@@ -329,7 +329,12 @@ export function formatField(field: FieldSpec | undefined, value: unknown): strin
     const parsed = normalizeSchemaValue(value)
     return parsed.tags.length ? parsed.tags.join(', ') : ''
   }
-  if (kind === 'person') return asPerson(value)?.name ?? ''
+  if (kind === 'person') {
+    return asPersonList(value)
+      .map((item) => item.name)
+      .filter(Boolean)
+      .join(' ')
+  }
   if (kind === 'ref') {
     const id = String(value ?? '').trim()
     return id
@@ -346,6 +351,7 @@ export function fieldHasValue(field: FieldSpec | undefined, value: unknown): boo
   if (field && resolveFieldType(field) === 'action') return true
   if (value == null) return false
   if (typeof value === 'string' && !value.trim()) return false
+  if (field && resolveFieldType(field) === 'person') return asPersonList(value).length > 0
   if (Array.isArray(value) && asStringList(value).length === 0) return false
   if (!field) return true
   const kind = resolveFieldType(field)

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -524,6 +524,7 @@ button.fsdb-detail-title-icon:hover{background:var(--dsw-hover);color:var(--dsw-
 .fsdb-media-pick-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-media-error{display:none}
 .fsdb-person{display:inline-flex;align-items:center;gap:6px;min-width:0;max-width:100%}
+.fsdb-person-list{display:inline-flex;flex-wrap:wrap;align-items:center;gap:6px;min-width:0;max-width:100%}
 .fsdb-person.is-empty{color:var(--dsw-label-3)}
 .fsdb-person-name{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .fsdb-person-face{display:inline-flex;flex:none;line-height:0}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -211,6 +211,7 @@ test('deletable tables can pick rows and bulk-delete next to refresh', () => {
   assert.doesNotMatch(cells, /<RefFieldPop/)
   assert.doesNotMatch(cells, /<RecordPickPanel/)
   const people = readFileSync(resolve(import.meta.dirname, './person-cell.tsx'), 'utf8')
+  assert.match(people, /asPersonList/)
   assert.match(people, /kind: 'user', name: '用户'/)
   assert.match(people, /kind: 'system', name: '系统'/)
   assert.match(people, /listCollection/)

--- a/packages/core-file-system/src/web/person-cell.tsx
+++ b/packages/core-file-system/src/web/person-cell.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { ArrowPathIcon, CpuChipIcon, UserIcon } from '@heroicons/react/16/solid'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
-import { asPerson, personKey, type PersonValue } from '@biu/type-file-system'
+import { asPerson, asPersonList, personKey, type PersonValue } from '@biu/type-file-system'
 import { listCollection } from './db-client.ts'
 
 type ChatPerson = {
@@ -62,11 +62,12 @@ export async function loadAgents(): Promise<ChatPerson[]> {
 }
 
 export function PersonFace({ value, empty = '' }: { value: unknown; empty?: string }) {
-  const person = asPerson(value)
+  const people = asPersonList(value)
   const [sessionNames, setSessionNames] = useState<Map<string, string>>(() => new Map())
+  const needAgents = people.some((item) => item.kind === 'agent' && item.sessionId)
 
   useEffect(() => {
-    if (!person || person.kind !== 'agent' || !person.sessionId) return
+    if (!needAgents) return
     let cancelled = false
     void loadAgents()
       .then((rows) => {
@@ -79,9 +80,9 @@ export function PersonFace({ value, empty = '' }: { value: unknown; empty?: stri
     return () => {
       cancelled = true
     }
-  }, [person?.kind, person?.sessionId])
+  }, [needAgents])
 
-  if (!person) {
+  if (!people.length) {
     return empty ? (
       <span className="fsdb-person is-empty">
         <UserIcon aria-hidden className="size-[14px]" />
@@ -90,27 +91,32 @@ export function PersonFace({ value, empty = '' }: { value: unknown; empty?: stri
     ) : null
   }
 
-  const displayName = resolveAgentName(person, sessionNames) || (person.kind === 'agent' ? '' : person.name)
-  const label = displayName || empty
-
   return (
-    <span className="fsdb-person" title={label || undefined}>
-      {person.kind === 'agent' && person.sessionId ? (
-        <span className="fsdb-person-face" aria-hidden>
-          <SidebarMascot
-            size={18}
-            sessionId={person.sessionId}
-            identity={resolveSessionMascot(person.sessionId)}
-            animate={false}
-            title={label || person.sessionId}
-          />
-        </span>
-      ) : (
-        <span className="fsdb-person-avatar" aria-hidden>
-          {person.kind === 'system' ? <CpuChipIcon className="size-[14px]" /> : <UserIcon className="size-[14px]" />}
-        </span>
-      )}
-      {label ? <span className="fsdb-person-name">{label}</span> : null}
+    <span className="fsdb-person-list">
+      {people.map((person) => {
+        const displayName = resolveAgentName(person, sessionNames) || (person.kind === 'agent' ? '' : person.name)
+        const label = displayName || empty
+        return (
+          <span key={personKey(person) || person.name} className="fsdb-person" title={label || undefined}>
+            {person.kind === 'agent' && person.sessionId ? (
+              <span className="fsdb-person-face" aria-hidden>
+                <SidebarMascot
+                  size={18}
+                  sessionId={person.sessionId}
+                  identity={resolveSessionMascot(person.sessionId)}
+                  animate={false}
+                  title={label || person.sessionId}
+                />
+              </span>
+            ) : (
+              <span className="fsdb-person-avatar" aria-hidden>
+                {person.kind === 'system' ? <CpuChipIcon className="size-[14px]" /> : <UserIcon className="size-[14px]" />}
+              </span>
+            )}
+            {label ? <span className="fsdb-person-name">{label}</span> : null}
+          </span>
+        )
+      })}
     </span>
   )
 }

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -57,7 +57,7 @@ test('page plugin stores pages in SQLite under .page', async () => {
   assert.equal(fields.score, undefined)
   assert.equal(fields.notes?.type, 'file')
   assert.equal(registered[0]?.schema.fields.tags?.enum, undefined)
-  assert.deepEqual(registered[0]?.schema.columns, ['title', 'tags'])
+  assert.deepEqual(registered[0]?.schema.columns, ['title', 'tags', 'createdBy', 'updatedBy'])
   assert.deepEqual(registered[0]?.records, { update: true, create: true, delete: true })
 
   const spec = registered[0]!

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -24,7 +24,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
       labelField: 'title',
       contentField: 'notes',
       parentField: 'parentId',
-      columns: ['title', 'tags'],
+        columns: ['title', 'tags', 'createdBy', 'updatedBy'],
       fields: {
         ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题', writable: true },

--- a/packages/type-file-system/src/index.test.ts
+++ b/packages/type-file-system/src/index.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { asImageSrc, asImageSrcList, asAttachment, asAttachmentList, asPerson, personKey, actionVisibleToUser, emptySchemaValue, hasCollectionDeleteQuery, isReservedSchemaFieldKey, isReservedSchemaFieldLabel, normalizeSchemaPack, normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, retagSchemaValue, schemaSearchHaystack, withBuiltinFields } from './index.ts'
+import { asImageSrc, asImageSrcList, asAttachment, asAttachmentList, asPerson, asPersonList, appendPerson, personKey, actionVisibleToUser, emptySchemaValue, hasCollectionDeleteQuery, isReservedSchemaFieldKey, isReservedSchemaFieldLabel, normalizeSchemaPack, normalizeSchemaValue, recordBuiltinValues, REQUIRED_RECORD_FIELD_KEYS, REQUIRED_RECORD_FIELDS, retagSchemaValue, schemaSearchHaystack, withBuiltinFields } from './index.ts'
 
 test('asImageSrc keeps http, data:image, and same-origin image paths', () => {
   assert.equal(asImageSrc('https://example.com/a.png'), 'https://example.com/a.png')
@@ -131,6 +131,7 @@ test('withBuiltinFields always includes writable facet and tags', () => {
   assert.equal(fields.createdBy?.writable, false)
   assert.equal(fields.updatedBy?.type, 'person')
   assert.equal(fields.updatedBy?.writable, false)
+  assert.equal(fields.updatedBy?.multiple, true)
 })
 
 test('recordBuiltinValues fills required record columns', () => {
@@ -165,6 +166,7 @@ test('required record fields are icon, tags, timestamps, facet, parent, and depe
   ])
   assert.equal(REQUIRED_RECORD_FIELDS.createdBy.type, 'person')
   assert.equal(REQUIRED_RECORD_FIELDS.updatedBy.type, 'person')
+  assert.equal(REQUIRED_RECORD_FIELDS.updatedBy.multiple, true)
   assert.equal(REQUIRED_RECORD_FIELDS.emoji.type, 'string')
   assert.equal(REQUIRED_RECORD_FIELDS.tags.type, 'multi-select')
   assert.equal(REQUIRED_RECORD_FIELDS.facet.type, 'facet')
@@ -179,6 +181,14 @@ test('asPerson reads user, system, and agent session ids', () => {
   assert.deepEqual(asPerson('系统'), { kind: 'system', name: '系统' })
   assert.equal(personKey(asPerson({ kind: 'agent', name: '指挥', sessionId: 's1' })), 's1')
   assert.equal(asPerson(''), null)
+})
+
+test('updatedBy is a person list that appends unique editors', () => {
+  const user = { kind: 'user' as const, name: '用户' }
+  const agent = { kind: 'agent' as const, name: '蓝', sessionId: 's1' }
+  assert.deepEqual(asPersonList(user), [user])
+  assert.deepEqual(appendPerson(user, agent), [user, agent])
+  assert.equal(appendPerson([user, agent], agent).length, 2)
 })
 
 test('hasCollectionDeleteQuery requires ids, q, or a non-empty filter', () => {

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -31,6 +31,8 @@ export type FieldSpec = {
   action?: string
   /** 由 list/get 计算写入记录，不能 PATCH。例如任务消耗。 */
   computed?: boolean
+  /** person：创建人一人；编辑人可多人。 */
+  multiple?: boolean
 }
 
 export type AttachmentValue = { name: string; href: string; bytes?: number }
@@ -69,6 +71,41 @@ export function personKey(person: PersonValue | null | undefined): string {
   if (person.kind === 'user') return 'user'
   if (person.kind === 'system') return 'system'
   return person.sessionId || person.name
+}
+
+export function asPersonList(value: unknown): PersonValue[] {
+  if (value == null || value === '') return []
+  if (Array.isArray(value)) {
+    const out: PersonValue[] = []
+    const seen = new Set<string>()
+    for (const item of value) {
+      const person = asPerson(item)
+      const key = personKey(person)
+      if (!person || !key || seen.has(key)) continue
+      seen.add(key)
+      out.push(person)
+    }
+    return out
+  }
+  const one = asPerson(value)
+  return one ? [one] : []
+}
+
+export function appendPerson(existing: unknown, actor: PersonValue | null | undefined): PersonValue[] {
+  const next = asPersonList(existing)
+  if (!actor) return next
+  const key = personKey(actor)
+  if (!key) return next
+  const idx = next.findIndex((item) => personKey(item) === key)
+  if (idx < 0) next.push(actor)
+  else next[idx] = actor
+  return next
+}
+
+export function commitPersons(list: PersonValue[]): unknown {
+  if (!list.length) return null
+  if (list.length === 1) return list[0]
+  return list
 }
 
 function hrefFromRecord(value: Record<string, unknown>) {
@@ -200,7 +237,7 @@ export const BUILTIN_FIELDS = {
   parentId: { type: 'ref', label: '父级', writable: true },
   dependsOn: { type: 'multi-ref', label: '依赖', writable: true },
   createdBy: { type: 'person', label: '创建人', writable: false },
-  updatedBy: { type: 'person', label: '编辑人', writable: false },
+  updatedBy: { type: 'person', label: '编辑人', writable: false, multiple: true },
 } as const satisfies Record<string, FieldSpec>
 
 /** 登记 CollectionSpec.schema.fields 必须声明的记录列。由登记方自己存；创建人/编辑人也可由 Core 叠一层。 */
@@ -412,7 +449,7 @@ export function recordBuiltinValues(row: Record<string, unknown> = {}) {
     parentId,
     dependsOn,
     createdBy: asPerson(row.createdBy),
-    updatedBy: asPerson(row.updatedBy),
+    updatedBy: commitPersons(asPersonList(row.updatedBy)),
   }
 }
 
@@ -459,7 +496,7 @@ export function withBuiltinFields(
   if (!next.createdBy) next.createdBy = BUILTIN_FIELDS.createdBy
   else next.createdBy = { ...BUILTIN_FIELDS.createdBy, ...next.createdBy, type: 'person', writable: false }
   if (!next.updatedBy) next.updatedBy = BUILTIN_FIELDS.updatedBy
-  else next.updatedBy = { ...BUILTIN_FIELDS.updatedBy, ...next.updatedBy, type: 'person', writable: false }
+  else next.updatedBy = { ...BUILTIN_FIELDS.updatedBy, ...next.updatedBy, type: 'person', writable: false, multiple: true }
   if (contentField === 'content' && !next.content) next.content = BUILTIN_FIELDS.content
   const ordered: Record<string, FieldSpec> = {
     id: next.id,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
创建人/编辑人都是系统自记，不能手工改。

- `createdBy`：单人，第一次写入后不再变
- `updatedBy`：多人列表，改字段或正文时把当前操作人追加进去
- 前端只展示，单元格不能点选改写
- 页面表默认显示这两列

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

