### PR TITLE
fix: 行内 LaTeX 插入与块级公式 ⌘L

### DIFF
--- a/packages/core-editor/src/web/editor-ask.test.ts
+++ b/packages/core-editor/src/web/editor-ask.test.ts
@@ -41,3 +41,21 @@ test('pickFromEditor uses the current selection', () => {
   assert.match(caret?.text ?? '', /你好世界/)
   editor.destroy()
 })
+
+test('pickFromEditor on block math uses the latex markdown', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: '$$E = mc^2$$',
+    contentType: 'markdown',
+  })
+  let pos = -1
+  editor.state.doc.descendants((node, p) => {
+    if (node.type.name === 'blockMath') pos = p
+  })
+  assert.ok(pos >= 0)
+  editor.chain().setNodeSelection(pos).run()
+  const ref = pickFromEditor(editor, '/pages/math')
+  assert.ok(ref)
+  assert.match(ref?.text ?? '', /E = mc\^2/)
+  editor.destroy()
+})

--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -1,3 +1,4 @@
+import { InputRule } from '@tiptap/core'
 import { Markdown } from '@tiptap/markdown'
 import Image from '@tiptap/extension-image'
 import { BlockMath, InlineMath, Mathematics } from '@tiptap/extension-mathematics'
@@ -9,6 +10,36 @@ import { headingSkin } from './heading-skin.ts'
 import { pageBlock } from './page-block.ts'
 import { pageFind } from './find-plugin.ts'
 import { slashCommand } from './slash.ts'
+
+/** 上游 insertInlineMath 读的是旧 selection，斜杠删掉 `/` 后会插到段落外，插不进去。 */
+const pageInlineMath = InlineMath.extend({
+  addCommands() {
+    const parent = this.parent?.() ?? {}
+    return {
+      ...parent,
+      insertInlineMath:
+        (options) =>
+        ({ commands }) => {
+          const latex = options.latex
+          if (!latex) return false
+          const content = { type: this.name, attrs: { latex } }
+          return options.pos != null ? commands.insertContentAt(options.pos, content) : commands.insertContent(content)
+        },
+    }
+  },
+  addInputRules() {
+    return [
+      new InputRule({
+        find: /(?<!\$)\$([^$\n]+)\$(?!\$)$/,
+        handler: ({ state, range, match }) => {
+          const latex = match[1].trim()
+          if (!latex) return
+          state.tr.replaceWith(range.from, range.to, this.type.create({ latex }))
+        },
+      }),
+    ]
+  },
+})
 
 const pageMathematics = Mathematics.extend({
   addExtensions() {
@@ -26,7 +57,7 @@ const pageMathematics = Mathematics.extend({
           editorOf().chain().setNodeSelection(pos).updateBlockMath({ latex: next }).focus().run()
         },
       }),
-      InlineMath.configure({
+      pageInlineMath.configure({
         katexOptions: { throwOnError: false, displayMode: false },
         onClick: (node, pos) => {
           const next = askLatex(String(node.attrs.latex ?? ''))

--- a/packages/core-editor/src/web/markdown-locus.test.ts
+++ b/packages/core-editor/src/web/markdown-locus.test.ts
@@ -111,3 +111,18 @@ test('caret in a heading uses the heading markdown line', () => {
   assert.equal(locus.insert, '# Hello'.length)
   editor.destroy()
 })
+
+test('block math node selection still has a markdown locus for ⌘L', () => {
+  const md = '前言\n\n$$\\sum x$$\n\n后记'
+  const editor = editorOf(md)
+  let pos = -1
+  editor.state.doc.descendants((node, p) => {
+    if (node.type.name === 'blockMath') pos = p
+  })
+  assert.ok(pos >= 0)
+  editor.chain().setNodeSelection(pos).run()
+  const locus = markdownLocusFromSelection(editor)
+  assert.ok(locus)
+  assert.match(locus.selection ?? locus.text, /\\sum x/)
+  editor.destroy()
+})

--- a/packages/core-editor/src/web/markdown-locus.ts
+++ b/packages/core-editor/src/web/markdown-locus.ts
@@ -59,7 +59,14 @@ export function markdownLocusFromRange(editor: Editor, from: number, to: number)
     const insert = insertInLine(prefix, full, start_line)
     return { start_line, end_line, text, insert }
   }
-  const selection = doc.textBetween(a, b, '\n').trim()
+  let selection = doc.textBetween(a, b, '\n').trim()
+  if (!selection) {
+    try {
+      selection = serialize(editor, doc.cut(a, b)).trim()
+    } catch {
+      selection = ''
+    }
+  }
   if (!selection) return null
   const prefix = serialize(editor, doc.cut(0, a))
   const through = serialize(editor, doc.cut(0, b))

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -154,6 +154,22 @@ $$\\sum_{i=1}^{n} x_i$$
   editor.destroy()
 })
 
+test('slash command inserts inline math into the current paragraph', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: '/',
+    contentType: 'markdown',
+  })
+  const from = editor.state.selection.from - 1
+  const math = SLASH_ITEMS.find((item) => item.id === 'math-inline')
+  assert.ok(math)
+  math!.command({ editor, range: { from: Math.max(1, from), to: editor.state.selection.from } })
+  assert.match(editor.getHTML(), /data-type="inline-math"/)
+  assert.match(editor.getHTML(), /x\^2/)
+  assert.match(editor.getMarkdown(), /\$x\^2\$/)
+  editor.destroy()
+})
+
 test('slash command inserts block math', () => {
   const editor = new Editor({
     extensions: pageEditorExtensions(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两处正文公式问题：

1. **行内 LaTeX 插不进去**：斜杠「行内公式」在删掉 `/` 之后仍按旧光标位置插入 inline atom，位置落在段落外，命令等于没执行。改为链式 `insertContent`，并加上 `$...$` 输入规则（原先误用 `$$...$$` 当行内）。
2. **块级公式挡住 ⌘L**：选中 atom 时 `textBetween` 为空，⌘L 被编辑器拦住却组不出 pick。现在对空选区改用该段 markdown，块级公式可以送到对话。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

