### PR TITLE
fix: 点公式能打开下方 LaTeX 输入

### DIFF
--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -1,4 +1,5 @@
-import { InputRule } from '@tiptap/core'
+import { InputRule, type Editor } from '@tiptap/core'
+import { Plugin, PluginKey } from '@tiptap/pm/state'
 import { Markdown } from '@tiptap/markdown'
 import Image from '@tiptap/extension-image'
 import { BlockMath, InlineMath, Mathematics } from '@tiptap/extension-mathematics'
@@ -16,8 +17,48 @@ function latexFromMarkdown(raw: unknown) {
   return String(raw ?? '').trim().replace(/\\([`*_[\]~])/g, '$1')
 }
 
+function mathAnchor(editor: Editor, pos: number) {
+  const dom = editor.view.nodeDOM(pos)
+  if (dom instanceof Element) return dom
+  try {
+    const mapped = editor.view.domAtPos(Math.max(0, pos))
+    const node = mapped.node
+    const el = node instanceof Element ? node : node.parentElement
+    return el?.closest('[data-type="inline-math"], [data-type="block-math"]') ?? el
+  } catch {
+    return null
+  }
+}
+
+function editLatex(editor: Editor | undefined, kind: 'block' | 'inline', node: { attrs: Record<string, unknown> }, pos: number) {
+  if (!editor || editor.isDestroyed) return
+  const anchor = mathAnchor(editor, pos)
+  if (!(anchor instanceof Element)) return
+  const name = kind === 'block' ? 'blockMath' : 'inlineMath'
+  openMathPop({
+    anchor,
+    latex: String(node.attrs.latex ?? ''),
+    onCommit: (next) => {
+      if (editor.isDestroyed) return
+      const current = editor.state.doc.nodeAt(pos)
+      if (!current || current.type.name !== name) return
+      if (next === String(current.attrs.latex ?? '')) return
+      const chain = editor.chain().setNodeSelection(pos)
+      if (kind === 'block') chain.updateBlockMath({ latex: next }).focus().run()
+      else chain.updateInlineMath({ latex: next }).focus().run()
+    },
+  })
+}
+
 /** 上游 insertInlineMath 读的是旧 selection，斜杠删掉 `/` 后会插到段落外，插不进去。 */
 const pageInlineMath = InlineMath.extend({
+  addOptions() {
+    const parent = this.parent?.() ?? {}
+    return {
+      ...parent,
+      katexOptions: { throwOnError: false, displayMode: false },
+    }
+  },
   addCommands() {
     const parent = this.parent?.() ?? {}
     return {
@@ -50,44 +91,58 @@ const pageInlineMath = InlineMath.extend({
   }),
 })
 
+const pageBlockMath = BlockMath.extend({
+  addOptions() {
+    const parent = this.parent?.() ?? {}
+    return {
+      ...parent,
+      katexOptions: { throwOnError: false, displayMode: true },
+    }
+  },
+  parseMarkdown: (token: { latex?: unknown }) => ({
+    type: 'blockMath',
+    attrs: { latex: latexFromMarkdown(token.latex) },
+  }),
+})
+
+const pageMathPopKey = new PluginKey('page-math-pop')
+
 const pageMathematics = Mathematics.extend({
   addExtensions() {
-    const editorOf = () => this.editor
-    const editLatex = (kind: 'block' | 'inline', node: { attrs: Record<string, unknown> }, pos: number) => {
-      const editor = editorOf()
-      if (editor.isDestroyed) return
-      const dom = editor.view.nodeDOM(pos)
-      const anchor = dom instanceof Element ? dom : null
-      if (!anchor) return
-      editor.chain().setNodeSelection(pos).focus().run()
-      const name = kind === 'block' ? 'blockMath' : 'inlineMath'
-      openMathPop({
-        anchor,
-        latex: String(node.attrs.latex ?? ''),
-        onCommit: (next) => {
-          if (editor.isDestroyed) return
-          const current = editor.state.doc.nodeAt(pos)
-          if (!current || current.type.name !== name) return
-          if (next === String(current.attrs.latex ?? '')) return
-          const chain = editor.chain().setNodeSelection(pos)
-          if (kind === 'block') chain.updateBlockMath({ latex: next }).focus().run()
-          else chain.updateInlineMath({ latex: next }).focus().run()
-        },
-      })
-    }
+    return [pageBlockMath, pageInlineMath]
+  },
+  addProseMirrorPlugins() {
+    const editor = this.editor
     return [
-      BlockMath.extend({
-        parseMarkdown: (token: { latex?: unknown }) => ({
-          type: 'blockMath',
-          attrs: { latex: latexFromMarkdown(token.latex) },
-        }),
-      }).configure({
-        katexOptions: { throwOnError: false, displayMode: true },
-        onClick: (node, pos) => editLatex('block', node, pos),
-      }),
-      pageInlineMath.configure({
-        katexOptions: { throwOnError: false, displayMode: false },
-        onClick: (node, pos) => editLatex('inline', node, pos),
+      new Plugin({
+        key: pageMathPopKey,
+        props: {
+          handleDOMEvents: {
+            click(view, event) {
+              const target = event.target
+              if (!(target instanceof Element)) return false
+              const wrap = target.closest('[data-type="inline-math"], [data-type="block-math"]')
+              if (!(wrap instanceof Element) || !view.dom.contains(wrap)) return false
+              let pos = -1
+              try {
+                pos = view.posAtDOM(wrap, 0)
+              } catch {
+                return false
+              }
+              let node = view.state.doc.nodeAt(pos)
+              if (!node || (node.type.name !== 'inlineMath' && node.type.name !== 'blockMath')) {
+                const $pos = view.state.doc.resolve(pos)
+                node = $pos.nodeAfter ?? $pos.nodeBefore ?? node
+                if ($pos.nodeAfter) pos = $pos.pos
+                else if ($pos.nodeBefore) pos = $pos.pos - $pos.nodeBefore.nodeSize
+              }
+              if (!node || (node.type.name !== 'inlineMath' && node.type.name !== 'blockMath')) return false
+              event.preventDefault()
+              editLatex(editor, node.type.name === 'blockMath' ? 'block' : 'inline', node, pos)
+              return true
+            },
+          },
+        },
       }),
     ]
   },

--- a/packages/core-editor/src/web/math-pop.test.ts
+++ b/packages/core-editor/src/web/math-pop.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { Editor } from '@tiptap/core'
 import { closeMathPop, openMathPop } from './math-pop.ts'
+import { pageEditorExtensions } from './kit.ts'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -8,6 +10,9 @@ test('math pop opens below the formula and commits on Enter, not via window.prom
   const kit = await readFile(resolve(import.meta.dirname, './kit.ts'), 'utf8')
   assert.match(kit, /openMathPop/)
   assert.doesNotMatch(kit, /window\.prompt/)
+  assert.doesNotMatch(kit, /const editorOf = \(\) => this\.editor/)
+  assert.match(kit, /pageMathPopKey/)
+  assert.match(kit, /handleDOMEvents/)
   const css = await readFile(resolve(import.meta.dirname, './style.ts'), 'utf8')
   assert.match(css, /\.page-math-pop\{[^}]*position:fixed/)
   assert.match(css, /\.page-math-pop\{[^}]*z-index:10000/)
@@ -57,4 +62,23 @@ test('Escape closes the math pop without committing', () => {
   assert.equal(document.querySelector('[data-testid="page-math-pop"]'), null)
   closeMathPop()
   anchor.remove()
+})
+
+test('clicking inline math opens the latex pop without crashing', () => {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  const editor = new Editor({
+    element: host,
+    extensions: pageEditorExtensions(),
+    content: '见 $x^2$ 公式',
+    contentType: 'markdown',
+  })
+  const el = host.querySelector('[data-type="inline-math"]')
+  assert.ok(el instanceof HTMLElement)
+  el.click()
+  const pop = document.querySelector('[data-testid="page-math-pop"]')
+  assert.ok(pop, 'click should open the pop under the formula')
+  closeMathPop()
+  editor.destroy()
+  host.remove()
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点公式时报 `Cannot read properties of undefined (reading 'isDestroyed')`，浮窗出不来。原因是 `Mathematics` 父扩展上没有 `this.editor`。

改为在 ProseMirror 里点 `inline-math` / `block-math` 节点时打开下方输入框。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

