### PR TITLE
fix(arena-rogue): 全屏铺满画布，修复 DPR 只画左上角

### DIFF
--- a/.plugin-dev/arena-rogue/game.ts
+++ b/.plugin-dev/arena-rogue/game.ts
@@ -38,7 +38,6 @@ type Floater = { x: number; y: number; life: number; text: string; color: string
 type Mine = { x: number; y: number; life: number; r: number }
 
 const TAU = Math.PI * 2
-const ARENA = 920
 
 function rand(a: number, b: number) {
   return a + Math.random() * (b - a)
@@ -78,8 +77,17 @@ export class ArenaGame {
   stats = { rate: 1, dmg: 1, spread: 0, magnet: 80 }
   w = 1080
   h = 720
+  dpr = 1
   spawnT = 0
   left = 0
+
+  get fieldW() {
+    return Math.max(280, this.w)
+  }
+
+  get fieldH() {
+    return Math.max(280, this.h)
+  }
 
   get weaponId() {
     return WEAPONS[this.weapon]!.id
@@ -112,14 +120,15 @@ export class ArenaGame {
     if (this.left <= 0) return
     this.left -= 1
     const a = rand(0, TAU)
-    const d = ARENA * 0.42
+    const hw = this.fieldW * 0.46
+    const hh = this.fieldH * 0.46
     const roll = Math.random()
     const kind: Enemy['kind'] = this.wave > 4 && roll > 0.82 ? 'mage' : this.wave > 2 && roll > 0.62 ? 'tank' : roll > 0.45 ? 'runner' : 'grunt'
     const hp = kind === 'tank' ? 70 + this.wave * 12 : kind === 'mage' ? 28 + this.wave * 4 : kind === 'runner' ? 16 + this.wave * 3 : 22 + this.wave * 5
     const r = kind === 'tank' ? 18 : kind === 'runner' ? 10 : 13
     this.enemies.push({
-      x: Math.cos(a) * d,
-      y: Math.sin(a) * d,
+      x: Math.cos(a) * hw,
+      y: Math.sin(a) * hh,
       vx: 0,
       vy: 0,
       hp,
@@ -347,9 +356,8 @@ export class ArenaGame {
       p.x += d.x * speed * dt
       p.y += d.y * speed * dt
     }
-    const lim = ARENA / 2 - 24
-    p.x = clamp(p.x, -lim, lim)
-    p.y = clamp(p.y, -lim, lim)
+    p.x = clamp(p.x, -this.fieldW / 2 + 24, this.fieldW / 2 - 24)
+    p.y = clamp(p.y, -this.fieldH / 2 + 24, this.fieldH / 2 - 24)
 
     this.spawnT -= dt
     if (this.spawnT <= 0 && this.left > 0) {
@@ -481,9 +489,18 @@ export class ArenaGame {
     this.floats = this.floats.filter((f) => f.life > 0)
   }
 
+  space(ctx: CanvasRenderingContext2D) {
+    const canvas = ctx.canvas
+    const cssW = canvas?.clientWidth || this.w
+    const bitmapW = canvas?.width || 0
+    if (cssW > 0 && bitmapW > 0) this.dpr = bitmapW / cssW
+    ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0)
+  }
+
   draw(ctx: CanvasRenderingContext2D) {
-    const { w, h } = this
-    ctx.setTransform(1, 0, 0, 1, 0, 0)
+    const w = this.fieldW
+    const h = this.fieldH
+    this.space(ctx)
     ctx.clearRect(0, 0, w, h)
     ctx.fillStyle = '#07080c'
     ctx.fillRect(0, 0, w, h)
@@ -493,19 +510,23 @@ export class ArenaGame {
 
     ctx.strokeStyle = 'rgba(255,255,255,0.06)'
     ctx.lineWidth = 1
-    for (let i = -ARENA / 2; i <= ARENA / 2; i += 40) {
+    const left = -w / 2
+    const top = -h / 2
+    for (let x = left; x <= w / 2; x += 40) {
       ctx.beginPath()
-      ctx.moveTo(i, -ARENA / 2)
-      ctx.lineTo(i, ARENA / 2)
+      ctx.moveTo(x, top)
+      ctx.lineTo(x, h / 2)
       ctx.stroke()
+    }
+    for (let y = top; y <= h / 2; y += 40) {
       ctx.beginPath()
-      ctx.moveTo(-ARENA / 2, i)
-      ctx.lineTo(ARENA / 2, i)
+      ctx.moveTo(left, y)
+      ctx.lineTo(w / 2, y)
       ctx.stroke()
     }
     ctx.strokeStyle = 'rgba(239,238,236,0.18)'
     ctx.lineWidth = 3
-    ctx.strokeRect(-ARENA / 2, -ARENA / 2, ARENA, ARENA)
+    ctx.strokeRect(left, top, w, h)
 
     for (const m of this.mines) {
       ctx.fillStyle = 'rgba(249,115,22,0.25)'
@@ -581,7 +602,7 @@ export class ArenaGame {
       ctx.globalAlpha = 1
     }
 
-    ctx.setTransform(1, 0, 0, 1, 0, 0)
+    this.space(ctx)
     this.hud(ctx)
   }
 

--- a/.plugin-dev/arena-rogue/web.tsx
+++ b/.plugin-dev/arena-rogue/web.tsx
@@ -29,6 +29,7 @@ function ArenaApp() {
       canvas.style.height = `${h}px`
       g.w = w
       g.h = h
+      g.dpr = dpr
       const ctx = canvas.getContext('2d')
       if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     }
@@ -110,11 +111,12 @@ function ArenaApp() {
     <div
       data-testid="arena-rogue-root"
       style={{
+        position: 'absolute',
+        inset: 0,
         width: '100%',
         height: '100%',
         minHeight: 0,
         background: '#07080c',
-        position: 'relative',
         overflow: 'hidden',
       }}
     >
@@ -122,7 +124,15 @@ function ArenaApp() {
         ref={canvasRef}
         tabIndex={0}
         data-testid="arena-rogue-canvas"
-        style={{ display: 'block', width: '100%', height: '100%', outline: 'none', cursor: 'crosshair' }}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          outline: 'none',
+          cursor: 'crosshair',
+        }}
       />
     </div>
   )

--- a/packages/core-plugin-system/src/host/arena-rogue.test.ts
+++ b/packages/core-plugin-system/src/host/arena-rogue.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { ArenaGame } from '../../../../.plugin-dev/arena-rogue/game.ts'
 
 test('arena-rogue is a resizable window plugin with 12 weapons and extras slot', async () => {
   const dir = resolve(import.meta.dirname, '../../../../.plugin-dev/arena-rogue')
@@ -11,6 +12,7 @@ test('arena-rogue is a resizable window plugin with 12 weapons and extras slot',
     shell?: { width: number; height: number; resizable?: boolean }
   }
   const web = await readFile(resolve(dir, 'web.tsx'), 'utf8')
+  const game = await readFile(resolve(dir, 'game.ts'), 'utf8')
   const weapons = await readFile(resolve(dir, 'weapons.ts'), 'utf8')
   assert.equal(manifest.id, 'arena-rogue')
   assert.equal(manifest.headless, undefined)
@@ -19,5 +21,43 @@ test('arena-rogue is a resizable window plugin with 12 weapons and extras slot',
   assert.match(web, /export const name = 'arena-rogue'/)
   assert.match(web, /plugin-store-extras/)
   assert.match(web, /key: 'arena-rogue'/)
+  assert.match(web, /inset: 0/)
+  assert.doesNotMatch(game, /setTransform\(1,\s*0,\s*0,\s*1/)
+  assert.match(game, /fieldW/)
+  assert.match(game, /fieldH/)
   assert.equal([...weapons.matchAll(/id: '/g)].length, 12)
+})
+
+test('draw applies devicePixelRatio transform and fills the css window', () => {
+  const g = new ArenaGame()
+  g.w = 1920
+  g.h = 1080
+  g.dpr = 1
+  g.start()
+  const transforms: number[][] = []
+  const fills: Array<{ w: number; h: number }> = []
+  const ctx = new Proxy(
+    {
+      canvas: { width: 3840, height: 2160, clientWidth: 1920, clientHeight: 1080 },
+      setTransform(a: number, b: number, c: number, d: number, e: number, f: number) {
+        transforms.push([a, b, c, d, e, f])
+      },
+      fillRect(_x: number, _y: number, w: number, h: number) {
+        fills.push({ w, h })
+      },
+    },
+    {
+      get(target, prop, recv) {
+        if (prop in target) return Reflect.get(target, prop, recv)
+        return () => {}
+      },
+      set() {
+        return true
+      },
+    },
+  ) as unknown as CanvasRenderingContext2D
+  g.draw(ctx)
+  assert.deepEqual(transforms[0], [2, 0, 0, 2, 0, 0])
+  assert.equal(g.dpr, 2)
+  assert.ok(fills.some((row) => row.w === 1920 && row.h === 1080))
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
全屏后游戏缩在左上角，是 canvas 按 `devicePixelRatio` 放大了 bitmap，但 `draw()` 里又 `setTransform(1,…)` 用 CSS 坐标去画，等于只画了左上 1/4。

- 每帧用 `canvas.width / clientWidth` 设 `setTransform(dpr,…)`，HUD 同样走这套坐标
- 场地改成跟随窗口的矩形（不再 `min(w,h)` 小方块），全屏时铺满
- 根节点/canvas `inset:0` 拉满插件窗口
- 单测：dpr=2 时 transform 为 `[2,0,0,2,0,0]`，clear/fill 用 1920×1080 CSS 尺寸

请把沙箱里的 `arena-rogue` 再 pack 一次后再开全屏看。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

