### PR TITLE
fix: 公式输入浮窗在公式正下方居中

### DIFF
--- a/packages/core-editor/src/web/math-pop.test.ts
+++ b/packages/core-editor/src/web/math-pop.test.ts
@@ -33,6 +33,10 @@ test('math pop opens below the formula and commits on Enter, not via window.prom
   const pop = document.querySelector('[data-testid="page-math-pop"]')
   assert.ok(pop instanceof HTMLElement)
   assert.equal(pop.style.top, '66px')
+  const formulaMid = 24 + 56 / 2
+  const left = Number.parseFloat(pop.style.left)
+  const popMid = left + (pop.getBoundingClientRect().width || 0) / 2
+  assert.ok(Math.abs(popMid - formulaMid) < 1, `pop should sit under the formula, not left-aligned (left=${pop.style.left})`)
   const input = pop.querySelector('textarea')
   assert.ok(input)
   assert.equal(input.value, 'x^2')
@@ -81,4 +85,37 @@ test('clicking inline math opens the latex pop without crashing', () => {
   closeMathPop()
   editor.destroy()
   host.remove()
+})
+
+test('block math pop sits under the formula, not the left edge of the block', () => {
+  const anchor = document.createElement('div')
+  const katex = document.createElement('span')
+  katex.className = 'katex-display'
+  anchor.appendChild(katex)
+  document.body.appendChild(anchor)
+  Object.defineProperty(anchor, 'getBoundingClientRect', {
+    value: () => ({ top: 80, bottom: 120, left: 40, right: 700, width: 660, height: 40, x: 40, y: 80, toJSON() {} }),
+  })
+  Object.defineProperty(katex, 'getBoundingClientRect', {
+    value: () => ({ top: 80, bottom: 120, left: 200, right: 360, width: 160, height: 40, x: 200, y: 80, toJSON() {} }),
+  })
+  openMathPop({
+    anchor,
+    latex: '\\sum x',
+    onCommit: () => undefined,
+  })
+  const pop = document.querySelector('[data-testid="page-math-pop"]')
+  assert.ok(pop instanceof HTMLElement)
+  Object.defineProperty(pop, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => {
+      const left = Number.parseFloat(pop.style.left) || 0
+      return { top: 126, bottom: 160, left, right: left + 220, width: 220, height: 34, x: left, y: 126, toJSON() {} }
+    },
+  })
+  window.dispatchEvent(new Event('resize'))
+  assert.equal(pop.style.top, '126px')
+  assert.equal(pop.style.left, '170px')
+  closeMathPop()
+  anchor.remove()
 })

--- a/packages/core-editor/src/web/math-pop.ts
+++ b/packages/core-editor/src/web/math-pop.ts
@@ -15,18 +15,24 @@ export function closeMathPop() {
   open = null
 }
 
+function mathVisual(anchor: Element) {
+  return anchor.querySelector('.katex-display, .katex') ?? anchor
+}
+
 function placeBelow(panel: HTMLElement, anchor: Element) {
-  const r = anchor.getBoundingClientRect()
+  const r = mathVisual(anchor).getBoundingClientRect()
   const gap = 6
   const pad = 8
-  panel.style.left = `${Math.max(pad, r.left)}px`
   panel.style.top = `${r.bottom + gap}px`
   const box = panel.getBoundingClientRect()
-  if (box.right > window.innerWidth - pad) {
-    panel.style.left = `${Math.max(pad, window.innerWidth - pad - box.width)}px`
-  }
-  if (box.bottom > window.innerHeight - pad) {
-    panel.style.top = `${Math.max(pad, r.top - box.height - gap)}px`
+  const width = box.width || panel.offsetWidth
+  const mid = r.left + r.width / 2
+  const maxLeft = Math.max(pad, window.innerWidth - pad - width)
+  const left = Math.min(maxLeft, Math.max(pad, mid - width / 2))
+  panel.style.left = `${left}px`
+  const placed = panel.getBoundingClientRect()
+  if (placed.bottom > window.innerHeight - pad) {
+    panel.style.top = `${Math.max(pad, r.top - (placed.height || box.height) - gap)}px`
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点块级公式时，LaTeX 浮窗原先用公式节点左缘对齐，块级节点往往比公式本身宽，看起来像在左下方。

改为对齐内部 KaTeX 的水平中心，浮窗在公式正下方；超出视口再夹紧。测试覆盖居中位置，而不是贴 left。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

