### PR TITLE
fix: 搜索栏固定在详情右上角

### DIFF
--- a/packages/core-editor/src/web/find-bar.tsx
+++ b/packages/core-editor/src/web/find-bar.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useRef, type KeyboardEvent } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { createPortal } from 'react-dom'
 import { ChevronDownIcon, ChevronUpIcon, MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/16/solid'
+
+function pinHost(from: HTMLElement | null) {
+  const body = from?.closest('.fsdb-right-body')
+  return body instanceof HTMLElement ? body : null
+}
 
 export function FindBar({
   query,
@@ -19,10 +25,30 @@ export function FindBar({
   onClose: () => void
 }) {
   const input = useRef<HTMLInputElement>(null)
+  const mark = useRef<HTMLSpanElement>(null)
+  const [host, setHost] = useState<HTMLElement | null | undefined>(undefined)
+
+  useLayoutEffect(() => {
+    const root = pinHost(mark.current)
+    if (!root) {
+      setHost(null)
+      return
+    }
+    const slot = document.createElement('div')
+    slot.className = 'page-find-slot'
+    root.prepend(slot)
+    setHost(slot)
+    return () => {
+      slot.remove()
+      setHost(undefined)
+    }
+  }, [])
+
   useEffect(() => {
+    if (host === undefined) return
     input.current?.focus()
     input.current?.select()
-  }, [])
+  }, [host])
 
   const onKey = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Escape') {
@@ -39,7 +65,7 @@ export function FindBar({
 
   const label = query.trim() ? `${total ? index + 1 : 0}/${total}` : ''
 
-  return (
+  const bar = (
     <div className="page-find" data-testid="page-find" role="search">
       <div className="page-find-box">
         <MagnifyingGlassIcon aria-hidden className="page-find-icon" />
@@ -67,6 +93,13 @@ export function FindBar({
         </button>
       </div>
     </div>
+  )
+
+  return (
+    <>
+      <span ref={mark} hidden aria-hidden data-page-find-anchor="" />
+      {host === undefined ? null : host ? createPortal(bar, host) : bar}
+    </>
   )
 }
 

--- a/packages/core-editor/src/web/find.test.ts
+++ b/packages/core-editor/src/web/find.test.ts
@@ -70,6 +70,17 @@ test('isFindHotkey is command/ctrl f without shift', () => {
   assert.equal(isFindHotkey({ key: 'f', metaKey: true, ctrlKey: false, altKey: false, shiftKey: true }), false)
 })
 
+test('find bar pins to the inspector scrollport, not the editor flow', () => {
+  const src = readFileSync(resolve(import.meta.dirname, './find-bar.tsx'), 'utf8')
+  assert.match(src, /createPortal/)
+  assert.match(src, /fsdb-right-body/)
+  assert.match(src, /page-find-slot/)
+  assert.match(src, /root\.prepend/)
+  assert.match(PAGE_EDITOR_STYLE, /\.page-find-slot\{[^}]*position:sticky/)
+  assert.match(PAGE_EDITOR_STYLE, /\.page-find-slot\{[^}]*height:0/)
+  assert.doesNotMatch(PAGE_EDITOR_STYLE, /\.page-find\{[^}]*position:sticky/)
+})
+
 test('find hits use rose tag text and wash', () => {
   assert.match(PAGE_EDITOR_STYLE, new RegExp(`\\.page-find-hit\\{[^}]*color:${TAG_TONE_ROSE}`))
   assert.match(PAGE_EDITOR_STYLE, /color-mix\(in srgb,#e255a1 22%,transparent\)/)

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -71,7 +71,8 @@ export const PAGE_EDITOR_STYLE = `
 .page-slash-label{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:13px;font-weight:600;line-height:1.2}
 .page-slash-keys{flex:none;color:var(--dsw-label-3);font-size:12px;font-weight:500}
 .page-slash-foot{display:flex;align-items:center;justify-content:space-between;gap:8px;flex:none;margin-top:2px;padding:6px 8px 4px;border-top:1px solid var(--dsw-border);color:var(--dsw-label-3);font-size:12px;font-weight:500}
-.page-find{position:sticky;top:8px;z-index:18;display:flex;justify-content:flex-end;margin:0 0 8px;pointer-events:none}
+.page-find-slot{position:sticky;top:0;z-index:28;flex:none;height:0;display:flex;justify-content:flex-end;overflow:visible;pointer-events:none}
+.page-find{position:relative;z-index:28;display:flex;justify-content:flex-end;margin:0;padding:8px 12px 0 0;pointer-events:none}
 .page-find-box{pointer-events:auto;display:flex;align-items:center;gap:4px;min-width:240px;max-width:min(360px,100%);padding:4px 6px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(15,15,15,.16)}
 .page-find-icon{flex:none;width:14px;height:14px;color:#7B7B79}
 .page-find-input{flex:1 1 auto;min-width:0;margin:0;border:0;padding:4px 4px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;outline:none}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
⌘F 搜索栏原先 sticky 在编辑器文档流里，滚回顶部会被标题和属性区顶下去。

现在挂到详情滚动容器 `.fsdb-right-body` 顶端的零高槽上，始终贴着视口右上角，不再跟着正文/属性走。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

