### PR TITLE
fix: 源码模式后所见即所得吃不到 insert 的新行

### DIFF
--- a/packages/core-editor/src/web/insert-sync.test.ts
+++ b/packages/core-editor/src/web/insert-sync.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Editor } from '@tiptap/core'
+import { pageEditorExtensions } from './kit.ts'
+import { shouldApplyRemoteMarkdown } from './page-editor.tsx'
+
+function insertAfter(text: string, insertLine: number, newStr: string) {
+  const lines = text.split('\n')
+  lines.splice(insertLine, 0, newStr)
+  return lines.join('\n')
+}
+
+test('insert writes the new line into markdown source', () => {
+  const before = '# 欢迎\n\n第一段\n\n末段'
+  const next = insertAfter(before, 2, '你好')
+  assert.match(next, /你好/)
+  assert.equal(next.split('\n')[2], '你好')
+})
+
+test('tiptap paints an inserted markdown line as a paragraph', () => {
+  const md = insertAfter('# 欢迎\n\n第一段\n\n末段', 2, '你好')
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: md,
+    contentType: 'markdown',
+  })
+  assert.match(editor.getHTML(), /你好/)
+  assert.match(editor.getMarkdown(), /你好/)
+  editor.destroy()
+})
+
+test('remote insert applies when the wysiwyg editor is not live', () => {
+  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: false, hasJump: false }), true)
+  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: false }), false)
+  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: true }), true)
+  assert.equal(shouldApplyRemoteMarkdown({ focused: false, live: true, hasJump: false }), true)
+})

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -149,9 +149,10 @@ test('page editor applies later value when it is not focused', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-editor.tsx'), 'utf8')
+  assert.match(src, /shouldApplyRemoteMarkdown/)
   assert.match(src, /contentJumpForRecord/)
-  assert.match(src, /if \(editor\.isFocused && !contentJumpForRecord\(record\.id\)\) return/)
-  assert.doesNotMatch(src, /editor\.isDestroyed \|\| editor\.isFocused/)
+  assert.match(src, /editorHostIsLive\(editor\)/)
+  assert.doesNotMatch(src, /if \(editor\.isFocused && !contentJumpForRecord\(record\.id\)\) return/)
   assert.match(src, /md === saved\.current/)
 })
 

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -15,6 +15,17 @@ import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { bindEditorTextHost } from '@biu/core-pick/web'
 import { markdownLocusFromElement, markdownLocusFromSelection } from './markdown-locus.ts'
 
+/** 本地正在打字时不要用远端正文盖掉；源码模式 / 未挂上的编辑器不算在打字。 */
+export function shouldApplyRemoteMarkdown(args: {
+  focused: boolean
+  live: boolean
+  hasJump: boolean
+}) {
+  if (args.hasJump) return true
+  if (args.focused && args.live) return false
+  return true
+}
+
 function jumpToPending(editor: Editor, markdown: string, recordId: string, force = false) {
   requestAnimationFrame(() => {
     if (editor.isDestroyed) return
@@ -177,7 +188,15 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
       jumpToPending(editor, md, record.id)
       return
     }
-    if (editor.isFocused && !contentJumpForRecord(record.id)) return
+    if (
+      !shouldApplyRemoteMarkdown({
+        focused: editor.isFocused,
+        live: editorHostIsLive(editor),
+        hasJump: Boolean(contentJumpForRecord(record.id)),
+      })
+    ) {
+      return
+    }
     saved.current = md
     editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
     jumpToPending(editor, md, record.id, true)
@@ -195,20 +214,22 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
 
   useEffect(() => {
     if (!editor || editor.isDestroyed || !source) return
-    if (timer.current) clearTimeout(timer.current)
+    if (!timer.current) return
+    clearTimeout(timer.current)
+    timer.current = null
     const next = editor.getMarkdown()
-    if (next !== saved.current) {
-      saved.current = next
-      onChange?.(next)
-    }
+    if (next === saved.current) return
+    saved.current = next
+    onChange?.(next)
   }, [source, editor])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed || source) return
-    const md = saved.current
+    const md = asMarkdown(value)
+    saved.current = md
     if (md === editor.getMarkdown()) return
     editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
-  }, [source, editor])
+  }, [source, editor, value])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
insert 命令本身没坏：源码模式能看到「你好」说明 Markdown 已经写进文件。

问题在 TipTap 灌源。切到源码会卸掉 `EditorContent`，但 `editor.isFocused` 仍可能为 true，旧逻辑会跳过 `setContent`。切回正文时文档还是旧稿。

改成：只有「聚焦且 DOM 还挂着」才跳过远端正文；源码/未挂载会灌上新 Markdown。进源码只在有未完成 debounce 时才 flush TipTap，避免把旧文档盖回去。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

