### PR TITLE
切 session 时真正保住当前检查器 tab

### DIFF
--- a/packages/web-app-shell/src/web/inspector-panels.test.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { inspectorPanelMatches, inspectorViewProps, inspectorTabCollectionPath, inspectorTabIsOpen, pruneOpenedForCollections, resolveInspectorTab } from './inspector-panels.ts'
+import { inspectorPanelMatches, inspectorViewProps, inspectorTabCollectionPath, inspectorTabIsOpen, pruneOpenedForCollections, resolveInspectorTab, rememberedInspectorTab } from './inspector-panels.ts'
 
 test('inspector only offers session panels when a session is selected', () => {
   const extra = { centerKinds: ['session'], requiresSession: true }
@@ -48,6 +48,13 @@ test('inspector keeps the restored tab even before its panel is listed', () => {
     resolveInspectorTab('database:/tasks', [], ['database:/pages', 'database:/tasks']),
     'database:/tasks',
   )
+})
+
+test('remembered inspector tab prefers the locally clicked pane', () => {
+  const opened = ['database:/pages', 'database:/tasks']
+  assert.equal(rememberedInspectorTab(opened, 'database:/tasks', 'database:/pages'), 'database:/tasks')
+  assert.equal(rememberedInspectorTab(opened, '', 'database:/tasks'), 'database:/tasks')
+  assert.equal(rememberedInspectorTab(opened, 'database:/tasks::x', 'database:/tasks::old'), 'database:/tasks')
 })
 
 test('legacy untagged panels stay out of the inspector', () => {

--- a/packages/web-app-shell/src/web/inspector-panels.ts
+++ b/packages/web-app-shell/src/web/inspector-panels.ts
@@ -82,3 +82,15 @@ export function resolveInspectorTab(current: string, allowed: string[], opened: 
     : [...opened]
   return hanging[0] ?? ''
 }
+
+/** 切回 session：本机刚点过的栏优先，再才用后端记下的 tab。 */
+export function rememberedInspectorTab(opened: string[], cached?: string, stored?: string) {
+  if (cached && opened.includes(cached)) return cached
+  if (stored && opened.includes(stored)) return stored
+  const hint = cached || stored || ''
+  if (hint) {
+    const bySlot = opened.find((id) => slotTabId(id) === slotTabId(hint))
+    if (bySlot) return bySlot
+  }
+  return hint
+}

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -25,7 +25,7 @@ import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts'
 import { getInspectorCaption, getInspectorCaptionVersion, subscribeInspectorCaptions } from './inspector-captions.ts'
-import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
+import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId, rememberedInspectorTab } from './inspector-panels.ts'
 import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import {
@@ -185,6 +185,7 @@ export const SessionInspector = memo(function SessionInspector({
   const tabsRef = useRef<HTMLDivElement>(null)
   const hydratingRef = useRef(false)
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const persistForRef = useRef<string | null>(sessionId)
   const lastSentRef = useRef('')
   const tabRef = useRef(tab)
   const openedRef = useRef(opened)
@@ -198,8 +199,16 @@ export const SessionInspector = memo(function SessionInspector({
       dbPaths: snapshotInspectorDbPaths(),
     }
   }, [])
+  const flushInspector = useCallback(
+    (id: string, bind: SessionInspectorBind) => {
+      const body = JSON.stringify(bind)
+      lastSentRef.current = body
+      void sessionView.patchInspector(id, bind)
+    },
+    [sessionView],
+  )
   const queuePersist = useCallback(
-    (partial?: SessionInspectorBind) => {
+    (partial?: SessionInspectorBind, delay = 280) => {
       if (!sessionId || hydratingRef.current) return
       const next = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
       const packed = JSON.stringify(next)
@@ -211,18 +220,17 @@ export const SessionInspector = memo(function SessionInspector({
         const latest = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
         const body = JSON.stringify(latest)
         if (body === lastSentRef.current) return
-        lastSentRef.current = body
-        void sessionView.patchInspector(sessionId, latest)
-      }, 280)
+        flushInspector(sessionId, latest)
+      }, delay)
     },
-    [captureBind, sessionId, sessionView],
+    [captureBind, flushInspector, sessionId],
   )
   const setTab = useCallback(
     (next: string) => {
       tabRef.current = next
       setTabState(next)
       writeTabCache(sessionId, next)
-      queuePersist({ tab: next })
+      queuePersist({ tab: next }, 0)
     },
     [queuePersist, sessionId],
   )
@@ -232,7 +240,7 @@ export const SessionInspector = memo(function SessionInspector({
       setOpened(next)
       writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
-      queuePersist({ opened: next })
+      queuePersist({ opened: next }, 0)
     },
     [queuePersist, sessionId],
   )
@@ -245,6 +253,15 @@ export const SessionInspector = memo(function SessionInspector({
   const dragRef = useRef<{ startX: number; startWidth: number; last: number } | null>(null)
 
   useLayoutEffect(() => {
+    const prev = persistForRef.current
+    if (prev && prev !== sessionId) {
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current)
+        persistTimerRef.current = null
+      }
+      flushInspector(prev, captureBind())
+    }
+    persistForRef.current = sessionId
     hydratingRef.current = true
     if (persistTimerRef.current) {
       clearTimeout(persistTimerRef.current)
@@ -266,10 +283,7 @@ export const SessionInspector = memo(function SessionInspector({
     }
     const bind = currentSession?.inspector
     const openedNext = bind?.opened ?? readOpened(sessionId)
-    const remembered = bind?.tab ?? readTab(sessionId)
-    const tabNext = openedNext.includes(remembered)
-      ? remembered
-      : openedNext.find((id) => slotTabId(id) === slotTabId(remembered)) ?? remembered
+    const tabNext = rememberedInspectorTab(openedNext, readTab(sessionId), bind?.tab)
     openedRef.current = openedNext
     tabRef.current = tabNext
     setOpened(openedNext)
@@ -313,11 +327,10 @@ export const SessionInspector = memo(function SessionInspector({
       if (next !== current) {
         tabRef.current = next
         writeTabCache(sessionId, next)
-        queuePersist({ tab: next })
       }
       return next
     })
-  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened, queuePersist])
+  }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened])
 
   useEffect(() => {
     const onTab = (event: Event) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
切 session 总回到第一栏，是因为当前 tab 用 280ms debounce 写后端，一切走就把计时器取消了，记下的仍是第一栏。回来时又用这份过期数据。

改动：点 tab 马上写；切走前把上一 session 立刻 flush；恢复时本机刚点过的栏优先于后端；面板纠偏不再把「第一栏」写回。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

