### PR TITLE
卸载只删 .plugin，保留 .plugin-dev 沙箱

### DIFF
--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -128,6 +128,33 @@ test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<
   }
 })
 
+test('uninstall deletes .plugin/<id>/ and leaves .plugin-dev/<id>/', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
+  const pluginDir = join(dir, '.plugin')
+  const sandboxDir = join(dir, '.plugin-dev')
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), sandboxDir).open()
+    await store.initSandbox({
+      id: 'store-keep-src',
+      name: 'Keep src',
+      hostJs: `export const name = 'store-keep-src'\nexport function apply() {}\n`,
+    })
+    await store.pack('store-keep-src')
+    await access(join(pluginDir, 'store-keep-src', 'host.js'))
+    await access(join(sandboxDir, 'store-keep-src', 'host.ts'))
+    await store.uninstall('store-keep-src')
+    await assert.rejects(() => access(join(pluginDir, 'store-keep-src', 'host.js')))
+    await access(join(sandboxDir, 'store-keep-src', 'host.ts'))
+    await access(join(sandboxDir, 'store-keep-src', 'manifest.json'))
+    const row = (await store.listSandboxes()).find((item) => item.id === 'store-keep-src')
+    assert.ok(row)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
 test('web-only plugin opens without host.js', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
   try {

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve, sep } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { Service, type Context, type Plugin } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
@@ -66,6 +66,13 @@ export function defaultStatePath() {
 
 function isSafeId(id: string) {
   return /^[a-z][a-z0-9-]{1,40}$/.test(id)
+}
+
+/** 用分隔符判断，避免 `.plugin` 误匹配 `.plugin-dev`。 */
+export function isPathInside(root: string, dir: string) {
+  const base = resolve(root)
+  const target = resolve(dir)
+  return target === base || target.startsWith(`${base}${sep}`)
 }
 
 function importHostModule(code: string) {
@@ -370,13 +377,15 @@ export class PluginStoreService extends Service {
     this.invalidateList()
   }
 
-  /** 卸载：停运行，并删掉 .plugin/<id>/ 代码。 */
+  /** 卸载：停运行，只删 .plugin/<id>/，不动 .plugin-dev。 */
   async uninstall(id: string) {
     if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
     await this.hub().drop(id)
     this.setEnabled(id, false)
-    const hit = await this.findPluginDir(id)
-    if (hit) await rm(hit, { recursive: true, force: true })
+    const dest = this.pluginPath(id)
+    if (isPathInside(this.pluginDir, dest) && !isPathInside(this.sandboxDir, dest) && existsSync(dest)) {
+      await rm(dest, { recursive: true, force: true })
+    }
     this.invalidateList()
     const lastRunAt = { ...this.state.lastRunAt }
     delete lastRunAt[id]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
卸载只删除 `.plugin/<id>/` 已安装代码，不会删 `.plugin-dev/<id>/` 沙箱。删除路径用目录分隔符判断，避免 `.plugin` 当前缀误匹配到 `.plugin-dev`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

