### PR TITLE
feat: 公式下方弹出 LaTeX 输入

### DIFF
--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -10,6 +10,7 @@ import { headingSkin } from './heading-skin.ts'
 import { pageBlock } from './page-block.ts'
 import { pageFind } from './find-plugin.ts'
 import { slashCommand } from './slash.ts'
+import { openMathPop } from './math-pop.ts'
 
 /** 上游 insertInlineMath 读的是旧 selection，斜杠删掉 `/` 后会插到段落外，插不进去。 */
 const pageInlineMath = InlineMath.extend({
@@ -44,26 +45,36 @@ const pageInlineMath = InlineMath.extend({
 const pageMathematics = Mathematics.extend({
   addExtensions() {
     const editorOf = () => this.editor
-    const askLatex = (current: string) => {
-      if (typeof window === 'undefined' || typeof window.prompt !== 'function') return null
-      return window.prompt('LaTeX 公式', current)
+    const editLatex = (kind: 'block' | 'inline', node: { attrs: Record<string, unknown> }, pos: number) => {
+      const editor = editorOf()
+      if (editor.isDestroyed) return
+      const dom = editor.view.nodeDOM(pos)
+      const anchor = dom instanceof Element ? dom : null
+      if (!anchor) return
+      editor.chain().setNodeSelection(pos).focus().run()
+      const name = kind === 'block' ? 'blockMath' : 'inlineMath'
+      openMathPop({
+        anchor,
+        latex: String(node.attrs.latex ?? ''),
+        onCommit: (next) => {
+          if (editor.isDestroyed) return
+          const current = editor.state.doc.nodeAt(pos)
+          if (!current || current.type.name !== name) return
+          if (next === String(current.attrs.latex ?? '')) return
+          const chain = editor.chain().setNodeSelection(pos)
+          if (kind === 'block') chain.updateBlockMath({ latex: next }).focus().run()
+          else chain.updateInlineMath({ latex: next }).focus().run()
+        },
+      })
     }
     return [
       BlockMath.configure({
         katexOptions: { throwOnError: false, displayMode: true },
-        onClick: (node, pos) => {
-          const next = askLatex(String(node.attrs.latex ?? ''))
-          if (next == null) return
-          editorOf().chain().setNodeSelection(pos).updateBlockMath({ latex: next }).focus().run()
-        },
+        onClick: (node, pos) => editLatex('block', node, pos),
       }),
       pageInlineMath.configure({
         katexOptions: { throwOnError: false, displayMode: false },
-        onClick: (node, pos) => {
-          const next = askLatex(String(node.attrs.latex ?? ''))
-          if (next == null) return
-          editorOf().chain().setNodeSelection(pos).updateInlineMath({ latex: next }).focus().run()
-        },
+        onClick: (node, pos) => editLatex('inline', node, pos),
       }),
     ]
   },

--- a/packages/core-editor/src/web/math-pop.test.ts
+++ b/packages/core-editor/src/web/math-pop.test.ts
@@ -1,0 +1,60 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { closeMathPop, openMathPop } from './math-pop.ts'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+test('math pop opens below the formula and commits on Enter, not via window.prompt', async () => {
+  const kit = await readFile(resolve(import.meta.dirname, './kit.ts'), 'utf8')
+  assert.match(kit, /openMathPop/)
+  assert.doesNotMatch(kit, /window\.prompt/)
+  const css = await readFile(resolve(import.meta.dirname, './style.ts'), 'utf8')
+  assert.match(css, /\.page-math-pop\{[^}]*position:fixed/)
+  assert.match(css, /\.page-math-pop\{[^}]*z-index:10000/)
+
+  const anchor = document.createElement('span')
+  document.body.appendChild(anchor)
+  Object.defineProperty(anchor, 'getBoundingClientRect', {
+    value: () => ({ top: 40, bottom: 60, left: 24, right: 80, width: 56, height: 20, x: 24, y: 40, toJSON() {} }),
+  })
+  let committed = ''
+  openMathPop({
+    anchor,
+    latex: 'x^2',
+    onCommit: (next) => {
+      committed = next
+    },
+  })
+  const pop = document.querySelector('[data-testid="page-math-pop"]')
+  assert.ok(pop instanceof HTMLElement)
+  assert.equal(pop.style.top, '66px')
+  const input = pop.querySelector('textarea')
+  assert.ok(input)
+  assert.equal(input.value, 'x^2')
+  input.value = 'y^2'
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+  assert.equal(committed, 'y^2')
+  assert.equal(document.querySelector('[data-testid="page-math-pop"]'), null)
+  anchor.remove()
+})
+
+test('Escape closes the math pop without committing', () => {
+  const anchor = document.createElement('span')
+  document.body.appendChild(anchor)
+  let committed = 'untouched'
+  openMathPop({
+    anchor,
+    latex: 'E=mc^2',
+    onCommit: (next) => {
+      committed = next
+    },
+  })
+  const input = document.querySelector('.page-math-pop-input')
+  assert.ok(input instanceof HTMLTextAreaElement)
+  input.value = 'changed'
+  input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  assert.equal(committed, 'untouched')
+  assert.equal(document.querySelector('[data-testid="page-math-pop"]'), null)
+  closeMathPop()
+  anchor.remove()
+})

--- a/packages/core-editor/src/web/math-pop.ts
+++ b/packages/core-editor/src/web/math-pop.ts
@@ -1,0 +1,82 @@
+type Open = {
+  panel: HTMLElement
+  onDoc: (event: Event) => void
+  onScroll: () => void
+}
+
+let open: Open | null = null
+
+export function closeMathPop() {
+  if (!open) return
+  document.removeEventListener('pointerdown', open.onDoc, true)
+  window.removeEventListener('scroll', open.onScroll, true)
+  window.removeEventListener('resize', open.onScroll)
+  open.panel.remove()
+  open = null
+}
+
+function placeBelow(panel: HTMLElement, anchor: Element) {
+  const r = anchor.getBoundingClientRect()
+  const gap = 6
+  const pad = 8
+  panel.style.left = `${Math.max(pad, r.left)}px`
+  panel.style.top = `${r.bottom + gap}px`
+  const box = panel.getBoundingClientRect()
+  if (box.right > window.innerWidth - pad) {
+    panel.style.left = `${Math.max(pad, window.innerWidth - pad - box.width)}px`
+  }
+  if (box.bottom > window.innerHeight - pad) {
+    panel.style.top = `${Math.max(pad, r.top - box.height - gap)}px`
+  }
+}
+
+/** 点公式后在下方弹出 LaTeX 输入，不用浏览器 prompt。 */
+export function openMathPop(args: { anchor: Element; latex: string; onCommit: (next: string) => void }) {
+  closeMathPop()
+  const panel = document.createElement('div')
+  panel.className = 'page-math-pop'
+  panel.dataset.testid = 'page-math-pop'
+  const input = document.createElement('textarea')
+  input.className = 'page-math-pop-input'
+  input.value = args.latex
+  input.rows = args.latex.includes('\n') || args.latex.length > 48 ? 3 : 1
+  input.setAttribute('aria-label', 'LaTeX')
+  input.spellcheck = false
+  panel.appendChild(input)
+  document.body.appendChild(panel)
+  const onScroll = () => {
+    if (args.anchor.isConnected) placeBelow(panel, args.anchor)
+    else closeMathPop()
+  }
+  placeBelow(panel, args.anchor)
+  const finish = (commit: boolean) => {
+    const next = input.value
+    closeMathPop()
+    if (commit) args.onCommit(next)
+  }
+  input.addEventListener('keydown', (event) => {
+    event.stopPropagation()
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      finish(false)
+      return
+    }
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault()
+      finish(true)
+    }
+  })
+  const onDoc = (event: Event) => {
+    const target = event.target
+    if (target instanceof Node && panel.contains(target)) return
+    finish(true)
+  }
+  window.addEventListener('scroll', onScroll, true)
+  window.addEventListener('resize', onScroll)
+  requestAnimationFrame(() => {
+    document.addEventListener('pointerdown', onDoc, true)
+  })
+  open = { panel, onDoc, onScroll }
+  input.focus()
+  input.select()
+}

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -99,5 +99,7 @@ export const PAGE_EDITOR_STYLE = `
 .page-color-grid button.is-on{box-shadow:0 0 0 2px var(--dsw-business)}
 .page-color-clear{width:100%;margin:8px 0 0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label-2);font:inherit;font-size:12px;font-weight:600;cursor:pointer;text-align:left}
 .page-color-clear:hover{background:var(--dsw-hover);color:var(--dsw-label)}
+.page-math-pop{position:fixed;z-index:10000;min-width:220px;max-width:min(360px,calc(100vw - 16px));padding:6px 8px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(15,15,15,.16)}
+.page-math-pop-input{display:block;width:100%;margin:0;border:0;padding:2px 0;background:transparent;color:var(--dsw-label);font-family:var(--font-mono);font-size:13px;line-height:1.45;outline:none;resize:none}
 .page-editor .tiptap mark{border-radius:2px;padding:0 .08em}
 `


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点公式不再弹出浏览器自带的 `prompt`。改为在公式正下方出现输入框：Enter 保存，Esc 取消，点外面也会保存。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

