### PR TITLE
feat: 搜索命中用玫粉字色和浅底

### DIFF
--- a/packages/core-editor/src/web/find.test.ts
+++ b/packages/core-editor/src/web/find.test.ts
@@ -7,6 +7,8 @@ import { resolve } from 'node:path'
 import { applyEditorFind } from './find-plugin.ts'
 import { pageEditorExtensions } from './kit.ts'
 import { isFindHotkey } from './find-bar.tsx'
+import { PAGE_EDITOR_STYLE } from './style.ts'
+import { TAG_TONE_ROSE } from '@biu/public-ui'
 
 test('findRanges is case-insensitive and walks every hit', () => {
   assert.deepEqual(findRanges('Hello hello HELLO', 'hello'), [
@@ -66,4 +68,10 @@ test('isFindHotkey is command/ctrl f without shift', () => {
   assert.equal(isFindHotkey({ key: 'f', metaKey: true, ctrlKey: false, altKey: false, shiftKey: false }), true)
   assert.equal(isFindHotkey({ key: 'f', metaKey: false, ctrlKey: true, altKey: false, shiftKey: false }), true)
   assert.equal(isFindHotkey({ key: 'f', metaKey: true, ctrlKey: false, altKey: false, shiftKey: true }), false)
+})
+
+test('find hits use rose tag text and wash', () => {
+  assert.match(PAGE_EDITOR_STYLE, new RegExp(`\\.page-find-hit\\{[^}]*color:${TAG_TONE_ROSE}`))
+  assert.match(PAGE_EDITOR_STYLE, /color-mix\(in srgb,#e255a1 22%,transparent\)/)
+  assert.match(PAGE_EDITOR_STYLE, /color-mix\(in srgb,#e255a1 34%,transparent\)/)
 })

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -1,3 +1,5 @@
+import { TAG_TONE_ROSE } from '@biu/public-ui'
+
 export const PAGE_EDITOR_STYLE = `
 .page-editor{position:relative;overflow:visible;min-width:0;width:100%;padding:6px 0 48px;padding-left:0;color:var(--dsw-label);font-family:var(--font-sans);font-size:15px;line-height:1.7;letter-spacing:-.003em}
 .page-editor.is-source{font-family:var(--font-mono);font-size:14px;letter-spacing:0}
@@ -76,8 +78,9 @@ export const PAGE_EDITOR_STYLE = `
 .page-find-count{flex:none;min-width:2.4em;color:#7B7B79;font-size:12px;font-weight:600;text-align:right}
 .page-find-btn{flex:none;display:inline-flex;align-items:center;justify-content:center;width:22px;height:22px;margin:0;border:0;border-radius:5px;padding:0;background:transparent;color:#EFEEEC;cursor:pointer}
 .page-find-btn:hover{background:var(--dsw-hover)}
-.page-find-hit{background:color-mix(in srgb,var(--dsw-business) 22%,transparent);border-radius:2px}
-.page-find-hit.is-current{background:color-mix(in srgb,var(--dsw-business) 42%,transparent)}
+.page-find-hit{color:${TAG_TONE_ROSE};background:color-mix(in srgb,${TAG_TONE_ROSE} 22%,transparent);border-radius:2px}
+.page-find-hit.is-current{background:color-mix(in srgb,${TAG_TONE_ROSE} 34%,transparent)}
+.page-editor .page-find-hit,.page-editor .page-find-hit *{color:${TAG_TONE_ROSE}}
 .page-bubble{display:flex;flex-wrap:nowrap;align-items:center;gap:2px;padding:4px}
 .page-bubble button{display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;margin:0;border:0;border-radius:6px;padding:0 7px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:700;cursor:pointer}
 .page-bubble button:hover,.page-bubble button.is-on{background:var(--dsw-hover)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
⌘F 命中高亮改成合集标签玫粉：字色 `#e255a1`，背景 22% wash，当前项 34% wash。所见即所得和源码模式共用 `.page-find-hit`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

