### PR TITLE
feat: 编辑器颜色跟标签色板，改二级菜单

### DIFF
--- a/packages/core-editor/src/web/color-swatches.ts
+++ b/packages/core-editor/src/web/color-swatches.ts
@@ -1,21 +1,24 @@
+import { TAG_TONES } from '@biu/public-ui'
+
+/** 与合集标签相同的色相。 */
+export const EDITOR_TONES = TAG_TONES
+
+/** 标签字色。 */
+export function tagTextColor(tone: string) {
+  return tone
+}
+
+/** 标签浅底：22% 叠在透明上，和 `.biu-tag` 背景一致。 */
+export function tagWashColor(tone: string) {
+  return `color-mix(in srgb, ${tone} 22%, transparent)`
+}
+
 export const TEXT_COLORS = [
   { label: '默认', value: '' },
-  { label: '红', value: '#E11D48' },
-  { label: '橙', value: '#F97316' },
-  { label: '黄', value: '#EAB308' },
-  { label: '绿', value: '#22C55E' },
-  { label: '青', value: '#22D3EE' },
-  { label: '蓝', value: '#38BDF8' },
-  { label: '紫', value: '#A78BFA' },
+  ...EDITOR_TONES.map((value) => ({ label: value, value })),
 ] as const
 
 export const HIGHLIGHT_COLORS = [
   { label: '无', value: '' },
-  { label: '黄', value: '#FEF08A' },
-  { label: '绿', value: '#BBF7D0' },
-  { label: '青', value: '#A5F3FC' },
-  { label: '蓝', value: '#BAE6FD' },
-  { label: '紫', value: '#E9D5FF' },
-  { label: '粉', value: '#FBCFE8' },
-  { label: '红', value: '#FECACA' },
+  ...EDITOR_TONES.map((value) => ({ label: value, value: tagWashColor(value) })),
 ] as const

--- a/packages/core-editor/src/web/color.test.ts
+++ b/packages/core-editor/src/web/color.test.ts
@@ -1,17 +1,24 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
+import { TAG_TONES } from '@biu/public-ui'
 import { pageEditorExtensions } from './kit.ts'
-import { HIGHLIGHT_COLORS, TEXT_COLORS } from './color-swatches.ts'
+import { EDITOR_TONES, HIGHLIGHT_COLORS, TEXT_COLORS, tagWashColor } from './color-swatches.ts'
 
-test('color and highlight palettes have defaults plus hues', () => {
+test('color palettes follow supertag tones', () => {
+  assert.deepEqual([...EDITOR_TONES], [...TAG_TONES])
   assert.ok(TEXT_COLORS.some((item) => item.value === ''))
-  assert.ok(TEXT_COLORS.some((item) => item.value === '#E11D48'))
   assert.ok(HIGHLIGHT_COLORS.some((item) => item.value === ''))
-  assert.ok(HIGHLIGHT_COLORS.some((item) => item.value === '#FEF08A'))
+  for (const tone of TAG_TONES) {
+    assert.ok(TEXT_COLORS.some((item) => item.value === tone))
+    assert.ok(HIGHLIGHT_COLORS.some((item) => item.value === tagWashColor(tone)))
+  }
+  assert.ok(tagWashColor('#5b9fd6').includes('22%'))
 })
 
-test('tiptap Color and Highlight apply to a selection', () => {
+test('tiptap Color and Highlight apply tag tones', () => {
+  const text = TAG_TONES[0]!
+  const wash = tagWashColor(text)
   const editor = new Editor({
     extensions: pageEditorExtensions(),
     content: '你好世界',
@@ -20,12 +27,12 @@ test('tiptap Color and Highlight apply to a selection', () => {
   const from = 1
   const to = from + '你好'.length
   editor.commands.setTextSelection({ from, to })
-  editor.commands.setColor('#E11D48')
-  assert.equal(editor.isActive('textStyle', { color: '#E11D48' }), true)
+  editor.commands.setColor(text)
+  assert.equal(editor.isActive('textStyle', { color: text }), true)
   assert.match(editor.getHTML(), /style="color:/)
-  editor.commands.setHighlight({ color: '#FEF08A' })
-  assert.equal(editor.isActive('highlight', { color: '#FEF08A' }), true)
-  assert.match(editor.getHTML(), /<(span|mark)[^>]*(data-color|#FEF08A|background-color)/)
+  editor.commands.setHighlight({ color: wash })
+  assert.equal(editor.isActive('highlight', { color: wash }), true)
+  assert.match(editor.getHTML(), /<(span|mark)[^>]*(data-color|background-color)/)
   const md = editor.getMarkdown()
   editor.destroy()
 
@@ -35,7 +42,7 @@ test('tiptap Color and Highlight apply to a selection', () => {
     contentType: 'markdown',
   })
   again.commands.setTextSelection({ from, to })
-  assert.equal(again.isActive('textStyle', { color: '#E11D48' }), true)
-  assert.equal(again.isActive('highlight', { color: '#FEF08A' }), true)
+  assert.equal(again.isActive('textStyle', { color: text }), true)
+  assert.equal(again.isActive('highlight', { color: wash }), true)
   again.destroy()
 })

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -100,9 +100,12 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /SourceEditor/)
   assert.match(src, /FindBar/)
   assert.match(src, /isFindHotkey/)
-  assert.match(src, /ColorPicks/)
+  assert.match(src, /ColorMenus/)
+  assert.match(src, /HeadlessPopover/)
   assert.match(src, /setColor/)
   assert.match(src, /toggleHighlight/)
+  assert.doesNotMatch(src, /ColorPicks/)
+  assert.doesNotMatch(src, /page-bubble-palette/)
 })
 
 test('page editor hydrates markdown after content fetch', async () => {

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
+import { HeadlessPopover } from '@biu/public-ui'
 import { SourceEditor, type SourceEditorHandle } from './source-editor.tsx'
 import { usePageSourceMode } from './source-mode.ts'
 import { EditorContent, useEditor } from '@tiptap/react'
@@ -16,7 +17,7 @@ import { bindEditorTextHost } from '@biu/core-pick/web'
 import { markdownLocusFromElement, markdownLocusFromSelection } from './markdown-locus.ts'
 import { FindBar, isFindHotkey } from './find-bar.tsx'
 import { applyEditorFind } from './find-plugin.ts'
-import { TEXT_COLORS, HIGHLIGHT_COLORS } from './color-swatches.ts'
+import { EDITOR_TONES, tagTextColor, tagWashColor } from './color-swatches.ts'
 
 /** 本地正在打字时不要用远端正文盖掉；源码模式 / 未挂上的编辑器不算在打字。 */
 export function shouldApplyRemoteMarkdown(args: {
@@ -45,83 +46,134 @@ function asMarkdown(value: unknown) {
   return String(value)
 }
 
-function Swatch({
-  label,
-  value,
-  current,
-  kind,
-  onPick,
-}: {
-  label: string
-  value: string
-  current: string
-  kind: 'text' | 'mark'
-  onPick: () => void
-}) {
-  const on = Boolean(value) && current.toLowerCase() === value.toLowerCase()
-  return (
-    <button
-      type="button"
-      className={on ? 'is-on' : undefined}
-      title={label}
-      aria-label={label}
-      aria-pressed={on}
-      data-testid={kind === 'text' ? `page-color-${value || 'none'}` : `page-highlight-${value || 'none'}`}
-      onMouseDown={(event: MouseEvent) => {
-        event.preventDefault()
-        onPick()
-      }}
-    >
-      <span
-        className={kind === 'text' ? 'page-bubble-letter' : 'page-bubble-mark'}
-        style={kind === 'text' ? { color: value || '#F0EFED' } : { background: value || 'transparent' }}
-      >
-        {kind === 'text' ? 'A' : ''}
-      </span>
-    </button>
-  )
+function holdSelection(event: MouseEvent) {
+  event.preventDefault()
 }
 
-function ColorPicks({ editor }: { editor: Editor }) {
+function ColorMenus({
+  editor,
+  open,
+  onOpen,
+}: {
+  editor: Editor
+  open: 'text' | 'mark' | null
+  onOpen: (next: 'text' | 'mark' | null) => void
+}) {
   const color = String(editor.getAttributes('textStyle').color ?? '')
   const highlight = String(editor.getAttributes('highlight').color ?? '')
+
+  const flyout = (kind: 'text' | 'mark') => {
+    const current = kind === 'text' ? color : highlight
+    return (
+      <div
+        className="page-color-menu"
+        role="menu"
+        aria-label={kind === 'text' ? '文字颜色' : '背景色'}
+        onMouseDown={holdSelection}
+      >
+        <div className="page-color-menu-h">{kind === 'text' ? '文字颜色' : '背景色'}</div>
+        <div className="page-color-grid">
+          {EDITOR_TONES.map((tone) => {
+            const value = kind === 'text' ? tagTextColor(tone) : tagWashColor(tone)
+            const on = current.toLowerCase() === value.toLowerCase()
+            return (
+              <button
+                key={tone}
+                type="button"
+                role="menuitemradio"
+                className={on ? 'is-on' : undefined}
+                aria-checked={on}
+                aria-label={tone}
+                data-testid={kind === 'text' ? `page-color-${tone}` : `page-highlight-${tone}`}
+                style={
+                  kind === 'text'
+                    ? { color: tone, background: 'transparent' }
+                    : { background: tagWashColor(tone), color: tone }
+                }
+                onMouseDown={holdSelection}
+                onClick={() => {
+                  if (kind === 'text') editor.chain().focus().setColor(value).run()
+                  else editor.chain().focus().toggleHighlight({ color: value }).run()
+                  onOpen(null)
+                }}
+              >
+                {kind === 'text' ? 'A' : ''}
+              </button>
+            )
+          })}
+        </div>
+        <button
+          type="button"
+          className="page-color-clear"
+          data-testid={kind === 'text' ? 'page-color-none' : 'page-highlight-none'}
+          onMouseDown={holdSelection}
+          onClick={() => {
+            if (kind === 'text') editor.chain().focus().unsetColor().run()
+            else editor.chain().focus().unsetHighlight().run()
+            onOpen(null)
+          }}
+        >
+          清除
+        </button>
+      </div>
+    )
+  }
+
   return (
     <>
-      <span className="page-bubble-palette" role="group" aria-label="文字颜色">
-        {TEXT_COLORS.map((item) => (
-          <Swatch
-            key={`c-${item.value || 'none'}`}
-            label={item.label}
-            value={item.value}
-            current={color}
-            kind="text"
-            onPick={() => {
-              if (!item.value) editor.chain().focus().unsetColor().run()
-              else editor.chain().focus().setColor(item.value).run()
-            }}
-          />
-        ))}
-      </span>
-      <span className="page-bubble-palette" role="group" aria-label="背景色">
-        {HIGHLIGHT_COLORS.map((item) => (
-          <Swatch
-            key={`h-${item.value || 'none'}`}
-            label={item.label}
-            value={item.value}
-            current={highlight}
-            kind="mark"
-            onPick={() => {
-              if (!item.value) editor.chain().focus().unsetHighlight().run()
-              else editor.chain().focus().toggleHighlight({ color: item.value }).run()
-            }}
-          />
-        ))}
-      </span>
+      <HeadlessPopover
+        open={open === 'text'}
+        onOpenChange={(next) => onOpen(next ? 'text' : null)}
+        side="bottom"
+        align="start"
+        trigger={
+          <button
+            type="button"
+            className={color || open === 'text' ? 'is-on' : undefined}
+            title="文字颜色"
+            aria-label="文字颜色"
+            aria-haspopup="menu"
+            aria-expanded={open === 'text'}
+            onMouseDown={holdSelection}
+          >
+            <span className="page-bubble-letter" style={{ color: color || '#F0EFED' }}>
+              A
+            </span>
+          </button>
+        }
+      >
+        {flyout('text')}
+      </HeadlessPopover>
+      <HeadlessPopover
+        open={open === 'mark'}
+        onOpenChange={(next) => onOpen(next ? 'mark' : null)}
+        side="bottom"
+        align="start"
+        trigger={
+          <button
+            type="button"
+            className={highlight || open === 'mark' ? 'is-on' : undefined}
+            title="背景色"
+            aria-label="背景色"
+            aria-haspopup="menu"
+            aria-expanded={open === 'mark'}
+            onMouseDown={holdSelection}
+          >
+            <span
+              className="page-bubble-mark"
+              style={{ background: highlight || 'color-mix(in srgb, var(--dsw-label) 18%, transparent)' }}
+            />
+          </button>
+        }
+      >
+        {flyout('mark')}
+      </HeadlessPopover>
     </>
   )
 }
 
 function Bubble({ editor }: { editor: Editor }) {
+  const [colorOpen, setColorOpen] = useState<'text' | 'mark' | null>(null)
   const btn = (label: string, on: boolean, run: () => void) => (
     <button
       type="button"
@@ -140,7 +192,11 @@ function Bubble({ editor }: { editor: Editor }) {
       editor={editor}
       className="page-bubble"
       aria-label="文字样式"
-      shouldShow={({ editor: current, from, to }) => !current.isActive('table') && from !== to}
+      shouldShow={({ editor: current, from, to }) => {
+        if (current.isActive('table')) return false
+        if (colorOpen) return true
+        return from !== to
+      }}
     >
       {btn('B', editor.isActive('bold'), () => editor.chain().focus().toggleBold().run())}
       {btn('I', editor.isActive('italic'), () => editor.chain().focus().toggleItalic().run())}
@@ -148,7 +204,7 @@ function Bubble({ editor }: { editor: Editor }) {
       {btn('</>', editor.isActive('code'), () => editor.chain().focus().toggleCode().run())}
       {btn('H1', editor.isActive('heading', { level: 1 }), () => editor.chain().focus().toggleHeading({ level: 1 }).run())}
       {btn('H2', editor.isActive('heading', { level: 2 }), () => editor.chain().focus().toggleHeading({ level: 2 }).run())}
-      <ColorPicks editor={editor} />
+      <ColorMenus editor={editor} open={colorOpen} onOpen={setColorOpen} />
     </BubbleMenu>
   )
 }

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -78,13 +78,18 @@ export const PAGE_EDITOR_STYLE = `
 .page-find-btn:hover{background:var(--dsw-hover)}
 .page-find-hit{background:color-mix(in srgb,var(--dsw-business) 22%,transparent);border-radius:2px}
 .page-find-hit.is-current{background:color-mix(in srgb,var(--dsw-business) 42%,transparent)}
-.page-bubble{display:flex;flex-wrap:wrap;align-items:center;gap:2px;padding:4px;max-width:min(360px,calc(100vw - 48px))}
+.page-bubble{display:flex;flex-wrap:nowrap;align-items:center;gap:2px;padding:4px}
 .page-bubble button{display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;margin:0;border:0;border-radius:6px;padding:0 7px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:700;cursor:pointer}
 .page-bubble button:hover,.page-bubble button.is-on{background:var(--dsw-hover)}
 .page-bubble button.is-on{color:var(--dsw-business)}
-.page-bubble-palette{display:flex;align-items:center;gap:2px;flex:1 1 100%;padding:2px 2px 0}
-.page-bubble-palette button{min-width:22px;width:22px;height:22px;padding:0}
 .page-bubble-letter{font-size:12px;font-weight:800;line-height:1;border-bottom:2px solid currentColor}
 .page-bubble-mark{display:block;width:12px;height:12px;border-radius:3px;border:1px solid var(--dsw-border);box-sizing:border-box}
+.page-color-menu{z-index:90;width:168px;padding:8px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(15,15,15,.16)}
+.page-color-menu-h{padding:0 2px 6px;color:var(--dsw-label-3);font-size:11px;font-weight:600}
+.page-color-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:6px}
+.page-color-grid button{min-width:0;width:32px;height:32px;padding:0;border:1px solid var(--dsw-border);border-radius:6px;font-size:13px;font-weight:800}
+.page-color-grid button.is-on{box-shadow:0 0 0 2px var(--dsw-business)}
+.page-color-clear{width:100%;margin:8px 0 0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label-2);font:inherit;font-size:12px;font-weight:600;cursor:pointer;text-align:left}
+.page-color-clear:hover{background:var(--dsw-hover);color:var(--dsw-label)}
 .page-editor .tiptap mark{border-radius:2px;padding:0 .08em}
 `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
编辑器气泡不再平铺色块。文字色 / 背景色各一个入口，点开二级菜单再选。

色板跟合集标签一致：`TAG_TONES` 做字色，背景用标签同款 `color-mix(..., 22%, transparent)`。菜单打开时气泡保持显示，避免 portal 把选区菜单收掉。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

