### PR TITLE
列表拖手不再单独缩进

### DIFF
--- a/packages/core-editor/src/web/page-block-handle.test.ts
+++ b/packages/core-editor/src/web/page-block-handle.test.ts
@@ -2,10 +2,12 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
 import {
+  HANDLE_RAIL,
   beginHandleDrag,
   deleteHandleBlock,
   duplicateHandleBlock,
   handleBlockFromDom,
+  handleRailLeft,
   insertParagraphAfter,
   insertParagraphBefore,
   resolveHandleBlock,
@@ -128,4 +130,24 @@ test('beginHandleDrag selects a table as a node and marks move', () => {
   assert.equal(editor.view.dragging?.move, true)
   assert.equal(transfer.effectAllowed, 'move')
   editor.destroy()
+})
+
+test('handleRailLeft is the same for indented list boxes and top-level paragraphs', () => {
+  const hostLeft = 40
+  const contentLeft = 40
+  const paragraphBoxLeft = 40
+  const listItemBoxLeft = 64
+  assert.equal(handleRailLeft(hostLeft, contentLeft), contentLeft - hostLeft - HANDLE_RAIL)
+  assert.equal(handleRailLeft(hostLeft, contentLeft), handleRailLeft(hostLeft, contentLeft))
+  assert.notEqual(paragraphBoxLeft - hostLeft - HANDLE_RAIL, listItemBoxLeft - hostLeft - HANDLE_RAIL)
+  assert.equal(handleRailLeft(hostLeft, contentLeft), paragraphBoxLeft - hostLeft - HANDLE_RAIL)
+  assert.notEqual(handleRailLeft(hostLeft, contentLeft), listItemBoxLeft - hostLeft - HANDLE_RAIL)
+})
+
+test('page block handle x uses the editor rail, not the node box', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const src = await readFile(resolve(import.meta.dirname, './page-block-handle.tsx'), 'utf8')
+  assert.match(src, /handleRailLeft\(hostBox\.left, contentBox\.left\)/)
+  assert.doesNotMatch(src, /left: box\.left - hostBox\.left - HANDLE_RAIL/)
 })

--- a/packages/core-editor/src/web/page-block-handle.ts
+++ b/packages/core-editor/src/web/page-block-handle.ts
@@ -7,6 +7,13 @@ export type HandleBlock = {
   node: Node
 }
 
+/** 所有块共用一条轨道，不跟列表缩进。 */
+export const HANDLE_RAIL = 28
+
+export function handleRailLeft(hostLeft: number, contentLeft: number, rail = HANDLE_RAIL) {
+  return contentLeft - hostLeft - rail
+}
+
 /** 列表项单独成块；其余取紧贴文档的顶层块（引用整段、段落、插件块等）。 */
 export function resolveHandleBlock($pos: ResolvedPos): HandleBlock | null {
   for (let depth = $pos.depth; depth >= 1; depth--) {

--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -6,12 +6,12 @@ import {
   deleteHandleBlock,
   duplicateHandleBlock,
   handleBlockAtPointer,
+  handleRailLeft,
   insertParagraphAfter,
   insertParagraphBefore,
   type HandleBlock,
 } from './page-block-handle.ts'
 
-const HANDLE_RAIL = 28
 const GRIP_H = 26
 
 type HandleTarget = HandleBlock & { top: number; left: number; height: number; gripTop: number }
@@ -33,12 +33,13 @@ function readTarget(editor: Editor, host: HTMLElement, clientX: number, clientY:
   if (!(el instanceof HTMLElement)) return null
   const hostBox = host.getBoundingClientRect()
   const box = el.getBoundingClientRect()
+  const contentBox = editor.view.dom.getBoundingClientRect()
   const line = lineCoords(editor, found) ?? { top: box.top, bottom: box.top + GRIP_H }
   const gripTop = (line.top + line.bottom) / 2 - box.top - GRIP_H / 2
   return {
     ...found,
     top: box.top - hostBox.top,
-    left: box.left - hostBox.left - HANDLE_RAIL,
+    left: handleRailLeft(hostBox.left, contentBox.left),
     height: Math.max(box.height, GRIP_H),
     gripTop: Math.max(0, gripTop),
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
列表项把手之前用节点自己的 `box.left`，列表有 `padding-left`，拖手会跟着缩进。现在 x 只跟编辑器正文左缘，和段落、标题同一条垂直线。

测过：`page-block-handle` 8 项通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

