### PR TITLE
fix: 行内 LaTeX 与文字基线对齐

### DIFF
--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -88,6 +88,11 @@ test('slash suggestion uses a fixed high stacking context', async () => {
   assert.match(css, /\.page-editor \.page-block\{[^}]*isolation:isolate/)
   assert.match(css, /\.page-editor \.tiptap ul\{list-style-type:disc\}/)
   assert.match(css, /\.page-editor \.tiptap ol\{list-style-type:decimal\}/)
+  assert.match(css, /div\[data-type=block-math\]\.tiptap-mathematics-render\{[^}]*margin:8px 0/)
+  assert.match(css, /span\[data-type=inline-math\]\{[^}]*display:inline/)
+  assert.match(css, /span\[data-type=inline-math\]\{[^}]*vertical-align:baseline/)
+  assert.doesNotMatch(css, /\.tiptap \.tiptap-mathematics-render\{margin:8px 0/)
+  assert.doesNotMatch(css, /span\[data-type=inline-math\]\{[^}]*display:inline-block/)
 })
 
 test('markdown roundtrips image and table', () => {

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -48,9 +48,10 @@ export const PAGE_EDITOR_STYLE = `
 .page-editor .tiptap th,.page-editor .tiptap td{border:1px solid var(--dsw-border);padding:6px 8px;vertical-align:top}
 .page-editor .tiptap th{background:var(--dsw-hover);font-weight:650;text-align:left}
 .page-editor .tiptap .selectedCell{background:color-mix(in srgb,var(--dsw-business) 14%,transparent)}
-.page-editor .tiptap .tiptap-mathematics-render{margin:8px 0;overflow-x:auto}
+.page-editor .tiptap div[data-type=block-math].tiptap-mathematics-render{margin:8px 0;overflow-x:auto}
 .page-editor .tiptap .tiptap-mathematics-render--editable{cursor:pointer}
-.page-editor .tiptap span[data-type=inline-math]{display:inline-block;padding:0 .15em;cursor:pointer}
+.page-editor .tiptap span[data-type=inline-math]{display:inline;margin:0;padding:0 .12em;line-height:inherit;vertical-align:baseline;overflow:visible;cursor:pointer}
+.page-editor .tiptap span[data-type=inline-math] .katex{font-size:1em}
 .page-editor .tiptap .block-math-error,.page-editor .tiptap .inline-math-error{color:var(--dsw-label-3);font-family:var(--font-mono);font-size:13px}
 .page-editor .tiptap code{display:inline;padding:.12em .35em;border-radius:4px;background:var(--dsw-hover);font-family:var(--font-mono);font-size:.9em}
 .page-editor .tiptap pre{display:block;margin:8px 0;padding:10px 12px;border:1px solid var(--dsw-border);border-radius:10px;background:var(--dsw-chat-code-bg,var(--dsw-sidebar));overflow-x:auto;white-space:pre;font-family:var(--font-mono)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
用的是官方 `@tiptap/extension-mathematics` + KaTeX。偏上是我们自己的样式：把块级公式的 `margin: 8px 0` 和 `inline-block` 套到了行内公式上，`$x^2$` 会整块抬离文字基线。

行内改为 `display:inline`、跟基线对齐、去掉上下边距；块级 `E=mc^2` 仍保留上下边距。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

