### PR TITLE
1/3 斜杠：HTML / 需求卡片补上 plugin id

### DIFF
--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -226,7 +226,10 @@ export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
       kind: string
+      plugin: string
       label: string
+      blockType?: string
+      blockTypeLabel?: string
       hint?: string
       aliases?: string[]
       defaults?: Record<string, unknown> | (() => Record<string, unknown>)
@@ -236,7 +239,10 @@ export function apply(ctx: {
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'html',
+    plugin: name,
     label: 'HTML 直接渲染',
+    blockType: 'html',
+    blockTypeLabel: 'HTML',
     hint: 'HTML 直接渲染进文档，无外框（悬停浮出编辑/预览）',
     aliases: ['html', 'html直', '静态html'],
     defaults: { html: HTML_DIRECT_SAMPLE },
@@ -244,7 +250,10 @@ export function apply(ctx: {
   })
   ctx.pageEditor.registerBlock({
     kind: 'htmlframe',
+    plugin: name,
     label: 'HTML iframe 沙箱',
+    blockType: 'html',
+    blockTypeLabel: 'HTML',
     hint: 'iframe 隔离小网页，无外框，可跑脚本/幻灯片',
     aliases: ['iframe', 'htmlf', 'frame', '幻灯片', 'slide'],
     defaults: { html: HTML_FRAME_SAMPLE, height: 300 },

--- a/.plugin-dev/page-req-cards/web.tsx
+++ b/.plugin-dev/page-req-cards/web.tsx
@@ -203,7 +203,10 @@ export function apply(ctx: {
   pageEditor: {
     registerBlock: (spec: {
       kind: string
+      plugin: string
       label: string
+      blockType?: string
+      blockTypeLabel?: string
       hint?: string
       aliases?: string[]
       defaults?: Record<string, unknown> | (() => Record<string, unknown>)
@@ -213,7 +216,10 @@ export function apply(ctx: {
 }) {
   ctx.pageEditor.registerBlock({
     kind: 'req',
+    plugin: name,
     label: '需求卡片',
+    blockType: 'req',
+    blockTypeLabel: '需求卡片',
     hint: '结构化记录一条需求/待办：类型·状态·优先级',
     aliases: ['需求', 'req', 'requirement', 'todo', '任务'],
     defaults: REQ_DEFAULTS,

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -184,3 +184,15 @@ test('page-excalidraw sandbox stores scenes as page assets', async () => {
   assert.doesNotMatch(src, /border-\[var\(--border\)\]/)
   assert.match(src, /refresh/)
 })
+
+test('html and req page blocks register plugin id for slash', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const html = await readFile(resolve(import.meta.dirname, '../../../../.plugin-dev/page-html-blocks/web.tsx'), 'utf8')
+  const req = await readFile(resolve(import.meta.dirname, '../../../../.plugin-dev/page-req-cards/web.tsx'), 'utf8')
+  assert.match(html, /plugin: name/)
+  assert.match(html, /kind: 'html'/)
+  assert.match(html, /kind: 'htmlframe'/)
+  assert.match(req, /plugin: name/)
+  assert.match(req, /kind: 'req'/)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
问题 1/3：需求卡片、HTML 块启用后斜杠没有。

`pageEditor.registerBlock` 必须带 `plugin`（与插件 id 相同），这两个沙箱没写，apply 一启用就失败。已补 `plugin: name`。

改的是 `.plugin-dev`，需要重新 pack 后再启用。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

