### PR TITLE
Editor 正文块拖拽把手与操作菜单

### DIFF
--- a/packages/core-editor/package.json
+++ b/packages/core-editor/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.1"
   },
   "dependencies": {
+    "@biu/public-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0"
   }
 }

--- a/packages/core-editor/src/web/page-block-handle.test.ts
+++ b/packages/core-editor/src/web/page-block-handle.test.ts
@@ -1,0 +1,67 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Editor } from '@tiptap/core'
+import {
+  deleteHandleBlock,
+  duplicateHandleBlock,
+  insertParagraphAfter,
+  insertParagraphBefore,
+  resolveHandleBlock,
+} from './page-block-handle.ts'
+import { pageEditorExtensions } from './kit.ts'
+
+function editorOf(markdown: string) {
+  return new Editor({
+    extensions: pageEditorExtensions(),
+    content: markdown,
+    contentType: 'markdown',
+  })
+}
+
+test('resolveHandleBlock picks top-level paragraph', () => {
+  const editor = editorOf('你好\n\n世界')
+  const first = editor.state.doc.child(0)
+  const $pos = editor.state.doc.resolve(2)
+  const found = resolveHandleBlock($pos)
+  assert.ok(found)
+  assert.equal(found!.pos, 0)
+  assert.equal(found!.node.type.name, 'paragraph')
+  assert.equal(found!.node.textContent, first.textContent)
+  editor.destroy()
+})
+
+test('resolveHandleBlock picks listItem inside a list', () => {
+  const editor = editorOf('- 甲\n- 乙')
+  let itemPos = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (itemPos < 0 && node.type.name === 'listItem') itemPos = pos
+  })
+  assert.ok(itemPos >= 0)
+  const $pos = editor.state.doc.resolve(itemPos + 2)
+  const found = resolveHandleBlock($pos)
+  assert.ok(found)
+  assert.equal(found!.node.type.name, 'listItem')
+  editor.destroy()
+})
+
+test('insert before / after / duplicate / delete a paragraph', () => {
+  const editor = editorOf('第一段\n\n第二段')
+  const firstText = editor.state.doc.child(0).textContent
+  insertParagraphBefore(editor, 0)
+  assert.equal(editor.state.doc.child(0).textContent, '')
+  assert.equal(editor.state.doc.child(1).textContent, firstText)
+
+  const firstPos = editor.state.doc.child(0).nodeSize
+  const firstNode = editor.state.doc.child(1)
+  insertParagraphAfter(editor, firstPos, firstNode)
+  assert.equal(editor.state.doc.child(2).textContent, '')
+
+  duplicateHandleBlock(editor, firstPos, firstNode)
+  const texts: string[] = []
+  for (let i = 0; i < editor.state.doc.childCount; i++) texts.push(editor.state.doc.child(i).textContent)
+  assert.equal(texts.filter((t) => t === firstText).length, 2)
+
+  deleteHandleBlock(editor, 0, editor.state.doc.child(0))
+  assert.notEqual(editor.state.doc.child(0).textContent, '')
+  editor.destroy()
+})

--- a/packages/core-editor/src/web/page-block-handle.ts
+++ b/packages/core-editor/src/web/page-block-handle.ts
@@ -1,0 +1,35 @@
+import type { Editor } from '@tiptap/core'
+import type { Node, ResolvedPos } from '@tiptap/pm/model'
+
+export type HandleBlock = {
+  pos: number
+  node: Node
+}
+
+/** 列表项单独成块；其余取紧贴文档的顶层块（引用整段、段落、插件块等）。 */
+export function resolveHandleBlock($pos: ResolvedPos): HandleBlock | null {
+  for (let depth = $pos.depth; depth >= 1; depth--) {
+    const node = $pos.node(depth)
+    const parent = $pos.node(depth - 1)
+    if (parent.type.name === 'doc' || node.type.name === 'listItem') {
+      return { pos: $pos.before(depth), node }
+    }
+  }
+  return null
+}
+
+export function deleteHandleBlock(editor: Editor, pos: number, node: Node) {
+  editor.chain().focus().deleteRange({ from: pos, to: pos + node.nodeSize }).run()
+}
+
+export function insertParagraphBefore(editor: Editor, pos: number) {
+  editor.chain().focus().insertContentAt(pos, { type: 'paragraph' }).run()
+}
+
+export function insertParagraphAfter(editor: Editor, pos: number, node: Node) {
+  editor.chain().focus().insertContentAt(pos + node.nodeSize, { type: 'paragraph' }).run()
+}
+
+export function duplicateHandleBlock(editor: Editor, pos: number, node: Node) {
+  editor.chain().focus().insertContentAt(pos + node.nodeSize, node.toJSON()).run()
+}

--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -1,0 +1,137 @@
+import { useCallback, useEffect, useRef, useState, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react'
+import type { Editor } from '@tiptap/core'
+import { NodeSelection } from '@tiptap/pm/state'
+import { HeadlessDismiss } from '@biu/public-ui'
+import {
+  deleteHandleBlock,
+  duplicateHandleBlock,
+  insertParagraphAfter,
+  insertParagraphBefore,
+  resolveHandleBlock,
+  type HandleBlock,
+} from './page-block-handle.ts'
+
+type HandleTarget = HandleBlock & { top: number }
+
+function readTarget(editor: Editor, clientX: number, clientY: number): HandleTarget | null {
+  const coords = editor.view.posAtCoords({ left: clientX, top: clientY })
+  if (!coords) return null
+  const found = resolveHandleBlock(editor.state.doc.resolve(coords.pos))
+  if (!found) return null
+  const dom = editor.view.nodeDOM(found.pos)
+  const el = dom instanceof HTMLElement ? dom : dom?.parentElement
+  if (!(el instanceof HTMLElement)) return null
+  const wrap = editor.view.dom.getBoundingClientRect()
+  return { ...found, top: el.getBoundingClientRect().top - wrap.top }
+}
+
+export function PageBlockHandle({ editor }: { editor: Editor }) {
+  const [target, setTarget] = useState<HandleTarget | null>(null)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const dragged = useRef(false)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  const hide = useCallback(() => {
+    setMenuOpen(false)
+    setTarget(null)
+  }, [])
+
+  useEffect(() => {
+    const root = editor.view.dom
+    const wrap = root.closest('.page-editor')
+    if (!(wrap instanceof HTMLElement)) return
+
+    const onMove = (event: MouseEvent) => {
+      if (menuOpen) return
+      if (!editor.isEditable) {
+        setTarget(null)
+        return
+      }
+      if (event.target instanceof Element && event.target.closest('.page-block-handle')) return
+      const next = readTarget(editor, event.clientX, event.clientY)
+      setTarget(next)
+    }
+
+    const onLeave = (event: MouseEvent) => {
+      if (menuOpen) return
+      const to = event.relatedTarget
+      if (to instanceof Node && wrap.contains(to)) return
+      setTarget(null)
+    }
+
+    wrap.addEventListener('mousemove', onMove)
+    wrap.addEventListener('mouseleave', onLeave)
+    return () => {
+      wrap.removeEventListener('mousemove', onMove)
+      wrap.removeEventListener('mouseleave', onLeave)
+    }
+  }, [editor, menuOpen])
+
+  if (!target || !editor.isEditable) return null
+
+  const run = (fn: () => void) => (event: ReactMouseEvent) => {
+    event.preventDefault()
+    fn()
+    hide()
+  }
+
+  const onDragStart = (event: DragEvent) => {
+    dragged.current = true
+    setMenuOpen(false)
+    const { view } = editor
+    const selection = NodeSelection.create(view.state.doc, target.pos)
+    view.dispatch(view.state.tr.setSelection(selection))
+    view.dragging = { slice: selection.content(), move: true }
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/plain', '')
+  }
+
+  const onDragEnd = () => {
+    editor.view.dragging = null
+  }
+
+  const onGripClick = (event: ReactMouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    if (dragged.current) {
+      dragged.current = false
+      return
+    }
+    setMenuOpen((open) => !open)
+  }
+
+  return (
+    <div className="page-block-handle" style={{ top: target.top }} data-testid="page-block-handle">
+      <button
+        type="button"
+        className="page-block-handle-grip"
+        draggable
+        aria-label="拖拽或打开块菜单"
+        data-testid="page-block-handle-grip"
+        onClick={onGripClick}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+      >
+        <span className="page-block-handle-dots" aria-hidden />
+      </button>
+      {menuOpen ? (
+        <HeadlessDismiss onDismiss={() => setMenuOpen(false)} insideRef={menuRef}>
+          <div ref={menuRef} className="page-block-handle-menu" role="menu" data-testid="page-block-handle-menu">
+            <button type="button" role="menuitem" onMouseDown={run(() => insertParagraphBefore(editor, target.pos))}>
+              向上插入
+            </button>
+            <button type="button" role="menuitem" onMouseDown={run(() => insertParagraphAfter(editor, target.pos, target.node))}>
+              向下插入
+            </button>
+            <button type="button" role="menuitem" onMouseDown={run(() => duplicateHandleBlock(editor, target.pos, target.node))}>
+              复制
+            </button>
+            <button type="button" role="menuitem" onMouseDown={run(() => deleteHandleBlock(editor, target.pos, target.node))}>
+              删除
+            </button>
+          </div>
+        </HeadlessDismiss>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -5,6 +5,7 @@ import type { Editor } from '@tiptap/core'
 import { Selection } from '@tiptap/pm/state'
 import type { FsContentProps } from '@biu/type-file-system/ui'
 import { pageEditorExtensions } from './kit.ts'
+import { PageBlockHandle } from './page-block-handle.tsx'
 import { editorHostIsLive } from './editor-live.ts'
 import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
 
@@ -149,6 +150,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
   return (
     <div className="page-editor">
       <EditorContent editor={editor} />
+      {writable !== false ? <PageBlockHandle editor={editor} /> : null}
       {writable !== false ? <Bubble editor={editor} /> : null}
     </div>
   )

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,6 +1,14 @@
 export const PAGE_EDITOR_STYLE = `
-.page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
+.page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;padding-left:28px;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
 .page-editor .tiptap{outline:none;min-height:240px}
+.page-block-handle{position:absolute;left:4px;z-index:6;display:flex;flex-direction:column;align-items:flex-start}
+.page-block-handle-grip{display:flex;align-items:center;justify-content:center;width:18px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:var(--dsw-label-3);cursor:grab}
+.page-block-handle-grip:hover,.page-block-handle-grip:focus-visible{background:var(--dsw-hover);color:var(--dsw-label-2)}
+.page-block-handle-grip:active{cursor:grabbing}
+.page-block-handle-dots{display:block;width:8px;height:14px;background-image:radial-gradient(circle,currentColor 1.05px,transparent 1.15px);background-size:4px 4.5px;background-position:0 0}
+.page-block-handle-menu{position:absolute;left:0;top:24px;z-index:40;min-width:132px;padding:4px;display:flex;flex-direction:column;gap:1px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 28px rgba(15,15,15,.12)}
+.page-block-handle-menu button{display:block;width:100%;margin:0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;text-align:left;cursor:pointer}
+.page-block-handle-menu button:hover{background:var(--dsw-hover)}
 .page-editor .tiptap>:first-child{margin-top:0}
 .page-editor .tiptap p,.page-editor .tiptap h1,.page-editor .tiptap h2,.page-editor .tiptap h3,.page-editor .tiptap ul,.page-editor .tiptap ol,.page-editor .tiptap blockquote,.page-editor .tiptap pre{margin:2px 0}
 .page-editor .tiptap p{min-height:1.7em}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
每个可编辑 block 悬浮时在左侧显示拖拽点：可拖动整块排序，点击打开菜单（向上插入、向下插入、复制、删除）。列表项单独成块，引用等顶层块整段操作。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

