### PR TITLE
fix: 小人悬浮窗不抢侧栏热区，聊天顶栏可展开侧栏

### DIFF
--- a/packages/web-app-shell/src/web/brand-corner.test.ts
+++ b/packages/web-app-shell/src/web/brand-corner.test.ts
@@ -105,6 +105,7 @@ test('shell columns stay three tracks without animating on window resize', () =>
   assert.match(frame, /is-closed flex/)
   assert.match(frame, /is-flyout-open/)
   assert.match(frame, /sidebar-flyout-host/)
+  assert.match(frame, /isSidebarFlyoutIgnoreTarget/)
   assert.match(frame, /sidebar-edge-hot/)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*top:\s*60px/s)
   assert.match(css, /\.sidebar-flyout-host\.is-collapsed \.app-side-bar\.is-closed\s*\{[^}]*bottom:\s*60px/s)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -635,7 +635,7 @@ function Shell(props: SlotProps) {
   const chatHeader = (
     <header className="chat-view-header" data-biu-ignore>
       <div className="chat-view-header-left">
-        {sidebarNarrow ? (
+        {leftHidden || sidebarNarrow ? (
           <button
             type="button"
             className="chat-view-header-expand"

--- a/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
+++ b/packages/web-app-shell/src/web/shell-sidebar-frame.tsx
@@ -5,6 +5,7 @@ import { chromeIcon } from './chrome-icon.ts'
 import { ShellSidePlaces } from './shell-chrome.tsx'
 import {
   isSidebarFlyoutKeepTarget,
+  isSidebarFlyoutIgnoreTarget,
   SIDEBAR_FLYOUT_HIDE_MS,
   shouldKeepSidebarFlyout,
 } from './sidebar-flyout.ts'
@@ -105,6 +106,10 @@ export const ShellSidebarFrame = memo(function ShellSidebarFrame({
       const shell = host?.parentElement
       const raw = shell ? getComputedStyle(shell).getPropertyValue('--sidebar-flyout-width') : ''
       const width = Number.parseFloat(raw) || 240
+      if (isSidebarFlyoutIgnoreTarget(event.target)) {
+        if (peekRef.current) scheduleHide()
+        return
+      }
       if (
         isSidebarFlyoutKeepTarget(event.target, host) ||
         shouldKeepSidebarFlyout(event.clientX, event.clientY, peekRef.current, width, window.innerWidth, window.innerHeight)

--- a/packages/web-app-shell/src/web/sidebar-flyout.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { isSidebarFlyoutKeepTarget, shouldKeepSidebarFlyout } from './sidebar-flyout.ts'
+import { isSidebarFlyoutIgnoreTarget, isSidebarFlyoutKeepTarget, shouldKeepSidebarFlyout } from './sidebar-flyout.ts'
 
 test('only the upper-middle left edge wakes the flyout', () => {
   const vh = 1000
@@ -26,4 +26,18 @@ test('portaled sidebar menus still count as inside', () => {
   assert.equal(isSidebarFlyoutKeepTarget(document.body, host), false)
   host.remove()
   menu.remove()
+})
+
+test('composer mascot popover does not count as the sidebar flyout', () => {
+  const host = document.createElement('div')
+  const cluster = document.createElement('div')
+  cluster.className = 'brand-corner-cluster'
+  const menu = document.createElement('div')
+  menu.className = 'chat-sidebar-popover brand-agent-menu'
+  cluster.append(menu)
+  document.body.append(host, cluster)
+  assert.equal(isSidebarFlyoutIgnoreTarget(menu), true)
+  assert.equal(isSidebarFlyoutKeepTarget(menu, host), false)
+  host.remove()
+  cluster.remove()
 })

--- a/packages/web-app-shell/src/web/sidebar-flyout.ts
+++ b/packages/web-app-shell/src/web/sidebar-flyout.ts
@@ -4,6 +4,8 @@ export const SIDEBAR_FLYOUT_HIDE_MS = 240
 export const SIDEBAR_FLYOUT_WAKE_TOP = 0.22
 export const SIDEBAR_FLYOUT_WAKE_BOTTOM = 0.42
 export const SIDEBAR_FLYOUT_KEEP = '.brand-agent-menu, .chat-sidebar-popover, [data-sidebar-flyout-keep]'
+/** 输入框上的小人及其悬浮窗不算侧栏热区。 */
+export const SIDEBAR_FLYOUT_IGNORE = '.brand-corner-cluster'
 
 export function isSidebarFlyoutWakeY(clientY: number, viewportHeight: number) {
   if (viewportHeight <= 0) return true
@@ -26,8 +28,13 @@ export function shouldKeepSidebarFlyout(
   return false
 }
 
+export function isSidebarFlyoutIgnoreTarget(node: EventTarget | null) {
+  return node instanceof Element && Boolean(node.closest(SIDEBAR_FLYOUT_IGNORE))
+}
+
 export function isSidebarFlyoutKeepTarget(node: EventTarget | null, host: Element | null) {
   if (!(node instanceof Element)) return false
+  if (isSidebarFlyoutIgnoreTarget(node)) return false
   if (host?.contains(node)) return true
   return Boolean(node.closest(SIDEBAR_FLYOUT_KEEP))
 }

--- a/packages/web-app-shell/src/web/sidebar-text-color.test.ts
+++ b/packages/web-app-shell/src/web/sidebar-text-color.test.ts
@@ -44,6 +44,7 @@ describe('sidebar text colors', () => {
     expect(shell).toMatch(/ShellSidebarFrame/)
     expect(shell).toMatch(/SIDEBAR_TAG_AT/)
     expect(shell).toMatch(/data-testid="header-sidebar-expand"/)
+    expect(shell).toMatch(/leftHidden \|\| sidebarNarrow/)
     const overlay = readFileSync(resolve(import.meta.dirname, './chat-overlay.ts'), 'utf8')
     expect(overlay).toMatch(/SIDEBAR_LABEL_AT = SIDEBAR_MIN/)
     expect(overlay).toMatch(/SIDEBAR_TAG_AT = SIDEBAR_MAX/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两处侧栏体验：

1. 点输入框上方小人打开会话悬浮窗后，鼠标移到窗口上不再唤醒左侧栏热区（`.brand-corner-cluster` 从 keep 里排除）。
2. 侧栏完全收起时，聊天顶栏左侧出现与数据页相同的展开按钮（`leftHidden || sidebarNarrow`）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

