### PR TITLE
fix: 自定义页面插件块也能出现拖手

### DIFF
--- a/packages/core-editor/src/web/page-block-handle.test.ts
+++ b/packages/core-editor/src/web/page-block-handle.test.ts
@@ -4,6 +4,7 @@ import { Editor } from '@tiptap/core'
 import {
   deleteHandleBlock,
   duplicateHandleBlock,
+  handleBlockFromDom,
   insertParagraphAfter,
   insertParagraphBefore,
   resolveHandleBlock,
@@ -64,4 +65,51 @@ test('insert before / after / duplicate / delete a paragraph', () => {
   deleteHandleBlock(editor, 0, editor.state.doc.child(0))
   assert.notEqual(editor.state.doc.child(0).textContent, '')
   editor.destroy()
+})
+
+test('resolveHandleBlock picks pageBlock atom at the gap beside it', () => {
+  const editor = editorOf(`:::pageBlock {kind=html plugin=page-html-blocks}
+{"html":"<p>hi</p>"}
+:::
+`)
+  let blockPos = -1
+  let blockSize = 0
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'pageBlock') {
+      blockPos = pos
+      blockSize = node.nodeSize
+    }
+  })
+  assert.ok(blockPos >= 0)
+  const atStart = resolveHandleBlock(editor.state.doc.resolve(blockPos))
+  assert.equal(atStart?.node.type.name, 'pageBlock')
+  assert.equal(atStart?.pos, blockPos)
+  const after = resolveHandleBlock(editor.state.doc.resolve(blockPos + blockSize))
+  assert.equal(after?.node.type.name, 'pageBlock')
+  assert.equal(after?.pos, blockPos)
+  editor.destroy()
+})
+
+test('handleBlockFromDom maps a nested iframe back to the pageBlock atom', () => {
+  const host = document.createElement('div')
+  document.body.append(host)
+  const editor = new Editor({
+    element: host,
+    extensions: pageEditorExtensions(),
+    content: `:::pageBlock {kind=html plugin=page-html-blocks}
+{"html":"<p>hi</p>"}
+:::
+`,
+    contentType: 'markdown',
+  })
+  const hole = host.querySelector('[draggable="true"]')
+  assert.ok(hole instanceof HTMLElement)
+  hole.classList.add('page-block')
+  hole.setAttribute('data-page-block', 'html')
+  const iframe = document.createElement('iframe')
+  hole.append(iframe)
+  const found = handleBlockFromDom(editor, iframe)
+  assert.equal(found?.node.type.name, 'pageBlock')
+  editor.destroy()
+  host.remove()
 })

--- a/packages/core-editor/src/web/page-block-handle.ts
+++ b/packages/core-editor/src/web/page-block-handle.ts
@@ -15,7 +15,56 @@ export function resolveHandleBlock($pos: ResolvedPos): HandleBlock | null {
       return { pos: $pos.before(depth), node }
     }
   }
+  if ($pos.depth === 0) {
+    const after = $pos.nodeAfter
+    if (after?.isBlock) return { pos: $pos.pos, node: after }
+    const before = $pos.nodeBefore
+    if (before?.isBlock) return { pos: $pos.pos - before.nodeSize, node: before }
+  }
   return null
+}
+
+function blockAtDocPos(editor: Editor, pos: number): HandleBlock | null {
+  if (pos < 0 || pos > editor.state.doc.content.size) return null
+  const node = editor.state.doc.nodeAt(pos)
+  if (node?.isBlock) return { pos, node }
+  return resolveHandleBlock(editor.state.doc.resolve(pos))
+}
+
+/** React 插件块 / iframe：从 DOM 反查 pageBlock。 */
+export function handleBlockFromDom(editor: Editor, start: EventTarget | null): HandleBlock | null {
+  let el = start instanceof Element ? start : null
+  const root = editor.view.dom
+  while (el && el !== root) {
+    if (el instanceof HTMLElement && (el.hasAttribute('data-page-block') || el.classList.contains('page-block') || el.hasAttribute('data-node-view-wrapper'))) {
+      try {
+        const pos = editor.view.posAtDOM(el, 0)
+        const found = blockAtDocPos(editor, pos)
+        if (found) return found
+      } catch {
+        /* keep walking */
+      }
+    }
+    el = el.parentElement
+  }
+  return null
+}
+
+/** 鼠标下的顶层块：坐标、atom 的 inside、再退回 DOM。 */
+export function handleBlockAtPointer(editor: Editor, clientX: number, clientY: number): HandleBlock | null {
+  const view = editor.view
+  const content = view.dom.getBoundingClientRect()
+  const probeX = Math.min(Math.max(clientX, content.left + 8), content.right - 8)
+  const coords = view.posAtCoords({ left: probeX, top: clientY })
+  if (coords) {
+    const fromPos = resolveHandleBlock(editor.state.doc.resolve(coords.pos))
+    if (fromPos) return fromPos
+    if (coords.inside >= 0) {
+      const inner = blockAtDocPos(editor, coords.inside)
+      if (inner) return inner
+    }
+  }
+  return handleBlockFromDom(editor, document.elementFromPoint(clientX, clientY))
 }
 
 export function deleteHandleBlock(editor: Editor, pos: number, node: Node) {

--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -5,9 +5,9 @@ import { HeadlessDismiss } from '@biu/public-ui'
 import {
   deleteHandleBlock,
   duplicateHandleBlock,
+  handleBlockAtPointer,
   insertParagraphAfter,
   insertParagraphBefore,
-  resolveHandleBlock,
   type HandleBlock,
 } from './page-block-handle.ts'
 
@@ -26,14 +26,11 @@ function lineCoords(editor: Editor, found: HandleBlock) {
 }
 
 function readTarget(editor: Editor, host: HTMLElement, clientX: number, clientY: number): HandleTarget | null {
-  const content = editor.view.dom.getBoundingClientRect()
-  const probeX = Math.min(Math.max(clientX, content.left + 8), content.right - 8)
-  const coords = editor.view.posAtCoords({ left: probeX, top: clientY })
-  if (!coords) return null
-  const found = resolveHandleBlock(editor.state.doc.resolve(coords.pos))
+  const found = handleBlockAtPointer(editor, clientX, clientY)
   if (!found) return null
-  const dom = editor.view.nodeDOM(found.pos)
-  const el = dom instanceof HTMLElement ? dom : dom?.parentElement
+  const content = editor.view.dom.getBoundingClientRect()
+  const raw = editor.view.nodeDOM(found.pos)
+  const el = raw instanceof HTMLElement ? raw : raw?.parentElement
   if (!(el instanceof HTMLElement)) return null
   const hostBox = host.getBoundingClientRect()
   const box = el.getBoundingClientRect()

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, type MouseEvent } from 'react'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper } from '@tiptap/react'
 import { PlayIcon } from '@heroicons/react/16/solid'
@@ -60,7 +60,7 @@ export function PageBlockMissing({ kind, plugin, data }: { kind: string; plugin:
   )
 }
 
-export function PageBlockView({ node, updateAttributes, editor }: NodeViewProps) {
+export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeViewProps) {
   usePageEditorVersion()
   const kind = String(node.attrs.kind ?? 'card')
   const plugin = String(node.attrs.plugin ?? '').trim()
@@ -68,6 +68,8 @@ export function PageBlockView({ node, updateAttributes, editor }: NodeViewProps)
   const spec = getPageEditor()?.block(kind)
   const cloneFrom = typeof data.cloneFrom === 'string' ? data.cloneFrom : ''
   const file = typeof data.file === 'string' ? data.file : ''
+  const pickId = `${plugin || 'page-block'}:${kind}`
+  const pickLabel = spec?.label || kind
   const update = (patch: Record<string, unknown>, opts?: { replace?: boolean }) => {
     updateAttributes({ data: opts?.replace ? patch : { ...data, ...patch } })
   }
@@ -85,8 +87,26 @@ export function PageBlockView({ node, updateAttributes, editor }: NodeViewProps)
     }
   }, [cloneFrom, file])
 
+  const onMouseDown = (event: MouseEvent) => {
+    if (!editor.isEditable || editor.isDestroyed) return
+    if (event.target instanceof Element && event.target.closest('textarea, input, select, button, a')) return
+    const pos = getPos()
+    if (typeof pos !== 'number') return
+    editor.chain().setNodeSelection(pos).run()
+  }
+
   return (
-    <NodeViewWrapper className="page-block" data-page-block={kind} data-page-block-plugin={plugin} data-testid={`page-block-${kind}`}>
+    <NodeViewWrapper
+      className="page-block"
+      data-page-block={kind}
+      data-page-block-plugin={plugin}
+      data-page-block-capture=""
+      data-biu-kind="plugin"
+      data-biu-id={pickId}
+      data-biu-label={pickLabel}
+      data-testid={`page-block-${kind}`}
+      onMouseDown={onMouseDown}
+    >
       {cloneFrom ? (
         <div className="page-block-missing">正在复制附件…</div>
       ) : View ? (

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -158,13 +158,17 @@ test('pageBlock node view skips react update when attrs are unchanged', async ()
   assert.match(src, /return true/)
 })
 
-test('pageBlock capture includes drawing surfaces', async () => {
+test('pageBlock capture includes every registered block shell', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-block.ts'), 'utf8')
+  const view = await readFile(resolve(import.meta.dirname, './page-block-view.tsx'), 'utf8')
+  assert.match(src, /closest\('\.page-block/)
   assert.match(src, /data-page-block-capture/)
-  assert.match(src, /\.excalidraw/)
-  assert.match(src, /canvas/)
+  assert.match(view, /data-page-block-capture=""/)
+  assert.match(view, /data-biu-kind="plugin"/)
+  assert.match(view, /data-biu-id=\{pickId\}/)
+  assert.match(view, /setNodeSelection\(pos\)/)
 })
 
 test('registerBlock requires plugin id', () => {

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -144,9 +144,7 @@ export const pageBlock = Node.create({
       },
       stopEvent: ({ event }) => {
         const target = event.target as HTMLElement | null
-        return Boolean(
-          target?.closest('textarea, input, select, button, canvas, .excalidraw, [data-page-block-capture]'),
-        )
+        return Boolean(target?.closest('.page-block, [data-page-block-capture], textarea, input, select, button, canvas, .excalidraw'))
       },
     })
   },

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -17,6 +17,8 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .tiptap h3{font-size:1.25em;font-weight:650;line-height:1.3;margin-top:.6em}
 .page-editor .tiptap [data-heading-plugin]{border-radius:8px}
 .page-editor .page-block{margin:12px 0;position:relative;z-index:0;isolation:isolate;overflow:hidden}
+.page-editor .page-block iframe{pointer-events:none}
+.page-editor .page-block.ProseMirror-selectednode iframe{pointer-events:auto}
 .page-editor .page-block.ProseMirror-selectednode{outline:none;box-shadow:none}
 .page-editor .page-block[data-page-block=excalidraw]{outline:none;box-shadow:none;border:0;border-radius:8px}
 .page-editor .page-block-missing{display:flex;flex-direction:column;gap:0;padding:12px 14px;border:1px dashed var(--dsw-border);border-radius:8px;color:var(--dsw-label-3);font-size:13px}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
拖手还是编辑器里那一只悬浮把手，不是插件自己包的。探测以前只认 depth≥1，自定义 `pageBlock`（atom）和 iframe 经常算不到。

现在：
- 文档 gap 上的 atom 用 nodeAfter / nodeBefore
- 从 DOM 的 `.page-block` / iframe 反查节点
- iframe 默认 `pointer-events: none`，选中块后才可点内部

段落、标题、列表项行为不变。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

