### PR TITLE
检查器状态绑死到 session 并落盘

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -1059,6 +1059,7 @@ export function apply(ctx: Context) {
         extraTools?: string[]
         tags?: string[]
         pinned?: boolean
+        inspector?: SessionConfig['inspector'] | null
       } = {}
       if (typeof payload.title === 'string' || payload.title === null) patch.title = payload.title as string | null
       if (typeof payload.model === 'string') patch.model = payload.model
@@ -1072,9 +1073,13 @@ export function apply(ctx: Context) {
       if (Array.isArray(payload.extraTools)) patch.extraTools = payload.extraTools.map((name) => String(name))
       if (Array.isArray(payload.tags)) patch.tags = payload.tags.map((name) => String(name))
       if (typeof payload.pinned === 'boolean') patch.pinned = payload.pinned
+      if (payload.inspector === null) patch.inspector = null
+      else if (payload.inspector && typeof payload.inspector === 'object' && !Array.isArray(payload.inspector)) {
+        patch.inspector = payload.inspector as SessionConfig['inspector']
+      }
       const record = await ctx.sessions.patchConfig(
         route.params.id,
-        patch as SessionConfig & { title?: string | null; systemPrompt?: string | null },
+        patch as SessionConfig & { title?: string | null; systemPrompt?: string | null; inspector?: SessionConfig['inspector'] | null },
       )
       const resolved = chat.resolveEffective(record.id)
       route.send(200, {
@@ -1101,6 +1106,7 @@ export function apply(ctx: Context) {
         ...(item.mascot ? { mascot: item.mascot } : {}),
         tags: item.config?.tags ?? [],
         pinned: Boolean(item.config?.pinned),
+        ...(item.config?.inspector ? { inspector: item.config.inspector } : {}),
       })),
     })
   })

--- a/packages/core-file-system/package.json
+++ b/packages/core-file-system/package.json
@@ -8,7 +8,8 @@
     "./host": "./src/host/index.ts",
     "./web": "./src/web/index.tsx",
     "./database-ui": "./src/web/database-ui.ts",
-    "./main-data-route": "./src/web/main-data-route.ts"
+    "./main-data-route": "./src/web/main-data-route.ts",
+    "./inspector-db-route": "./src/web/inspector-db-route.ts"
   },
   "dependencies": {
     "@biu/database-ui": "0.1.0",

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -17,6 +17,8 @@ import {
   setInspectorAgentFollow,
   clearInspectorDbPath,
   isInspectorPaneAbandoned,
+  snapshotInspectorDbPaths,
+  restoreInspectorDbPaths,
 } from './inspector-db-route.ts'
 
 function clearInspectorPanes() {
@@ -315,4 +317,17 @@ test('view db_update writes the source table view, not /views', () => {
   assert.equal(seen[0]?.collection, '/pages')
   assert.equal(seen[0]?.view?.id, 'mine')
   assert.equal(getInspectorDbPath('database:/pages'), '')
+})
+
+test('inspector db paths restore replaces the global pane map', () => {
+  setInspectorDbPath('database:/pages', '/database/pages')
+  setInspectorDbPath('database:/tasks', '/database/tasks')
+  assert.equal(snapshotInspectorDbPaths()['database:/pages'], '/database/pages')
+  restoreInspectorDbPaths({ 'database:/sessions': '/database/sessions' })
+  assert.equal(getInspectorDbPath('database:/pages'), '')
+  assert.equal(getInspectorDbPath('database:/tasks'), '')
+  assert.equal(getInspectorDbPath('database:/sessions'), '/database/sessions')
+  restoreInspectorDbPaths({})
+  assert.equal(getInspectorDbPath('database:/sessions'), '')
+  assert.deepEqual(snapshotInspectorDbPaths(), {})
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -188,6 +188,52 @@ export function setInspectorDbPath(paneId: string, next?: string) {
   bump()
 }
 
+function listStoredPaneIds() {
+  const ids = new Set<string>(paths.keys())
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i) ?? ''
+      if (key.startsWith(STORAGE_PREFIX)) ids.add(key.slice(STORAGE_PREFIX.length))
+    }
+  } catch {
+    /* ignore */
+  }
+  return ids
+}
+
+/** 当前检查器各栏路径，写入 session.config.inspector.dbPaths。 */
+export function snapshotInspectorDbPaths(): Record<string, string> {
+  const next: Record<string, string> = {}
+  for (const paneId of listStoredPaneIds()) {
+    const path = panePath(paneId)
+    if (path) next[paneId] = path
+  }
+  return next
+}
+
+/** 切 session 时用该条记录覆盖全局栏路径，避免多 session 抢一份。 */
+export function restoreInspectorDbPaths(next?: Record<string, string>) {
+  const incoming: Record<string, string> = {}
+  if (next) {
+    for (const [paneId, path] of Object.entries(next)) {
+      const id = String(paneId).trim()
+      const stored = isInspectorDatabasePath(path) ? path : ''
+      if (id && stored) incoming[id] = stored
+    }
+  }
+  const stale = [...listStoredPaneIds()].filter((id) => !(id in incoming))
+  for (const paneId of stale) {
+    paths.delete(paneId)
+    writeStoredPath(paneId, '')
+  }
+  abandonedPanes.clear()
+  for (const [paneId, path] of Object.entries(incoming)) {
+    paths.set(paneId, path)
+    writeStoredPath(paneId, path)
+  }
+  bump()
+}
+
 /** 关掉检查器里这一栏时清掉路径，避免左侧再点同一页又把右侧弹回来。 */
 export function clearInspectorDbPath(paneId: string) {
   if (!paneId) return

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -397,7 +397,7 @@ export class SessionsService extends Service {
   /** 合并写入会话配置；传 null/空字符串可清除 title / systemPrompt。 */
   async patchConfig(
     id: string,
-    patch: SessionConfig & { title?: string | null; systemPrompt?: string | null },
+    patch: SessionConfig & { title?: string | null; systemPrompt?: string | null; inspector?: SessionConfig['inspector'] | null },
   ) {
     const record = await this.require(id)
     const next = mergeSessionConfig(record.config, patch)
@@ -456,6 +456,8 @@ export class SessionsService extends Service {
     const source = await this.require(sourceId)
     const used = await this.collectUsedMascots()
     const mascot = pickSessionMascot(childId, used)
+    const sourceConfig = { ...(source.config ?? {}) }
+    delete sourceConfig.inspector
     const record: SessionRecord = {
       id: childId,
       version: source.version,
@@ -463,7 +465,7 @@ export class SessionsService extends Service {
       ...(source.project ? { project: { ...source.project } } : {}),
       mascot,
       config: normalizeSessionConfig({
-        ...(source.config ?? {}),
+        ...sourceConfig,
         title: nameFromSessionMascot(mascot),
       }),
     }

--- a/packages/host-sessions/src/host/session-config.test.ts
+++ b/packages/host-sessions/src/host/session-config.test.ts
@@ -49,23 +49,18 @@ test('session config stores inspector bind', async () => {
   const record = await ctx.sessions.create()
   await ctx.sessions.patchConfig(record.id, {
     inspector: {
-      open: true,
-      width: 400,
       tab: 'database:/pages',
       opened: ['database:/pages'],
       dbPaths: { 'database:/pages': '/database/pages' },
-      follow: true,
     },
   })
   const again = await ctx.sessions.require(record.id)
-  assert.equal(again.config?.inspector?.open, true)
-  assert.equal(again.config?.inspector?.width, 400)
   assert.equal(again.config?.inspector?.tab, 'database:/pages')
   assert.deepEqual(again.config?.inspector?.opened, ['database:/pages'])
   assert.equal(again.config?.inspector?.dbPaths?.['database:/pages'], '/database/pages')
-  assert.equal(again.config?.inspector?.follow, true)
+  assert.deepEqual(Object.keys(again.config?.inspector ?? {}).sort(), ['dbPaths', 'opened', 'tab'])
   const listed = await ctx.sessions.listSummaries()
-  assert.equal(listed.find((item) => item.id === record.id)?.config?.inspector?.open, true)
+  assert.deepEqual(listed.find((item) => item.id === record.id)?.config?.inspector?.opened, ['database:/pages'])
   await ctx.sessions.patchConfig(record.id, { inspector: null })
   const cleared = await ctx.sessions.require(record.id)
   assert.equal(cleared.config?.inspector, undefined)

--- a/packages/host-sessions/src/host/session-config.test.ts
+++ b/packages/host-sessions/src/host/session-config.test.ts
@@ -41,3 +41,32 @@ test('session config stores tags and pin', async () => {
   assert.equal(cleared.config?.pinned, undefined)
   assert.equal(cleared.config?.tags, undefined)
 })
+
+test('session config stores inspector bind', async () => {
+  const ctx = new Context()
+  await ctx.plugin(sessionStore, { driver: 'memory' })
+  await ctx.plugin(sessions)
+  const record = await ctx.sessions.create()
+  await ctx.sessions.patchConfig(record.id, {
+    inspector: {
+      open: true,
+      width: 400,
+      tab: 'database:/pages',
+      opened: ['database:/pages'],
+      dbPaths: { 'database:/pages': '/database/pages' },
+      follow: true,
+    },
+  })
+  const again = await ctx.sessions.require(record.id)
+  assert.equal(again.config?.inspector?.open, true)
+  assert.equal(again.config?.inspector?.width, 400)
+  assert.equal(again.config?.inspector?.tab, 'database:/pages')
+  assert.deepEqual(again.config?.inspector?.opened, ['database:/pages'])
+  assert.equal(again.config?.inspector?.dbPaths?.['database:/pages'], '/database/pages')
+  assert.equal(again.config?.inspector?.follow, true)
+  const listed = await ctx.sessions.listSummaries()
+  assert.equal(listed.find((item) => item.id === record.id)?.config?.inspector?.open, true)
+  await ctx.sessions.patchConfig(record.id, { inspector: null })
+  const cleared = await ctx.sessions.require(record.id)
+  assert.equal(cleared.config?.inspector, undefined)
+})

--- a/packages/host-sessions/src/host/sessions.test.ts
+++ b/packages/host-sessions/src/host/sessions.test.ts
@@ -153,9 +153,13 @@ test('fork copies the append-only log into a child session', async () => {
   await ctx.plugin(sessions)
   const parent = await ctx.sessions.create()
   await ctx.sessions.append(parent.id, { type: 'user/message', text: 'keep', kind: 'wake' })
+  await ctx.sessions.patchConfig(parent.id, {
+    inspector: { open: true, dbPaths: { 'database:/pages': '/database/pages' } },
+  })
   const child = await ctx.sessions.fork(parent.id)
   assert.notEqual(child.id, parent.id)
   assert.equal(ctx.sessions.deriveMessages(child.id).some((item) => item.content === 'keep'), true)
+  assert.equal(child.config?.inspector, undefined)
   await ctx.sessions.append(child.id, { type: 'assistant/message', text: 'child-only' })
   assert.equal((await ctx.sessions.require(parent.id)).events.some((item) => item.type === 'assistant/message'), false)
 })

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -82,22 +82,17 @@ export interface SessionConfig {
   /** 分面 */
   facet?: { tags: string[]; values: Record<string, Record<string, unknown>> }
   createdAt?: number
-  /** 右侧检查器与当前 session 绑死；换环境/换机从这条记录恢复。 */
+  /** 右侧检查器页签与各栏库路径，跟这条 session 走。 */
   inspector?: SessionInspectorBind
 }
 
-/** 检查器开合、宽度、页签、库路径、跟随，均跟这条 session 走。 */
+/** 检查器打开的页签和各栏库路径，跟这条 session 走。开合/宽度/跟随只记本机。 */
 export type SessionInspectorBind = {
-  open?: boolean
-  width?: number
   tab?: string
   opened?: string[]
   dbPaths?: Record<string, string>
-  follow?: boolean
 }
 
-const INSPECTOR_WIDTH_MIN = 240
-const INSPECTOR_WIDTH_MAX = 1000
 const INSPECTOR_OPENED_MAX = 24
 const INSPECTOR_DB_PATHS_MAX = 32
 
@@ -109,10 +104,6 @@ export function normalizeInspectorBind(value: unknown): SessionInspectorBind | u
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
   const raw = value as Record<string, unknown>
   const next: SessionInspectorBind = {}
-  if (typeof raw.open === 'boolean') next.open = raw.open
-  if (typeof raw.width === 'number' && Number.isFinite(raw.width)) {
-    next.width = Math.min(INSPECTOR_WIDTH_MAX, Math.max(INSPECTOR_WIDTH_MIN, Math.round(raw.width)))
-  }
   if (typeof raw.tab === 'string') next.tab = raw.tab.trim().slice(0, 160)
   if (Array.isArray(raw.opened)) {
     next.opened = [...new Set(raw.opened.map((item) => String(item).trim()).filter(Boolean))].slice(0, INSPECTOR_OPENED_MAX)
@@ -128,7 +119,6 @@ export function normalizeInspectorBind(value: unknown): SessionInspectorBind | u
     }
     next.dbPaths = dbPaths
   }
-  if (typeof raw.follow === 'boolean') next.follow = raw.follow
   return Object.keys(next).length ? next : undefined
 }
 
@@ -136,11 +126,10 @@ export function mergeInspectorBind(
   base: SessionInspectorBind | undefined,
   patch: SessionInspectorBind,
 ): SessionInspectorBind | undefined {
-  const next: SessionInspectorBind = { ...(base ?? {}) }
-  if (typeof patch.open === 'boolean') next.open = patch.open
-  if (typeof patch.width === 'number' && Number.isFinite(patch.width)) {
-    next.width = Math.min(INSPECTOR_WIDTH_MAX, Math.max(INSPECTOR_WIDTH_MIN, Math.round(patch.width)))
-  }
+  const next: SessionInspectorBind = {}
+  if (typeof base?.tab === 'string') next.tab = base.tab
+  if (Array.isArray(base?.opened)) next.opened = [...base.opened]
+  if (base?.dbPaths) next.dbPaths = { ...base.dbPaths }
   if (typeof patch.tab === 'string') next.tab = patch.tab.trim().slice(0, 160)
   if (Array.isArray(patch.opened)) {
     next.opened = [...new Set(patch.opened.map((item) => String(item).trim()).filter(Boolean))].slice(0, INSPECTOR_OPENED_MAX)
@@ -150,7 +139,6 @@ export function mergeInspectorBind(
     if (dbPaths) next.dbPaths = dbPaths
     else delete next.dbPaths
   }
-  if (typeof patch.follow === 'boolean') next.follow = patch.follow
   return Object.keys(next).length ? next : undefined
 }
 

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -82,6 +82,76 @@ export interface SessionConfig {
   /** 分面 */
   facet?: { tags: string[]; values: Record<string, Record<string, unknown>> }
   createdAt?: number
+  /** 右侧检查器与当前 session 绑死；换环境/换机从这条记录恢复。 */
+  inspector?: SessionInspectorBind
+}
+
+/** 检查器开合、宽度、页签、库路径、跟随，均跟这条 session 走。 */
+export type SessionInspectorBind = {
+  open?: boolean
+  width?: number
+  tab?: string
+  opened?: string[]
+  dbPaths?: Record<string, string>
+  follow?: boolean
+}
+
+const INSPECTOR_WIDTH_MIN = 240
+const INSPECTOR_WIDTH_MAX = 1000
+const INSPECTOR_OPENED_MAX = 24
+const INSPECTOR_DB_PATHS_MAX = 32
+
+function isInspectorDbPath(value: string) {
+  return value === '/database' || value.startsWith('/database/')
+}
+
+export function normalizeInspectorBind(value: unknown): SessionInspectorBind | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined
+  const raw = value as Record<string, unknown>
+  const next: SessionInspectorBind = {}
+  if (typeof raw.open === 'boolean') next.open = raw.open
+  if (typeof raw.width === 'number' && Number.isFinite(raw.width)) {
+    next.width = Math.min(INSPECTOR_WIDTH_MAX, Math.max(INSPECTOR_WIDTH_MIN, Math.round(raw.width)))
+  }
+  if (typeof raw.tab === 'string') next.tab = raw.tab.trim().slice(0, 160)
+  if (Array.isArray(raw.opened)) {
+    next.opened = [...new Set(raw.opened.map((item) => String(item).trim()).filter(Boolean))].slice(0, INSPECTOR_OPENED_MAX)
+  }
+  if (raw.dbPaths && typeof raw.dbPaths === 'object' && !Array.isArray(raw.dbPaths)) {
+    const dbPaths: Record<string, string> = {}
+    for (const [paneId, path] of Object.entries(raw.dbPaths as Record<string, unknown>)) {
+      const id = String(paneId).trim()
+      const stored = String(path ?? '').trim()
+      if (!id || !isInspectorDbPath(stored)) continue
+      dbPaths[id] = stored
+      if (Object.keys(dbPaths).length >= INSPECTOR_DB_PATHS_MAX) break
+    }
+    next.dbPaths = dbPaths
+  }
+  if (typeof raw.follow === 'boolean') next.follow = raw.follow
+  return Object.keys(next).length ? next : undefined
+}
+
+export function mergeInspectorBind(
+  base: SessionInspectorBind | undefined,
+  patch: SessionInspectorBind,
+): SessionInspectorBind | undefined {
+  const next: SessionInspectorBind = { ...(base ?? {}) }
+  if (typeof patch.open === 'boolean') next.open = patch.open
+  if (typeof patch.width === 'number' && Number.isFinite(patch.width)) {
+    next.width = Math.min(INSPECTOR_WIDTH_MAX, Math.max(INSPECTOR_WIDTH_MIN, Math.round(patch.width)))
+  }
+  if (typeof patch.tab === 'string') next.tab = patch.tab.trim().slice(0, 160)
+  if (Array.isArray(patch.opened)) {
+    next.opened = [...new Set(patch.opened.map((item) => String(item).trim()).filter(Boolean))].slice(0, INSPECTOR_OPENED_MAX)
+  }
+  if (patch.dbPaths) {
+    const dbPaths = normalizeInspectorBind({ dbPaths: patch.dbPaths })?.dbPaths
+    if (dbPaths) next.dbPaths = dbPaths
+    else delete next.dbPaths
+  }
+  if (typeof patch.follow === 'boolean') next.follow = patch.follow
+  return Object.keys(next).length ? next : undefined
 }
 
 export function normalizeSessionConfig(value: unknown): SessionConfig | undefined {
@@ -114,12 +184,14 @@ export function normalizeSessionConfig(value: unknown): SessionConfig | undefine
     }
     next.facet = { tags, values }
   }
+  const inspector = normalizeInspectorBind(raw.inspector)
+  if (inspector) next.inspector = inspector
   return Object.keys(next).length ? next : undefined
 }
 
 export function mergeSessionConfig(
   base: SessionConfig | undefined,
-  patch: SessionConfig & { title?: string | null; systemPrompt?: string | null },
+  patch: SessionConfig & { title?: string | null; systemPrompt?: string | null; inspector?: SessionInspectorBind | null },
 ): SessionConfig | undefined {
   const next: SessionConfig = { ...(base ?? {}) }
   if ('title' in patch) {
@@ -159,6 +231,15 @@ export function mergeSessionConfig(
   }
   if (typeof patch.createdAt === 'number' && Number.isFinite(patch.createdAt) && patch.createdAt > 0) {
     next.createdAt = patch.createdAt
+  }
+  if ('inspector' in patch) {
+    if (patch.inspector == null) delete next.inspector
+    else {
+      const incoming = normalizeInspectorBind(patch.inspector) ?? patch.inspector
+      const inspector = mergeInspectorBind(next.inspector, incoming)
+      if (inspector) next.inspector = inspector
+      else delete next.inspector
+    }
   }
   return Object.keys(next).length ? next : undefined
 }

--- a/packages/web-app-shell/package.json
+++ b/packages/web-app-shell/package.json
@@ -13,7 +13,8 @@
     "@biu/public-ui": "0.1.0",
     "@biu/public-mascot": "0.1.0",
     "@biu/type-file-system": "0.1.0",
-    "@biu/core-file-system": "0.1.0"
+    "@biu/core-file-system": "0.1.0",
+    "@biu/type-session": "0.1.0"
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -423,6 +423,18 @@ function Shell(props: SlotProps) {
       /* ignore */
     }
   }, [])
+  const onInspectorLayoutHydrate = useCallback((next: { open: boolean; width: number }) => {
+    const width = Math.min(1000, Math.max(240, Math.round(next.width)))
+    layoutSnap.current.inspectorWidth = width
+    layoutSnap.current.inspectorVisible = next.open
+    applyInspector(next.open)
+    setInspectorWidth(width)
+    try {
+      localStorage.setItem('cordis.inspector.width', String(width))
+    } catch {
+      /* ignore */
+    }
+  }, [applyInspector])
   const activeModule = moduleIdFromPath(location.pathname, pluginModules)
   useEffect(() => {
     const onWidth = (event: Event) => {
@@ -808,6 +820,7 @@ function Shell(props: SlotProps) {
         slots={slots}
         renderSlot={props.renderSlot}
         collections={collections}
+        onLayoutHydrate={onInspectorLayoutHydrate}
       />
 
       <SessionConfigDialog

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -423,18 +423,6 @@ function Shell(props: SlotProps) {
       /* ignore */
     }
   }, [])
-  const onInspectorLayoutHydrate = useCallback((next: { open: boolean; width: number }) => {
-    const width = Math.min(1000, Math.max(240, Math.round(next.width)))
-    layoutSnap.current.inspectorWidth = width
-    layoutSnap.current.inspectorVisible = next.open
-    applyInspector(next.open)
-    setInspectorWidth(width)
-    try {
-      localStorage.setItem('cordis.inspector.width', String(width))
-    } catch {
-      /* ignore */
-    }
-  }, [applyInspector])
   const activeModule = moduleIdFromPath(location.pathname, pluginModules)
   useEffect(() => {
     const onWidth = (event: Event) => {
@@ -820,7 +808,6 @@ function Shell(props: SlotProps) {
         slots={slots}
         renderSlot={props.renderSlot}
         collections={collections}
-        onLayoutHydrate={onInspectorLayoutHydrate}
       />
 
       <SessionConfigDialog

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -28,6 +28,15 @@ import { getInspectorCaption, getInspectorCaptionVersion, subscribeInspectorCapt
 import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
 import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
+import {
+  isInspectorAgentFollow,
+  restoreInspectorDbPaths,
+  setInspectorAgentFollow,
+  snapshotInspectorDbPaths,
+  subscribeInspectorAgentFollow,
+  subscribeInspectorDbPath,
+} from '@biu/core-file-system/inspector-db-route'
+import { mergeInspectorBind, type SessionInspectorBind } from '@biu/type-session'
 
 function captionTableIcon(icon?: string) {
   const name = (icon ?? '').trim().toLowerCase()
@@ -82,6 +91,7 @@ export type SessionInspectorProps = {
   slots: SlotsService
   renderSlot: (name: string) => ReactNode
   collections?: Array<{ path: string }>
+  onLayoutHydrate?: (next: { open: boolean; width: number }) => void
 }
 
 function inspectorTabStorageKey(sid: string | null | undefined) {
@@ -103,6 +113,39 @@ function readOpened(sid: string | null | undefined): string[] {
   }
 }
 
+function readTab(sid: string | null | undefined): string {
+  try {
+    return localStorage.getItem(inspectorTabStorageKey(sid)) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+function writeOpenedCache(sid: string | null | undefined, next: string[]) {
+  try {
+    localStorage.setItem(inspectorOpenedKey(sid), JSON.stringify(next))
+  } catch {
+    /* ignore */
+  }
+}
+
+function writeTabCache(sid: string | null | undefined, next: string) {
+  try {
+    localStorage.setItem(inspectorTabStorageKey(sid), next)
+  } catch {
+    /* ignore */
+  }
+}
+
+const DEFAULT_INSPECTOR_WIDTH = 320
+
+function layoutFromBind(bind?: SessionInspectorBind) {
+  return {
+    open: bind?.open === true,
+    width: typeof bind?.width === 'number' && Number.isFinite(bind.width) ? bind.width : DEFAULT_INSPECTOR_WIDTH,
+  }
+}
+
 export const SessionInspector = memo(function SessionInspector({
   open,
   width,
@@ -113,6 +156,7 @@ export const SessionInspector = memo(function SessionInspector({
   slots,
   renderSlot,
   collections,
+  onLayoutHydrate,
 }: SessionInspectorProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const sessions = useSessionView((state) => state.sessions)
@@ -153,28 +197,59 @@ export const SessionInspector = memo(function SessionInspector({
   const plusMenuRef = useRef<HTMLDivElement>(null)
   const [plusPos, setPlusPos] = useState<{ right: number; top: number } | null>(null)
   const tabsRef = useRef<HTMLDivElement>(null)
+  const hydratingRef = useRef(false)
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const lastSentRef = useRef('')
+  const tabRef = useRef(tab)
+  const openedRef = useRef(opened)
+  tabRef.current = tab
+  openedRef.current = opened
+  const rowPresent = Boolean(sessionId && sessions.some((item) => item.id === sessionId))
+  const captureBind = useCallback((): SessionInspectorBind => {
+    return {
+      open,
+      width,
+      tab: tabRef.current,
+      opened: openedRef.current,
+      dbPaths: snapshotInspectorDbPaths(),
+      follow: isInspectorAgentFollow(),
+    }
+  }, [open, width])
+  const queuePersist = useCallback(
+    (partial?: SessionInspectorBind) => {
+      if (!sessionId || hydratingRef.current) return
+      const next = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
+      const packed = JSON.stringify(next)
+      if (packed === lastSentRef.current) return
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current)
+      persistTimerRef.current = setTimeout(() => {
+        persistTimerRef.current = null
+        if (!sessionId || hydratingRef.current) return
+        const latest = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
+        const body = JSON.stringify(latest)
+        if (body === lastSentRef.current) return
+        lastSentRef.current = body
+        void sessionView.patchInspector(sessionId, latest)
+      }, 280)
+    },
+    [captureBind, sessionId, sessionView],
+  )
   const setTab = useCallback(
     (next: string) => {
       setTabState(next)
-      try {
-        localStorage.setItem(inspectorTabStorageKey(sessionId), next)
-      } catch {
-        /* ignore */
-      }
+      writeTabCache(sessionId, next)
+      queuePersist({ tab: next })
     },
-    [sessionId],
+    [queuePersist, sessionId],
   )
   const persistOpened = useCallback(
     (next: string[]) => {
       setOpened(next)
-      try {
-        localStorage.setItem(inspectorOpenedKey(sessionId), JSON.stringify(next))
-      } catch {
-        /* ignore */
-      }
+      writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
+      queuePersist({ opened: next })
     },
-    [sessionId],
+    [queuePersist, sessionId],
   )
 
   useEffect(() => {
@@ -184,14 +259,67 @@ export const SessionInspector = memo(function SessionInspector({
   }, [collections, opened, persistOpened])
   const dragRef = useRef<{ startX: number; startWidth: number; last: number } | null>(null)
 
-  useEffect(() => {
-    setOpened(readOpened(sessionId))
-    try {
-      setTabState(localStorage.getItem(inspectorTabStorageKey(sessionId)) ?? '')
-    } catch {
-      setTabState('')
+  useLayoutEffect(() => {
+    hydratingRef.current = true
+    if (persistTimerRef.current) {
+      clearTimeout(persistTimerRef.current)
+      persistTimerRef.current = null
     }
-  }, [sessionId])
+    if (!sessionId) {
+      lastSentRef.current = ''
+      setOpened(readOpened(null))
+      setTabState(readTab(null))
+      restoreInspectorDbPaths({})
+      setInspectorAgentFollow(false)
+      onLayoutHydrate?.({ open: false, width: DEFAULT_INSPECTOR_WIDTH })
+      const idle = window.setTimeout(() => {
+        hydratingRef.current = false
+      }, 80)
+      return () => window.clearTimeout(idle)
+    }
+    if (!rowPresent) {
+      const idle = window.setTimeout(() => {
+        hydratingRef.current = false
+      }, 80)
+      return () => window.clearTimeout(idle)
+    }
+    const bind = currentSession?.inspector
+    const openedNext = bind?.opened ?? readOpened(sessionId)
+    const tabNext = bind?.tab ?? readTab(sessionId)
+    setOpened(openedNext)
+    setTabState(tabNext)
+    writeOpenedCache(sessionId, openedNext)
+    writeTabCache(sessionId, tabNext)
+    restoreInspectorDbPaths(bind?.dbPaths)
+    setInspectorAgentFollow(bind?.follow === true)
+    const layout = layoutFromBind(bind)
+    onLayoutHydrate?.(layout)
+    lastSentRef.current = JSON.stringify({
+      open: layout.open,
+      width: layout.width,
+      tab: tabNext,
+      opened: openedNext,
+      dbPaths: bind?.dbPaths ?? {},
+      follow: bind?.follow === true,
+    })
+    const idle = window.setTimeout(() => {
+      hydratingRef.current = false
+    }, 80)
+    return () => window.clearTimeout(idle)
+  }, [onLayoutHydrate, rowPresent, sessionId])
+
+  useEffect(() => {
+    queuePersist({ open, width })
+  }, [open, queuePersist, width])
+
+  useEffect(() => {
+    const unsubPath = subscribeInspectorDbPath(() => queuePersist({ dbPaths: snapshotInspectorDbPaths() }))
+    const unsubFollow = subscribeInspectorAgentFollow(() => queuePersist({ follow: isInspectorAgentFollow() }))
+    return () => {
+      unsubPath()
+      unsubFollow()
+    }
+  }, [queuePersist])
 
   const focusTabId = extraTabs.find((item) => item.focusOnCall)?.id
   useEffect(() => {
@@ -199,31 +327,25 @@ export const SessionInspector = memo(function SessionInspector({
     setOpened((prev) => {
       if (prev.includes(focusTabId)) return prev
       const next = [...prev, focusTabId]
-      try {
-        localStorage.setItem(inspectorOpenedKey(sessionId), JSON.stringify(next))
-      } catch {
-        /* ignore */
-      }
+      writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
+      queuePersist({ opened: next })
       return next
     })
     setTab(focusTabId)
-  }, [focusCallId, focusTabId, sessionId, setTab])
+  }, [focusCallId, focusTabId, queuePersist, sessionId, setTab])
 
   useEffect(() => {
     if (focusCallId && focusTabId) return
     setTabState((current) => {
       const next = resolveInspectorTab(current, allowedTabs, opened)
       if (next !== current) {
-        try {
-          localStorage.setItem(inspectorTabStorageKey(sessionId), next)
-        } catch {
-          /* ignore */
-        }
+        writeTabCache(sessionId, next)
+        queuePersist({ tab: next })
       }
       return next
     })
-  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened])
+  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened, queuePersist])
 
   useEffect(() => {
     const onTab = (event: Event) => {

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -278,10 +278,8 @@ export const SessionInspector = memo(function SessionInspector({
       return () => window.clearTimeout(idle)
     }
     if (!rowPresent) {
-      const idle = window.setTimeout(() => {
-        hydratingRef.current = false
-      }, 80)
-      return () => window.clearTimeout(idle)
+      hydratingRef.current = true
+      return
     }
     const bind = currentSession?.inspector
     const openedNext = bind?.opened ?? readOpened(sessionId)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -29,11 +29,8 @@ import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOp
 import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import {
-  isInspectorAgentFollow,
   restoreInspectorDbPaths,
-  setInspectorAgentFollow,
   snapshotInspectorDbPaths,
-  subscribeInspectorAgentFollow,
   subscribeInspectorDbPath,
 } from '@biu/core-file-system/inspector-db-route'
 import { mergeInspectorBind, type SessionInspectorBind } from '@biu/type-session'
@@ -91,7 +88,6 @@ export type SessionInspectorProps = {
   slots: SlotsService
   renderSlot: (name: string) => ReactNode
   collections?: Array<{ path: string }>
-  onLayoutHydrate?: (next: { open: boolean; width: number }) => void
 }
 
 function inspectorTabStorageKey(sid: string | null | undefined) {
@@ -137,15 +133,6 @@ function writeTabCache(sid: string | null | undefined, next: string) {
   }
 }
 
-const DEFAULT_INSPECTOR_WIDTH = 320
-
-function layoutFromBind(bind?: SessionInspectorBind) {
-  return {
-    open: bind?.open === true,
-    width: typeof bind?.width === 'number' && Number.isFinite(bind.width) ? bind.width : DEFAULT_INSPECTOR_WIDTH,
-  }
-}
-
 export const SessionInspector = memo(function SessionInspector({
   open,
   width,
@@ -156,7 +143,6 @@ export const SessionInspector = memo(function SessionInspector({
   slots,
   renderSlot,
   collections,
-  onLayoutHydrate,
 }: SessionInspectorProps) {
   const sessionId = useSessionView((state) => state.sessionId)
   const sessions = useSessionView((state) => state.sessions)
@@ -207,14 +193,11 @@ export const SessionInspector = memo(function SessionInspector({
   const rowPresent = Boolean(sessionId && sessions.some((item) => item.id === sessionId))
   const captureBind = useCallback((): SessionInspectorBind => {
     return {
-      open,
-      width,
       tab: tabRef.current,
       opened: openedRef.current,
       dbPaths: snapshotInspectorDbPaths(),
-      follow: isInspectorAgentFollow(),
     }
-  }, [open, width])
+  }, [])
   const queuePersist = useCallback(
     (partial?: SessionInspectorBind) => {
       if (!sessionId || hydratingRef.current) return
@@ -270,8 +253,6 @@ export const SessionInspector = memo(function SessionInspector({
       setOpened(readOpened(null))
       setTabState(readTab(null))
       restoreInspectorDbPaths({})
-      setInspectorAgentFollow(false)
-      onLayoutHydrate?.({ open: false, width: DEFAULT_INSPECTOR_WIDTH })
       const idle = window.setTimeout(() => {
         hydratingRef.current = false
       }, 80)
@@ -289,34 +270,19 @@ export const SessionInspector = memo(function SessionInspector({
     writeOpenedCache(sessionId, openedNext)
     writeTabCache(sessionId, tabNext)
     restoreInspectorDbPaths(bind?.dbPaths)
-    setInspectorAgentFollow(bind?.follow === true)
-    const layout = layoutFromBind(bind)
-    onLayoutHydrate?.(layout)
     lastSentRef.current = JSON.stringify({
-      open: layout.open,
-      width: layout.width,
       tab: tabNext,
       opened: openedNext,
       dbPaths: bind?.dbPaths ?? {},
-      follow: bind?.follow === true,
     })
     const idle = window.setTimeout(() => {
       hydratingRef.current = false
     }, 80)
     return () => window.clearTimeout(idle)
-  }, [onLayoutHydrate, rowPresent, sessionId])
+  }, [rowPresent, sessionId])
 
   useEffect(() => {
-    queuePersist({ open, width })
-  }, [open, queuePersist, width])
-
-  useEffect(() => {
-    const unsubPath = subscribeInspectorDbPath(() => queuePersist({ dbPaths: snapshotInspectorDbPaths() }))
-    const unsubFollow = subscribeInspectorAgentFollow(() => queuePersist({ follow: isInspectorAgentFollow() }))
-    return () => {
-      unsubPath()
-      unsubFollow()
-    }
+    return subscribeInspectorDbPath(() => queuePersist({ dbPaths: snapshotInspectorDbPaths() }))
   }, [queuePersist])
 
   const focusTabId = extraTabs.find((item) => item.focusOnCall)?.id

--- a/packages/web-session-view/package.json
+++ b/packages/web-session-view/package.json
@@ -13,5 +13,8 @@
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",
     "react": "^19.1.1"
+  },
+  "dependencies": {
+    "@biu/type-session": "0.1.0"
   }
 }

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from 'react'
 import { Service, type Context } from 'cordis'
+import { mergeInspectorBind, type SessionInspectorBind } from '@biu/type-session'
 import {
   compactSessionEvents,
   mergeDispatchedUsageIntoNodes,
@@ -95,6 +96,7 @@ export interface SessionListItem {
   mascot?: { shape: string; color: string; eye?: number }
   tags?: string[]
   pinned?: boolean
+  inspector?: SessionInspectorBind
 }
 
 export type ConversationView = 'chat' | 'debug'
@@ -252,7 +254,8 @@ function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
       left.mascot?.eye !== right.mascot?.eye ||
       Boolean(left.busy) !== Boolean(right.busy) ||
       Boolean(left.pinned) !== Boolean(right.pinned) ||
-      (left.tags ?? []).join('\0') !== (right.tags ?? []).join('\0')
+      (left.tags ?? []).join('\0') !== (right.tags ?? []).join('\0') ||
+      JSON.stringify(left.inspector ?? null) !== JSON.stringify(right.inspector ?? null)
     ) {
       return false
     }
@@ -1202,6 +1205,26 @@ export class SessionViewService extends Service {
       throw error
     }
     void this.refreshSessions()
+  }
+
+  async patchInspector(id: string, inspector: SessionInspectorBind) {
+    const prev = this.value.sessions
+    const current = prev.find((item) => item.id === id)?.inspector
+    const nextBind = mergeInspectorBind(current, inspector)
+    this.replace({
+      sessions: prev.map((item) => (item.id === id ? { ...item, inspector: nextBind } : item)),
+    })
+    try {
+      const res = await fetch(`/api/sessions/${id}/config`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ inspector: nextBind ?? null }),
+      })
+      if (!res.ok) throw new Error(`inspector bind failed HTTP ${res.status}`)
+    } catch (error) {
+      this.replace({ sessions: prev, error: String(error) })
+      throw error
+    }
   }
 
   async deleteSession(id: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把右侧检查器与当前 session 绑死，写入 `session.config.inspector`（开合、宽度、页签、各栏 `/database` 路径、跟随开关），经现有 `PATCH /api/sessions/:id/config` 持久化。

切 session 时按该条记录恢复栏路径，避免多 session 抢本机 `localStorage` 里同一份 `inspector.dbPath:*`。本机 key 只作缓存；fork 子会话不复制检查器绑定。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

