### PR TITLE
fix: TipTap 搜索跳转对齐悬浮目录

### DIFF
--- a/packages/core-editor/src/web/find-plugin.ts
+++ b/packages/core-editor/src/web/find-plugin.ts
@@ -3,6 +3,7 @@ import type { Editor } from '@tiptap/core'
 import type { Node } from '@tiptap/pm/model'
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state'
 import { Decoration, DecorationSet } from '@tiptap/pm/view'
+import { scrollOutlineTarget } from '@biu/public-ui'
 import { findInPmDoc, wrapFindIndex } from './find-ranges.ts'
 
 export const FIND_PLUGIN = new PluginKey('page-find')
@@ -44,6 +45,10 @@ export const pageFind = Extension.create({
           decorations(state) {
             return FIND_PLUGIN.getState(state)?.set
           },
+          handleScrollToSelection(view) {
+            const query = FIND_PLUGIN.getState(view.state)?.query
+            return Boolean(String(query ?? '').trim())
+          },
         },
       }),
     ]
@@ -58,8 +63,27 @@ export function applyEditorFind(editor: Editor, query: string, index: number) {
   if (total) {
     const hit = hits[i]!
     tr.setSelection(TextSelection.create(editor.state.doc, hit.from, hit.to))
-    tr.scrollIntoView()
   }
   editor.view.dispatch(tr)
+  if (total) scrollFindLikeOutline(editor, hits[i]!.from)
   return { total, index: i }
+}
+
+/** 和悬浮目录 / content-jump 一样：滚详情里的块，而不是 PM 自带的 scrollIntoView。 */
+function scrollFindLikeOutline(editor: Editor, pos: number) {
+  try {
+    const mapped = editor.view.domAtPos(pos)
+    const node = mapped.node
+    const el = node instanceof Element ? node : node.parentElement
+    if (!(el instanceof HTMLElement)) return
+    const block =
+      el.closest('h1, h2, h3, p, li, blockquote, pre, table, .page-block') ?? el
+    const run = () => scrollOutlineTarget(block)
+    run()
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => requestAnimationFrame(run))
+    }
+  } catch {
+    /* jsdom 没有 layout */
+  }
 }

--- a/packages/core-editor/src/web/find-ranges.ts
+++ b/packages/core-editor/src/web/find-ranges.ts
@@ -1,5 +1,7 @@
 export type FindHit = { from: number; to: number }
 
+type TextPiece = { flatFrom: number; pos: number; text: string }
+
 export function wrapFindIndex(index: number, total: number) {
   if (total <= 0) return 0
   return ((index % total) + total) % total
@@ -21,21 +23,58 @@ export function findRanges(text: string, query: string): FindHit[] {
   return hits
 }
 
-export function findInPmDoc(doc: { descendants: (fn: (node: { isText?: boolean; text?: string | null }, pos: number) => void) => void }, query: string): FindHit[] {
+function posFromFlat(pieces: TextPiece[], offset: number) {
+  if (!pieces.length) return 0
+  if (offset <= 0) return pieces[0]!.pos
+  for (const piece of pieces) {
+    const end = piece.flatFrom + piece.text.length
+    if (offset <= end) return piece.pos + (offset - piece.flatFrom)
+  }
+  const last = pieces[pieces.length - 1]!
+  return last.pos + last.text.length
+}
+
+/** 在同一段落内跨 mark 搜可见文字，避免加粗/颜色把一次命中拆开。 */
+export function findInPmDoc(
+  doc: {
+    descendants: (
+      fn: (
+        node: {
+          isTextblock?: boolean
+          forEach?: (cb: (child: { isText?: boolean; text?: string | null }, offset: number) => void) => void
+        },
+        pos: number,
+      ) => boolean | void,
+    ) => void
+  },
+  query: string,
+): FindHit[] {
   const needle = query.trim()
   if (!needle) return []
   const q = needle.toLowerCase()
   const hits: FindHit[] = []
   doc.descendants((node, pos) => {
-    if (!node.isText || !node.text) return
-    const hay = node.text.toLowerCase()
+    if (!node.isTextblock || typeof node.forEach !== 'function') return
+    const pieces: TextPiece[] = []
+    let flat = ''
+    node.forEach((child, offset) => {
+      if (!child.isText || !child.text) return
+      pieces.push({ flatFrom: flat.length, pos: pos + 1 + offset, text: child.text })
+      flat += child.text
+    })
+    if (!flat) return false
+    const hay = flat.toLowerCase()
     let from = 0
     while (from <= hay.length - q.length) {
       const at = hay.indexOf(q, from)
       if (at < 0) break
-      hits.push({ from: pos + at, to: pos + at + needle.length })
+      hits.push({
+        from: posFromFlat(pieces, at),
+        to: posFromFlat(pieces, at + needle.length),
+      })
       from = at + Math.max(q.length, 1)
     }
+    return false
   })
   return hits
 }

--- a/packages/core-editor/src/web/find.test.ts
+++ b/packages/core-editor/src/web/find.test.ts
@@ -2,6 +2,8 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
 import { findInPmDoc, findRanges, wrapFindIndex } from './find-ranges.ts'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import { applyEditorFind } from './find-plugin.ts'
 import { pageEditorExtensions } from './kit.ts'
 import { isFindHotkey } from './find-bar.tsx'
@@ -37,6 +39,27 @@ test('findInPmDoc matches visible text positions', () => {
   applyEditorFind(editor, '你好', 1)
   assert.equal(editor.state.doc.textBetween(editor.state.selection.from, editor.state.selection.to), '你好')
   editor.destroy()
+})
+
+test('findInPmDoc matches across marks in one paragraph', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: '前 **你好**世界 后',
+    contentType: 'markdown',
+  })
+  const hits = findInPmDoc(editor.state.doc, '你好世界')
+  assert.equal(hits.length, 1)
+  applyEditorFind(editor, '你好世界', 0)
+  assert.equal(editor.state.doc.textBetween(editor.state.selection.from, editor.state.selection.to), '你好世界')
+  editor.destroy()
+})
+
+test('tiptap find jump uses outline scroll, not ProseMirror scrollIntoView', () => {
+  const plugin = readFileSync(resolve(import.meta.dirname, './find-plugin.ts'), 'utf8')
+  assert.match(plugin, /scrollOutlineTarget/)
+  assert.match(plugin, /scrollFindLikeOutline/)
+  assert.match(plugin, /handleScrollToSelection/)
+  assert.doesNotMatch(plugin, /tr\.scrollIntoView/)
 })
 
 test('isFindHotkey is command/ctrl f without shift', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
所见即所得里 ⌘F 命中后，ProseMirror 的 `scrollIntoView` 滚不到详情滚动容器，所以搜索栏上下一项等于没跳。源码模式 CodeMirror 本来就能跳，这次没改。

TipTap 现在和悬浮目录 / content-jump 一样：对准 `h1–h3 / p / li / …`，调用 `scrollOutlineTarget`（`block: start` + smooth），并双 rAF 再滚一次。查找进行中拦截 PM 默认选区滚动，避免把这次跳转顶掉。顺带让同一段落跨加粗/颜色的词也能搜到。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

