### PR TITLE
切 session 时保住检查器当前 tab

### DIFF
--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -39,6 +39,17 @@ test('inspector selects a hanging tab instead of showing an empty pane', () => {
   assert.equal(resolveInspectorTab('database::a1', ['database'], ['database::a1']), 'database::a1')
 })
 
+test('inspector keeps the restored tab even before its panel is listed', () => {
+  assert.equal(
+    resolveInspectorTab('database:/tasks', ['traj'], ['database:/pages', 'database:/tasks']),
+    'database:/tasks',
+  )
+  assert.equal(
+    resolveInspectorTab('database:/tasks', [], ['database:/pages', 'database:/tasks']),
+    'database:/tasks',
+  )
+})
+
 test('legacy untagged panels stay out of the inspector', () => {
   assert.equal(inspectorPanelMatches({}, 's1'), false)
   assert.equal(inspectorPanelMatches({ requiresSession: true }, null), false)

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -73,10 +73,12 @@ export function nextRepeatableTabId(tabId: string) {
 }
 
 export function resolveInspectorTab(current: string, allowed: string[], opened: string[] = []) {
-  const hanging = opened.filter((id) => allowed.includes(id) || allowed.includes(slotTabId(id)))
-  if (current && hanging.includes(current)) return current
+  if (current && opened.includes(current)) return current
   const currentSlot = current ? slotTabId(current) : ''
-  const bySlot = currentSlot ? hanging.find((id) => slotTabId(id) === currentSlot) : undefined
+  const bySlot = currentSlot ? opened.find((id) => slotTabId(id) === currentSlot) : undefined
   if (bySlot) return bySlot
+  const hanging = allowed.length
+    ? opened.filter((id) => allowed.includes(id) || allowed.includes(slotTabId(id)))
+    : [...opened]
   return hanging[0] ?? ''
 }

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -219,6 +219,7 @@ export const SessionInspector = memo(function SessionInspector({
   )
   const setTab = useCallback(
     (next: string) => {
+      tabRef.current = next
       setTabState(next)
       writeTabCache(sessionId, next)
       queuePersist({ tab: next })
@@ -227,6 +228,7 @@ export const SessionInspector = memo(function SessionInspector({
   )
   const persistOpened = useCallback(
     (next: string[]) => {
+      openedRef.current = next
       setOpened(next)
       writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
@@ -264,7 +266,12 @@ export const SessionInspector = memo(function SessionInspector({
     }
     const bind = currentSession?.inspector
     const openedNext = bind?.opened ?? readOpened(sessionId)
-    const tabNext = bind?.tab ?? readTab(sessionId)
+    const remembered = bind?.tab ?? readTab(sessionId)
+    const tabNext = openedNext.includes(remembered)
+      ? remembered
+      : openedNext.find((id) => slotTabId(id) === slotTabId(remembered)) ?? remembered
+    openedRef.current = openedNext
+    tabRef.current = tabNext
     setOpened(openedNext)
     setTabState(tabNext)
     writeOpenedCache(sessionId, openedNext)
@@ -304,6 +311,7 @@ export const SessionInspector = memo(function SessionInspector({
     setTabState((current) => {
       const next = resolveInspectorTab(current, allowedTabs, opened)
       if (next !== current) {
+        tabRef.current = next
         writeTabCache(sessionId, next)
         queuePersist({ tab: next })
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
三个字段够用：`opened` / `tab` / `dbPaths`。切 session 总落到第一栏，是因为面板列表还没齐时 `resolveInspectorTab` 把记下的 `tab` 收成 `opened[0]`。现在只要当前栏还在 `opened` 里就保住它。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

