### PR TITLE
fix: 源码模式选区用 TipTap 同款蓝，不再过亮

### DIFF
--- a/packages/core-editor/src/web/source-editor.test.tsx
+++ b/packages/core-editor/src/web/source-editor.test.tsx
@@ -13,6 +13,8 @@ test('source editor uses CodeMirror markdown highlighting and line numbers', () 
   assert.match(src, /syntaxHighlighting/)
   assert.match(src, /page-source-editor/)
   assert.match(src, /getLocus/)
+  assert.match(src, /cm-selectionLayer \.cm-selectionBackground[\s\S]*background: 'Highlight'/)
+  assert.doesNotMatch(src, /cm-selectionBackground[\s\S]*dsw-business/)
 })
 
 test('source editor mounts a CodeMirror view for markdown', async () => {

--- a/packages/core-editor/src/web/source-editor.tsx
+++ b/packages/core-editor/src/web/source-editor.tsx
@@ -69,8 +69,10 @@ const theme = EditorView.theme({
   '.cm-activeLine': { background: 'color-mix(in srgb, var(--dsw-hover) 70%, transparent)' },
   '.cm-activeLineGutter': { background: 'transparent', color: '#F0EFED' },
   '.cm-cursor': { borderLeftColor: 'var(--dsw-label)' },
-  '&.cm-focused .cm-selectionBackground, .cm-selectionBackground': {
-    background: 'color-mix(in srgb, var(--dsw-business) 28%, transparent)',
+  /* TipTap 用浏览器原生 ::selection（深色下是蓝）。不要用 --dsw-business，那是浅字色，混出来会过亮。 */
+  '.cm-content ::selection': { background: 'Highlight' },
+  '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionLayer .cm-selectionBackground': {
+    background: 'Highlight',
   },
 })
 

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -6,6 +6,7 @@ export const PAGE_EDITOR_STYLE = `
 .page-source{min-width:0;width:100%}
 .page-source .cm-editor{background:transparent}
 .page-source .cm-focused{outline:none}
+.page-source .cm-editor.cm-focused>.cm-scroller>.cm-selectionLayer .cm-selectionBackground,.page-source .cm-selectionLayer .cm-selectionBackground{background:Highlight}
 .page-editor .tiptap{outline:none;min-height:240px}
 .page-block-handle{position:absolute;z-index:6;width:28px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
 .page-block-handle-grip{flex:none;display:flex;align-items:center;justify-content:center;width:22px;height:26px;margin:0;border:0;border-radius:6px;padding:0;background:transparent;color:#EFEEEC;cursor:grab}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
源码（CodeMirror）选区原先用 `--dsw-business`（近白字色）做半透明底，深色页面上会发白过亮；官方 CodeMirror 聚焦选区 `#d7d4f0` 选择器也更具体，容易盖掉自定义。

所见即所得 TipTap 用的是浏览器原生 `::selection`（`color-scheme: dark` 下是系统蓝）。源码模式改为同一套 `Highlight`，选择器对齐 `.cm-selectionLayer`。

未改 markdown 序列化；官方仍可在源码里写 `&nbsp;`，只是不把实体字面量画在 WYSIWYG 上——那是另一件事，本 PR 只动选区颜色。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

