### PR TITLE
检查器位置只走 GET/PATCH，不再用本机缓存

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -1132,6 +1132,7 @@ export function apply(ctx: Context) {
       newestSeq: window.newestSeq,
       ...(record.project ? { project: record.project } : {}),
       ...(record.mascot ? { mascot: record.mascot } : {}),
+      ...(record.config ? { config: record.config } : {}),
     }
     const summaries = await ctx.sessions.listSummaries()
     const workers = []

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -61,15 +61,14 @@ test('each inspector database pane keeps its own path', () => {
   assert.equal(getInspectorDbPath('database::b'), '/database/tasks')
 })
 
-test('inspector pane remembers view and record after a memory reset', () => {
+test('inspector pane path stays in memory until restored from session bind', () => {
   const pane = 'database:/sessions'
   setInspectorDbPath(pane, '/database/sessions/view/mine')
-  setInspectorDbPath(pane, '/database/sessions/record/s1?view=mine')
+  assert.equal(getInspectorDbPath(pane), '/database/sessions/view/mine')
   resetInspectorDbPathMemory()
+  assert.equal(getInspectorDbPath(pane), '')
+  restoreInspectorDbPaths({ [pane]: '/database/sessions/record/s1?view=mine' })
   assert.equal(getInspectorDbPath(pane), '/database/sessions/record/s1?view=mine')
-  setInspectorDbPath(pane, '/database/sessions/view/board-1')
-  resetInspectorDbPathMemory()
-  assert.equal(getInspectorDbPath(pane), '/database/sessions/view/board-1')
 })
 
 test('window reveal event opens the inspector record path', async () => {
@@ -122,9 +121,7 @@ test('unique inspector reveal focuses the same page and opens a new pane for a d
   assert.equal(getInspectorDbPath('database:/notes'), '/database/notes/record/n1?view=all')
   showInInspector('/notes', '/database/notes/record/n2', { unique: true })
   assert.equal(getInspectorDbPath('database:/notes'), '/database/notes/record/n1?view=all')
-  const extra = [...Array.from({ length: localStorage.length }, (_, i) => localStorage.key(i) ?? '')]
-    .filter((key) => key.startsWith('inspector.dbPath:database:/notes::'))
-    .map((key) => key.slice('inspector.dbPath:'.length))
+  const extra = Object.keys(snapshotInspectorDbPaths()).filter((id) => id.startsWith('database:/notes::'))
   assert.equal(extra.length, 1)
   assert.equal(getInspectorDbPath(extra[0]!), '/database/notes/record/n2')
 })

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -6,7 +6,6 @@ import { upsertSavedView, savedViewFromRecord } from './view-storage.ts'
 import { type SavedView } from './saved-view.ts'
 
 const DEFAULT_PANE = 'database'
-const STORAGE_PREFIX = 'inspector.dbPath:'
 const listeners = new Set<() => void>()
 const paths = new Map<string, string>()
 const abandonedPanes = new Set<string>()
@@ -64,10 +63,6 @@ export function setInspectorAgentFollow(next: boolean) {
   bumpFollow()
 }
 
-function storageKey(paneId: string) {
-  return `${STORAGE_PREFIX}${paneId}`
-}
-
 function slotTabId(openedId: string) {
   const split = openedId.indexOf('::')
   return split === -1 ? openedId : openedId.slice(0, split)
@@ -78,35 +73,7 @@ function paneIdsForTab(tabId: string) {
   for (const id of paths.keys()) {
     if (id === tabId || slotTabId(id) === tabId) ids.add(id)
   }
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i) ?? ''
-      if (!key.startsWith(STORAGE_PREFIX)) continue
-      const id = key.slice(STORAGE_PREFIX.length)
-      if (id === tabId || slotTabId(id) === tabId) ids.add(id)
-    }
-  } catch {
-    /* ignore */
-  }
   return [...ids]
-}
-
-function readStoredPath(paneId: string) {
-  try {
-    const raw = localStorage.getItem(storageKey(paneId)) ?? ''
-    return isInspectorDatabasePath(raw) ? raw : ''
-  } catch {
-    return ''
-  }
-}
-
-function writeStoredPath(paneId: string, path: string) {
-  try {
-    if (!path) localStorage.removeItem(storageKey(paneId))
-    else localStorage.setItem(storageKey(paneId), path)
-  } catch {
-    /* ignore */
-  }
 }
 
 export function subscribeInspectorAgentWorking(fn: () => void) {
@@ -157,17 +124,14 @@ export function isInspectorDatabasePath(pathname: string) {
 
 function panePath(paneId = DEFAULT_PANE) {
   const mem = paths.get(paneId)
-  if (mem !== undefined) return isInspectorDatabasePath(mem) ? mem : ''
-  const stored = readStoredPath(paneId)
-  if (stored) paths.set(paneId, stored)
-  return stored
+  return mem && isInspectorDatabasePath(mem) ? mem : ''
 }
 
 export function getInspectorDbPath(paneId = DEFAULT_PANE) {
   return panePath(paneId)
 }
 
-/** 测试用：清空内存路径，模拟整页刷新后只剩 localStorage。 */
+/** 测试用：清空内存路径。 */
 export function resetInspectorDbPathMemory() {
   paths.clear()
   abandonedPanes.clear()
@@ -178,27 +142,14 @@ export function setInspectorDbPath(paneId: string, next?: string) {
   const path = next === undefined ? paneId : next
   const stored = isInspectorDatabasePath(path) ? path : ''
   if (stored) abandonedPanes.delete(id)
-  if ((paths.get(id) ?? '') === stored) {
-    writeStoredPath(id, stored)
-    return
-  }
+  if ((paths.get(id) ?? '') === stored) return
   if (!stored) paths.delete(id)
   else paths.set(id, stored)
-  writeStoredPath(id, stored)
   bump()
 }
 
 function listStoredPaneIds() {
-  const ids = new Set<string>(paths.keys())
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i) ?? ''
-      if (key.startsWith(STORAGE_PREFIX)) ids.add(key.slice(STORAGE_PREFIX.length))
-    }
-  } catch {
-    /* ignore */
-  }
-  return ids
+  return [...paths.keys()]
 }
 
 /** 当前检查器各栏路径，写入 session.config.inspector.dbPaths。 */
@@ -222,15 +173,9 @@ export function restoreInspectorDbPaths(next?: Record<string, string>) {
     }
   }
   const stale = [...listStoredPaneIds()].filter((id) => !(id in incoming))
-  for (const paneId of stale) {
-    paths.delete(paneId)
-    writeStoredPath(paneId, '')
-  }
+  for (const paneId of stale) paths.delete(paneId)
   abandonedPanes.clear()
-  for (const [paneId, path] of Object.entries(incoming)) {
-    paths.set(paneId, path)
-    writeStoredPath(paneId, path)
-  }
+  for (const [paneId, path] of Object.entries(incoming)) paths.set(paneId, path)
   bump()
 }
 

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -25,7 +25,7 @@ import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
 import { inspectorTabFromEvent, requestInspectorAction } from './chat-overlay.ts'
 import { getInspectorCaption, getInspectorCaptionVersion, subscribeInspectorCaptions } from './inspector-captions.ts'
-import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId, rememberedInspectorTab } from './inspector-panels.ts'
+import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOpenedForCollections, resolveInspectorTab, slotTabId } from './inspector-panels.ts'
 import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import {
@@ -90,49 +90,6 @@ export type SessionInspectorProps = {
   collections?: Array<{ path: string }>
 }
 
-function inspectorTabStorageKey(sid: string | null | undefined) {
-  return sid ? `inspector.tab:${sid}` : 'inspector.tab:home'
-}
-
-function inspectorOpenedKey(sid: string | null | undefined) {
-  return sid ? `inspector.opened:${sid}` : 'inspector.opened:home'
-}
-
-function readOpened(sid: string | null | undefined): string[] {
-  try {
-    const raw = localStorage.getItem(inspectorOpenedKey(sid))
-    if (!raw) return []
-    const parsed = JSON.parse(raw) as unknown
-    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : []
-  } catch {
-    return []
-  }
-}
-
-function readTab(sid: string | null | undefined): string {
-  try {
-    return localStorage.getItem(inspectorTabStorageKey(sid)) ?? ''
-  } catch {
-    return ''
-  }
-}
-
-function writeOpenedCache(sid: string | null | undefined, next: string[]) {
-  try {
-    localStorage.setItem(inspectorOpenedKey(sid), JSON.stringify(next))
-  } catch {
-    /* ignore */
-  }
-}
-
-function writeTabCache(sid: string | null | undefined, next: string) {
-  try {
-    localStorage.setItem(inspectorTabStorageKey(sid), next)
-  } catch {
-    /* ignore */
-  }
-}
-
 export const SessionInspector = memo(function SessionInspector({
   open,
   width,
@@ -177,21 +134,20 @@ export const SessionInspector = memo(function SessionInspector({
   const toolTabs = extraTabs.filter((item) => item.action)
 
   const [tab, setTabState] = useState('')
-  const [opened, setOpened] = useState(() => readOpened(sessionId))
+  const [opened, setOpened] = useState<string[]>([])
+  const inspectorReady = useSessionView((state) => state.inspectorReady)
+  const sessionInspector = useSessionView((state) => state.sessionInspector)
   const [plusOpen, setPlusOpen] = useState(false)
   const plusRef = useRef<HTMLDivElement>(null)
   const plusMenuRef = useRef<HTMLDivElement>(null)
   const [plusPos, setPlusPos] = useState<{ right: number; top: number } | null>(null)
   const tabsRef = useRef<HTMLDivElement>(null)
   const hydratingRef = useRef(false)
-  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const persistForRef = useRef<string | null>(sessionId)
-  const lastSentRef = useRef('')
   const tabRef = useRef(tab)
   const openedRef = useRef(opened)
   tabRef.current = tab
   openedRef.current = opened
-  const rowPresent = Boolean(sessionId && sessions.some((item) => item.id === sessionId))
   const captureBind = useCallback((): SessionInspectorBind => {
     return {
       tab: tabRef.current,
@@ -199,50 +155,30 @@ export const SessionInspector = memo(function SessionInspector({
       dbPaths: snapshotInspectorDbPaths(),
     }
   }, [])
-  const flushInspector = useCallback(
-    (id: string, bind: SessionInspectorBind) => {
-      const body = JSON.stringify(bind)
-      lastSentRef.current = body
-      void sessionView.patchInspector(id, bind)
-    },
-    [sessionView],
-  )
-  const queuePersist = useCallback(
-    (partial?: SessionInspectorBind, delay = 280) => {
+  const pushInspector = useCallback(
+    (partial?: SessionInspectorBind) => {
       if (!sessionId || hydratingRef.current) return
       const next = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
-      const packed = JSON.stringify(next)
-      if (packed === lastSentRef.current) return
-      if (persistTimerRef.current) clearTimeout(persistTimerRef.current)
-      persistTimerRef.current = setTimeout(() => {
-        persistTimerRef.current = null
-        if (!sessionId || hydratingRef.current) return
-        const latest = mergeInspectorBind(captureBind(), partial ?? {}) ?? captureBind()
-        const body = JSON.stringify(latest)
-        if (body === lastSentRef.current) return
-        flushInspector(sessionId, latest)
-      }, delay)
+      void sessionView.patchInspector(sessionId, next)
     },
-    [captureBind, flushInspector, sessionId],
+    [captureBind, sessionId, sessionView],
   )
   const setTab = useCallback(
     (next: string) => {
       tabRef.current = next
       setTabState(next)
-      writeTabCache(sessionId, next)
-      queuePersist({ tab: next }, 0)
+      pushInspector({ tab: next })
     },
-    [queuePersist, sessionId],
+    [pushInspector],
   )
   const persistOpened = useCallback(
     (next: string[]) => {
       openedRef.current = next
       setOpened(next)
-      writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
-      queuePersist({ opened: next }, 0)
+      pushInspector({ opened: next })
     },
-    [queuePersist, sessionId],
+    [pushInspector, sessionId],
   )
 
   useEffect(() => {
@@ -255,56 +191,45 @@ export const SessionInspector = memo(function SessionInspector({
   useLayoutEffect(() => {
     const prev = persistForRef.current
     if (prev && prev !== sessionId) {
-      if (persistTimerRef.current) {
-        clearTimeout(persistTimerRef.current)
-        persistTimerRef.current = null
-      }
-      flushInspector(prev, captureBind())
+      hydratingRef.current = false
+      void sessionView.patchInspector(prev, captureBind())
     }
     persistForRef.current = sessionId
     hydratingRef.current = true
-    if (persistTimerRef.current) {
-      clearTimeout(persistTimerRef.current)
-      persistTimerRef.current = null
-    }
     if (!sessionId) {
-      lastSentRef.current = ''
-      setOpened(readOpened(null))
-      setTabState(readTab(null))
+      setOpened([])
+      setTabState('')
       restoreInspectorDbPaths({})
-      const idle = window.setTimeout(() => {
-        hydratingRef.current = false
-      }, 80)
-      return () => window.clearTimeout(idle)
-    }
-    if (!rowPresent) {
-      hydratingRef.current = true
+      hydratingRef.current = false
       return
     }
-    const bind = currentSession?.inspector
-    const openedNext = bind?.opened ?? readOpened(sessionId)
-    const tabNext = rememberedInspectorTab(openedNext, readTab(sessionId), bind?.tab)
+    if (!inspectorReady) {
+      setOpened([])
+      setTabState('')
+      restoreInspectorDbPaths({})
+      return
+    }
+    const bind = sessionInspector
+    const openedNext = bind?.opened ?? []
+    const tabNext = bind?.tab && openedNext.includes(bind.tab) ? bind.tab : bind?.tab || openedNext[0] || ''
     openedRef.current = openedNext
     tabRef.current = tabNext
     setOpened(openedNext)
     setTabState(tabNext)
-    writeOpenedCache(sessionId, openedNext)
-    writeTabCache(sessionId, tabNext)
-    restoreInspectorDbPaths(bind?.dbPaths)
-    lastSentRef.current = JSON.stringify({
-      tab: tabNext,
-      opened: openedNext,
-      dbPaths: bind?.dbPaths ?? {},
-    })
-    const idle = window.setTimeout(() => {
+    restoreInspectorDbPaths(bind?.dbPaths ?? {})
+    if (tabNext) {
+      queueMicrotask(() => {
+        window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabNext }))
+        hydratingRef.current = false
+      })
+    } else {
       hydratingRef.current = false
-    }, 80)
-    return () => window.clearTimeout(idle)
-  }, [rowPresent, sessionId])
+    }
+  }, [captureBind, inspectorReady, sessionId, sessionView])
 
   useEffect(() => {
-    return subscribeInspectorDbPath(() => queuePersist({ dbPaths: snapshotInspectorDbPaths() }))
-  }, [queuePersist])
+    return subscribeInspectorDbPath(() => pushInspector({ dbPaths: snapshotInspectorDbPaths() }))
+  }, [pushInspector])
 
   const focusTabId = extraTabs.find((item) => item.focusOnCall)?.id
   useEffect(() => {
@@ -312,22 +237,18 @@ export const SessionInspector = memo(function SessionInspector({
     setOpened((prev) => {
       if (prev.includes(focusTabId)) return prev
       const next = [...prev, focusTabId]
-      writeOpenedCache(sessionId, next)
       window.dispatchEvent(new CustomEvent('biu:inspector-opened', { detail: { sessionId, opened: next } }))
-      queuePersist({ opened: next })
+      pushInspector({ opened: next })
       return next
     })
     setTab(focusTabId)
-  }, [focusCallId, focusTabId, queuePersist, sessionId, setTab])
+  }, [focusCallId, focusTabId, pushInspector, sessionId, setTab])
 
   useEffect(() => {
     if (focusCallId && focusTabId) return
     setTabState((current) => {
       const next = resolveInspectorTab(current, allowedTabs, opened)
-      if (next !== current) {
-        tabRef.current = next
-        writeTabCache(sessionId, next)
-      }
+      if (next !== current) tabRef.current = next
       return next
     })
   }, [sessionId, focusCallId, focusTabId, allowedTabs.join('|'), opened])

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -178,6 +178,9 @@ export interface SessionViewState {
   dispatchedUsage?: TrajectoryUsage
   /** 切会话且无缓存：保留上一段画面直到新数据到齐，避免先闪 EmptyHero */
   switchingSession: boolean
+  /** 当前 session 的检查器绑定，只来自 GET /api/sessions/:id */
+  sessionInspector?: SessionInspectorBind
+  inspectorReady: boolean
   error?: string
 }
 
@@ -202,6 +205,7 @@ const empty: SessionViewState = {
   dispatchedUsageByTurn: {},
   dispatchedTasksByTurn: {},
   switchingSession: false,
+  inspectorReady: false,
 }
 
 type SessionPayload = {
@@ -211,6 +215,8 @@ type SessionPayload = {
   totalTurns?: number
   totalEvents?: number
   project?: { name: string; path?: string; boundAt: number }
+  config?: { inspector?: SessionInspectorBind }
+  inspector?: SessionInspectorBind
   dispatchedUsage?: TrajectoryUsage
   dispatchedUsageByTurn?: Record<string, TrajectoryUsage>
   dispatchedTasksByTurn?: Record<string, DispatchedTaskRow[]>
@@ -428,6 +434,7 @@ export class SessionViewService extends Service {
       trajectoryLoading: false,
       totalTurns: 0,
       switchingSession: false,
+      ...this.pendingInspector(),
     })
     if (typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('biu:session-missing', { detail: { sessionId } }))
@@ -704,6 +711,19 @@ export class SessionViewService extends Service {
     return this.newSession()
   }
 
+  private pendingInspector(): Pick<SessionViewState, 'sessionInspector' | 'inspectorReady'> {
+    return { sessionInspector: undefined, inspectorReady: false }
+  }
+
+  private inspectorFromPayload(body: SessionPayload) {
+    return body.config?.inspector ?? body.inspector
+  }
+
+  private rememberSessionInspector(sessionId: string, inspector: SessionInspectorBind | undefined) {
+    const sessions = this.value.sessions.map((item) => (item.id === sessionId ? { ...item, inspector } : item))
+    return { sessionInspector: inspector, inspectorReady: true as const, sessions }
+  }
+
   async load(sessionId: string, options: { view?: ConversationView; wait?: boolean } = {}) {
     const view = options.view ?? this.value.view
     const wait = options.wait === true
@@ -742,6 +762,7 @@ export class SessionViewService extends Service {
             trajectoryHasMore: false,
             trajectoryLoading: false,
             switchingSession: true,
+            ...this.pendingInspector(),
           })
         } else {
           this.replace({
@@ -760,6 +781,7 @@ export class SessionViewService extends Service {
             trajectoryLoading: false,
             totalTurns: 0,
             switchingSession: true,
+            ...this.pendingInspector(),
           })
         }
         if (this.wantsTrajectory(view)) void this.ensureTrajectory()
@@ -788,6 +810,7 @@ export class SessionViewService extends Service {
           trajectoryHasMore: false,
           trajectoryLoading: false,
           switchingSession: true,
+          ...this.pendingInspector(),
         })
       } else {
         this.replace({
@@ -806,6 +829,7 @@ export class SessionViewService extends Service {
           trajectoryLoading: false,
           totalTurns: 0,
           switchingSession: true,
+          ...this.pendingInspector(),
         })
       }
     }
@@ -859,6 +883,7 @@ export class SessionViewService extends Service {
           dispatchedTasksByTurn: tasksByTurn,
           dispatchedUsage,
           nodes,
+          ...this.rememberSessionInspector(sessionId, this.inspectorFromPayload(body)),
         })
         this.syncDispatchedPoll()
         return
@@ -876,6 +901,7 @@ export class SessionViewService extends Service {
         trajectory: this.wantsTrajectory(view) ? this.value.trajectory : [],
         switchingSession: false,
         error: undefined,
+        ...this.rememberSessionInspector(sessionId, this.inspectorFromPayload(body)),
       })
       this.syncDispatchedPoll()
       if (this.wantsTrajectory(view)) void this.ensureTrajectory()
@@ -906,6 +932,7 @@ export class SessionViewService extends Service {
       dispatchedTasksByTurn: cached.dispatchedTasksByTurn,
       dispatchedUsage: cached.dispatchedUsage,
       switchingSession: false,
+      ...this.pendingInspector(),
     })
     this.syncDispatchedPoll()
     void this.refreshInbox(sessionId)

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -350,6 +350,37 @@ test('load fetches full session turns and skips trajectory until ensureTrajector
   assert.equal(calls.some((url) => url.includes('turns=24')), false)
 })
 
+test('load applies inspector bind from GET session, not the list cache', async () => {
+  mockFetch({
+    '/api/sessions/s1': () => ({
+      id: 's1',
+      events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+      hasMore: false,
+      totalTurns: 0,
+      config: {
+        inspector: {
+          tab: 'database:/tasks',
+          opened: ['database:/pages', 'database:/tasks'],
+          dbPaths: { 'database:/tasks': '/database/tasks' },
+        },
+      },
+    }),
+    '/api/sessions': () => ({
+      sessions: [{ id: 's1', title: 'A', eventCount: 1, updatedAt: 1 }],
+    }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  await view.refreshSessions()
+  assert.equal(view.get().inspectorReady, false)
+  await view.load('s1', { view: 'chat', wait: true })
+  assert.equal(view.get().inspectorReady, true)
+  assert.equal(view.get().sessionInspector?.tab, 'database:/tasks')
+  assert.deepEqual(view.get().sessionInspector?.opened, ['database:/pages', 'database:/tasks'])
+})
+
 test('fetchEventDetail and fetchEventRequest hit fine-grained APIs', async () => {
   const calls: string[] = []
   globalThis.fetch = (async (input: RequestInfo | URL) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
之前切 session 总回到第一栏，是因为位置存在本机 localStorage / 列表缓存里，和后端对不上，恢复时又把过期的第一栏写回去。

现在：
1. 切 session 只信 `GET /api/sessions/:id` 带回的 `config.inspector`，套上打开的栏、当前 tab、各栏路径。不用本机缓存。
2. 加栏 / 点 tab 立刻 `PATCH /api/sessions/:id/config`，不 debounce、不写 localStorage。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

