### PR TITLE
fix: 空段落不再输出 &nbsp;

### DIFF
--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -5,6 +5,7 @@ import { BlockMath, InlineMath, Mathematics } from '@tiptap/extension-mathematic
 import Placeholder from '@tiptap/extension-placeholder'
 import { TableKit } from '@tiptap/extension-table'
 import StarterKit from '@tiptap/starter-kit'
+import { Paragraph } from '@tiptap/extension-paragraph'
 import { pageTextStyle, pageHighlight, Color } from './color-marks.ts'
 import { headingSkin } from './heading-skin.ts'
 import { pageBlock } from './page-block.ts'
@@ -15,6 +16,27 @@ import { openMathPop } from './math-pop.ts'
 function latexFromMarkdown(raw: unknown) {
   return String(raw ?? '').trim().replace(/\\([`*_[\]~])/g, '$1')
 }
+
+function isBlankParagraph(node: { content?: unknown } | null | undefined) {
+  const content = Array.isArray(node?.content) ? node.content : []
+  if (content.length === 0) return true
+  if (content.length !== 1) return false
+  const item = content[0] as { type?: string; text?: string }
+  if (item?.type !== 'text') return false
+  const text = String(item.text ?? '')
+    .replace(/\u00a0/g, '')
+    .replace(/&nbsp;/gi, '')
+    .trim()
+  return !text
+}
+
+/** 官方空段会写成 &nbsp;，源码/正文里会直接看见这串字符。空段改成真正的空行。 */
+const pageParagraph = Paragraph.extend({
+  renderMarkdown: (node, h) => {
+    if (!node || isBlankParagraph(node)) return ''
+    return h.renderChildren(Array.isArray(node.content) ? node.content : [])
+  },
+})
 
 /** 上游 insertInlineMath 读的是旧 selection，斜杠删掉 `/` 后会插到段落外，插不进去。 */
 const pageInlineMath = InlineMath.extend({
@@ -97,7 +119,9 @@ export function pageEditorExtensions() {
   return [
     StarterKit.configure({
       heading: { levels: [1, 2, 3] },
+      paragraph: false,
     }),
+    pageParagraph,
     Markdown,
     pageTextStyle,
     Color,

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -64,6 +64,35 @@ test('heading stays a native h1 without node-view wrappers', () => {
   editor.destroy()
 })
 
+test('empty paragraphs serialize as blank lines, not &nbsp;', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: {
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hi' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+      ],
+    },
+  })
+  const md = editor.getMarkdown()
+  assert.doesNotMatch(md, /&nbsp;/)
+  assert.match(md, /hi/)
+  editor.destroy()
+  const loaded = new Editor({
+    extensions: pageEditorExtensions(),
+    content: 'a\n\n&nbsp;\n\n&nbsp;\n\nb',
+    contentType: 'markdown',
+  })
+  assert.doesNotMatch(loaded.getMarkdown(), /&nbsp;/)
+  assert.match(loaded.getHTML(), /<p>a<\/p>/)
+  assert.match(loaded.getHTML(), /<p>b<\/p>/)
+  loaded.destroy()
+})
+
 test('slash suggestion uses a fixed high stacking context', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
空行连按时，TipTap 官方 Paragraph 会把第二段起的空段落写成 markdown 里的 `&nbsp;`，源码模式和存盘正文里就会出现一串这个实体。

空段改为真正的空行；读入时仍把旧文件里的 `&nbsp;` 当成空段。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

