### PR TITLE
feat: 选区 pick 带上正文文件路径

### DIFF
--- a/packages/core-chat/src/web/composer-pick-node.tsx
+++ b/packages/core-chat/src/web/composer-pick-node.tsx
@@ -24,7 +24,6 @@ export const PickChipNode = Node.create({
       label: { default: '' },
       route: { default: '' },
       path: { default: null },
-      file: { default: null },
       start_line: { default: null },
       end_line: { default: null },
       text: { default: null },

--- a/packages/core-chat/src/web/composer-pick-node.tsx
+++ b/packages/core-chat/src/web/composer-pick-node.tsx
@@ -23,6 +23,8 @@ export const PickChipNode = Node.create({
       action: { default: null },
       label: { default: '' },
       route: { default: '' },
+      path: { default: null },
+      file: { default: null },
       start_line: { default: null },
       end_line: { default: null },
       text: { default: null },

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -95,7 +95,6 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /editorHostIsLive\(editor\)/)
   assert.match(src, /Selection\.atStart/)
   assert.match(src, /bindEditorTextHost/)
-  assert.match(src, /pickContentFile/)
   assert.match(src, /markdownLocusFromSelection/)
   assert.match(src, /usePageSourceMode/)
   assert.match(src, /SourceEditor/)

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -95,6 +95,7 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /editorHostIsLive\(editor\)/)
   assert.match(src, /Selection\.atStart/)
   assert.match(src, /bindEditorTextHost/)
+  assert.match(src, /pickContentFile/)
   assert.match(src, /markdownLocusFromSelection/)
   assert.match(src, /usePageSourceMode/)
   assert.match(src, /SourceEditor/)

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -12,7 +12,7 @@ import { editorHostIsLive } from './editor-live.ts'
 import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
 import { tryContentJump, contentJumpForRecord } from './content-jump.ts'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
-import { bindEditorTextHost } from '@biu/core-pick/web'
+import { bindEditorTextHost, pickContentFile } from '@biu/core-pick/web'
 import { markdownLocusFromElement, markdownLocusFromSelection } from './markdown-locus.ts'
 
 /** 本地正在打字时不要用远端正文盖掉；源码模式 / 未挂上的编辑器不算在打字。 */
@@ -102,7 +102,7 @@ function TableBar({ editor }: { editor: Editor }) {
   )
 }
 
-export function PageEditor({ record, value, writable, onChange }: FsContentProps) {
+export function PageEditor({ record, value, writable, onChange, path }: FsContentProps) {
   const source = usePageSourceMode(record.id)
   const saved = useRef(asMarkdown(value))
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -206,11 +206,13 @@ export function PageEditor({ record, value, writable, onChange }: FsContentProps
     if (!editor || editor.isDestroyed || source) return
     const el = editor.view.dom
     bindEditorTextHost(el, {
+      path: path || undefined,
+      file: path ? pickContentFile(path) : undefined,
       locusFromSelection: () => markdownLocusFromSelection(editor),
       locusFromElement: (node) => markdownLocusFromElement(editor, node),
     })
     return () => bindEditorTextHost(el, null)
-  }, [editor, source])
+  }, [editor, source, path])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed || !source) return

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -12,7 +12,7 @@ import { editorHostIsLive } from './editor-live.ts'
 import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
 import { tryContentJump, contentJumpForRecord } from './content-jump.ts'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
-import { bindEditorTextHost, pickContentFile } from '@biu/core-pick/web'
+import { bindEditorTextHost } from '@biu/core-pick/web'
 import { markdownLocusFromElement, markdownLocusFromSelection } from './markdown-locus.ts'
 
 /** 本地正在打字时不要用远端正文盖掉；源码模式 / 未挂上的编辑器不算在打字。 */
@@ -207,7 +207,6 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
     const el = editor.view.dom
     bindEditorTextHost(el, {
       path: path || undefined,
-      file: path ? pickContentFile(path) : undefined,
       locusFromSelection: () => markdownLocusFromSelection(editor),
       locusFromElement: (node) => markdownLocusFromElement(editor, node),
     })

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -2985,6 +2985,7 @@ export function CollectionBrowser({
           onNext={total > 1 ? () => void stepViewRecord(1) : undefined}
           canPrev={viewIndex == null ? total > 1 : viewIndex > 0}
           canNext={viewIndex == null ? total > 1 : viewIndex < total - 1}
+          collectionPath={collectionPath}
         />
       ) : null}
         </div>

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -138,6 +138,7 @@ export function RecordDetail({
   canNext,
   headingOutline = true,
   toolbar,
+  collectionPath,
 }: {
   selected: DbRecord
   schema: CollectionSchema
@@ -157,6 +158,7 @@ export function RecordDetail({
   canNext?: boolean
   headingOutline?: boolean
   toolbar?: ReactNode
+  collectionPath?: string
 }) {
   useEffect(() => {
     const onTitle = () => {
@@ -277,6 +279,7 @@ export function RecordDetail({
                           spec={spec}
                           value={detailBody}
                           writable={spec.writable}
+                          path={collectionPath ? `${collectionPath}/${selected.id}` : undefined}
                           onChange={(next) => void writePatch(selected, { [key]: next })}
                         />
                       </div>

--- a/packages/core-pick/src/host/index.test.ts
+++ b/packages/core-pick/src/host/index.test.ts
@@ -14,6 +14,5 @@ test('registers pick instructions on the system prompt', async () => {
   assert.match(text, /<pick/)
   assert.match(text, /kind\/id/)
   assert.match(text, /path/)
-  assert.match(text, /\.page/)
   assert.match(text, /db_content/)
 })

--- a/packages/core-pick/src/host/index.test.ts
+++ b/packages/core-pick/src/host/index.test.ts
@@ -13,4 +13,7 @@ test('registers pick instructions on the system prompt', async () => {
   const text = ctx.systemPrompt.assemble()
   assert.match(text, /<pick/)
   assert.match(text, /kind\/id/)
+  assert.match(text, /path/)
+  assert.match(text, /\.page/)
+  assert.match(text, /db_content/)
 })

--- a/packages/core-pick/src/host/index.ts
+++ b/packages/core-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。',
+    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区会带 path（db_content 记录路径，如 /pages/p002）和可选 file（工作区 Markdown，页面为 .page/<id>.md），以及 start_line/end_line/text；改正文用 db_content 的 path，不要只拿行号。',
   )
 }

--- a/packages/core-pick/src/host/index.ts
+++ b/packages/core-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区会带 path（db_content 记录路径，如 /pages/p002）和可选 file（工作区 Markdown，页面为 .page/<id>.md），以及 start_line/end_line/text；改正文用 db_content 的 path，不要只拿行号。',
+    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区会带 path（db_content 记录路径，如 /pages/p002）以及 start_line/end_line/text；改正文用 db_content 的 path，不要读工作区文件、也不要只拿行号。',
   )
 }

--- a/packages/core-pick/src/web/editor-host.test.ts
+++ b/packages/core-pick/src/web/editor-host.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { bindEditorTextHost, pickContentFile } from './editor-host.ts'
+import { bindEditorTextHost } from './editor-host.ts'
 import { textPickFromSelection } from './types.ts'
 
 test('text pick from a bound editor includes markdown source lines', () => {
@@ -10,7 +10,6 @@ test('text pick from a bound editor includes markdown source lines', () => {
   document.body.append(root)
   bindEditorTextHost(root, {
     path: '/pages/home',
-    file: '.page/home.md',
     locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL' }),
     locusFromElement: () => null,
   })
@@ -26,12 +25,6 @@ test('text pick from a bound editor includes markdown source lines', () => {
   assert.equal(ref.end_line, 5)
   assert.equal(ref.text, 'UNIQUESEL')
   assert.equal(ref.path, '/pages/home')
-  assert.equal(ref.file, '.page/home.md')
   bindEditorTextHost(root, null)
   root.remove()
-})
-
-test('page record path maps to the workspace markdown file', () => {
-  assert.equal(pickContentFile('/pages/p002'), '.page/p002.md')
-  assert.equal(pickContentFile('/tasks/t1'), undefined)
 })

--- a/packages/core-pick/src/web/editor-host.test.ts
+++ b/packages/core-pick/src/web/editor-host.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { bindEditorTextHost } from './editor-host.ts'
+import { bindEditorTextHost, pickContentFile } from './editor-host.ts'
 import { textPickFromSelection } from './types.ts'
 
 test('text pick from a bound editor includes markdown source lines', () => {
@@ -9,6 +9,8 @@ test('text pick from a bound editor includes markdown source lines', () => {
   root.append(leaf)
   document.body.append(root)
   bindEditorTextHost(root, {
+    path: '/pages/home',
+    file: '.page/home.md',
     locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL' }),
     locusFromElement: () => null,
   })
@@ -23,6 +25,13 @@ test('text pick from a bound editor includes markdown source lines', () => {
   assert.equal(ref.start_line, 5)
   assert.equal(ref.end_line, 5)
   assert.equal(ref.text, 'UNIQUESEL')
+  assert.equal(ref.path, '/pages/home')
+  assert.equal(ref.file, '.page/home.md')
   bindEditorTextHost(root, null)
   root.remove()
+})
+
+test('page record path maps to the workspace markdown file', () => {
+  assert.equal(pickContentFile('/pages/p002'), '.page/p002.md')
+  assert.equal(pickContentFile('/tasks/t1'), undefined)
 })

--- a/packages/core-pick/src/web/editor-host.ts
+++ b/packages/core-pick/src/web/editor-host.ts
@@ -1,8 +1,17 @@
 export type EditorTextLocus = { start_line: number; end_line: number; text: string }
 
 export type EditorTextHost = {
+  /** db_content 路径，如 /pages/p002 */
+  path?: string
+  /** 工作区 Markdown，页面为 .page/<id>.md */
+  file?: string
   locusFromSelection: () => EditorTextLocus | null
   locusFromElement: (el: Element) => EditorTextLocus | null
+}
+
+export function pickContentFile(path: string) {
+  const id = path.match(/^\/pages\/([^/]+)$/)?.[1]
+  return id ? `.page/${id}.md` : undefined
 }
 
 const hosts = new WeakMap<Element, EditorTextHost>()

--- a/packages/core-pick/src/web/editor-host.ts
+++ b/packages/core-pick/src/web/editor-host.ts
@@ -3,15 +3,8 @@ export type EditorTextLocus = { start_line: number; end_line: number; text: stri
 export type EditorTextHost = {
   /** db_content 路径，如 /pages/p002 */
   path?: string
-  /** 工作区 Markdown，页面为 .page/<id>.md */
-  file?: string
   locusFromSelection: () => EditorTextLocus | null
   locusFromElement: (el: Element) => EditorTextLocus | null
-}
-
-export function pickContentFile(path: string) {
-  const id = path.match(/^\/pages\/([^/]+)$/)?.[1]
-  return id ? `.page/${id}.md` : undefined
 }
 
 const hosts = new WeakMap<Element, EditorTextHost>()

--- a/packages/core-pick/src/web/index.tsx
+++ b/packages/core-pick/src/web/index.tsx
@@ -5,8 +5,8 @@ import { PickService, getPick, usePickState } from './service.ts'
 import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
-export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, lineSpanLabel, type PickRef } from './types.ts'
-export { bindEditorTextHost, editorHostFromNode } from './editor-host.ts'
+export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, withHostSource, lineSpanLabel, type PickRef } from './types.ts'
+export { bindEditorTextHost, editorHostFromNode, pickContentFile } from './editor-host.ts'
 export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, pickSurfaceFromNode, pickSurfaceAtPoint } from './resolve.ts'
 

--- a/packages/core-pick/src/web/index.tsx
+++ b/packages/core-pick/src/web/index.tsx
@@ -6,7 +6,7 @@ import { PickOverlay } from './overlay.tsx'
 
 export { PickService, usePickState } from './service.ts'
 export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, withHostSource, lineSpanLabel, type PickRef } from './types.ts'
-export { bindEditorTextHost, editorHostFromNode, pickContentFile } from './editor-host.ts'
+export { bindEditorTextHost, editorHostFromNode } from './editor-host.ts'
 export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, pickSurfaceFromNode, pickSurfaceAtPoint } from './resolve.ts'
 

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -75,11 +75,15 @@ test('text pick round-trips markdown source line numbers', () => {
       id: 'a1',
       label: '第一段',
       route: '/pages/home',
+      path: '/pages/home',
+      file: '.page/home.md',
       start_line: 5,
       end_line: 6,
       text: '第一段\n\nUNIQUESEL',
     },
   ])
+  assert.match(text, /path="\/pages\/home"/)
+  assert.match(text, /file="\.page\/home.md"/)
   assert.match(text, /start_line="5"/)
   assert.match(text, /end_line="6"/)
   assert.match(text, /text="第一段&#10;&#10;UNIQUESEL"/)
@@ -87,6 +91,8 @@ test('text pick round-trips markdown source line numbers', () => {
   assert.equal(parsed.refs[0]?.start_line, 5)
   assert.equal(parsed.refs[0]?.end_line, 6)
   assert.equal(parsed.refs[0]?.text, '第一段\n\nUNIQUESEL')
+  assert.equal(parsed.refs[0]?.path, '/pages/home')
+  assert.equal(parsed.refs[0]?.file, '.page/home.md')
 })
 
 test('selected body text becomes a text pick', () => {

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -76,14 +76,12 @@ test('text pick round-trips markdown source line numbers', () => {
       label: '第一段',
       route: '/pages/home',
       path: '/pages/home',
-      file: '.page/home.md',
       start_line: 5,
       end_line: 6,
       text: '第一段\n\nUNIQUESEL',
     },
   ])
   assert.match(text, /path="\/pages\/home"/)
-  assert.match(text, /file="\.page\/home.md"/)
   assert.match(text, /start_line="5"/)
   assert.match(text, /end_line="6"/)
   assert.match(text, /text="第一段&#10;&#10;UNIQUESEL"/)
@@ -92,7 +90,6 @@ test('text pick round-trips markdown source line numbers', () => {
   assert.equal(parsed.refs[0]?.end_line, 6)
   assert.equal(parsed.refs[0]?.text, '第一段\n\nUNIQUESEL')
   assert.equal(parsed.refs[0]?.path, '/pages/home')
-  assert.equal(parsed.refs[0]?.file, '.page/home.md')
 })
 
 test('selected body text becomes a text pick', () => {

--- a/packages/core-pick/src/web/resolve.ts
+++ b/packages/core-pick/src/web/resolve.ts
@@ -1,5 +1,5 @@
 import type { PickRef } from './types.ts'
-import { pickIdFromText, pickPreview, withPickLocus } from './types.ts'
+import { pickIdFromText, pickPreview, withHostSource, withPickLocus } from './types.ts'
 import { editorHostFromNode } from './editor-host.ts'
 
 const KIND = 'data-biu-kind'
@@ -118,13 +118,16 @@ function editorBlockPick(
     return {
       el,
       ref: withPickLocus(
-        {
-          kind: taggedKind,
-          id: taggedId,
-          ...(read(el, ACTION) ? { action: read(el, ACTION) } : {}),
-          label: read(el, LABEL) || taggedId,
-          route,
-        },
+        withHostSource(
+          {
+            kind: taggedKind,
+            id: taggedId,
+            ...(read(el, ACTION) ? { action: read(el, ACTION) } : {}),
+            label: read(el, LABEL) || taggedId,
+            route,
+          },
+          el,
+        ),
         editorHostFromNode(el)?.locusFromElement(el) ?? null,
       ),
     }
@@ -134,12 +137,15 @@ function editorBlockPick(
   return {
     el,
     ref: withPickLocus(
-      {
-        kind: 'block',
-        id: `${tag}:${pickIdFromText(text || tag)}`,
-        label: text || tag,
-        route,
-      },
+      withHostSource(
+        {
+          kind: 'block',
+          id: `${tag}:${pickIdFromText(text || tag)}`,
+          label: text || tag,
+          route,
+        },
+        el,
+      ),
       editorHostFromNode(el)?.locusFromElement(el) ?? null,
     ),
   }

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -6,6 +6,10 @@ export type PickRef = {
   action?: string
   label: string
   route: string
+  /** db_content 路径，如 /pages/p002。 */
+  path?: string
+  /** 工作区正文文件，页面为 .page/<id>.md。 */
+  file?: string
   /** Markdown 源码行号（1-based），不是可视编辑器行。 */
   start_line?: number
   end_line?: number
@@ -38,6 +42,7 @@ export function dedupePicks(refs: PickRef[]): PickRef[] {
       route: ref.route || prev.route,
       ...(ref.action || prev.action ? { action: ref.action || prev.action } : {}),
       ...locusFields(ref.start_line != null ? ref : prev),
+      ...sourceFields(ref.path || ref.file ? ref : prev),
     })
   }
   return [...map.values()]
@@ -50,6 +55,8 @@ export function formatPicks(refs: PickRef[]) {
       if (ref.action) attrs.push(`action="${escapeAttr(ref.action)}"`)
       if (ref.route) attrs.push(`route="${escapeAttr(ref.route)}"`)
       if (ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
+      if (ref.path) attrs.push(`path="${escapeAttr(ref.path)}"`)
+      if (ref.file) attrs.push(`file="${escapeAttr(ref.file)}"`)
       if (ref.start_line != null) attrs.push(`start_line="${ref.start_line}"`)
       if (ref.end_line != null) attrs.push(`end_line="${ref.end_line}"`)
       if (ref.text) attrs.push(`text="${escapeAttr(ref.text)}"`)
@@ -84,11 +91,21 @@ function parsePickAttrs(raw: string): PickRef | null {
     ...(attrs.action?.trim() ? { action: attrs.action.trim() } : {}),
     label: attrs.label?.trim() || id,
     route: attrs.route?.trim() || '',
+    ...sourceFields({ path: attrs.path?.trim(), file: attrs.file?.trim() }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
       text: text || undefined,
     }),
+  }
+}
+
+function sourceFields(ref: { path?: string; file?: string }) {
+  const path = ref.path?.trim()
+  const file = ref.file?.trim()
+  return {
+    ...(path ? { path } : {}),
+    ...(file ? { file } : {}),
   }
 }
 
@@ -149,7 +166,9 @@ export function lineSpanLabel(ref: PickRef) {
 
 export function chipLabel(ref: PickRef) {
   const lines = lineSpanLabel(ref)
+  const where = ref.file || ref.path
   if (ref.action) return `${ref.label} · ${ref.action}`
+  if (lines && where) return `${lines} ${where}`
   if (lines) return `${lines} ${ref.label}`
   return ref.label
 }
@@ -172,7 +191,16 @@ export function withPickLocus(ref: PickRef, locus: { start_line: number; end_lin
   return {
     ...ref,
     id: pickIdFromText(`${locus.start_line}:${locus.end_line}:${locus.text || ref.label}`),
+    ...sourceFields(ref),
     ...locusFields(locus),
+  }
+}
+
+export function withHostSource(ref: PickRef, node: Node | null): PickRef {
+  const host = editorHostFromNode(node)
+  return {
+    ...ref,
+    ...sourceFields({ path: host?.path || ref.path, file: host?.file || ref.file }),
   }
 }
 
@@ -188,7 +216,10 @@ export function textPickFromSelection(
   const anchor = 'anchorNode' in selection ? (selection as Selection).anchorNode : null
   const host = editorHostFromNode(anchor)
   const locus = host ? host.locusFromSelection() : null
-  return withPickLocus({ kind: 'text', id: pickIdFromText(raw), label, route }, locus)
+  return withPickLocus(
+    withHostSource({ kind: 'text', id: pickIdFromText(raw), label, route }, anchor),
+    locus,
+  )
 }
 
 export function pickChipAttrs(ref: PickRef) {
@@ -198,6 +229,8 @@ export function pickChipAttrs(ref: PickRef) {
     label: ref.label,
     route: ref.route,
     action: ref.action ?? null,
+    path: ref.path ?? null,
+    file: ref.file ?? null,
     start_line: ref.start_line ?? null,
     end_line: ref.end_line ?? null,
     text: ref.text ?? null,
@@ -209,6 +242,8 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
   const id = String(attrs.id ?? '').trim()
   if (!kind || !id) return null
   const action = String(attrs.action ?? '').trim()
+  const path = String(attrs.path ?? '').trim()
+  const file = String(attrs.file ?? '').trim()
   const start = Number(attrs.start_line)
   const end = Number(attrs.end_line)
   const text = typeof attrs.text === 'string' ? attrs.text.trim() : ''
@@ -218,6 +253,7 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
     label: String(attrs.label ?? '').trim() || id,
     route: String(attrs.route ?? ''),
     ...(action ? { action } : {}),
+    ...sourceFields({ path, file }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -8,8 +8,6 @@ export type PickRef = {
   route: string
   /** db_content 路径，如 /pages/p002。 */
   path?: string
-  /** 工作区正文文件，页面为 .page/<id>.md。 */
-  file?: string
   /** Markdown 源码行号（1-based），不是可视编辑器行。 */
   start_line?: number
   end_line?: number
@@ -42,7 +40,7 @@ export function dedupePicks(refs: PickRef[]): PickRef[] {
       route: ref.route || prev.route,
       ...(ref.action || prev.action ? { action: ref.action || prev.action } : {}),
       ...locusFields(ref.start_line != null ? ref : prev),
-      ...sourceFields(ref.path || ref.file ? ref : prev),
+      ...sourceFields(ref.path ? ref : prev),
     })
   }
   return [...map.values()]
@@ -56,7 +54,6 @@ export function formatPicks(refs: PickRef[]) {
       if (ref.route) attrs.push(`route="${escapeAttr(ref.route)}"`)
       if (ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
       if (ref.path) attrs.push(`path="${escapeAttr(ref.path)}"`)
-      if (ref.file) attrs.push(`file="${escapeAttr(ref.file)}"`)
       if (ref.start_line != null) attrs.push(`start_line="${ref.start_line}"`)
       if (ref.end_line != null) attrs.push(`end_line="${ref.end_line}"`)
       if (ref.text) attrs.push(`text="${escapeAttr(ref.text)}"`)
@@ -91,7 +88,7 @@ function parsePickAttrs(raw: string): PickRef | null {
     ...(attrs.action?.trim() ? { action: attrs.action.trim() } : {}),
     label: attrs.label?.trim() || id,
     route: attrs.route?.trim() || '',
-    ...sourceFields({ path: attrs.path?.trim(), file: attrs.file?.trim() }),
+    ...sourceFields({ path: attrs.path?.trim() }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
@@ -100,12 +97,10 @@ function parsePickAttrs(raw: string): PickRef | null {
   }
 }
 
-function sourceFields(ref: { path?: string; file?: string }) {
+function sourceFields(ref: { path?: string }) {
   const path = ref.path?.trim()
-  const file = ref.file?.trim()
   return {
     ...(path ? { path } : {}),
-    ...(file ? { file } : {}),
   }
 }
 
@@ -166,7 +161,7 @@ export function lineSpanLabel(ref: PickRef) {
 
 export function chipLabel(ref: PickRef) {
   const lines = lineSpanLabel(ref)
-  const where = ref.file || ref.path
+  const where = ref.path
   if (ref.action) return `${ref.label} · ${ref.action}`
   if (lines && where) return `${lines} ${where}`
   if (lines) return `${lines} ${ref.label}`
@@ -200,7 +195,7 @@ export function withHostSource(ref: PickRef, node: Node | null): PickRef {
   const host = editorHostFromNode(node)
   return {
     ...ref,
-    ...sourceFields({ path: host?.path || ref.path, file: host?.file || ref.file }),
+    ...sourceFields({ path: host?.path || ref.path }),
   }
 }
 
@@ -230,7 +225,6 @@ export function pickChipAttrs(ref: PickRef) {
     route: ref.route,
     action: ref.action ?? null,
     path: ref.path ?? null,
-    file: ref.file ?? null,
     start_line: ref.start_line ?? null,
     end_line: ref.end_line ?? null,
     text: ref.text ?? null,
@@ -243,7 +237,6 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
   if (!kind || !id) return null
   const action = String(attrs.action ?? '').trim()
   const path = String(attrs.path ?? '').trim()
-  const file = String(attrs.file ?? '').trim()
   const start = Number(attrs.start_line)
   const end = Number(attrs.end_line)
   const text = typeof attrs.text === 'string' ? attrs.text.trim() : ''
@@ -253,7 +246,7 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
     label: String(attrs.label ?? '').trim() || id,
     route: String(attrs.route ?? ''),
     ...(action ? { action } : {}),
-    ...sourceFields({ path, file }),
+    ...sourceFields({ path }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,

--- a/packages/type-file-system/src/ui.ts
+++ b/packages/type-file-system/src/ui.ts
@@ -74,6 +74,8 @@ export type FsContentProps = {
   value: unknown
   writable?: boolean
   onChange?: (next: unknown) => void
+  /** 记录路径，如 /pages/p002，给选区 pick 注入 db_content 句柄。 */
+  path?: string
 }
 
 /** 集合自定义呈现：谁 registerView(path)，谁才能在该 path 用这个 mode。 */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
编辑器选区 pick 以前只有 hashed id + 行号，agent 不知道这是哪条记录的正文。

现在注入 `path`（`db_content` 用的记录路径，如 `/pages/p002`），以及 `start_line` / `end_line` / `text`。不带工作区 `file`：改正文只走 `db_content`，不要直接读 `.page/*.md`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

