### PR TITLE
fix: 页面正文写回 .page Markdown

### DIFF
--- a/packages/core-page/package.json
+++ b/packages/core-page/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Core-Page：工作区 .page/pages.sqlite 存页面，图片和附件走仓库 .biu/assets",
+  "description": "Core-Page：正文在工作区 .page/<id>.md，列表索引 .page/pages.sqlite，图片和附件走仓库 .biu/assets",
   "exports": {
     "./host": "./src/host/index.ts",
     "./web": "./src/web/index.ts"

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -80,6 +80,10 @@ test('page plugin stores pages in SQLite under .page', async () => {
   assert.equal(loaded?.title, '新页面')
   const sqlite = await readFile(join(root, '.page/pages.sqlite'))
   assert.ok(sqlite.byteLength > 0)
+  const mdFile = await readFile(join(root, `.page/${created[0]!.id}.md`), 'utf8')
+  assert.match(mdFile, /^---\n/)
+  assert.match(mdFile, /title: 新页面/)
+  assert.match(mdFile, /# 标题\n内容/)
 
   const written = await spec.update!(created[0]!.id, {
     facet: { tags: ['dp'], values: { dp: { complexity: 'O(n)' } } },
@@ -143,14 +147,14 @@ test('PagesStore reads existing markdown files from .page', async () => {
   assert.equal(reads, afterListReads)
   const home = await store.get('home')
   assert.equal(home?.notes, 'hello\n')
-  assert.equal(reads, afterListReads)
+  assert.equal(reads, afterListReads + 1)
   await writeFile(join(root, PAGE_ROOT, 'other.md'), dumpMarkdown({ title: 'Other' }, ''), 'utf8')
   const onlyHome = await store.list(['home'])
   assert.equal(onlyHome.length, 1)
   assert.equal(onlyHome[0]?.id, 'home')
   const all = await store.list()
   assert.equal(all.map((row) => row.id).sort().join(','), 'home,other')
-  assert.equal(reads, afterListReads + 1)
+  assert.equal(reads, afterListReads + 3)
 })
 
 test('collectPageAssetNames picks page asset pointers', () => {

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -16,7 +16,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
       route: '/pages',
       title: '页面',
       inspector: true,
-      blurb: '页面存在工作区 .page/pages.sqlite。列表 db_list /pages 走 SQLite，不扫全部 Markdown；正文 notes 用 db_content / db_update。图片和附件与其它表一样在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
+      blurb: '每页正文在工作区 .page/<id>.md（YAML 头 + Markdown）。.page/pages.sqlite 只做列表索引，不扫全部文件。正文用 db_content；改标题/标签等用 db_update。图片和附件在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
       order: 25,
       icon: 'document',
     },

--- a/packages/core-page/src/host/store.ts
+++ b/packages/core-page/src/host/store.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'node:module'
 import type { DbRecord, SchemaFieldValue } from '@biu/type-file-system'
 import { emptySchemaValue, normalizeSchemaValue } from '@biu/type-file-system'
 import { dataPath } from '@biu/host-plugin-loader/data-dir'
-import { splitMarkdown } from './markdown.ts'
+import { dumpMarkdown, splitMarkdown } from './markdown.ts'
 
 export const PAGE_ROOT = '.page'
 export const PAGE_DB = '.page/pages.sqlite'
@@ -109,6 +109,23 @@ export function fileUrl(name: string) {
 function pageRel(id: string) {
   if (!ID_RE.test(id)) throw new Error(`invalid page id: ${id}`)
   return `${PAGE_ROOT}/${id}.md`
+}
+
+function matterFrom(row: PageRow): Record<string, unknown> {
+  return {
+    title: row.title,
+    tags: row.tags,
+    parentId: row.parentId,
+    dependsOn: row.dependsOn,
+    facet: row.facet,
+    emoji: row.emoji,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+function toMarkdown(row: PageRow) {
+  return dumpMarkdown(matterFrom(row), row.notes ?? '')
 }
 
 function rowFromFile(id: string, raw: string): PageRow {
@@ -216,14 +233,16 @@ export class PagesStore {
     try {
       names = await this.fs.list(PAGE_ROOT)
     } catch {
-      return
+      names = []
     }
     const existing = new Set(
       (this.db.prepare('SELECT id FROM pages').all() as Array<{ id: string }>).map((row) => row.id),
     )
+    const mdIds = new Set<string>()
     for (const name of names) {
       if (!name.endsWith('.md')) continue
       const id = name.slice(0, -3)
+      mdIds.add(id)
       if (!ID_RE.test(id) || existing.has(id)) continue
       try {
         const row = rowFromFile(id, await this.fs.read(pageRel(id)))
@@ -233,6 +252,21 @@ export class PagesStore {
         /* skip unreadable */
       }
     }
+    await this.backfillMarkdown(mdIds)
+  }
+
+  /** sqlite 里已有、磁盘还没有 `.page/<id>.md` 的页，把 notes 写回 Markdown。 */
+  private async backfillMarkdown(mdIds: Set<string>) {
+    if (!this.db) return
+    const rows = this.db.prepare('SELECT * FROM pages').all() as SqlPage[]
+    for (const sql of rows) {
+      if (mdIds.has(sql.id)) continue
+      await this.persistMarkdown(rowFromSql(sql))
+    }
+  }
+
+  private async persistMarkdown(row: PageRow) {
+    await this.fs.write(pageRel(row.id), toMarkdown(row))
   }
 
   private upsert(row: PageRow) {
@@ -274,8 +308,17 @@ export class PagesStore {
     if (!ID_RE.test(id)) return null
     const db = await this.openDb()
     await this.migrateMarkdown()
-    const hit = db.prepare('SELECT * FROM pages WHERE id = ?').get(id) as SqlPage | undefined
-    return hit ? rowFromSql(hit) : null
+    try {
+      const row = rowFromFile(id, await this.fs.read(pageRel(id)))
+      this.upsert(row)
+      return row
+    } catch {
+      const hit = db.prepare('SELECT * FROM pages WHERE id = ?').get(id) as SqlPage | undefined
+      if (!hit) return null
+      const row = rowFromSql(hit)
+      await this.persistMarkdown(row)
+      return row
+    }
   }
 
   async update(id: string, patch: Record<string, unknown>): Promise<PageRow> {
@@ -316,7 +359,7 @@ export class PagesStore {
     try {
       await unlink(this.fs.resolve(pageRel(id)))
     } catch {
-      /* markdown sidecar optional */
+      /* markdown already gone */
     }
     await this.gcAssets()
   }
@@ -386,6 +429,7 @@ export class PagesStore {
   private async write(row: PageRow) {
     await this.openDb()
     this.upsert(row)
+    await this.persistMarkdown(row)
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面正文不该只活在 sqlite 里。`.gitignore` 也写的是「.page Markdown 存储」。sqlite 当初是为了 `db_list` 不扫全部 md，结果 `write()` 只 upsert 数据库、不再落 `.page/<id>.md`，所以你打开 markdown 看不到正文。

现在 create/update 把 YAML 头 + notes 写回 `.page/<id>.md`。sqlite 继续当列表索引。已经只存在 sqlite 里的页，启动时若没有对应 md 会补写。读单页以 markdown 为准。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

