### PR TITLE
搜索开到左侧不改全局 Session

### DIFF
--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -209,7 +209,7 @@ export function openSearchHit(hit: { kind: SearchKind; id: string; record?: Reco
   )
 }
 
-/** Shift+Enter：左侧主区打开并改路由；会话会换成主 Session。 */
+/** Shift+Enter：左侧主区打开并改路由；只有会话会换成主 Session。 */
 export function searchHref(hit: { kind: SearchKind; id: string; record?: Record<string, unknown> }) {
   const view = viewOpenTarget(hit)
   if (view) return `/database${view.collection}/view/${encodeURIComponent(view.viewId)}`

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -369,8 +369,8 @@ export class SessionViewService extends Service {
   }
 
   /** URL → 状态：只由路由层调用，不回写 URL。
-   * `/s/:id` 打开该会话；其它页面打开最近一条对话，供全局悬浮窗使用。
-   * 会话表记录详情不切换主 session，详情自己 peek 该行日志。 */
+   * 只有 `/s/:id` 才换成主 Session。搜索把页面/其它记录开到左侧、进数据模块，都不改全局会话。
+   * 冷启动还没有会话时，给悬浮窗补最近一条。 */
   async applyRoute(route: AppRoute) {
     if (route.kind === 'session') {
       if (this.value.sessionId !== route.sessionId) {
@@ -403,10 +403,7 @@ export class SessionViewService extends Service {
       if (this.wantsTrajectory(route.view)) void this.ensureTrajectory()
       return
     }
-    if (route.kind === 'record' && route.collection === '/sessions') {
-      return
-    }
-    await this.loadMostRecentSession()
+    if (!this.value.sessionId) await this.loadMostRecentSession()
   }
 
   private async loadMostRecentSession(skipId?: string) {

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -762,7 +762,7 @@ test('forkCurrent inserts the child into the sidebar list', async () => {
   assert.equal(view.get().sessions.some((item) => item.id === 's2'), true)
 })
 
-test('home and module routes open the most recently updated chat', async () => {
+test('home cold-start picks latest chat; opening pages or data does not switch session', async () => {
   mockFetch({
     '/api/sessions': () => ({
       sessions: [
@@ -776,6 +776,12 @@ test('home and module routes open the most recently updated chat', async () => {
       hasMore: false,
       totalTurns: 0,
     }),
+    '/api/sessions/old?turns=': () => ({
+      id: 'old',
+      events: [{ type: 'session/open', version: 1, seq: 0, ts: 1 }],
+      hasMore: false,
+      totalTurns: 0,
+    }),
     '/api/approvals': () => ({ mode: 'auto', pending: [] }),
   })
   const ctx = new Context()
@@ -784,8 +790,26 @@ test('home and module routes open the most recently updated chat', async () => {
   await view.refreshSessions()
   await view.applyRoute({ kind: 'home' })
   assert.equal(view.get().sessionId, 'new')
+  await view.load('old', { view: 'chat', wait: true })
+  assert.equal(view.get().sessionId, 'old')
   await view.applyRoute({ kind: 'module', moduleId: 'database', path: '/database' })
-  assert.equal(view.get().sessionId, 'new')
+  assert.equal(view.get().sessionId, 'old')
+  await view.applyRoute({
+    kind: 'record',
+    moduleId: 'database',
+    path: '/database',
+    collection: '/pages',
+    recordId: 'p1',
+  })
+  assert.equal(view.get().sessionId, 'old')
+  await view.applyRoute({
+    kind: 'collection-view',
+    moduleId: 'database',
+    path: '/database',
+    collection: '/pages',
+    viewId: 'mine',
+  })
+  assert.equal(view.get().sessionId, 'old')
 })
 
 test('missing session route does not surface 404 and opens the latest chat', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
搜索把页面（或其它非会话记录）开到左侧主区时，会改路由到 `/database/...`。原先 `applyRoute` 对非 `/s/:id` 一律 `loadMostRecentSession()`，正在看的会话如果不是最近一条就会被换成最近会话。

现在只有 URL 是 `/s/:id` 才换全局 Session。已经有会话时，开页面/数据/合集视图都保持原会话。冷启动还没有会话时，才补最近一条给悬浮窗。

测过：`session-view` + `shell-search` 共 42 项通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

