### PR TITLE
feat: 正文开头回车回到标题末尾

### DIFF
--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -88,6 +88,7 @@ test('page editor bridges cursor to the record title', async () => {
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-editor.tsx'), 'utf8')
   assert.match(src, /handleKeyDown/)
+  assert.match(src, /shouldLeaveContentForTitle/)
   assert.match(src, /FOCUS_RECORD_TITLE/)
   assert.match(src, /FOCUS_RECORD_CONTENT/)
   assert.match(src, /jumpToPending/)

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -10,7 +10,7 @@ import type { FsContentProps } from '@biu/type-file-system/ui'
 import { pageEditorExtensions } from './kit.ts'
 import { PageBlockHandle } from './page-block-handle.tsx'
 import { editorHostIsLive } from './editor-live.ts'
-import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, isDocStartSelection } from './title-content-nav.ts'
+import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, shouldLeaveContentForTitle } from './title-content-nav.ts'
 import { tryContentJump, contentJumpForRecord } from './content-jump.ts'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { bindEditorTextHost, getPick } from '@biu/core-pick/web'
@@ -342,11 +342,10 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
             if (ref) getPick()?.attach([ref])
             return true
           }
-          if (event.key !== 'ArrowUp' || event.shiftKey || event.altKey || event.metaKey || event.ctrlKey) return false
           if (event.isComposing) return false
           const sel = view.state.selection
           const start = Selection.atStart(view.state.doc).from
-          if (!isDocStartSelection(sel.from, sel.empty, start)) return false
+          if (!shouldLeaveContentForTitle(event.key, event, sel.from, sel.empty, start)) return false
           event.preventDefault()
           window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
           return true
@@ -553,6 +552,16 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
       event.preventDefault()
       event.stopPropagation()
       sendToChat()
+      return
+    }
+    if (
+      source &&
+      sourceFind.current?.isAtStart() &&
+      shouldLeaveContentForTitle(event.key, event, 0, true, 0)
+    ) {
+      event.preventDefault()
+      event.stopPropagation()
+      window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
     }
   }
 

--- a/packages/core-editor/src/web/source-editor.test.tsx
+++ b/packages/core-editor/src/web/source-editor.test.tsx
@@ -13,6 +13,7 @@ test('source editor uses CodeMirror markdown highlighting and line numbers', () 
   assert.match(src, /syntaxHighlighting/)
   assert.match(src, /page-source-editor/)
   assert.match(src, /getLocus/)
+  assert.match(src, /isAtStart/)
 })
 
 test('source editor mounts a CodeMirror view for markdown', async () => {

--- a/packages/core-editor/src/web/source-editor.tsx
+++ b/packages/core-editor/src/web/source-editor.tsx
@@ -34,6 +34,7 @@ const findField = StateField.define({
 export type SourceEditorHandle = {
   applyFind: (query: string, index: number) => { total: number; index: number }
   getLocus: () => { start_line: number; end_line: number; text: string } | null
+  isAtStart: () => boolean
 }
 
 const mdHighlight = HighlightStyle.define([
@@ -155,6 +156,12 @@ export const SourceEditor = forwardRef<SourceEditorHandle, {
       const start_line = view.state.doc.lineAt(from).number
       const end_line = view.state.doc.lineAt(Math.max(from, to - 1)).number
       return { start_line, end_line, text }
+    },
+    isAtStart() {
+      const view = viewRef.current
+      if (!view) return false
+      const sel = view.state.selection.main
+      return sel.empty && sel.from === 0
     },
   }))
 

--- a/packages/core-editor/src/web/title-content-nav.test.ts
+++ b/packages/core-editor/src/web/title-content-nav.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { isDocStartSelection, shouldLeaveContentForTitle } from './title-content-nav.ts'
+
+test('isDocStartSelection requires an empty caret at doc start', () => {
+  assert.equal(isDocStartSelection(1, true, 1), true)
+  assert.equal(isDocStartSelection(1, false, 1), false)
+  assert.equal(isDocStartSelection(2, true, 1), false)
+})
+
+test('content Enter and ArrowUp at start leave for the title', () => {
+  const none = { shiftKey: false, altKey: false, metaKey: false, ctrlKey: false }
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 1, true, 1), true)
+  assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 1, true, 1), true)
+  assert.equal(shouldLeaveContentForTitle('Enter', { ...none, shiftKey: true }, 1, true, 1), false)
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 2, true, 1), false)
+  assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, true, 1), false)
+})

--- a/packages/core-editor/src/web/title-content-nav.ts
+++ b/packages/core-editor/src/web/title-content-nav.ts
@@ -4,3 +4,17 @@ export const FOCUS_RECORD_CONTENT = 'biu:focus-record-content'
 export function isDocStartSelection(from: number, empty: boolean, docStart: number) {
   return empty && from === docStart
 }
+
+/** 正文开头空选区：上方向键或回车回到标题末尾。 */
+export function shouldLeaveContentForTitle(
+  key: string,
+  flags: { shiftKey: boolean; altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean; isComposing?: boolean },
+  from: number,
+  empty: boolean,
+  docStart: number,
+) {
+  if (flags.isComposing) return false
+  if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
+  if (key !== 'ArrowUp' && key !== 'Enter') return false
+  return isDocStartSelection(from, empty, docStart)
+}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -457,6 +457,7 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(detail, /FOCUS_RECORD_CONTENT/)
   assert.match(detail, /FOCUS_RECORD_TITLE/)
   assert.match(detail, /shouldLeaveTitleForContent/)
+  assert.match(detail, /shouldLeaveContentForTitle/)
   assert.doesNotMatch(detail, /<h2 className="fsdb-detail-title-input">/)
   assert.match(style, /\.fsdb-detail-main\{[^}]*padding:80px 80px 24px/)
   assert.match(style, /\.fsdb-main > \.fsdb-detail-title-row\{[^}]*flex:none/)

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -9,7 +9,7 @@ import { FilePreview } from './fsdb-cells.tsx'
 import { PropertyRow } from './property-row.tsx'
 import { TableGlyph } from './nav-glyphs.tsx'
 import { normalizeRecordEmoji, recordPreviewEmoji } from './sidebar-preview.ts'
-import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, shouldLeaveTitleForContent } from './title-content-nav.ts'
+import { FOCUS_RECORD_CONTENT, FOCUS_RECORD_TITLE, shouldLeaveContentForTitle, shouldLeaveTitleForContent } from './title-content-nav.ts'
 import { HeadingOutline } from './heading-outline.tsx'
 
 function DetailTitleIcon({
@@ -300,8 +300,22 @@ export function RecordDetail({
                         onKeyDown={(event) => {
                           const el = event.currentTarget
                           if (!(el instanceof HTMLTextAreaElement)) return
-                          if (event.key !== 'ArrowUp' || event.shiftKey || event.nativeEvent.isComposing) return
-                          if (el.selectionStart !== 0 || el.selectionEnd !== 0) return
+                          if (
+                            !shouldLeaveContentForTitle(
+                              event.key,
+                              {
+                                shiftKey: event.shiftKey,
+                                altKey: event.altKey,
+                                metaKey: event.metaKey,
+                                ctrlKey: event.ctrlKey,
+                                isComposing: event.nativeEvent.isComposing,
+                              },
+                              el.selectionStart ?? 0,
+                              el.selectionStart === el.selectionEnd,
+                              0,
+                            )
+                          )
+                            return
                           event.preventDefault()
                           window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
                         }}

--- a/packages/core-file-system/src/web/title-content-nav.test.ts
+++ b/packages/core-file-system/src/web/title-content-nav.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { shouldLeaveTitleForContent } from './title-content-nav.ts'
+import { shouldLeaveContentForTitle, shouldLeaveTitleForContent } from './title-content-nav.ts'
 
 test('title Enter and last-line ArrowDown leave for content', () => {
   assert.equal(shouldLeaveTitleForContent('Enter', false, 'hello', 5), true)
@@ -9,4 +9,11 @@ test('title Enter and last-line ArrowDown leave for content', () => {
   assert.equal(shouldLeaveTitleForContent('ArrowDown', false, 'a\nb', 1), false)
   assert.equal(shouldLeaveTitleForContent('ArrowDown', false, 'a\nb', 3), true)
   assert.equal(shouldLeaveTitleForContent('ArrowUp', false, 'hello', 0), false)
+})
+
+test('content Enter at start leaves for title', () => {
+  const none = { shiftKey: false }
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 0, true, 0), true)
+  assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 0, true, 0), true)
+  assert.equal(shouldLeaveContentForTitle('Enter', { shiftKey: true }, 0, true, 0), false)
 })

--- a/packages/core-file-system/src/web/title-content-nav.ts
+++ b/packages/core-file-system/src/web/title-content-nav.ts
@@ -11,3 +11,16 @@ export function shouldLeaveTitleForContent(key: string, shiftKey: boolean, value
 export function isDocStartSelection(from: number, empty: boolean, docStart: number) {
   return empty && from === docStart
 }
+
+export function shouldLeaveContentForTitle(
+  key: string,
+  flags: { shiftKey: boolean; altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean; isComposing?: boolean },
+  from: number,
+  empty: boolean,
+  docStart: number,
+) {
+  if (flags.isComposing) return false
+  if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
+  if (key !== 'ArrowUp' && key !== 'Enter') return false
+  return isDocStartSelection(from, empty, docStart)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
正文最开头、空选区时按回车，不再插入空段落，而是把光标送到标题最后（和上方向键同一套 `FOCUS_RECORD_TITLE`）。所见即所得、源码模式、纯文本正文框都适用。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

