### PR TITLE
feat: 编辑器源码模式（CodeMirror）放在详情 action 栏

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,15 @@
         "packages/*"
       ],
       "dependencies": {
+        "@codemirror/commands": "^6.11.0",
+        "@codemirror/lang-markdown": "^6.5.2",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/language-data": "^6.5.2",
+        "@codemirror/state": "^6.7.4",
+        "@codemirror/view": "^6.43.11",
         "@excalidraw/excalidraw": "^0.18.1",
         "@heroicons/react": "^2.2.0",
+        "@lezer/highlight": "^1.2.3",
         "@tanstack/react-virtual": "^3.14.10",
         "@tiptap/extension-bubble-menu": "^3.30.5",
         "@tiptap/extension-heading": "^3.30.5",
@@ -775,6 +782,396 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.11.0.tgz",
+      "integrity": "sha512-/K4Rl5BN0OtTiPWmJCdqODu38XnDMsDxKY5rgrPnCkutPTJf2wVbkoixLfealF5Kwse/s8P8M5jAiURiwSwnFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-angular": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-angular/-/lang-angular-0.1.4.tgz",
+      "integrity": "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.3"
+      }
+    },
+    "node_modules/@codemirror/lang-cpp": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-cpp/-/lang-cpp-6.0.3.tgz",
+      "integrity": "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/cpp": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-go": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-go/-/lang-go-6.0.1.tgz",
+      "integrity": "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/go": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.12.tgz",
+      "integrity": "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-java": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-java/-/lang-java-6.0.2.tgz",
+      "integrity": "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/java": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-jinja": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-jinja/-/lang-jinja-6.0.1.tgz",
+      "integrity": "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-less": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-less/-/lang-less-6.0.2.tgz",
+      "integrity": "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-liquid": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-liquid/-/lang-liquid-6.3.2.tgz",
+      "integrity": "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.2.tgz",
+      "integrity": "sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-php": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+      "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/php": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sass/-/lang-sass-6.0.2.tgz",
+      "integrity": "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-css": "^6.2.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/sass": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-vue": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-vue/-/lang-vue-0.1.3.tgz",
+      "integrity": "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.1.2",
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.1"
+      }
+    },
+    "node_modules/@codemirror/lang-wast": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-wast/-/lang-wast-6.0.2.tgz",
+      "integrity": "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-xml": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.1.0.tgz",
+      "integrity": "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-yaml": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.3.tgz",
+      "integrity": "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.2.0",
+        "@lezer/lr": "^1.0.0",
+        "@lezer/yaml": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/language-data": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/language-data/-/language-data-6.5.2.tgz",
+      "integrity": "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-angular": "^0.1.0",
+        "@codemirror/lang-cpp": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-go": "^6.0.0",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/lang-java": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/lang-jinja": "^6.0.0",
+        "@codemirror/lang-json": "^6.0.0",
+        "@codemirror/lang-less": "^6.0.0",
+        "@codemirror/lang-liquid": "^6.0.0",
+        "@codemirror/lang-markdown": "^6.0.0",
+        "@codemirror/lang-php": "^6.0.0",
+        "@codemirror/lang-python": "^6.0.0",
+        "@codemirror/lang-rust": "^6.0.0",
+        "@codemirror/lang-sass": "^6.0.0",
+        "@codemirror/lang-sql": "^6.0.0",
+        "@codemirror/lang-vue": "^0.1.1",
+        "@codemirror/lang-wast": "^6.0.0",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/lang-yaml": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/legacy-modes": "^6.4.0"
+      }
+    },
+    "node_modules/@codemirror/legacy-modes": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.4.tgz",
+      "integrity": "sha512-/cZr6qZyl08iYNLGsJ862CXXNI51LryRFRE40ejgoIjXZz0C1rGkD3/Ek5jM/8w1ceRjqtt4qx/KLMh4zBTgew==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.4.tgz",
+      "integrity": "sha512-QhQIVRY+xHZDxwOSFrJ1eUMapJBUID3IdeAjf7dHO7zBUzSkyooHiodnalz5MG3iHzwixKMlAAyn7244y537EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.11.tgz",
+      "integrity": "sha512-2+esucbQX6wB2JYi1eDvdCPFTA31BN8oSy6xCmk3G6CloV11yOvEjYk+gH7kLrP0MuHG94E8WDhjs5oMiu3+Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.1.1",
@@ -1584,6 +1981,189 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/cpp": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-1.1.6.tgz",
+      "integrity": "sha512-vh9gWWJOXFVY8HBHK3Twzq8MgwG2iN4GSyzBP9sCGTe37P15x2R14VaBQk0VA0ezTRN1KHYBBsHhvpGZ2Xy/pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.6.tgz",
+      "integrity": "sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/go": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/go/-/go-1.0.1.tgz",
+      "integrity": "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/java": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lezer/java/-/java-1.1.3.tgz",
+      "integrity": "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.7.2.tgz",
+      "integrity": "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/php": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.6.tgz",
+      "integrity": "sha512-QJ2xNXPmsm/Z3IpThq8fnJrEIVpxhsIoj6GZBW0JYEd/l9zxpJZW216X4fzqQY4vgpdGIumypvI4uQjd4tnYtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.1.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+      "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/sass/-/sass-1.1.0.tgz",
+      "integrity": "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/xml": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+      "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/yaml": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.4.tgz",
+      "integrity": "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.4.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.4.tgz",
+      "integrity": "sha512-Wy0V7+SGUjnF9/TkiM1hKVDPj7jKXduPNboMVtHTA8dySMURWqfg/JZ9E2Sq8JgSJmkl7k7Qe9FLeMSrSraWmQ==",
+      "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
       "version": "0.6.3",
@@ -5149,6 +5729,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -7777,6 +8363,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
@@ -8680,6 +9272,7 @@
       "name": "@biu/core-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@biu/core-pick": "0.1.0",
         "@biu/public-ui": "0.1.0",
         "@biu/type-file-system": "0.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,8 +20,15 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/lang-markdown": "^6.5.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.7.4",
+    "@codemirror/view": "^6.43.11",
     "@excalidraw/excalidraw": "^0.18.1",
     "@heroicons/react": "^2.2.0",
+    "@lezer/highlight": "^1.2.3",
     "@tanstack/react-virtual": "^3.14.10",
     "@tiptap/extension-bubble-menu": "^3.30.5",
     "@tiptap/extension-heading": "^3.30.5",

--- a/packages/core-editor/package.json
+++ b/packages/core-editor/package.json
@@ -13,6 +13,13 @@
     "react": "^19.1.1"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.11.0",
+    "@codemirror/lang-markdown": "^6.5.2",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/language-data": "^6.5.2",
+    "@codemirror/state": "^6.7.4",
+    "@codemirror/view": "^6.43.11",
+    "@lezer/highlight": "^1.2.3",
     "@biu/core-pick": "0.1.0",
     "@biu/public-ui": "0.1.0",
     "@biu/type-file-system": "0.1.0"

--- a/packages/core-editor/src/web/index.test.ts
+++ b/packages/core-editor/src/web/index.test.ts
@@ -13,6 +13,7 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
   decorate(path: string, chrome: CollectionChrome) {
     this.paths.push(path)
     assert.equal(chrome.Content, PageEditor)
+    assert.ok(chrome.DetailTools)
     return { dispose() {} }
   }
   registerView(_path: string, _view: CollectionViewType) {

--- a/packages/core-editor/src/web/index.ts
+++ b/packages/core-editor/src/web/index.ts
@@ -4,8 +4,10 @@ import type { DatabaseUi } from '@biu/type-file-system/ui'
 import { PageEditor } from './page-editor.tsx'
 import { PageEditorService } from './service.ts'
 import { PAGE_EDITOR_STYLE } from './style.ts'
+import { SourceToggle } from './source-toggle.tsx'
 
 export { PageEditor, PageEditor as RecordEditor } from './page-editor.tsx'
+export { SourceToggle } from './source-toggle.tsx'
 export { PageEditorService, BASIC_BLOCK_TYPE, getPageEditor, usePageEditorVersion } from './service.ts'
 export type { HeadingReplacement, PageBlockSpec, PageBlockViewProps, SlashCommandSpec, SlashInsert } from './service.ts'
 export { pageEditorExtensions } from './kit.ts'
@@ -20,7 +22,7 @@ export function apply(ctx: Context) {
   new PageEditorService(ctx)
   const ui = ctx.get('databaseUi') as DatabaseUi
   for (const path of EDITOR_COLLECTIONS) {
-    ctx.effect(() => ui.decorate(path, { Content: PageEditor }).dispose)
+    ctx.effect(() => ui.decorate(path, { Content: PageEditor, DetailTools: SourceToggle }).dispose)
   }
 }
 

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -96,6 +96,8 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /Selection\.atStart/)
   assert.match(src, /bindEditorTextHost/)
   assert.match(src, /markdownLocusFromSelection/)
+  assert.match(src, /usePageSourceMode/)
+  assert.match(src, /SourceEditor/)
 })
 
 test('page editor hydrates markdown after content fetch', async () => {

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, type MouseEvent } from 'react'
+import { SourceEditor } from './source-editor.tsx'
+import { usePageSourceMode } from './source-mode.ts'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import type { Editor } from '@tiptap/core'
@@ -90,6 +92,7 @@ function TableBar({ editor }: { editor: Editor }) {
 }
 
 export function PageEditor({ record, value, writable, onChange }: FsContentProps) {
+  const source = usePageSourceMode(record.id)
   const saved = useRef(asMarkdown(value))
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hydratedId = useRef<string | null>(null)
@@ -181,14 +184,31 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
   }, [editor, record.id, value])
 
   useEffect(() => {
-    if (!editor || editor.isDestroyed) return
+    if (!editor || editor.isDestroyed || source) return
     const el = editor.view.dom
     bindEditorTextHost(el, {
       locusFromSelection: () => markdownLocusFromSelection(editor),
       locusFromElement: (node) => markdownLocusFromElement(editor, node),
     })
     return () => bindEditorTextHost(el, null)
-  }, [editor])
+  }, [editor, source])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || !source) return
+    if (timer.current) clearTimeout(timer.current)
+    const next = editor.getMarkdown()
+    if (next !== saved.current) {
+      saved.current = next
+      onChange?.(next)
+    }
+  }, [source, editor])
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || source) return
+    const md = saved.current
+    if (md === editor.getMarkdown()) return
+    editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
+  }, [source, editor])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return
@@ -223,6 +243,22 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
   }, [editor, record.id, value])
 
   if (!editor) return <div className="page-editor" data-testid="page-editor-pending" />
+
+  if (source) {
+    return (
+      <div className="page-editor is-source">
+        <SourceEditor
+          value={asMarkdown(value)}
+          writable={writable !== false}
+          onChange={(next) => {
+            if (next === saved.current) return
+            saved.current = next
+            onChange?.(next)
+          }}
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="page-editor">

--- a/packages/core-editor/src/web/source-editor.test.tsx
+++ b/packages/core-editor/src/web/source-editor.test.tsx
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { render, waitFor } from '@testing-library/react'
+import { SourceEditor } from './source-editor.tsx'
+
+test('source editor uses CodeMirror markdown highlighting and line numbers', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './source-editor.tsx'), 'utf8')
+  assert.match(src, /@codemirror\/view/)
+  assert.match(src, /markdown\(/)
+  assert.match(src, /lineNumbers/)
+  assert.match(src, /syntaxHighlighting/)
+  assert.match(src, /page-source-editor/)
+})
+
+test('source editor mounts a CodeMirror view for markdown', async () => {
+  const { container } = render(<SourceEditor value={'# Hello\n\nbody'} writable onChange={() => undefined} />)
+  await waitFor(() => {
+    assert.ok(container.querySelector('.cm-editor'))
+  })
+  assert.match(container.textContent ?? '', /Hello/)
+  assert.ok(container.querySelector('.cm-lineNumbers'))
+})

--- a/packages/core-editor/src/web/source-editor.tsx
+++ b/packages/core-editor/src/web/source-editor.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react'
+import { defaultKeymap, history, historyKeymap, indentWithTab } from '@codemirror/commands'
+import { markdown } from '@codemirror/lang-markdown'
+import { languages } from '@codemirror/language-data'
+import { HighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import { EditorState } from '@codemirror/state'
+import { EditorView, drawSelection, highlightActiveLine, highlightActiveLineGutter, keymap, lineNumbers } from '@codemirror/view'
+import { tags } from '@lezer/highlight'
+
+const mdHighlight = HighlightStyle.define([
+  { tag: tags.heading, color: '#F0EFED', fontWeight: '700' },
+  { tag: tags.strong, fontWeight: '700' },
+  { tag: tags.emphasis, fontStyle: 'italic' },
+  { tag: tags.strikethrough, textDecoration: 'line-through' },
+  { tag: tags.link, color: 'var(--dsw-business)' },
+  { tag: tags.url, color: 'var(--dsw-business)' },
+  { tag: tags.monospace, color: '#E8E0D0' },
+  { tag: tags.meta, color: '#7B7B79' },
+  { tag: tags.processingInstruction, color: '#7B7B79' },
+  { tag: tags.comment, color: '#7B7B79' },
+  { tag: tags.keyword, color: '#C4B5FD' },
+  { tag: tags.string, color: '#86EFAC' },
+  { tag: tags.number, color: '#FDBA74' },
+])
+
+const theme = EditorView.theme({
+  '&': {
+    background: 'transparent',
+    color: 'var(--dsw-label)',
+    fontSize: '14px',
+  },
+  '.cm-scroller': { fontFamily: 'var(--font-mono)', lineHeight: '1.65', overflow: 'visible' },
+  '.cm-content': { caretColor: 'var(--dsw-label)', padding: '0', minHeight: '240px' },
+  '.cm-gutters': {
+    background: 'transparent',
+    border: 'none',
+    color: '#7B7B79',
+    minWidth: '2.4em',
+  },
+  '.cm-activeLine': { background: 'color-mix(in srgb, var(--dsw-hover) 70%, transparent)' },
+  '.cm-activeLineGutter': { background: 'transparent', color: '#F0EFED' },
+  '.cm-cursor': { borderLeftColor: 'var(--dsw-label)' },
+  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
+    background: 'color-mix(in srgb, var(--dsw-business) 28%, transparent)',
+  },
+})
+
+export function SourceEditor({
+  value,
+  writable,
+  onChange,
+}: {
+  value: string
+  writable: boolean
+  onChange?: (next: string) => void
+}) {
+  const host = useRef<HTMLDivElement>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const onChangeRef = useRef(onChange)
+  onChangeRef.current = onChange
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const el = host.current
+    if (!el) return
+    const view = new EditorView({
+      parent: el,
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          history(),
+          drawSelection(),
+          lineNumbers(),
+          highlightActiveLine(),
+          highlightActiveLineGutter(),
+          keymap.of([...defaultKeymap, ...historyKeymap, indentWithTab]),
+          markdown({ codeLanguages: languages }),
+          syntaxHighlighting(mdHighlight),
+          EditorView.lineWrapping,
+          theme,
+          EditorView.updateListener.of((update) => {
+            if (!update.docChanged) return
+            if (timer.current) clearTimeout(timer.current)
+            timer.current = setTimeout(() => {
+              onChangeRef.current?.(update.state.doc.toString())
+            }, 400)
+          }),
+          EditorState.readOnly.of(!writable),
+          EditorView.editable.of(writable),
+        ],
+      }),
+    })
+    viewRef.current = view
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+      view.destroy()
+      viewRef.current = null
+    }
+  }, [writable])
+
+  useEffect(() => {
+    const view = viewRef.current
+    if (!view) return
+    const current = view.state.doc.toString()
+    if (current === value) return
+    if (view.hasFocus) return
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: value },
+    })
+  }, [value])
+
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current)
+    },
+    [],
+  )
+
+  return <div className="page-source" data-testid="page-source-editor" ref={host} />
+}

--- a/packages/core-editor/src/web/source-mode.test.ts
+++ b/packages/core-editor/src/web/source-mode.test.ts
@@ -1,0 +1,15 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { isPageSourceMode, setPageSourceMode, togglePageSourceMode } from './source-mode.ts'
+
+test('source mode is off until toggled for that record', () => {
+  setPageSourceMode('home', false)
+  assert.equal(isPageSourceMode('home'), false)
+  togglePageSourceMode('home')
+  assert.equal(isPageSourceMode('home'), true)
+  togglePageSourceMode('home')
+  assert.equal(isPageSourceMode('home'), false)
+  togglePageSourceMode('other')
+  assert.equal(isPageSourceMode('home'), false)
+  assert.equal(isPageSourceMode('other'), true)
+})

--- a/packages/core-editor/src/web/source-mode.ts
+++ b/packages/core-editor/src/web/source-mode.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react'
+
+const modes = new Map<string, boolean>()
+let seq = 0
+const listeners = new Set<() => void>()
+
+function bump() {
+  seq += 1
+  for (const fn of listeners) fn()
+}
+
+export function isPageSourceMode(recordId: string) {
+  return Boolean(modes.get(recordId))
+}
+
+export function setPageSourceMode(recordId: string, on: boolean) {
+  const id = String(recordId ?? '').trim()
+  if (!id) return
+  const next = Boolean(on)
+  if (Boolean(modes.get(id)) === next) return
+  modes.set(id, next)
+  bump()
+}
+
+export function togglePageSourceMode(recordId: string) {
+  setPageSourceMode(recordId, !isPageSourceMode(recordId))
+}
+
+export function usePageSourceMode(recordId: string) {
+  useSyncExternalStore(
+    (fn) => {
+      listeners.add(fn)
+      return () => listeners.delete(fn)
+    },
+    () => seq,
+  )
+  return isPageSourceMode(recordId)
+}

--- a/packages/core-editor/src/web/source-toggle.test.tsx
+++ b/packages/core-editor/src/web/source-toggle.test.tsx
@@ -1,0 +1,15 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { fireEvent, render } from '@testing-library/react'
+import { SourceToggle } from './source-toggle.tsx'
+import { isPageSourceMode, setPageSourceMode } from './source-mode.ts'
+
+test('source toggle flips markdown source mode for the record', () => {
+  setPageSourceMode('home', false)
+  const { getByTestId } = render(<SourceToggle record={{ id: 'home' }} />)
+  const btn = getByTestId('page-source-toggle')
+  assert.equal(btn.getAttribute('aria-pressed'), 'false')
+  fireEvent.click(btn)
+  assert.equal(isPageSourceMode('home'), true)
+  assert.equal(btn.getAttribute('aria-pressed'), 'true')
+})

--- a/packages/core-editor/src/web/source-toggle.tsx
+++ b/packages/core-editor/src/web/source-toggle.tsx
@@ -1,0 +1,22 @@
+import { CodeBracketIcon } from '@heroicons/react/16/solid'
+import type { DbRecord } from '@biu/type-file-system'
+import { togglePageSourceMode, usePageSourceMode } from './source-mode.ts'
+
+export function SourceToggle({ record }: { record: DbRecord }) {
+  const source = usePageSourceMode(record.id)
+  const label = source ? '正文' : '源码'
+  return (
+    <button
+      type="button"
+      className={`tasks-icon-btn${source ? ' is-on' : ''}`}
+      title={label}
+      data-dock-tip={label}
+      data-testid="page-source-toggle"
+      aria-pressed={source}
+      aria-label={source ? '切换到正文' : '切换到源码'}
+      onClick={() => togglePageSourceMode(record.id)}
+    >
+      <CodeBracketIcon aria-hidden className="size-4" />
+    </button>
+  )
+}

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,5 +1,10 @@
 export const PAGE_EDITOR_STYLE = `
 .page-editor{position:relative;overflow:visible;min-width:0;width:100%;padding:6px 0 48px;padding-left:0;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
+.page-editor.is-source{font-family:var(--font-mono);font-size:14px;letter-spacing:0}
+.page-source{min-width:0;width:100%}
+.page-source .cm-editor{background:transparent}
+.page-source .cm-focused{outline:none}
+.fsdb-page .fsdb-detail-actions .tasks-icon-btn.is-on{color:var(--dsw-business)}
 .page-editor .tiptap{outline:none;min-height:240px}
 .page-block-handle{position:absolute;z-index:6;width:28px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
 .page-block-handle-grip{flex:none;display:flex;align-items:center;justify-content:center;width:22px;height:26px;margin:0;border:0;border-radius:6px;padding:0;background:transparent;color:#EFEEEC;cursor:grab}

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2039,6 +2039,8 @@ export function CollectionBrowser({
   function RecordActions({ row, place }: { row: DbRecord; place: 'row' | 'detail' }) {
     const Actions = chrome?.Actions
     const Action = chrome?.Action
+    const DetailTools = chrome?.DetailTools
+    const extras = place === 'detail' && DetailTools ? <DetailTools record={row} /> : null
     const busy = actingRef.current
     const placed = placedActions(schema, place).filter((action) => {
       if (place !== 'detail' || !nested) return true
@@ -2055,8 +2057,15 @@ export function CollectionBrowser({
         </div>
       )
     if (Actions) {
-      if (!placed.length) return null
-      return wrap(<Actions actions={placed} record={row} busy={busy} place={place} run={(action) => void runAction(row, action)} />)
+      if (!placed.length && !extras) return null
+      return wrap(
+        <>
+          {placed.length ? (
+            <Actions actions={placed} record={row} busy={busy} place={place} run={(action) => void runAction(row, action)} />
+          ) : null}
+          {extras}
+        </>,
+      )
     }
     const actions = visibleActions(schema, row, place).filter((action) => {
       if (place !== 'detail' || !nested) return true
@@ -2065,27 +2074,30 @@ export function CollectionBrowser({
     const rowShown = actions.filter(
       (action) => Action || actionIcon(action.id) || action.id === 'open-split' || action.id === 'open-page',
     )
-    if (!rowShown.length) return null
+    if (!rowShown.length && !extras) return null
     return wrap(
-      rowShown.map((action) => {
-        const run = () => void runAction(row, action)
-        if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
-        const glyph = actionIcon(action.id)
-        return (
-          <button
-            key={action.id}
-            type="button"
-            className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
-            title={action.label}
-            data-dock-tip={action.label}
-            aria-label={`${action.label} ${labelOf(row)}`}
-            disabled={busy}
-            onClick={run}
-          >
-            {glyph ?? action.label}
-          </button>
-        )
-      }),
+      <>
+        {rowShown.map((action) => {
+          const run = () => void runAction(row, action)
+          if (Action) return <Action key={action.id} action={action} record={row} busy={busy} run={run} />
+          const glyph = actionIcon(action.id)
+          return (
+            <button
+              key={action.id}
+              type="button"
+              className={`tasks-icon-btn${action.tone === 'danger' ? ' is-danger' : ''}`}
+              title={action.label}
+              data-dock-tip={action.label}
+              aria-label={`${action.label} ${labelOf(row)}`}
+              disabled={busy}
+              onClick={run}
+            >
+              {glyph ?? action.label}
+            </button>
+          )
+        })}
+        {extras}
+      </>,
     )
   }
 

--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -25,6 +25,17 @@ test('decorate merges cells; later layer wins; dispose restores', () => {
   assert.equal(ui.chrome('/plugins').cells?.name, undefined)
 })
 
+test('decorate merges DetailTools; later layer wins', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  const First = () => null
+  const Second = () => null
+  ui.decorate('/pages', { DetailTools: First })
+  assert.equal(ui.chrome('/pages').DetailTools, First)
+  ui.decorate('/pages', { DetailTools: Second })
+  assert.equal(ui.chrome('/pages').DetailTools, Second)
+})
+
 test('decorate merges Actions; later layer wins', () => {
   const ctx = new Context()
   const ui = new DatabaseUiService(ctx)

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -8,6 +8,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
   const cells: CollectionChrome['cells'] = {}
   let Action: CollectionChrome['Action']
   let Actions: CollectionChrome['Actions']
+  let DetailTools: CollectionChrome['DetailTools']
   let Icon: CollectionChrome['Icon']
   let Title: CollectionChrome['Title']
   let Board: CollectionChrome['Board']
@@ -20,6 +21,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
     Object.assign(cells, layer.cells)
     if (layer.Action) Action = layer.Action
     if (layer.Actions) Actions = layer.Actions
+    if (layer.DetailTools) DetailTools = layer.DetailTools
     if (layer.Icon) Icon = layer.Icon
     if (layer.Title) Title = layer.Title
     if (layer.Board) Board = layer.Board
@@ -35,7 +37,7 @@ function mergeChrome(layers: CollectionChrome[]): CollectionChrome {
       }
     }
   }
-  return { cells, Action, Actions, Icon, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
+  return { cells, Action, Actions, DetailTools, Icon, Title, Board, Content, panes: panes.length ? panes : undefined, openRow, listViews, lockedFiltersFromSearch }
 }
 
 function mergeViews(layers: CollectionViewType[]): CollectionViewType[] {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -145,6 +145,7 @@ test('table title opens record from the title-side button', () => {
 test('title cell row tools skip the overflow action menu', () => {
   assert.match(browser, /const Actions = chrome\?\.Actions/)
   assert.match(browser, /placedActions\(schema, place\)/)
+  assert.match(browser, /chrome\?\.DetailTools/)
   assert.match(browser, /<Actions actions=\{placed\} record=\{row\}/)
   assert.match(browser, /toolbar=\{<RecordActions row=\{selected\} place="detail" \/>\}/)
   assert.match(browser, /data-testid="fsdb-detail-actions"/)

--- a/packages/type-file-system/src/ui.ts
+++ b/packages/type-file-system/src/ui.ts
@@ -44,6 +44,8 @@ export type CollectionChrome = {
   Action?: ComponentType<FsActionProps>
   /** 整组动作。有则宿主不再按条 map，前端完全由登记方 decorate。 */
   Actions?: ComponentType<FsActionsProps>
+  /** 详情底部 action 栏额外按钮（与记录动作同一排）。 */
+  DetailTools?: ComponentType<{ record: DbRecord }>
   /** 记录独立图标属性。有 emoji 用 emoji；不传则详情/侧栏/面包屑用集合 glyph。 */
   Icon?: ComponentType<{ record: DbRecord }>
   Title?: ComponentType<{ record: DbRecord; label: string }>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面/任务等正文编辑器增加 **Markdown 源码模式**：

- 详情底部 action 栏（与记录操作同一排）有 `</>` 切换
- 源码用 CodeMirror：Markdown 高亮、行号、当前行高亮
- 切回正文时把源码灌回 TipTap

无记录动作时也会单独画出这条 action 栏，保证源码按钮能出现。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

