### PR TITLE
斜杠登记 HTML/需求块，表格可加行列

### DIFF
--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -226,7 +226,10 @@ export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
       kind: string
+      plugin: string
       label: string
+      blockType?: string
+      blockTypeLabel?: string
       hint?: string
       aliases?: string[]
       defaults?: Record<string, unknown> | (() => Record<string, unknown>)
@@ -236,7 +239,10 @@ export function apply(ctx: {
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'html',
+    plugin: name,
     label: 'HTML 直接渲染',
+    blockType: 'html',
+    blockTypeLabel: 'HTML',
     hint: 'HTML 直接渲染进文档，无外框（悬停浮出编辑/预览）',
     aliases: ['html', 'html直', '静态html'],
     defaults: { html: HTML_DIRECT_SAMPLE },
@@ -244,7 +250,10 @@ export function apply(ctx: {
   })
   ctx.pageEditor.registerBlock({
     kind: 'htmlframe',
+    plugin: name,
     label: 'HTML iframe 沙箱',
+    blockType: 'html',
+    blockTypeLabel: 'HTML',
     hint: 'iframe 隔离小网页，无外框，可跑脚本/幻灯片',
     aliases: ['iframe', 'htmlf', 'frame', '幻灯片', 'slide'],
     defaults: { html: HTML_FRAME_SAMPLE, height: 300 },

--- a/.plugin-dev/page-req-cards/web.tsx
+++ b/.plugin-dev/page-req-cards/web.tsx
@@ -203,7 +203,10 @@ export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
       kind: string
+      plugin: string
       label: string
+      blockType?: string
+      blockTypeLabel?: string
       hint?: string
       aliases?: string[]
       defaults?: Record<string, unknown> | (() => Record<string, unknown>)
@@ -213,7 +216,10 @@ export function apply(ctx: {
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'req',
+    plugin: name,
     label: '需求卡片',
+    blockType: 'req',
+    blockTypeLabel: '需求卡片',
     hint: '结构化记录一条需求/待办：类型·状态·优先级',
     aliases: ['需求', 'req', 'requirement', 'todo', '任务'],
     defaults: REQ_DEFAULTS,

--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -44,7 +44,7 @@ export function pageEditorExtensions() {
     Markdown,
     Image.configure({ inline: false, allowBase64: true }),
     TableKit.configure({
-      table: { resizable: true },
+      table: { resizable: true, allowTableNodeSelection: true },
     }),
     pageMathematics,
     Placeholder.configure({

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -122,6 +122,16 @@ test('slash command inserts a table', () => {
   assert.ok(table)
   table!.command({ editor, range: { from: Math.max(1, from), to: editor.state.selection.from } })
   assert.equal(editor.isActive('table'), true)
+  editor.chain().focus().addRowAfter().run()
+  editor.chain().focus().addColumnAfter().run()
+  let rows = 0
+  let cells = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === 'tableRow') rows += 1
+    if (node.type.name === 'tableCell' || node.type.name === 'tableHeader') cells += 1
+  })
+  assert.equal(rows, 4)
+  assert.equal(cells, 16)
   editor.destroy()
 })
 

--- a/packages/core-editor/src/web/page-block-handle.test.ts
+++ b/packages/core-editor/src/web/page-block-handle.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
 import {
+  beginHandleDrag,
   deleteHandleBlock,
   duplicateHandleBlock,
   handleBlockFromDom,
@@ -112,4 +113,19 @@ test('handleBlockFromDom maps a nested iframe back to the pageBlock atom', () =>
   assert.equal(found?.node.type.name, 'pageBlock')
   editor.destroy()
   host.remove()
+})
+
+test('beginHandleDrag selects a table as a node and marks move', () => {
+  const editor = editorOf('| 甲 | 乙 |\n| --- | --- |\n| 1 | 2 |\n')
+  let tablePos = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (tablePos < 0 && node.type.name === 'table') tablePos = pos
+  })
+  assert.ok(tablePos >= 0)
+  const transfer = { effectAllowed: 'copy', setData() {} }
+  assert.equal(beginHandleDrag(editor, tablePos, transfer), true)
+  assert.equal(editor.state.selection.constructor.name, 'NodeSelection')
+  assert.equal(editor.view.dragging?.move, true)
+  assert.equal(transfer.effectAllowed, 'move')
+  editor.destroy()
 })

--- a/packages/core-editor/src/web/page-block-handle.ts
+++ b/packages/core-editor/src/web/page-block-handle.ts
@@ -1,5 +1,6 @@
 import type { Editor } from '@tiptap/core'
 import type { Node, ResolvedPos } from '@tiptap/pm/model'
+import { NodeSelection } from '@tiptap/pm/state'
 
 export type HandleBlock = {
   pos: number
@@ -81,4 +82,23 @@ export function insertParagraphAfter(editor: Editor, pos: number, node: Node) {
 
 export function duplicateHandleBlock(editor: Editor, pos: number, node: Node) {
   editor.chain().focus().insertContentAt(pos + node.nodeSize, node.toJSON()).run()
+}
+
+/** 左侧把手拖块：整块 NodeSelection + move，避免 HTML5 默认复制。 */
+export function beginHandleDrag(
+  editor: Editor,
+  pos: number,
+  dataTransfer: { effectAllowed: string; setData: (type: string, data: string) => void } | null,
+) {
+  const { view } = editor
+  const node = view.state.doc.nodeAt(pos)
+  if (!node) return false
+  const selection = NodeSelection.create(view.state.doc, pos)
+  view.dispatch(view.state.tr.setSelection(selection))
+  view.dragging = { slice: selection.content(), move: true }
+  if (dataTransfer) {
+    dataTransfer.effectAllowed = 'move'
+    dataTransfer.setData('text/plain', '\u00a0')
+  }
+  return true
 }

--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import type { Editor } from '@tiptap/core'
-import { NodeSelection } from '@tiptap/pm/state'
 import { HeadlessDismiss } from '@biu/public-ui'
 import {
+  beginHandleDrag,
   deleteHandleBlock,
   duplicateHandleBlock,
   handleBlockAtPointer,
@@ -97,12 +97,7 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
   const onDragStart = (event: DragEvent) => {
     dragged.current = true
     setMenuOpen(false)
-    const { view } = editor
-    const selection = NodeSelection.create(view.state.doc, target.pos)
-    view.dispatch(view.state.tr.setSelection(selection))
-    view.dragging = { slice: selection.content(), move: true }
-    event.dataTransfer.effectAllowed = 'move'
-    event.dataTransfer.setData('text/plain', '')
+    beginHandleDrag(editor, target.pos, event.dataTransfer)
   }
 
   const onDragEnd = () => {

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -42,13 +42,47 @@ function Bubble({ editor }: { editor: Editor }) {
   )
 
   return (
-    <BubbleMenu editor={editor} className="page-bubble" aria-label="文字样式">
+    <BubbleMenu
+      editor={editor}
+      className="page-bubble"
+      aria-label="文字样式"
+      shouldShow={({ editor: current, from, to }) => !current.isActive('table') && from !== to}
+    >
       {btn('B', editor.isActive('bold'), () => editor.chain().focus().toggleBold().run())}
       {btn('I', editor.isActive('italic'), () => editor.chain().focus().toggleItalic().run())}
       {btn('S', editor.isActive('strike'), () => editor.chain().focus().toggleStrike().run())}
       {btn('</>', editor.isActive('code'), () => editor.chain().focus().toggleCode().run())}
       {btn('H1', editor.isActive('heading', { level: 1 }), () => editor.chain().focus().toggleHeading({ level: 1 }).run())}
       {btn('H2', editor.isActive('heading', { level: 2 }), () => editor.chain().focus().toggleHeading({ level: 2 }).run())}
+    </BubbleMenu>
+  )
+}
+
+function TableBar({ editor }: { editor: Editor }) {
+  const btn = (label: string, run: () => void) => (
+    <button
+      type="button"
+      onMouseDown={(event: MouseEvent) => {
+        event.preventDefault()
+        run()
+      }}
+    >
+      {label}
+    </button>
+  )
+  return (
+    <BubbleMenu
+      editor={editor}
+      pluginKey="page-table-bar"
+      className="page-bubble"
+      aria-label="表格"
+      shouldShow={({ editor: current }) => current.isActive('table')}
+    >
+      {btn('+列', () => editor.chain().focus().addColumnAfter().run())}
+      {btn('+行', () => editor.chain().focus().addRowAfter().run())}
+      {btn('删列', () => editor.chain().focus().deleteColumn().run())}
+      {btn('删行', () => editor.chain().focus().deleteRow().run())}
+      {btn('删表', () => editor.chain().focus().deleteTable().run())}
     </BubbleMenu>
   )
 }
@@ -82,6 +116,13 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
           event.preventDefault()
           window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
           return true
+        },
+        handleDOMEvents: {
+          dragover(view, event) {
+            if (!view.dragging?.move || !event.dataTransfer) return false
+            event.dataTransfer.dropEffect = 'move'
+            return false
+          },
         },
       },
       onUpdate: ({ editor: current }) => {
@@ -176,6 +217,7 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
       <EditorContent editor={editor} />
       {writable !== false ? <PageBlockHandle editor={editor} /> : null}
       {writable !== false ? <Bubble editor={editor} /> : null}
+      {writable !== false ? <TableBar editor={editor} /> : null}
     </div>
   )
 }

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -184,3 +184,15 @@ test('page-excalidraw sandbox stores scenes as page assets', async () => {
   assert.doesNotMatch(src, /border-\[var\(--border\)\]/)
   assert.match(src, /refresh/)
 })
+
+test('html and req page blocks register plugin id for slash', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const html = await readFile(resolve(import.meta.dirname, '../../../../.plugin-dev/page-html-blocks/web.tsx'), 'utf8')
+  const req = await readFile(resolve(import.meta.dirname, '../../../../.plugin-dev/page-req-cards/web.tsx'), 'utf8')
+  assert.match(html, /plugin: name/)
+  assert.match(html, /kind: 'html'/)
+  assert.match(html, /kind: 'htmlframe'/)
+  assert.match(req, /plugin: name/)
+  assert.match(req, /kind: 'req'/)
+})

--- a/packages/core-plugin-system/src/web/index.tsx
+++ b/packages/core-plugin-system/src/web/index.tsx
@@ -297,7 +297,6 @@ function PluginExtrasLayer(props: SlotProps) {
   const [fullscreenId, setFullscreenId] = useState<string | null>(null)
 
   useEffect(() => {
-    if (extras.length === 0) return
     let cancelled = false
     const load = () => {
       void readJson<{ items: StoreListing[] }>('/api/db/list?path=/plugins')
@@ -314,7 +313,7 @@ function PluginExtrasLayer(props: SlotProps) {
       cancelled = true
       window.clearInterval(timer)
     }
-  }, [extras.map((item) => item.id).join('|')])
+  }, [])
 
   async function closePlugin(id: string) {
     try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
斜杠看不到需求卡片 / HTML 块：`registerBlock` 现在强制 `plugin` id，这两个无头插件没写，启用时 apply 直接抛错，块登记不上。已补上 `plugin: name`。

表格是官方 `@tiptap/extension-table`（TableKit）。默认 `allowTableNodeSelection: false`，整表拖会失败或变成复制。已打开官方选项，把手拖块标 `move`，光标在表内时用官方命令条：+列 / +行 / 删列 / 删行 / 删表。

悬浮窗：无头页面插件本来就不会进 `plugin-store-extras`。有窗口的插件列表会提前拉，避免还没对上 listing 时误判。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

