### PR TITLE
fix: 编辑器块把手对齐并补上左侧悬停热区

### DIFF
--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -11,18 +11,38 @@ import {
   type HandleBlock,
 } from './page-block-handle.ts'
 
-type HandleTarget = HandleBlock & { top: number }
+type HandleTarget = HandleBlock & { top: number; height: number; gripTop: number }
 
-function readTarget(editor: Editor, clientX: number, clientY: number): HandleTarget | null {
-  const coords = editor.view.posAtCoords({ left: clientX, top: clientY })
+function lineCoords(editor: Editor, found: HandleBlock) {
+  const inside = found.node.isAtom || found.node.isLeaf || found.node.nodeSize < 2 ? found.pos : found.pos + 1
+  try {
+    return editor.view.coordsAtPos(inside)
+  } catch {
+    return null
+  }
+}
+
+function readTarget(editor: Editor, host: HTMLElement, clientX: number, clientY: number): HandleTarget | null {
+  const content = editor.view.dom.getBoundingClientRect()
+  const probeX = Math.min(Math.max(clientX, content.left + 8), content.right - 8)
+  const coords = editor.view.posAtCoords({ left: probeX, top: clientY })
   if (!coords) return null
   const found = resolveHandleBlock(editor.state.doc.resolve(coords.pos))
   if (!found) return null
   const dom = editor.view.nodeDOM(found.pos)
   const el = dom instanceof HTMLElement ? dom : dom?.parentElement
   if (!(el instanceof HTMLElement)) return null
-  const wrap = editor.view.dom.getBoundingClientRect()
-  return { ...found, top: el.getBoundingClientRect().top - wrap.top }
+  const hostBox = host.getBoundingClientRect()
+  const box = el.getBoundingClientRect()
+  const line = lineCoords(editor, found) ?? { top: box.top, bottom: box.top + 22 }
+  const gripH = 22
+  const gripTop = (line.top + line.bottom) / 2 - box.top - gripH / 2
+  return {
+    ...found,
+    top: box.top - hostBox.top,
+    height: Math.max(box.height, gripH),
+    gripTop: Math.max(0, gripTop),
+  }
 }
 
 export function PageBlockHandle({ editor }: { editor: Editor }) {
@@ -47,8 +67,8 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
         setTarget(null)
         return
       }
-      if (event.target instanceof Element && event.target.closest('.page-block-handle')) return
-      const next = readTarget(editor, event.clientX, event.clientY)
+      if (event.target instanceof Element && event.target.closest('.page-block-handle-menu')) return
+      const next = readTarget(editor, wrap, event.clientX, event.clientY)
       setTarget(next)
     }
 
@@ -101,10 +121,15 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
   }
 
   return (
-    <div className="page-block-handle" style={{ top: target.top }} data-testid="page-block-handle">
+    <div
+      className="page-block-handle"
+      style={{ top: target.top, height: target.height }}
+      data-testid="page-block-handle"
+    >
       <button
         type="button"
         className="page-block-handle-grip"
+        style={{ marginTop: target.gripTop }}
         draggable
         aria-label="拖拽或打开块菜单"
         data-testid="page-block-handle-grip"
@@ -116,7 +141,13 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
       </button>
       {menuOpen ? (
         <HeadlessDismiss onDismiss={() => setMenuOpen(false)} insideRef={menuRef}>
-          <div ref={menuRef} className="page-block-handle-menu" role="menu" data-testid="page-block-handle-menu">
+          <div
+            ref={menuRef}
+            className="page-block-handle-menu"
+            style={{ top: target.gripTop }}
+            role="menu"
+            data-testid="page-block-handle-menu"
+          >
             <button type="button" role="menuitem" onMouseDown={run(() => insertParagraphBefore(editor, target.pos))}>
               向上插入
             </button>

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,12 +1,12 @@
 export const PAGE_EDITOR_STYLE = `
 .page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;padding-left:28px;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
 .page-editor .tiptap{outline:none;min-height:240px}
-.page-block-handle{position:absolute;left:4px;z-index:6;display:flex;flex-direction:column;align-items:flex-start}
-.page-block-handle-grip{display:flex;align-items:center;justify-content:center;width:18px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:var(--dsw-label-3);cursor:grab}
+.page-block-handle{position:absolute;left:0;z-index:6;width:28px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
+.page-block-handle-grip{flex:none;display:flex;align-items:center;justify-content:center;width:18px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:var(--dsw-label-3);cursor:grab}
 .page-block-handle-grip:hover,.page-block-handle-grip:focus-visible{background:var(--dsw-hover);color:var(--dsw-label-2)}
 .page-block-handle-grip:active{cursor:grabbing}
 .page-block-handle-dots{display:block;width:8px;height:14px;background-image:radial-gradient(circle,currentColor 1.05px,transparent 1.15px);background-size:4px 4.5px;background-position:0 0}
-.page-block-handle-menu{position:absolute;left:0;top:24px;z-index:40;min-width:132px;padding:4px;display:flex;flex-direction:column;gap:1px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 28px rgba(15,15,15,.12)}
+.page-block-handle-menu{position:absolute;left:22px;top:0;z-index:40;min-width:132px;padding:4px;display:flex;flex-direction:column;gap:1px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 28px rgba(15,15,15,.12)}
 .page-block-handle-menu button{display:block;width:100%;margin:0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;text-align:left;cursor:pointer}
 .page-block-handle-menu button:hover{background:var(--dsw-hover)}
 .page-editor .tiptap>:first-child{margin-top:0}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两处修正：

1. 把手相对 `.page-editor` 定位，并按首行行高垂直居中，不再整块顶对齐导致偏上。
2. 左侧整列（含正文到按钮之间的空隙）作为块高热区；探测坐标会夹到正文区域内，从段落移到拖拽按钮途中不会卸掉把手。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

