### PR TITLE
fix: 打字光标跳文末、公式反斜杠叠增

### DIFF
--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -12,6 +12,10 @@ import { pageFind } from './find-plugin.ts'
 import { slashCommand } from './slash.ts'
 import { openMathPop } from './math-pop.ts'
 
+function latexFromMarkdown(raw: unknown) {
+  return String(raw ?? '').trim().replace(/\\([`*_[\]~])/g, '$1')
+}
+
 /** 上游 insertInlineMath 读的是旧 selection，斜杠删掉 `/` 后会插到段落外，插不进去。 */
 const pageInlineMath = InlineMath.extend({
   addCommands() {
@@ -40,6 +44,10 @@ const pageInlineMath = InlineMath.extend({
       }),
     ]
   },
+  parseMarkdown: (token: { latex?: unknown }) => ({
+    type: 'inlineMath',
+    attrs: { latex: latexFromMarkdown(token.latex) },
+  }),
 })
 
 const pageMathematics = Mathematics.extend({
@@ -68,7 +76,12 @@ const pageMathematics = Mathematics.extend({
       })
     }
     return [
-      BlockMath.configure({
+      BlockMath.extend({
+        parseMarkdown: (token: { latex?: unknown }) => ({
+          type: 'blockMath',
+          attrs: { latex: latexFromMarkdown(token.latex) },
+        }),
+      }).configure({
         katexOptions: { throwOnError: false, displayMode: true },
         onClick: (node, pos) => editLatex('block', node, pos),
       }),

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -159,6 +159,29 @@ $$\\sum_{i=1}^{n} x_i$$
   editor.destroy()
 })
 
+test('latex markdown does not accumulate backslashes across reloads', () => {
+  let md = '的 $a_b$ 的\n\n$$\\sum_{i=1}^{n} x_i$$\n'
+  const counts: number[] = []
+  for (let i = 0; i < 4; i++) {
+    const editor = new Editor({
+      extensions: pageEditorExtensions(),
+      content: md,
+      contentType: 'markdown',
+    })
+    md = editor.getMarkdown()
+    counts.push((md.match(/\\/g) ?? []).length)
+    editor.destroy()
+  }
+  assert.equal(counts[0], counts[3])
+  const again = new Editor({
+    extensions: pageEditorExtensions(),
+    content: md,
+    contentType: 'markdown',
+  })
+  assert.equal(again.getMarkdown(), md)
+  again.destroy()
+})
+
 test('slash command inserts inline math into the current paragraph', () => {
   const editor = new Editor({
     extensions: pageEditorExtensions(),

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -169,5 +169,7 @@ test('page editor applies later value when it is not focused', async () => {
   assert.match(src, /editorHostIsLive\(editor\)/)
   assert.doesNotMatch(src, /if \(editor\.isFocused && !contentJumpForRecord\(record\.id\)\) return/)
   assert.match(src, /md === saved\.current/)
+  assert.match(src, /leavingSource/)
+  assert.match(src, /sourceMode\.current/)
 })
 

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -262,6 +262,7 @@ function TableBar({ editor }: { editor: Editor }) {
 export function PageEditor({ record, value, writable, onChange, path }: FsContentProps) {
   const source = usePageSourceMode(record.id)
   const saved = useRef(asMarkdown(value))
+  const sourceMode = useRef(source)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const hydratedId = useRef<string | null>(null)
   const sourceFind = useRef<SourceEditorHandle>(null)
@@ -405,7 +406,10 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
   }, [source, editor])
 
   useEffect(() => {
-    if (!editor || editor.isDestroyed || source) return
+    if (!editor || editor.isDestroyed) return
+    const leavingSource = sourceMode.current && !source
+    sourceMode.current = source
+    if (source || !leavingSource) return
     const md = asMarkdown(value)
     saved.current = md
     if (md === editor.getMarkdown()) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点公式下方输入的 PR 已合入。

另外修了打字时光标跳到最后一行、正文里狂增反斜杠：

- 切回所见即所得的 `setContent` 误绑在每次 `value` 回写上。保存后会整篇重载，光标跑到文末，公式/下划线被 markdown 再转义一次，`\` 越叠越多。现在只在离开源码模式时才套远端正文。
- 公式解析会解开误加的 `\_` 一类转义。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

