### PR TITLE
拖拽把手移到正文左侧，不再挡住文字

### DIFF
--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -11,7 +11,9 @@ import {
   type HandleBlock,
 } from './page-block-handle.ts'
 
-type HandleTarget = HandleBlock & { top: number; height: number; gripTop: number }
+const HANDLE_RAIL = 24
+
+type HandleTarget = HandleBlock & { top: number; left: number; height: number; gripTop: number }
 
 function lineCoords(editor: Editor, found: HandleBlock) {
   const inside = found.node.isAtom || found.node.isLeaf || found.node.nodeSize < 2 ? found.pos : found.pos + 1
@@ -40,6 +42,7 @@ function readTarget(editor: Editor, host: HTMLElement, clientX: number, clientY:
   return {
     ...found,
     top: box.top - hostBox.top,
+    left: box.left - hostBox.left - HANDLE_RAIL,
     height: Math.max(box.height, gripH),
     gripTop: Math.max(0, gripTop),
   }
@@ -67,7 +70,7 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
         setTarget(null)
         return
       }
-      if (event.target instanceof Element && event.target.closest('.page-block-handle-menu')) return
+      if (event.target instanceof Element && event.target.closest('.page-block-handle')) return
       const next = readTarget(editor, wrap, event.clientX, event.clientY)
       setTarget(next)
     }
@@ -123,7 +126,7 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
   return (
     <div
       className="page-block-handle"
-      style={{ top: target.top, height: target.height }}
+      style={{ top: target.top, left: target.left, height: target.height }}
       data-testid="page-block-handle"
     >
       <button

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,7 +1,7 @@
 export const PAGE_EDITOR_STYLE = `
-.page-editor{position:relative;min-width:0;width:100%;padding:6px 0 48px;padding-left:0;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
+.page-editor{position:relative;overflow:visible;min-width:0;width:100%;padding:6px 0 48px;padding-left:0;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
 .page-editor .tiptap{outline:none;min-height:240px}
-.page-block-handle{position:absolute;left:0;z-index:6;width:28px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
+.page-block-handle{position:absolute;z-index:6;width:24px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
 .page-block-handle-grip{flex:none;display:flex;align-items:center;justify-content:center;width:18px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:var(--dsw-label-3);cursor:grab}
 .page-block-handle-grip:hover,.page-block-handle-grip:focus-visible{background:var(--dsw-hover);color:var(--dsw-label-2)}
 .page-block-handle-grip:active{cursor:grabbing}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`.page-editor` 左侧 padding 仍为 0。拖拽把手按当前块左缘向外挂 24px，压在详情页已有的左右边距上，不再叠在文字上。列表项会贴在该行左侧而不是整页最左。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

