### PR TITLE
fix: 选区 pick 增加 selection，查找不再弹出气泡

### DIFF
--- a/packages/core-chat/src/web/composer-pick-node.tsx
+++ b/packages/core-chat/src/web/composer-pick-node.tsx
@@ -27,6 +27,7 @@ export const PickChipNode = Node.create({
       start_line: { default: null },
       end_line: { default: null },
       text: { default: null },
+      selection: { default: null },
     }
   },
   parseHTML() {

--- a/packages/core-editor/src/web/editor-ask.test.ts
+++ b/packages/core-editor/src/web/editor-ask.test.ts
@@ -33,6 +33,7 @@ test('pickFromEditor uses the current selection', () => {
   assert.ok(ref)
   assert.equal(ref?.path, '/pages/home')
   assert.match(ref?.text ?? '', /你好/)
+  assert.equal(ref?.selection, '你好')
   editor.commands.setTextSelection(1)
   assert.equal(pickFromEditor(editor, '/pages/home'), null)
   editor.destroy()

--- a/packages/core-editor/src/web/editor-ask.ts
+++ b/packages/core-editor/src/web/editor-ask.ts
@@ -40,7 +40,7 @@ export function isSendChatHotkey(event: {
 
 export function pickFromLocus(path: string | undefined, locus: MarkdownLocus | null, route = typeof window === 'undefined' ? '' : window.location.pathname): PickRef | null {
   if (!locus?.text.trim()) return null
-  const label = pickPreview(locus.text, 80)
+  const label = pickPreview(locus.selection || locus.text, 80)
   if (!label) return null
   return withPickLocus(
     {

--- a/packages/core-editor/src/web/find-plugin.ts
+++ b/packages/core-editor/src/web/find-plugin.ts
@@ -62,7 +62,7 @@ export function applyEditorFind(editor: Editor, query: string, index: number) {
   const tr = editor.state.tr.setMeta(FIND_PLUGIN, { query, index: i })
   if (total) {
     const hit = hits[i]!
-    tr.setSelection(TextSelection.create(editor.state.doc, hit.from, hit.to))
+    tr.setSelection(TextSelection.create(editor.state.doc, hit.from))
   }
   editor.view.dispatch(tr)
   if (total) scrollFindLikeOutline(editor, hits[i]!.from)

--- a/packages/core-editor/src/web/find.test.ts
+++ b/packages/core-editor/src/web/find.test.ts
@@ -37,9 +37,11 @@ test('findInPmDoc matches visible text positions', () => {
   assert.equal(hits.length, 2)
   const first = applyEditorFind(editor, '你好', 0)
   assert.equal(first.total, 2)
-  assert.equal(editor.state.doc.textBetween(editor.state.selection.from, editor.state.selection.to), '你好')
+  assert.equal(editor.state.selection.empty, true)
+  assert.equal(editor.state.selection.from, hits[0]!.from)
   applyEditorFind(editor, '你好', 1)
-  assert.equal(editor.state.doc.textBetween(editor.state.selection.from, editor.state.selection.to), '你好')
+  assert.equal(editor.state.selection.empty, true)
+  assert.equal(editor.state.selection.from, hits[1]!.from)
   editor.destroy()
 })
 
@@ -52,8 +54,15 @@ test('findInPmDoc matches across marks in one paragraph', () => {
   const hits = findInPmDoc(editor.state.doc, '你好世界')
   assert.equal(hits.length, 1)
   applyEditorFind(editor, '你好世界', 0)
-  assert.equal(editor.state.doc.textBetween(editor.state.selection.from, editor.state.selection.to), '你好世界')
+  assert.equal(editor.state.selection.empty, true)
+  assert.equal(editor.state.selection.from, hits[0]!.from)
   editor.destroy()
+})
+
+test('find jump does not range-select, so the style bubble stays down', () => {
+  const plugin = readFileSync(resolve(import.meta.dirname, './find-plugin.ts'), 'utf8')
+  assert.match(plugin, /TextSelection\.create\(editor\.state\.doc, hit\.from\)/)
+  assert.doesNotMatch(plugin, /TextSelection\.create\(editor\.state\.doc, hit\.from, hit\.to\)/)
 })
 
 test('tiptap find jump uses outline scroll, not ProseMirror scrollIntoView', () => {

--- a/packages/core-editor/src/web/markdown-locus.test.ts
+++ b/packages/core-editor/src/web/markdown-locus.test.ts
@@ -32,7 +32,8 @@ test('selection maps to markdown source lines, not visual blocks', () => {
   assert.ok(locus)
   assert.equal(locus.start_line, 5)
   assert.equal(locus.end_line, 5)
-  assert.match(locus.text, /UNIQUESEL/)
+  assert.equal(locus.text, 'UNIQUESEL')
+  assert.equal(locus.selection, 'UNIQUESEL')
   editor.destroy()
 })
 
@@ -48,6 +49,8 @@ test('multi-line selection spans markdown source lines', () => {
   assert.equal(locus.end_line, 5)
   assert.match(locus.text, /bravo/)
   assert.match(locus.text, /charlie/)
+  assert.match(locus.selection ?? '', /bravo/)
+  assert.match(locus.selection ?? '', /charlie/)
   editor.destroy()
 })
 
@@ -60,5 +63,21 @@ test('heading selection uses the heading markdown line', () => {
   assert.ok(locus)
   assert.equal(locus.start_line, 1)
   assert.match(locus.text, /Hello title/)
+  assert.equal(locus.selection, 'Hello title')
+  editor.destroy()
+})
+
+test('locus keeps source lines in text and the highlight in selection', () => {
+  const md = '勃，三尺微命，一介书生。'
+  const editor = editorOf(md)
+  const from = posOf(editor, '三尺微命')
+  assert.ok(from != null)
+  editor.commands.setTextSelection({ from, to: from + '三尺微命'.length })
+  const locus = markdownLocusFromSelection(editor)
+  assert.ok(locus)
+  assert.equal(locus.start_line, 1)
+  assert.equal(locus.end_line, 1)
+  assert.equal(locus.text, '勃，三尺微命，一介书生。')
+  assert.equal(locus.selection, '三尺微命')
   editor.destroy()
 })

--- a/packages/core-editor/src/web/markdown-locus.ts
+++ b/packages/core-editor/src/web/markdown-locus.ts
@@ -1,7 +1,7 @@
 import type { Editor } from '@tiptap/core'
 import type { Node as PmNode } from '@tiptap/pm/model'
 
-export type MarkdownLocus = { start_line: number; end_line: number; text: string }
+export type MarkdownLocus = { start_line: number; end_line: number; text: string; selection?: string }
 
 function serialize(editor: Editor, doc: PmNode) {
   const manager = editor.storage.markdown?.manager as { serialize?: (json: unknown) => string } | undefined
@@ -21,12 +21,14 @@ function linesOf(md: string, start: number, end: number) {
   return lines.slice(from - 1, to).join('\n')
 }
 
-/** 选区对应 Markdown 源码行号（1-based），不是可视编辑器行。 */
+/** 选区对应 Markdown 源码行号（1-based）。text 是整行源码，selection 是高亮片段。 */
 export function markdownLocusFromRange(editor: Editor, from: number, to: number): MarkdownLocus | null {
   const doc = editor.state.doc
   const a = Math.max(0, Math.min(from, to))
   const b = Math.max(a, Math.max(from, to))
   if (a === b) return null
+  const selection = doc.textBetween(a, b, '\n').trim()
+  if (!selection) return null
   const full = serialize(editor, doc)
   const prefix = serialize(editor, doc.cut(0, a))
   const through = serialize(editor, doc.cut(0, b))
@@ -37,8 +39,8 @@ export function markdownLocusFromRange(editor: Editor, from: number, to: number)
   start_line = Math.min(Math.max(1, start_line), total)
   end_line = Math.min(Math.max(start_line, end_line), total)
   const text = linesOf(full, start_line, end_line)
-  if (!text.trim() && !editor.state.doc.textBetween(a, b, '\n').trim()) return null
-  return { start_line, end_line, text }
+  if (!text.trim()) return null
+  return { start_line, end_line, text, selection }
 }
 
 export function markdownLocusFromSelection(editor: Editor): MarkdownLocus | null {

--- a/packages/core-editor/src/web/source-editor.tsx
+++ b/packages/core-editor/src/web/source-editor.tsx
@@ -33,7 +33,7 @@ const findField = StateField.define({
 
 export type SourceEditorHandle = {
   applyFind: (query: string, index: number) => { total: number; index: number }
-  getLocus: () => { start_line: number; end_line: number; text: string } | null
+  getLocus: () => { start_line: number; end_line: number; text: string; selection: string } | null
 }
 
 const mdHighlight = HighlightStyle.define([
@@ -150,11 +150,13 @@ export const SourceEditor = forwardRef<SourceEditorHandle, {
       if (sel.empty) return null
       const from = Math.min(sel.from, sel.to)
       const to = Math.max(sel.from, sel.to)
-      const text = view.state.doc.sliceString(from, to)
-      if (!text.trim()) return null
+      const selection = view.state.doc.sliceString(from, to).trim()
+      if (!selection) return null
       const start_line = view.state.doc.lineAt(from).number
       const end_line = view.state.doc.lineAt(Math.max(from, to - 1)).number
-      return { start_line, end_line, text }
+      const start = view.state.doc.line(start_line)
+      const end = view.state.doc.line(end_line)
+      return { start_line, end_line, text: view.state.doc.sliceString(start.from, end.to), selection }
     },
   }))
 

--- a/packages/core-pick/src/host/index.test.ts
+++ b/packages/core-pick/src/host/index.test.ts
@@ -15,4 +15,5 @@ test('registers pick instructions on the system prompt', async () => {
   assert.match(text, /kind\/id/)
   assert.match(text, /path/)
   assert.match(text, /db_content/)
+  assert.match(text, /selection/)
 })

--- a/packages/core-pick/src/host/index.ts
+++ b/packages/core-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区会带 path（db_content 记录路径，如 /pages/p002）以及 start_line/end_line/text；改正文用 db_content 的 path，不要读工作区文件、也不要只拿行号。',
+    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区 kind=text 带 path（db_content 记录路径）、start_line/end_line（定位行）、text（对应源码整行）和 selection（用户高亮的片段）；改正文用 db_content 的 path，不要读工作区文件。',
   )
 }

--- a/packages/core-pick/src/web/editor-host.test.ts
+++ b/packages/core-pick/src/web/editor-host.test.ts
@@ -10,7 +10,7 @@ test('text pick from a bound editor includes markdown source lines', () => {
   document.body.append(root)
   bindEditorTextHost(root, {
     path: '/pages/home',
-    locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL' }),
+    locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL', selection: '第一段' }),
     locusFromElement: () => null,
   })
   const fake = {
@@ -24,6 +24,7 @@ test('text pick from a bound editor includes markdown source lines', () => {
   assert.equal(ref.start_line, 5)
   assert.equal(ref.end_line, 5)
   assert.equal(ref.text, 'UNIQUESEL')
+  assert.equal(ref.selection, '第一段')
   assert.equal(ref.path, '/pages/home')
   bindEditorTextHost(root, null)
   root.remove()

--- a/packages/core-pick/src/web/editor-host.ts
+++ b/packages/core-pick/src/web/editor-host.ts
@@ -1,4 +1,4 @@
-export type EditorTextLocus = { start_line: number; end_line: number; text: string }
+export type EditorTextLocus = { start_line: number; end_line: number; text: string; selection?: string }
 
 export type EditorTextHost = {
   /** db_content 路径，如 /pages/p002 */

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -79,17 +79,31 @@ test('text pick round-trips markdown source line numbers', () => {
       start_line: 5,
       end_line: 6,
       text: '第一段\n\nUNIQUESEL',
+      selection: 'UNIQUESEL',
     },
   ])
   assert.match(text, /path="\/pages\/home"/)
   assert.match(text, /start_line="5"/)
   assert.match(text, /end_line="6"/)
   assert.match(text, /text="第一段&#10;&#10;UNIQUESEL"/)
+  assert.match(text, /selection="UNIQUESEL"/)
+  assert.doesNotMatch(text, /label=/)
   const parsed = parsePicks(text)
   assert.equal(parsed.refs[0]?.start_line, 5)
   assert.equal(parsed.refs[0]?.end_line, 6)
   assert.equal(parsed.refs[0]?.text, '第一段\n\nUNIQUESEL')
+  assert.equal(parsed.refs[0]?.selection, 'UNIQUESEL')
   assert.equal(parsed.refs[0]?.path, '/pages/home')
+  assert.equal(chipLabel({
+    kind: 'text',
+    id: 'a1',
+    label: '整行',
+    route: '/',
+    text: '勃，三尺微命，一介书生。',
+    selection: '三尺微命',
+    start_line: 11,
+    path: '/pages/p000',
+  }), '三尺微命')
 })
 
 test('selected body text becomes a text pick', () => {

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -11,8 +11,10 @@ export type PickRef = {
   /** Markdown 源码行号（1-based），不是可视编辑器行。 */
   start_line?: number
   end_line?: number
-  /** 对应源码片段。 */
+  /** 对应源码整行。 */
   text?: string
+  /** 用户高亮的片段。 */
+  selection?: string
 }
 
 export function pickKey(ref: PickRef) {
@@ -52,11 +54,12 @@ export function formatPicks(refs: PickRef[]) {
       const attrs = [`kind="${escapeAttr(ref.kind)}"`, `id="${escapeAttr(ref.id)}"`]
       if (ref.action) attrs.push(`action="${escapeAttr(ref.action)}"`)
       if (ref.route) attrs.push(`route="${escapeAttr(ref.route)}"`)
-      if (ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
+      if (ref.kind !== 'text' && ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
       if (ref.path) attrs.push(`path="${escapeAttr(ref.path)}"`)
       if (ref.start_line != null) attrs.push(`start_line="${ref.start_line}"`)
       if (ref.end_line != null) attrs.push(`end_line="${ref.end_line}"`)
       if (ref.text) attrs.push(`text="${escapeAttr(ref.text)}"`)
+      if (ref.selection) attrs.push(`selection="${escapeAttr(ref.selection)}"`)
       return `<pick ${attrs.join(' ')} />`
     })
     .join('\n')
@@ -82,17 +85,19 @@ function parsePickAttrs(raw: string): PickRef | null {
   const start = Number(attrs.start_line)
   const end = Number(attrs.end_line)
   const text = attrs.text?.trim() ?? ''
+  const selection = attrs.selection?.trim() ?? ''
   return {
     kind,
     id,
     ...(attrs.action?.trim() ? { action: attrs.action.trim() } : {}),
-    label: attrs.label?.trim() || id,
+    label: attrs.label?.trim() || (kind === 'text' ? selection || text : '') || id,
     route: attrs.route?.trim() || '',
     ...sourceFields({ path: attrs.path?.trim() }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
       text: text || undefined,
+      selection: selection || undefined,
     }),
   }
 }
@@ -104,14 +109,16 @@ function sourceFields(ref: { path?: string }) {
   }
 }
 
-function locusFields(ref: { start_line?: number; end_line?: number; text?: string }) {
+function locusFields(ref: { start_line?: number; end_line?: number; text?: string; selection?: string }) {
   const start = ref.start_line
   const end = ref.end_line
   const text = ref.text?.trim()
+  const selection = ref.selection?.trim()
   return {
     ...(start != null ? { start_line: start } : {}),
     ...(end != null ? { end_line: end } : {}),
     ...(text ? { text } : {}),
+    ...(selection ? { selection } : {}),
   }
 }
 
@@ -160,6 +167,10 @@ export function lineSpanLabel(ref: PickRef) {
 }
 
 export function chipLabel(ref: PickRef) {
+  if (ref.kind === 'text') {
+    const snippet = pickPreview(ref.selection || ref.text || ref.label, 24)
+    return snippet || '选区'
+  }
   const lines = lineSpanLabel(ref)
   const where = ref.path
   if (ref.action) return `${ref.label} · ${ref.action}`
@@ -181,13 +192,16 @@ export function pickIdFromText(raw: string) {
   return hash.toString(16)
 }
 
-export function withPickLocus(ref: PickRef, locus: { start_line: number; end_line: number; text: string } | null | undefined): PickRef {
+export function withPickLocus(ref: PickRef, locus: { start_line: number; end_line: number; text: string; selection?: string } | null | undefined): PickRef {
   if (!locus) return ref
   return {
     ...ref,
-    id: pickIdFromText(`${locus.start_line}:${locus.end_line}:${locus.text || ref.label}`),
+    id: pickIdFromText(`${locus.start_line}:${locus.end_line}:${locus.selection || locus.text || ref.label}`),
     ...sourceFields(ref),
-    ...locusFields(locus),
+    ...locusFields({
+      ...locus,
+      selection: locus.selection || ref.selection,
+    }),
   }
 }
 
@@ -212,7 +226,7 @@ export function textPickFromSelection(
   const host = editorHostFromNode(anchor)
   const locus = host ? host.locusFromSelection() : null
   return withPickLocus(
-    withHostSource({ kind: 'text', id: pickIdFromText(raw), label, route }, anchor),
+    withHostSource({ kind: 'text', id: pickIdFromText(raw), label, route, selection: raw.trim() }, anchor),
     locus,
   )
 }
@@ -228,6 +242,7 @@ export function pickChipAttrs(ref: PickRef) {
     start_line: ref.start_line ?? null,
     end_line: ref.end_line ?? null,
     text: ref.text ?? null,
+    selection: ref.selection ?? null,
   }
 }
 
@@ -240,10 +255,11 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
   const start = Number(attrs.start_line)
   const end = Number(attrs.end_line)
   const text = typeof attrs.text === 'string' ? attrs.text.trim() : ''
+  const selection = typeof attrs.selection === 'string' ? attrs.selection.trim() : ''
   return {
     kind,
     id,
-    label: String(attrs.label ?? '').trim() || id,
+    label: String(attrs.label ?? '').trim() || (kind === 'text' ? selection || text : '') || id,
     route: String(attrs.route ?? ''),
     ...(action ? { action } : {}),
     ...sourceFields({ path }),
@@ -251,6 +267,7 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,
       text: text || undefined,
+      selection: selection || undefined,
     }),
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选区送到对话时：

- 去掉 kind=text 的 `label`（和正文重复）
- 保留 `text` 为对应 Markdown 源码整行
- 新增 `selection` 为用户实际高亮（例如「三尺微命」）

查找命中不再 range-select，只落光标并用玫粉装饰标出，避免样式气泡跟着搜出来。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

