### PR TITLE
fix: 含高亮 HTML 的选区 pick 在气泡里显示为芯片

### DIFF
--- a/packages/core-chat/src/web/user-bubble-editor.test.tsx
+++ b/packages/core-chat/src/web/user-bubble-editor.test.tsx
@@ -17,4 +17,16 @@ describe('UserBubbleEditor', () => {
     expect(html.indexOf('看')).toBeLessThan(html.indexOf('user-pick-chip'))
     expect(html.indexOf('user-pick-chip')).toBeLessThan(html.indexOf('吧'))
   })
+
+  it('renders a pick-only message as a chip, not the raw tag', async () => {
+    const text =
+      '<pick kind="text" id="3c6fe4e9" route="/s/abc" path="/pages/p000" start_line="7" end_line="9" text="**<mark data-color=&quot;color-mix(in srgb, #c4554d 22%, transparent)&quot;>遥襟甫畅，逸兴遄飞。</mark>**" selection="遥襟甫畅" />'
+    const { container } = render(<UserBubbleEditor text={text} />)
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="user-pick-chip"]')).toBeTruthy()
+    })
+    expect(container.textContent).not.toContain('<pick')
+    expect(container.textContent).not.toContain('<mark')
+    expect(container.textContent).toContain('遥襟甫畅')
+  })
 })

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -106,6 +106,50 @@ test('text pick round-trips markdown source line numbers', () => {
   }), '三尺微命')
 })
 
+test('text pick with > in source still round-trips as a chip handle', () => {
+  const text = formatPicks([
+    {
+      kind: 'text',
+      id: 'gt1',
+      label: 'x',
+      route: '/s/abc',
+      path: '/pages/p000',
+      start_line: 3,
+      end_line: 5,
+      text: '千里逢迎，高朋满座。>\n层峦耸翠',
+      selection: '高朋满座',
+    },
+  ])
+  assert.match(text, /&gt;/)
+  const parsed = parsePicks(text)
+  assert.equal(parsed.refs.length, 1)
+  assert.equal(parsed.refs[0]?.text, '千里逢迎，高朋满座。>\n层峦耸翠')
+  assert.equal(parsed.rest, '')
+  const parts = splitPickStream(text)
+  assert.equal(parts.length, 1)
+  assert.equal(parts[0]?.type, 'pick')
+})
+
+test('legacy unescaped > inside text attr still parses', () => {
+  const raw = '<pick kind="text" id="x" route="/s/a" path="/pages/p000" start_line="3" end_line="5" text="甲 > 乙" />'
+  const parsed = parsePicks(raw)
+  assert.equal(parsed.refs.length, 1)
+  assert.equal(parsed.refs[0]?.text, '甲 > 乙')
+})
+
+test('pick text with highlight HTML still becomes one chip', () => {
+  const raw =
+    '<pick kind="text" id="3c6fe4e9" route="/s/abc" path="/pages/p000" start_line="7" end_line="9" text="**<mark data-color=&quot;color-mix(in srgb, #c4554d 22%, transparent)&quot;>遥襟甫畅</mark>高而北辰远。**" selection="遥襟甫畅" />'
+  const parsed = parsePicks(raw)
+  assert.equal(parsed.refs.length, 1)
+  assert.equal(parsed.refs[0]?.id, '3c6fe4e9')
+  assert.match(parsed.refs[0]?.text ?? '', /遥襟甫畅/)
+  assert.equal(parsed.refs[0]?.selection, '遥襟甫畅')
+  assert.equal(parsed.rest, '')
+  const parts = splitPickStream(raw)
+  assert.equal(parts[0]?.type, 'pick')
+})
+
 test('selected body text becomes a text pick', () => {
   const fake = {
     isCollapsed: false,

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -65,11 +65,16 @@ export function formatPicks(refs: PickRef[]) {
     .join('\n')
 }
 
-const PICK_TAG = /<pick\b([^>]*)\/>/gi
+const PICK_TAG = /<pick\b((?:[^>"']|"[^"]*"|'[^']*')*)\s*\/?>/gi
 const ATTR = /(\w+)="([^"]*)"/g
 
 function unescapeAttr(value: string) {
-  return value.replace(/&#10;/g, '\n').replace(/&quot;/g, '"').replace(/&amp;/g, '&')
+  return value
+    .replace(/&#10;/g, '\n')
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
 }
 
 function parsePickAttrs(raw: string): PickRef | null {
@@ -157,7 +162,12 @@ export function parsePicks(text: string): { refs: PickRef[]; rest: string } {
 }
 
 function escapeAttr(value: string) {
-  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/\n/g, '&#10;')
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/\n/g, '&#10;')
 }
 
 export function lineSpanLabel(ref: PickRef) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
只 pick、不打字时，用户气泡会把整段 `<pick>` XML 展开。原因是 `text` 里带了高亮 HTML（`<mark ...>`），旧正则在第一个 `>` 处截断，芯片解析失败。

改为按引号扫描属性，并对 `<` `>` 转义；你这条带 mark 的滕王阁选区也能收成芯片。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

