### PR TITLE
feat: 选中正文把 Markdown 源码行号交给 agent

### DIFF
--- a/packages/core-chat/src/web/composer-pick-node.tsx
+++ b/packages/core-chat/src/web/composer-pick-node.tsx
@@ -1,14 +1,9 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 import { createRoot, type Root } from 'react-dom/client'
-import { PickChip, type PickRef } from '@biu/core-pick/web'
+import { PickChip, pickRefFromAttrs, type PickRef } from '@biu/core-pick/web'
 
 function refFromAttrs(attrs: Record<string, unknown>): PickRef {
-  const kind = String(attrs.kind ?? '')
-  const id = String(attrs.id ?? '')
-  const label = String(attrs.label ?? id)
-  const route = String(attrs.route ?? '')
-  const action = attrs.action ? String(attrs.action) : undefined
-  return { kind, id, label, route, ...(action ? { action } : {}) }
+  return pickRefFromAttrs(attrs) ?? { kind: '', id: '', label: '', route: '' }
 }
 
 function PickChipView({ attrs, onRemove }: { attrs: Record<string, unknown>; onRemove?: () => void }) {
@@ -28,6 +23,9 @@ export const PickChipNode = Node.create({
       action: { default: null },
       label: { default: '' },
       route: { default: '' },
+      start_line: { default: null },
+      end_line: { default: null },
+      text: { default: null },
     }
   },
   parseHTML() {

--- a/packages/core-chat/src/web/composer-tiptap.ts
+++ b/packages/core-chat/src/web/composer-tiptap.ts
@@ -1,18 +1,8 @@
 import type { Editor } from '@tiptap/react'
-import { formatPick, pickKey, splitPickStream, type PickRef } from '@biu/core-pick/web'
+import { formatPick, pickChipAttrs, pickKey, pickRefFromAttrs, splitPickStream, type PickRef } from '@biu/core-pick/web'
 
 function attrsToRef(attrs: Record<string, unknown>): PickRef | null {
-  const kind = String(attrs.kind ?? '').trim()
-  const id = String(attrs.id ?? '').trim()
-  if (!kind || !id) return null
-  const action = String(attrs.action ?? '').trim()
-  return {
-    kind,
-    id,
-    label: String(attrs.label ?? '').trim() || id,
-    route: String(attrs.route ?? ''),
-    ...(action ? { action } : {}),
-  }
+  return pickRefFromAttrs(attrs)
 }
 
 export function serializeComposer(editor: Editor | null): { text: string; refs: PickRef[]; plain: string } {
@@ -63,13 +53,7 @@ export function jsonFromDraft(raw: string) {
       const ref = part.ref
       content.push({
         type: 'pickChip',
-        attrs: {
-          kind: ref.kind,
-          id: ref.id,
-          label: ref.label,
-          route: ref.route,
-          action: ref.action ?? null,
-        },
+        attrs: pickChipAttrs(ref),
       })
     }
   }
@@ -98,13 +82,7 @@ export function collectPickKeys(editor: Editor | null) {
 function chipContent(ref: PickRef) {
   return {
     type: 'pickChip',
-    attrs: {
-      kind: ref.kind,
-      id: ref.id,
-      label: ref.label,
-      route: ref.route,
-      action: ref.action ?? null,
-    },
+    attrs: pickChipAttrs(ref),
   }
 }
 

--- a/packages/core-editor/package.json
+++ b/packages/core-editor/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.1"
   },
   "dependencies": {
+    "@biu/core-pick": "0.1.0",
     "@biu/public-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0"
   }

--- a/packages/core-editor/src/web/index.ts
+++ b/packages/core-editor/src/web/index.ts
@@ -9,6 +9,7 @@ export { PageEditor, PageEditor as RecordEditor } from './page-editor.tsx'
 export { PageEditorService, BASIC_BLOCK_TYPE, getPageEditor, usePageEditorVersion } from './service.ts'
 export type { HeadingReplacement, PageBlockSpec, PageBlockViewProps, SlashCommandSpec, SlashInsert } from './service.ts'
 export { pageEditorExtensions } from './kit.ts'
+export { markdownLocusFromRange, markdownLocusFromSelection, markdownLocusFromElement } from './markdown-locus.ts'
 
 export const name = 'core-editor-ui'
 export const inject = ['databaseUi']

--- a/packages/core-editor/src/web/markdown-locus.test.ts
+++ b/packages/core-editor/src/web/markdown-locus.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Editor } from '@tiptap/core'
+import { pageEditorExtensions } from './kit.ts'
+import { markdownLocusFromRange, markdownLocusFromSelection } from './markdown-locus.ts'
+
+function editorOf(markdown: string) {
+  return new Editor({
+    extensions: pageEditorExtensions(),
+    content: markdown,
+    contentType: 'markdown',
+  })
+}
+
+function posOf(editor: Editor, needle: string) {
+  let found: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found != null || !node.isText || !node.text) return
+    const idx = node.text.indexOf(needle)
+    if (idx >= 0) found = pos + idx
+  })
+  return found
+}
+
+test('selection maps to markdown source lines, not visual blocks', () => {
+  const md = '# 欢迎\n\n第一段\n\nUNIQUESEL\n\n末段'
+  const editor = editorOf(md)
+  const from = posOf(editor, 'UNIQUESEL')
+  assert.ok(from != null)
+  editor.commands.setTextSelection({ from, to: from + 'UNIQUESEL'.length })
+  const locus = markdownLocusFromSelection(editor)
+  assert.ok(locus)
+  assert.equal(locus.start_line, 5)
+  assert.equal(locus.end_line, 5)
+  assert.match(locus.text, /UNIQUESEL/)
+  editor.destroy()
+})
+
+test('multi-line selection spans markdown source lines', () => {
+  const md = 'alpha\n\nbravo\n\ncharlie'
+  const editor = editorOf(md)
+  const from = posOf(editor, 'bravo')
+  const to = posOf(editor, 'charlie')
+  assert.ok(from != null && to != null)
+  const locus = markdownLocusFromRange(editor, from, to + 'charlie'.length)
+  assert.ok(locus)
+  assert.equal(locus.start_line, 3)
+  assert.equal(locus.end_line, 5)
+  assert.match(locus.text, /bravo/)
+  assert.match(locus.text, /charlie/)
+  editor.destroy()
+})
+
+test('heading selection uses the heading markdown line', () => {
+  const md = '# Hello title\n\nbody'
+  const editor = editorOf(md)
+  const from = posOf(editor, 'Hello title')
+  assert.ok(from != null)
+  const locus = markdownLocusFromRange(editor, from, from + 'Hello title'.length)
+  assert.ok(locus)
+  assert.equal(locus.start_line, 1)
+  assert.match(locus.text, /Hello title/)
+  editor.destroy()
+})

--- a/packages/core-editor/src/web/markdown-locus.ts
+++ b/packages/core-editor/src/web/markdown-locus.ts
@@ -1,0 +1,59 @@
+import type { Editor } from '@tiptap/core'
+import type { Node as PmNode } from '@tiptap/pm/model'
+
+export type MarkdownLocus = { start_line: number; end_line: number; text: string }
+
+function serialize(editor: Editor, doc: PmNode) {
+  const manager = editor.storage.markdown?.manager as { serialize?: (json: unknown) => string } | undefined
+  if (typeof manager?.serialize === 'function') return manager.serialize(doc.toJSON())
+  return editor.getMarkdown()
+}
+
+function lineAtEnd(md: string) {
+  if (!md) return 1
+  return md.slice(0, md.length).split('\n').length
+}
+
+function linesOf(md: string, start: number, end: number) {
+  const lines = md.split('\n')
+  const from = Math.min(Math.max(1, start), Math.max(lines.length, 1))
+  const to = Math.min(Math.max(from, end), Math.max(lines.length, 1))
+  return lines.slice(from - 1, to).join('\n')
+}
+
+/** 选区对应 Markdown 源码行号（1-based），不是可视编辑器行。 */
+export function markdownLocusFromRange(editor: Editor, from: number, to: number): MarkdownLocus | null {
+  const doc = editor.state.doc
+  const a = Math.max(0, Math.min(from, to))
+  const b = Math.max(a, Math.max(from, to))
+  if (a === b) return null
+  const full = serialize(editor, doc)
+  const prefix = serialize(editor, doc.cut(0, a))
+  const through = serialize(editor, doc.cut(0, b))
+  let start_line = lineAtEnd(prefix)
+  if (prefix.endsWith('\n')) start_line = Math.max(1, lineAtEnd(prefix.slice(0, -1)) + 1)
+  let end_line = lineAtEnd(through.replace(/\n$/, ''))
+  const total = Math.max(full.split('\n').length, 1)
+  start_line = Math.min(Math.max(1, start_line), total)
+  end_line = Math.min(Math.max(start_line, end_line), total)
+  const text = linesOf(full, start_line, end_line)
+  if (!text.trim() && !editor.state.doc.textBetween(a, b, '\n').trim()) return null
+  return { start_line, end_line, text }
+}
+
+export function markdownLocusFromSelection(editor: Editor): MarkdownLocus | null {
+  const { from, to } = editor.state.selection
+  return markdownLocusFromRange(editor, from, to)
+}
+
+export function markdownLocusFromElement(editor: Editor, el: Element): MarkdownLocus | null {
+  const view = editor.view
+  if (!view.dom.contains(el)) return null
+  try {
+    const from = view.posAtDOM(el, 0)
+    const to = view.posAtDOM(el, el.childNodes.length)
+    return markdownLocusFromRange(editor, from, to)
+  } catch {
+    return null
+  }
+}

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -94,6 +94,8 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /CONTENT_JUMP_EVENT/)
   assert.match(src, /editorHostIsLive\(editor\)/)
   assert.match(src, /Selection\.atStart/)
+  assert.match(src, /bindEditorTextHost/)
+  assert.match(src, /markdownLocusFromSelection/)
 })
 
 test('page editor hydrates markdown after content fetch', async () => {

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -10,6 +10,8 @@ import { editorHostIsLive } from './editor-live.ts'
 import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
 import { tryContentJump, contentJumpForRecord } from './content-jump.ts'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
+import { bindEditorTextHost } from '@biu/core-pick/web'
+import { markdownLocusFromElement, markdownLocusFromSelection } from './markdown-locus.ts'
 
 function jumpToPending(editor: Editor, markdown: string, recordId: string, force = false) {
   requestAnimationFrame(() => {
@@ -177,6 +179,16 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
     editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
     jumpToPending(editor, md, record.id, true)
   }, [editor, record.id, value])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return
+    const el = editor.view.dom
+    bindEditorTextHost(el, {
+      locusFromSelection: () => markdownLocusFromSelection(editor),
+      locusFromElement: (node) => markdownLocusFromElement(editor, node),
+    })
+    return () => bindEditorTextHost(el, null)
+  }, [editor])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return

--- a/packages/core-pick/src/web/editor-host.test.ts
+++ b/packages/core-pick/src/web/editor-host.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { bindEditorTextHost } from './editor-host.ts'
+import { textPickFromSelection } from './types.ts'
+
+test('text pick from a bound editor includes markdown source lines', () => {
+  const root = document.createElement('div')
+  const leaf = document.createTextNode('第一段')
+  root.append(leaf)
+  document.body.append(root)
+  bindEditorTextHost(root, {
+    locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL' }),
+    locusFromElement: () => null,
+  })
+  const fake = {
+    isCollapsed: false,
+    rangeCount: 1,
+    toString: () => '第一段',
+    anchorNode: leaf,
+  }
+  const ref = textPickFromSelection('/pages/home', fake)
+  assert.ok(ref)
+  assert.equal(ref.start_line, 5)
+  assert.equal(ref.end_line, 5)
+  assert.equal(ref.text, 'UNIQUESEL')
+  bindEditorTextHost(root, null)
+  root.remove()
+})

--- a/packages/core-pick/src/web/editor-host.ts
+++ b/packages/core-pick/src/web/editor-host.ts
@@ -1,0 +1,24 @@
+export type EditorTextLocus = { start_line: number; end_line: number; text: string }
+
+export type EditorTextHost = {
+  locusFromSelection: () => EditorTextLocus | null
+  locusFromElement: (el: Element) => EditorTextLocus | null
+}
+
+const hosts = new WeakMap<Element, EditorTextHost>()
+
+export function bindEditorTextHost(el: Element | null, host: EditorTextHost | null) {
+  if (!el) return
+  if (host) hosts.set(el, host)
+  else hosts.delete(el)
+}
+
+export function editorHostFromNode(node: Node | null): EditorTextHost | null {
+  let el: Element | null = node instanceof Element ? node : node?.parentElement ?? null
+  while (el) {
+    const host = hosts.get(el)
+    if (host) return host
+    el = el.parentElement
+  }
+  return null
+}

--- a/packages/core-pick/src/web/index.tsx
+++ b/packages/core-pick/src/web/index.tsx
@@ -5,7 +5,8 @@ import { PickService, getPick, usePickState } from './service.ts'
 import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
-export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, type PickRef } from './types.ts'
+export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, lineSpanLabel, type PickRef } from './types.ts'
+export { bindEditorTextHost, editorHostFromNode } from './editor-host.ts'
 export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, pickSurfaceFromNode, pickSurfaceAtPoint } from './resolve.ts'
 

--- a/packages/core-pick/src/web/overlay.test.ts
+++ b/packages/core-pick/src/web/overlay.test.ts
@@ -56,6 +56,7 @@ test('pointerup prefers a text selection over object picks', () => {
   assert.match(overlay, /textPickFromSelection/)
   assert.match(overlay, /inReadable/)
   assert.match(overlay, /\.chat-stage/)
+  assert.match(overlay, /page-editor/)
 })
 
 test('pointerup does not attach picks after pick mode has exited', () => {

--- a/packages/core-pick/src/web/overlay.tsx
+++ b/packages/core-pick/src/web/overlay.tsx
@@ -60,7 +60,8 @@ export function PickOverlay(_props: SlotProps) {
       if (event.button !== 0) return
       if (ignorePickCapture(event.target, event)) return
       const inReadable =
-        event.target instanceof Element && Boolean(event.target.closest('.chat-stage'))
+        event.target instanceof Element &&
+        Boolean(event.target.closest('.chat-stage, .page-editor, .tiptap, [data-testid="page-editor"]'))
       if (!inReadable) event.preventDefault()
       drag = { x: event.clientX, y: event.clientY, boxed: false }
     }

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -68,6 +68,27 @@ test('formatPicks emits data handles only', () => {
   assert.doesNotMatch(text, /class=|svg|html/i)
 })
 
+test('text pick round-trips markdown source line numbers', () => {
+  const text = formatPicks([
+    {
+      kind: 'text',
+      id: 'a1',
+      label: '第一段',
+      route: '/pages/home',
+      start_line: 5,
+      end_line: 6,
+      text: '第一段\n\nUNIQUESEL',
+    },
+  ])
+  assert.match(text, /start_line="5"/)
+  assert.match(text, /end_line="6"/)
+  assert.match(text, /text="第一段&#10;&#10;UNIQUESEL"/)
+  const parsed = parsePicks(text)
+  assert.equal(parsed.refs[0]?.start_line, 5)
+  assert.equal(parsed.refs[0]?.end_line, 6)
+  assert.equal(parsed.refs[0]?.text, '第一段\n\nUNIQUESEL')
+})
+
 test('selected body text becomes a text pick', () => {
   const fake = {
     isCollapsed: false,

--- a/packages/core-pick/src/web/resolve.ts
+++ b/packages/core-pick/src/web/resolve.ts
@@ -1,5 +1,6 @@
 import type { PickRef } from './types.ts'
-import { pickIdFromText, pickPreview } from './types.ts'
+import { pickIdFromText, pickPreview, withPickLocus } from './types.ts'
+import { editorHostFromNode } from './editor-host.ts'
 
 const KIND = 'data-biu-kind'
 const ID = 'data-biu-id'
@@ -116,25 +117,31 @@ function editorBlockPick(
   if (taggedKind && taggedId) {
     return {
       el,
-      ref: {
-        kind: taggedKind,
-        id: taggedId,
-        ...(read(el, ACTION) ? { action: read(el, ACTION) } : {}),
-        label: read(el, LABEL) || taggedId,
-        route,
-      },
+      ref: withPickLocus(
+        {
+          kind: taggedKind,
+          id: taggedId,
+          ...(read(el, ACTION) ? { action: read(el, ACTION) } : {}),
+          label: read(el, LABEL) || taggedId,
+          route,
+        },
+        editorHostFromNode(el)?.locusFromElement(el) ?? null,
+      ),
     }
   }
   const tag = (el.getAttribute('data-page-block') || el.tagName).toLowerCase()
   const text = pickPreview(el.textContent ?? '', 80)
   return {
     el,
-    ref: {
-      kind: 'block',
-      id: `${tag}:${pickIdFromText(text || tag)}`,
-      label: text || tag,
-      route,
-    },
+    ref: withPickLocus(
+      {
+        kind: 'block',
+        id: `${tag}:${pickIdFromText(text || tag)}`,
+        label: text || tag,
+        route,
+      },
+      editorHostFromNode(el)?.locusFromElement(el) ?? null,
+    ),
   }
 }
 

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -1,9 +1,16 @@
+import { editorHostFromNode } from './editor-host.ts'
+
 export type PickRef = {
   kind: string
   id: string
   action?: string
   label: string
   route: string
+  /** Markdown 源码行号（1-based），不是可视编辑器行。 */
+  start_line?: number
+  end_line?: number
+  /** 对应源码片段。 */
+  text?: string
 }
 
 export function pickKey(ref: PickRef) {
@@ -30,6 +37,7 @@ export function dedupePicks(refs: PickRef[]): PickRef[] {
       label: ref.label || prev.label,
       route: ref.route || prev.route,
       ...(ref.action || prev.action ? { action: ref.action || prev.action } : {}),
+      ...locusFields(ref.start_line != null ? ref : prev),
     })
   }
   return [...map.values()]
@@ -42,6 +50,9 @@ export function formatPicks(refs: PickRef[]) {
       if (ref.action) attrs.push(`action="${escapeAttr(ref.action)}"`)
       if (ref.route) attrs.push(`route="${escapeAttr(ref.route)}"`)
       if (ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
+      if (ref.start_line != null) attrs.push(`start_line="${ref.start_line}"`)
+      if (ref.end_line != null) attrs.push(`end_line="${ref.end_line}"`)
+      if (ref.text) attrs.push(`text="${escapeAttr(ref.text)}"`)
       return `<pick ${attrs.join(' ')} />`
     })
     .join('\n')
@@ -51,7 +62,7 @@ const PICK_TAG = /<pick\b([^>]*)\/>/gi
 const ATTR = /(\w+)="([^"]*)"/g
 
 function unescapeAttr(value: string) {
-  return value.replace(/&quot;/g, '"').replace(/&amp;/g, '&')
+  return value.replace(/&#10;/g, '\n').replace(/&quot;/g, '"').replace(/&amp;/g, '&')
 }
 
 function parsePickAttrs(raw: string): PickRef | null {
@@ -64,12 +75,31 @@ function parsePickAttrs(raw: string): PickRef | null {
   const kind = attrs.kind?.trim()
   const id = attrs.id?.trim()
   if (!kind || !id) return null
+  const start = Number(attrs.start_line)
+  const end = Number(attrs.end_line)
+  const text = attrs.text?.trim() ?? ''
   return {
     kind,
     id,
     ...(attrs.action?.trim() ? { action: attrs.action.trim() } : {}),
     label: attrs.label?.trim() || id,
     route: attrs.route?.trim() || '',
+    ...locusFields({
+      start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
+      end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
+      text: text || undefined,
+    }),
+  }
+}
+
+function locusFields(ref: { start_line?: number; end_line?: number; text?: string }) {
+  const start = ref.start_line
+  const end = ref.end_line
+  const text = ref.text?.trim()
+  return {
+    ...(start != null ? { start_line: start } : {}),
+    ...(end != null ? { end_line: end } : {}),
+    ...(text ? { text } : {}),
   }
 }
 
@@ -108,11 +138,19 @@ export function parsePicks(text: string): { refs: PickRef[]; rest: string } {
 }
 
 function escapeAttr(value: string) {
-  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/\n/g, '&#10;')
+}
+
+export function lineSpanLabel(ref: PickRef) {
+  if (ref.start_line == null) return ''
+  if (ref.end_line != null && ref.end_line !== ref.start_line) return `L${ref.start_line}–${ref.end_line}`
+  return `L${ref.start_line}`
 }
 
 export function chipLabel(ref: PickRef) {
+  const lines = lineSpanLabel(ref)
   if (ref.action) return `${ref.label} · ${ref.action}`
+  if (lines) return `${lines} ${ref.label}`
   return ref.label
 }
 
@@ -129,7 +167,16 @@ export function pickIdFromText(raw: string) {
   return hash.toString(16)
 }
 
-/** 选取态下划到的一段正文；空选区返回 null。 */
+export function withPickLocus(ref: PickRef, locus: { start_line: number; end_line: number; text: string } | null | undefined): PickRef {
+  if (!locus) return ref
+  return {
+    ...ref,
+    id: pickIdFromText(`${locus.start_line}:${locus.end_line}:${locus.text || ref.label}`),
+    ...locusFields(locus),
+  }
+}
+
+/** 选取态下划到的一段正文；空选区返回 null。编辑器选区附带 Markdown 源码行号。 */
 export function textPickFromSelection(
   route: string,
   selection: Pick<Selection, 'isCollapsed' | 'toString' | 'rangeCount'> | null = typeof window === 'undefined' ? null : window.getSelection(),
@@ -138,7 +185,45 @@ export function textPickFromSelection(
   const raw = selection.toString()
   const label = pickPreview(raw, 80)
   if (!label) return null
-  return { kind: 'text', id: pickIdFromText(raw), label, route }
+  const anchor = 'anchorNode' in selection ? (selection as Selection).anchorNode : null
+  const host = editorHostFromNode(anchor)
+  const locus = host ? host.locusFromSelection() : null
+  return withPickLocus({ kind: 'text', id: pickIdFromText(raw), label, route }, locus)
+}
+
+export function pickChipAttrs(ref: PickRef) {
+  return {
+    kind: ref.kind,
+    id: ref.id,
+    label: ref.label,
+    route: ref.route,
+    action: ref.action ?? null,
+    start_line: ref.start_line ?? null,
+    end_line: ref.end_line ?? null,
+    text: ref.text ?? null,
+  }
+}
+
+export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null {
+  const kind = String(attrs.kind ?? '').trim()
+  const id = String(attrs.id ?? '').trim()
+  if (!kind || !id) return null
+  const action = String(attrs.action ?? '').trim()
+  const start = Number(attrs.start_line)
+  const end = Number(attrs.end_line)
+  const text = typeof attrs.text === 'string' ? attrs.text.trim() : ''
+  return {
+    kind,
+    id,
+    label: String(attrs.label ?? '').trim() || id,
+    route: String(attrs.route ?? ''),
+    ...(action ? { action } : {}),
+    ...locusFields({
+      start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
+      end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
+      text: text || undefined,
+    }),
+  }
 }
 
 export function pickDomAttrs(kind: string, id: string, label?: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选取编辑器正文时，经 core-pick 把选中内容对应的 **Markdown 源码行号**（不是可视编辑器行）和源码片段传给 agent。

- 用 `getMarkdown()` 前缀序列化把 ProseMirror 选区映射到 `start_line` / `end_line`
- `<pick>` 增加 `start_line` / `end_line` / `text`，输入框芯片往返保留
- 选取模式允许在 `.page-editor` 里划词
- 点选编辑器块时同样带上行号

关联 #24、#20（db_content 按源码行定位）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

