### PR TITLE
feat: 编辑器所有块类型都能被 Pick 光标捕捉

### DIFF
--- a/packages/core-pick/src/web/chip.test.ts
+++ b/packages/core-pick/src/web/chip.test.ts
@@ -28,6 +28,7 @@ test('kind maps to distinct heroicons', () => {
   assert.equal(pickKindIcon('session'), lu.ChatBubbleLeftIcon)
   assert.equal(pickKindIcon('message'), lu.ChatBubbleLeftIcon)
   assert.equal(pickKindIcon('text'), lu.DocumentTextIcon)
+  assert.equal(pickKindIcon('block'), lu.DocumentTextIcon)
   assert.notEqual(pickKindIcon('text'), pickKindIcon('session'))
   assert.equal(pickKindIcon('task'), lu.CheckCircleIcon)
   assert.equal(pickKindIcon('tasks'), lu.CheckCircleIcon)

--- a/packages/core-pick/src/web/chip.tsx
+++ b/packages/core-pick/src/web/chip.tsx
@@ -64,6 +64,7 @@ const KIND_ICONS: Record<string, Glyph> = {
   tag: TagIcon,
   facet: RectangleStackIcon,
   record: ClipboardDocumentCheckIcon,
+  block: DocumentTextIcon,
 }
 
 export function pickKindIcon(kind: string): Glyph {

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { pickSurfaceAtPoint, resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox } from './resolve.ts'
+import { pickSurfaceAtPoint, resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, editorBlockElFromNode } from './resolve.ts'
 import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks, textPickFromSelection } from './types.ts'
 
 test('splitPickStream keeps text and chips in order', () => {
@@ -289,4 +289,47 @@ test('dedupePicks keeps one chip per kind+id', () => {
   assert.equal(refs[0]?.id, 't1')
   assert.equal(refs[0]?.action, 'open')
   assert.equal(refs[1]?.id, 't2')
+})
+
+test('editor paragraphs headings lists and plugin shells are pickable', () => {
+  const root = document.createElement('div')
+  root.className = 'tiptap'
+  const p = document.createElement('p')
+  p.textContent = '一段正文'
+  const h2 = document.createElement('h2')
+  h2.textContent = '小标题'
+  const li = document.createElement('li')
+  const inner = document.createElement('p')
+  inner.textContent = '列表项'
+  li.append(inner)
+  const ul = document.createElement('ul')
+  ul.append(li)
+  const block = document.createElement('div')
+  block.className = 'page-block'
+  block.setAttribute('data-page-block', 'html')
+  block.setAttribute('data-biu-kind', 'plugin')
+  block.setAttribute('data-biu-id', 'page-html-blocks:html')
+  block.setAttribute('data-biu-label', 'HTML')
+  root.append(p, h2, ul, block)
+  document.body.append(root)
+  stubBox(p, 0, 0, 100, 20)
+  stubBox(h2, 0, 24, 100, 20)
+  stubBox(li, 0, 48, 100, 20)
+  stubBox(inner, 0, 48, 100, 20)
+  stubBox(block, 0, 72, 100, 40)
+  const fromP = resolvePickFromNode(p, '/pages/p1')
+  assert.equal(fromP?.ref.kind, 'block')
+  assert.equal(fromP?.ref.label, '一段正文')
+  assert.equal(editorBlockElFromNode(inner), li)
+  const fromLi = resolvePickFromNode(inner, '/pages/p1')
+  assert.equal(fromLi?.ref.kind, 'block')
+  assert.equal(fromLi?.ref.label, '列表项')
+  const fromPlugin = resolvePickFromNode(block, '/pages/p1')
+  assert.equal(fromPlugin?.ref.kind, 'plugin')
+  assert.equal(fromPlugin?.ref.id, 'page-html-blocks:html')
+  const hits = resolvePicksInRect({ left: 0, top: 0, width: 120, height: 120 }, '/pages/p1', root)
+  const kinds = hits.map((item) => item.ref.kind).sort()
+  assert.ok(kinds.includes('block'))
+  assert.ok(kinds.includes('plugin'))
+  root.remove()
 })

--- a/packages/core-pick/src/web/resolve.ts
+++ b/packages/core-pick/src/web/resolve.ts
@@ -1,4 +1,5 @@
 import type { PickRef } from './types.ts'
+import { pickIdFromText, pickPreview } from './types.ts'
 
 const KIND = 'data-biu-kind'
 const ID = 'data-biu-id'
@@ -68,7 +69,7 @@ export function resolvePickFromNode(
     if (kind && id && highlight) break
     node = node.parentElement
   }
-  if (!kind || !id || !highlight) return null
+  if (!kind || !id || !highlight) return editorBlockPick(start, route, surface)
   return {
     el: highlight,
     ref: {
@@ -76,6 +77,61 @@ export function resolvePickFromNode(
       id,
       ...(action ? { action } : {}),
       label: label || id,
+      route,
+    },
+  }
+}
+
+const EDITOR_ROOT = '.tiptap, [data-testid="page-editor"]'
+
+function isEditorBlockEl(el: HTMLElement) {
+  if (el.classList.contains('page-block') || el.hasAttribute('data-page-block')) return true
+  return /^(P|H1|H2|H3|LI|BLOCKQUOTE|PRE|HR)$/.test(el.tagName)
+}
+
+/** 编辑器顶层块：列表项、引用、插件块、段落/标题。 */
+export function editorBlockElFromNode(start: Element | null): HTMLElement | null {
+  const root = start?.closest(EDITOR_ROOT)
+  if (!root || !(start instanceof Element)) return null
+  let found: HTMLElement | null = null
+  let el: Element | null = start
+  while (el && el !== root) {
+    if (el instanceof HTMLElement && isEditorBlockEl(el)) found = el
+    el = el.parentElement
+  }
+  return found
+}
+
+function editorBlockPick(
+  start: Element | null,
+  route: string,
+  surface: Element | null,
+): { el: HTMLElement; ref: PickRef } | null {
+  const el = editorBlockElFromNode(start)
+  if (!el || isPickIgnored(el) || inHiddenPane(el)) return null
+  if (surface && !surface.contains(el)) return null
+  const taggedKind = read(el, KIND)
+  const taggedId = read(el, ID)
+  if (taggedKind && taggedId) {
+    return {
+      el,
+      ref: {
+        kind: taggedKind,
+        id: taggedId,
+        ...(read(el, ACTION) ? { action: read(el, ACTION) } : {}),
+        label: read(el, LABEL) || taggedId,
+        route,
+      },
+    }
+  }
+  const tag = (el.getAttribute('data-page-block') || el.tagName).toLowerCase()
+  const text = pickPreview(el.textContent ?? '', 80)
+  return {
+    el,
+    ref: {
+      kind: 'block',
+      id: `${tag}:${pickIdFromText(text || tag)}`,
+      label: text || tag,
       route,
     },
   }
@@ -173,12 +229,14 @@ export function visiblePickBox(el: Element): ClientBox | null {
   return box
 }
 
+export const EDITOR_BLOCK_SEL =
+  '.tiptap > p, .tiptap > h1, .tiptap > h2, .tiptap > h3, .tiptap > blockquote, .tiptap > pre, .tiptap > hr, .tiptap .page-block, .tiptap [data-page-block], .tiptap li'
+
 /**
- * 框选：命中所有带 kind+id 的对象节点（不采内部 action）。
- * 点选仍走 resolvePickFromNode，可以打到按钮上的 action。
+ * 框选：命中所有带 kind+id 的对象节点，以及编辑器里的段落/标题/列表/插件块。
  */
 export function resolvePicksInRect(box: ClientBox, route: string, root: ParentNode = document) {
-  const nodes = root.querySelectorAll('[data-biu-kind][data-biu-id]')
+  const nodes = root.querySelectorAll(`[data-biu-kind][data-biu-id], ${EDITOR_BLOCK_SEL}`)
   const seen = new Set<string>()
   const hits: { el: HTMLElement; ref: PickRef }[] = []
   for (const node of Array.from(nodes)) {

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -122,6 +122,13 @@ export function pickPreview(text: string, max = 48) {
   return value.length > max ? `${value.slice(0, max)}…` : value
 }
 
+export function pickIdFromText(raw: string) {
+  let hash = 0
+  const key = raw.replace(/\s+/g, ' ').trim()
+  for (let i = 0; i < key.length; i += 1) hash = (hash * 33 + key.charCodeAt(i)) >>> 0
+  return hash.toString(16)
+}
+
 /** 选取态下划到的一段正文；空选区返回 null。 */
 export function textPickFromSelection(
   route: string,
@@ -131,10 +138,7 @@ export function textPickFromSelection(
   const raw = selection.toString()
   const label = pickPreview(raw, 80)
   if (!label) return null
-  let hash = 0
-  const key = raw.replace(/\s+/g, ' ').trim()
-  for (let i = 0; i < key.length; i += 1) hash = (hash * 33 + key.charCodeAt(i)) >>> 0
-  return { kind: 'text', id: hash.toString(16), label, route }
+  return { kind: 'text', id: pickIdFromText(raw), label, route }
 }
 
 export function pickDomAttrs(kind: string, id: string, label?: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Pick 光标现在能打到编辑器里所有类型的块：段落、标题、列表项、引用、代码块、分割线，以及 registerBlock 的插件壳。框选同样覆盖这些块，不要求每块自己写 data-biu。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

