### PR TITLE
侧栏唤醒热区收到中间偏上，给目录留正中

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -114,7 +114,8 @@ test('shell columns stay three tracks without animating on window resize', () =>
   assert.match(css, /\.app-shell-agent > main\s*\{[^}]*grid-column:\s*2/s)
   assert.match(css, /\.app-shell-agent > \.session-inspector\s*\{[^}]*grid-column:\s*3/s)
   assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*width:\s*20px/s)
-  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*top:\s*0/s)
+  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*top:\s*22vh/s)
+  assert.match(css, /\.sidebar-edge-hot\s*\{[^}]*height:\s*20vh/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed\.is-flyout-open \.sidebar-edge-hot\s*\{[^}]*width:\s*var\(--sidebar-flyout-width/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*z-index:\s*81/s)
   assert.match(

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -107,7 +107,7 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
       const width = Number.parseFloat(raw) || 240
       if (
         isSidebarFlyoutKeepTarget(event.target, host) ||
-        shouldKeepSidebarFlyout(event.clientX, peekRef.current, width, window.innerWidth)
+        shouldKeepSidebarFlyout(event.clientX, event.clientY, peekRef.current, width, window.innerWidth, window.innerHeight)
       ) {
         openPeek()
         return

--- a/packages/web-app-shell/src/web/sidebar-flyout.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.test.ts
@@ -2,16 +2,19 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { isSidebarFlyoutKeepTarget, shouldKeepSidebarFlyout } from './sidebar-flyout.ts'
 
-test('left edge keeps flyout even before it is open', () => {
-  assert.equal(shouldKeepSidebarFlyout(8, false, 240), true)
-  assert.equal(shouldKeepSidebarFlyout(20, false, 240), true)
-  assert.equal(shouldKeepSidebarFlyout(21, false, 240), false)
+test('only the upper-middle left edge wakes the flyout', () => {
+  const vh = 1000
+  assert.equal(shouldKeepSidebarFlyout(8, 300, false, 240, 1200, vh), true)
+  assert.equal(shouldKeepSidebarFlyout(20, 400, false, 240, 1200, vh), true)
+  assert.equal(shouldKeepSidebarFlyout(8, 500, false, 240, 1200, vh), false)
+  assert.equal(shouldKeepSidebarFlyout(8, 80, false, 240, 1200, vh), false)
+  assert.equal(shouldKeepSidebarFlyout(21, 300, false, 240, 1200, vh), false)
 })
 
 test('once peeking, the full panel width keeps the flyout', () => {
-  assert.equal(shouldKeepSidebarFlyout(180, true, 240), true)
-  assert.equal(shouldKeepSidebarFlyout(248, true, 240), true)
-  assert.equal(shouldKeepSidebarFlyout(260, true, 240), false)
+  assert.equal(shouldKeepSidebarFlyout(180, 500, true, 240, 1200, 1000), true)
+  assert.equal(shouldKeepSidebarFlyout(248, 80, true, 240, 1200, 1000), true)
+  assert.equal(shouldKeepSidebarFlyout(260, 300, true, 240, 1200, 1000), false)
 })
 
 test('portaled sidebar menus still count as inside', () => {

--- a/packages/web-app-shell/src/web/sidebar-flyout.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.ts
@@ -1,15 +1,27 @@
 export const SIDEBAR_FLYOUT_EDGE = 20
 export const SIDEBAR_FLYOUT_HIDE_MS = 240
+/** 唤醒热区：视口中间偏上，把正中留给标题目录。 */
+export const SIDEBAR_FLYOUT_WAKE_TOP = 0.22
+export const SIDEBAR_FLYOUT_WAKE_BOTTOM = 0.42
 export const SIDEBAR_FLYOUT_KEEP = '.brand-agent-menu, .chat-sidebar-popover, [data-sidebar-flyout-keep]'
+
+export function isSidebarFlyoutWakeY(clientY: number, viewportHeight: number) {
+  if (viewportHeight <= 0) return true
+  const top = viewportHeight * SIDEBAR_FLYOUT_WAKE_TOP
+  const bottom = viewportHeight * SIDEBAR_FLYOUT_WAKE_BOTTOM
+  return clientY >= top && clientY <= bottom
+}
 
 export function shouldKeepSidebarFlyout(
   clientX: number,
+  clientY: number,
   peeking: boolean,
   panelWidth: number,
   viewportWidth = Number.POSITIVE_INFINITY,
+  viewportHeight = 0,
 ) {
   if (clientX < 0 || clientX > viewportWidth) return false
-  if (clientX <= SIDEBAR_FLYOUT_EDGE) return true
+  if (clientX <= SIDEBAR_FLYOUT_EDGE && isSidebarFlyoutWakeY(clientY, viewportHeight)) return true
   if (peeking && clientX <= panelWidth + 8) return true
   return false
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1430,8 +1430,9 @@ body {
   pointer-events: auto;
   position: fixed;
   left: 0;
-  top: 0;
-  bottom: 0;
+  top: 22vh;
+  bottom: auto;
+  height: 20vh;
   width: 20px;
   z-index: 80;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
收起后的左侧栏唤醒热区不再铺满整条左缘，只占视口中间偏上（约 22vh–42vh）。正中留给标题目录。侧栏一旦打开，仍按整栏宽度保持，离开后再收。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

