### PR TITLE
修好收起侧栏悬停偶发消失

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -103,6 +103,7 @@ test('shell columns stay three tracks without animating on window resize', () =>
   assert.match(css, /\.app-shell-module\.is-window-resizing\s*\{[^}]*transition:\s*none/s)
   assert.doesNotMatch(css, /\.app-shell-agent\.is-sidebar-collapsed\s*\{/)
   assert.match(frame, /is-closed flex/)
+  assert.match(frame, /is-flyout-open/)
   assert.match(frame, /sidebar-flyout-host/)
   assert.match(frame, /sidebar-edge-hot/)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*top:\s*60px/s)
@@ -112,15 +113,15 @@ test('shell columns stay three tracks without animating on window resize', () =>
   assert.doesNotMatch(css, /\.sidebar-flyout-host\.is-collapsed\s*\{[^}]*position:\s*fixed/s)
   assert.match(css, /\.app-shell-agent > main\s*\{[^}]*grid-column:\s*2/s)
   assert.match(css, /\.app-shell-agent > \.session-inspector\s*\{[^}]*grid-column:\s*3/s)
-  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*width:\s*12px/s)
-  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*top:\s*60px/s)
-  assert.match(css, /\.sidebar-flyout-host\.is-collapsed:hover \.sidebar-edge-hot\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/s)
+  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*width:\s*20px/s)
+  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*top:\s*0/s)
+  assert.match(css, /\.sidebar-flyout-host\.is-collapsed\.is-flyout-open \.sidebar-edge-hot\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*z-index:\s*81/s)
   assert.match(
     css,
-    /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*transform 0s linear 180ms, opacity 0s linear 180ms/s,
+    /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*transform 0s linear 240ms, opacity 0s linear 240ms, pointer-events 0s linear 240ms/s,
   )
-  assert.match(css, /\.sidebar-flyout-host\.is-collapsed:hover \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*none/s)
+  assert.match(css, /\.sidebar-flyout-host\.is-collapsed\.is-flyout-open \.app-side-bar\.is-closed\s*\{[^}]*transition:\s*none/s)
   assert.doesNotMatch(css, /\.sidebar-flyout-host\.is-collapsed:focus-within/)
   assert.doesNotMatch(css, /\.sidebar-flyout-host\.is-collapsed:hover\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/)
   assert.match(css, /\.app-side-bar\s*\{[^}]*min-width:\s*0/s)

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -1,8 +1,13 @@
-import { memo, useEffect, useRef, type ReactNode } from 'react'
+import { memo, useEffect, useRef, useState, type ReactNode } from 'react'
 import { ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '@heroicons/react/16/solid'
 import { SidebarBrandLockup } from '@biu/public-mascot'
 import { chromeIcon } from './chrome-icon.ts'
 import { ShellSidePlaces } from './shell-chrome.tsx'
+import {
+  isSidebarFlyoutKeepTarget,
+  SIDEBAR_FLYOUT_HIDE_MS,
+  shouldKeepSidebarFlyout,
+} from './sidebar-flyout.ts'
 
 export type ShellSidebarFrameProps = {
   visible: boolean
@@ -39,6 +44,11 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
   children,
 }: ShellSidebarFrameProps) {
   const dragRef = useRef<{ startX: number; startWidth: number; last: number } | null>(null)
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const peekRef = useRef(false)
+  const hideRef = useRef<number | null>(null)
+  const [peek, setPeek] = useState(false)
+
   useEffect(() => {
     const onMove = (event: PointerEvent) => {
       const drag = dragRef.current
@@ -63,8 +73,65 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
     }
   }, [onWidthChange, onWidthLive])
 
+  useEffect(() => {
+    if (visible) {
+      peekRef.current = false
+      setPeek(false)
+      if (hideRef.current != null) {
+        clearTimeout(hideRef.current)
+        hideRef.current = null
+      }
+      return
+    }
+
+    const openPeek = () => {
+      if (hideRef.current != null) {
+        clearTimeout(hideRef.current)
+        hideRef.current = null
+      }
+      peekRef.current = true
+      setPeek(true)
+    }
+    const scheduleHide = () => {
+      if (hideRef.current != null) return
+      hideRef.current = window.setTimeout(() => {
+        hideRef.current = null
+        peekRef.current = false
+        setPeek(false)
+      }, SIDEBAR_FLYOUT_HIDE_MS)
+    }
+    const onPointer = (event: PointerEvent) => {
+      const host = hostRef.current
+      const shell = host?.parentElement
+      const raw = shell ? getComputedStyle(shell).getPropertyValue('--sidebar-flyout-width') : ''
+      const width = Number.parseFloat(raw) || 240
+      if (
+        isSidebarFlyoutKeepTarget(event.target, host) ||
+        shouldKeepSidebarFlyout(event.clientX, peekRef.current, width, window.innerWidth)
+      ) {
+        openPeek()
+        return
+      }
+      if (peekRef.current) scheduleHide()
+    }
+    window.addEventListener('pointermove', onPointer)
+    window.addEventListener('pointerdown', onPointer)
+    return () => {
+      window.removeEventListener('pointermove', onPointer)
+      window.removeEventListener('pointerdown', onPointer)
+      if (hideRef.current != null) {
+        clearTimeout(hideRef.current)
+        hideRef.current = null
+      }
+    }
+  }, [visible])
+
   return (
-    <div className={`sidebar-flyout-host${visible ? '' : ' is-collapsed'}`} data-testid="sidebar-flyout-host">
+    <div
+      ref={hostRef}
+      className={`sidebar-flyout-host${visible ? '' : ' is-collapsed'}${!visible && peek ? ' is-flyout-open' : ''}`}
+      data-testid="sidebar-flyout-host"
+    >
       {visible ? null : <div className="sidebar-edge-hot" data-testid="sidebar-edge-hot" aria-hidden />}
     <aside
       className={`app-side-bar min-h-0 flex-col overflow-hidden border-r border-(--dsw-border) bg-(--dsw-sidebar)${narrow ? ' is-narrow' : ''}${showTags ? ' is-wide' : ''}${visible ? ' flex' : ' is-closed flex'}`}

--- a/packages/web-app-shell/src/web/sidebar-flyout.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.test.ts
@@ -1,0 +1,26 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { isSidebarFlyoutKeepTarget, shouldKeepSidebarFlyout } from './sidebar-flyout.ts'
+
+test('left edge keeps flyout even before it is open', () => {
+  assert.equal(shouldKeepSidebarFlyout(8, false, 240), true)
+  assert.equal(shouldKeepSidebarFlyout(20, false, 240), true)
+  assert.equal(shouldKeepSidebarFlyout(21, false, 240), false)
+})
+
+test('once peeking, the full panel width keeps the flyout', () => {
+  assert.equal(shouldKeepSidebarFlyout(180, true, 240), true)
+  assert.equal(shouldKeepSidebarFlyout(248, true, 240), true)
+  assert.equal(shouldKeepSidebarFlyout(260, true, 240), false)
+})
+
+test('portaled sidebar menus still count as inside', () => {
+  const host = document.createElement('div')
+  const menu = document.createElement('div')
+  menu.className = 'brand-agent-menu'
+  document.body.append(host, menu)
+  assert.equal(isSidebarFlyoutKeepTarget(menu, host), true)
+  assert.equal(isSidebarFlyoutKeepTarget(document.body, host), false)
+  host.remove()
+  menu.remove()
+})

--- a/packages/web-app-shell/src/web/sidebar-flyout.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.ts
@@ -1,0 +1,21 @@
+export const SIDEBAR_FLYOUT_EDGE = 20
+export const SIDEBAR_FLYOUT_HIDE_MS = 240
+export const SIDEBAR_FLYOUT_KEEP = '.brand-agent-menu, .chat-sidebar-popover, [data-sidebar-flyout-keep]'
+
+export function shouldKeepSidebarFlyout(
+  clientX: number,
+  peeking: boolean,
+  panelWidth: number,
+  viewportWidth = Number.POSITIVE_INFINITY,
+) {
+  if (clientX < 0 || clientX > viewportWidth) return false
+  if (clientX <= SIDEBAR_FLYOUT_EDGE) return true
+  if (peeking && clientX <= panelWidth + 8) return true
+  return false
+}
+
+export function isSidebarFlyoutKeepTarget(node: EventTarget | null, host: Element | null) {
+  if (!(node instanceof Element)) return false
+  if (host?.contains(node)) return true
+  return Boolean(node.closest(SIDEBAR_FLYOUT_KEEP))
+}

--- a/web/style.css
+++ b/web/style.css
@@ -1430,9 +1430,9 @@ body {
   pointer-events: auto;
   position: fixed;
   left: 0;
-  top: 60px;
-  bottom: 60px;
-  width: 12px;
+  top: 0;
+  bottom: 0;
+  width: 20px;
   z-index: 80;
 }
 
@@ -1454,21 +1454,24 @@ body {
   transform: translateX(calc(-100% - 8px));
   opacity: 0;
   pointer-events: none;
-  /* 贴窗口左缘时 :hover 会闪断；收起延迟一帧以上，避免消失又弹出 */
-  transition: transform 0s linear 180ms, opacity 0s linear 180ms;
+  /* 贴窗口左缘时 :hover 会闪断；坐标锁定打开后，收起连 pointer-events 一起延迟 */
+  transition: transform 0s linear 240ms, opacity 0s linear 240ms, pointer-events 0s linear 240ms;
   z-index: 81;
 }
 
-.sidebar-flyout-host.is-collapsed:hover {
+.sidebar-flyout-host.is-collapsed:hover,
+.sidebar-flyout-host.is-collapsed.is-flyout-open {
   pointer-events: auto;
 }
 
 /* 唤醒后把热区铺满栏宽、垫在栏下面，避免指针刚离开 12px 条就丢 :hover */
-.sidebar-flyout-host.is-collapsed:hover .sidebar-edge-hot {
+.sidebar-flyout-host.is-collapsed:hover .sidebar-edge-hot,
+.sidebar-flyout-host.is-collapsed.is-flyout-open .sidebar-edge-hot {
   width: var(--sidebar-flyout-width, 240px);
 }
 
-.sidebar-flyout-host.is-collapsed:hover .app-side-bar.is-closed {
+.sidebar-flyout-host.is-collapsed:hover .app-side-bar.is-closed,
+.sidebar-flyout-host.is-collapsed.is-flyout-open .app-side-bar.is-closed {
   transform: none;
   opacity: 1;
   pointer-events: auto;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
收起后的左侧栏之前只靠 CSS `:hover`。热区只有 12px，栏体 `pointer-events` 在悬停闪断时立刻变成 none，指针从热区移进栏里时会打到后面的主栏，侧栏就偶发收掉。

现在用窗口指针坐标锁定：贴左缘 20px 打开，打开后整栏宽度内保持；离开后 240ms 再收。弹出菜单（会话菜单等）也算在栏内。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

