### PR TITLE
feat: pick 行号用括号展示，载荷改为 JSON

### DIFF
--- a/packages/core-pick/src/host/index.test.ts
+++ b/packages/core-pick/src/host/index.test.ts
@@ -11,7 +11,7 @@ test('registers pick instructions on the system prompt', async () => {
   await ctx.plugin(systemPrompt)
   await ctx.plugin(pick)
   const text = ctx.systemPrompt.assemble()
-  assert.match(text, /<pick/)
+  assert.match(text, /<pick>/)
   assert.match(text, /kind\/id/)
   assert.match(text, /path/)
   assert.match(text, /db_content/)

--- a/packages/core-pick/src/host/index.ts
+++ b/packages/core-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick kind id ... />，必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区 kind=text 带 path（db_content 记录路径）、start_line/end_line（定位行）、text（对应源码整行）。有高亮时带 selection；无选区时带 insert（该行 markdown 源码里的 0-based 插入点，插在 text 的第 insert 个字符之前，不是可视编辑器列）。改正文用 db_content 的 path，不要读工作区文件。',
+    '若用户消息含一条或多条 <pick>{"kind","id",...}</pick> JSON 句柄（旧的 <pick kind id ... /> 属性写法仍有效），必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区 kind=text 带 path（db_content 记录路径）、start_line/end_line（数字，定位行）、text（对应源码整行）。有高亮时带 selection；无选区时带 insert（该行 markdown 源码里的 0-based 插入点，插在 text 的第 insert 个字符之前，不是可视编辑器列）。改正文用 db_content 的 path，不要读工作区文件。',
   )
 }

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -60,12 +60,60 @@ test('picking does not look through the chat overlay', () => {
   panel.remove()
 })
 
-test('formatPicks emits data handles only', () => {
+test('formatPicks emits JSON handles only', () => {
   const text = formatPicks([
     { kind: 'session', id: 'abc', label: '聊天', route: '/s/abc' },
   ])
-  assert.equal(text, '<pick kind="session" id="abc" route="/s/abc" label="聊天" />')
+  assert.equal(text, '<pick>{"kind":"session","id":"abc","route":"/s/abc","label":"聊天"}</pick>')
   assert.doesNotMatch(text, /class=|svg|html/i)
+})
+
+test('chip label puts line span in parentheses after the name', () => {
+  assert.equal(
+    chipLabel({
+      kind: 'page',
+      id: 'p1',
+      label: '说明',
+      route: '/',
+      path: '/docs/README.md',
+      start_line: 9,
+      end_line: 10,
+    }),
+    'README.md (9-10)',
+  )
+  assert.equal(
+    chipLabel({
+      kind: 'page',
+      id: 'p1',
+      label: '说明',
+      route: '/',
+      path: '/docs/README.md',
+      start_line: 9,
+      end_line: 9,
+    }),
+    'README.md (9)',
+  )
+})
+
+test('JSON pick keeps line numbers when text contains quotes and >', () => {
+  const text = formatPicks([
+    {
+      kind: 'text',
+      id: 'q1',
+      label: 'x',
+      route: '/s/a',
+      path: '/pages/p000',
+      start_line: 4,
+      end_line: 6,
+      text: '甲 > 乙 "丙"',
+      selection: '乙 "丙"',
+    },
+  ])
+  const parsed = parsePicks(text)
+  assert.equal(parsed.refs[0]?.start_line, 4)
+  assert.equal(parsed.refs[0]?.end_line, 6)
+  assert.equal(parsed.refs[0]?.text, '甲 > 乙 "丙"')
+  assert.equal(parsed.refs[0]?.selection, '乙 "丙"')
 })
 
 test('text pick round-trips markdown source line numbers', () => {
@@ -82,12 +130,12 @@ test('text pick round-trips markdown source line numbers', () => {
       selection: 'UNIQUESEL',
     },
   ])
-  assert.match(text, /path="\/pages\/home"/)
-  assert.match(text, /start_line="5"/)
-  assert.match(text, /end_line="6"/)
-  assert.match(text, /text="第一段&#10;&#10;UNIQUESEL"/)
-  assert.match(text, /selection="UNIQUESEL"/)
-  assert.doesNotMatch(text, /label=/)
+  assert.match(text, /"path":"\/pages\/home"/)
+  assert.match(text, /"start_line":5/)
+  assert.match(text, /"end_line":6/)
+  assert.match(text, /"text":"第一段\\n\\nUNIQUESEL"/)
+  assert.match(text, /"selection":"UNIQUESEL"/)
+  assert.doesNotMatch(text, /"label"/)
   const parsed = parsePicks(text)
   assert.equal(parsed.refs[0]?.start_line, 5)
   assert.equal(parsed.refs[0]?.end_line, 6)
@@ -103,7 +151,7 @@ test('text pick round-trips markdown source line numbers', () => {
     selection: '三尺微命',
     start_line: 11,
     path: '/pages/p000',
-  }), '三尺微命')
+  }), '三尺微命 (11)')
 })
 
 test('caret pick round-trips insert offset in the markdown line', () => {
@@ -121,12 +169,12 @@ test('caret pick round-trips insert offset in the markdown line', () => {
       insert,
     },
   ])
-  assert.match(text, new RegExp(`insert="${insert}"`))
-  assert.doesNotMatch(text, /selection=/)
+  assert.match(text, new RegExp(`"insert":${insert}`))
+  assert.doesNotMatch(text, /"selection"/)
   const parsed = parsePicks(text)
   assert.equal(parsed.refs[0]?.insert, insert)
   assert.equal(parsed.refs[0]?.text, '前 **粗体** 后')
-  assert.equal(chipLabel(parsed.refs[0]!), `L1:${insert}`)
+  assert.equal(chipLabel(parsed.refs[0]!), '前 **粗体** 后 (1)')
 })
 
 test('text pick with > in source still round-trips as a chip handle', () => {
@@ -143,7 +191,7 @@ test('text pick with > in source still round-trips as a chip handle', () => {
       selection: '高朋满座',
     },
   ])
-  assert.match(text, /&gt;/)
+  assert.match(text, /"text":"千里逢迎，高朋满座。>\\n层峦耸翠"/)
   const parsed = parsePicks(text)
   assert.equal(parsed.refs.length, 1)
   assert.equal(parsed.refs[0]?.text, '千里逢迎，高朋满座。>\n层峦耸翠')

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -52,23 +52,29 @@ export function dedupePicks(refs: PickRef[]): PickRef[] {
 
 export function formatPicks(refs: PickRef[]) {
   return dedupePicks(refs)
-    .map((ref) => {
-      const attrs = [`kind="${escapeAttr(ref.kind)}"`, `id="${escapeAttr(ref.id)}"`]
-      if (ref.action) attrs.push(`action="${escapeAttr(ref.action)}"`)
-      if (ref.route) attrs.push(`route="${escapeAttr(ref.route)}"`)
-      if (ref.kind !== 'text' && ref.label) attrs.push(`label="${escapeAttr(ref.label)}"`)
-      if (ref.path) attrs.push(`path="${escapeAttr(ref.path)}"`)
-      if (ref.start_line != null) attrs.push(`start_line="${ref.start_line}"`)
-      if (ref.end_line != null) attrs.push(`end_line="${ref.end_line}"`)
-      if (ref.text) attrs.push(`text="${escapeAttr(ref.text)}"`)
-      if (ref.selection) attrs.push(`selection="${escapeAttr(ref.selection)}"`)
-      else if (ref.insert != null) attrs.push(`insert="${ref.insert}"`)
-      return `<pick ${attrs.join(' ')} />`
-    })
+    .map((ref) => `<pick>${encodePickJson(pickPayload(ref))}</pick>`)
     .join('\n')
 }
 
-const PICK_TAG = /<pick\b((?:[^>"']|"[^"]*"|'[^']*')*)\s*\/?>/gi
+function pickPayload(ref: PickRef) {
+  const data: Record<string, unknown> = { kind: ref.kind, id: ref.id }
+  if (ref.action) data.action = ref.action
+  if (ref.route) data.route = ref.route
+  if (ref.kind !== 'text' && ref.label) data.label = ref.label
+  if (ref.path) data.path = ref.path
+  if (ref.start_line != null) data.start_line = ref.start_line
+  if (ref.end_line != null) data.end_line = ref.end_line
+  if (ref.text) data.text = ref.text
+  if (ref.selection) data.selection = ref.selection
+  else if (ref.insert != null) data.insert = ref.insert
+  return data
+}
+
+function encodePickJson(data: unknown) {
+  return JSON.stringify(data).replace(/</g, '\\u003c')
+}
+
+const PICK_ANY = /<pick>([\s\S]*?)<\/pick>|<pick\b((?:[^>"']|"[^"]*"|'[^']*')*)\s*\/?>/gi
 const ATTR = /(\w+)="([^"]*)"/g
 
 function unescapeAttr(value: string) {
@@ -134,6 +140,19 @@ function locusFields(ref: { start_line?: number; end_line?: number; text?: strin
   }
 }
 
+function parsePickToken(jsonBody: string | undefined, attrBody: string | undefined): PickRef | null {
+  if (jsonBody != null && jsonBody !== '') {
+    try {
+      const data = JSON.parse(jsonBody) as Record<string, unknown>
+      return pickRefFromAttrs(data)
+    } catch {
+      return null
+    }
+  }
+  if (attrBody != null) return parsePickAttrs(attrBody)
+  return null
+}
+
 export function formatPick(ref: PickRef) {
   return formatPicks([ref])
 }
@@ -141,12 +160,12 @@ export function formatPick(ref: PickRef) {
 /** 按原文顺序拆成文字段和 pick 块，供输入框混排还原。 */
 export function splitPickStream(text: string): Array<{ type: 'text'; value: string } | { type: 'pick'; ref: PickRef }> {
   const parts: Array<{ type: 'text'; value: string } | { type: 'pick'; ref: PickRef }> = []
-  PICK_TAG.lastIndex = 0
+  PICK_ANY.lastIndex = 0
   let last = 0
   let match: RegExpExecArray | null
-  while ((match = PICK_TAG.exec(text))) {
+  while ((match = PICK_ANY.exec(text))) {
     if (match.index > last) parts.push({ type: 'text', value: text.slice(last, match.index) })
-    const ref = parsePickAttrs(match[1] ?? '')
+    const ref = parsePickToken(match[1], match[2])
     if (ref) parts.push({ type: 'pick', ref })
     else parts.push({ type: 'text', value: match[0] })
     last = match.index + match[0].length
@@ -156,10 +175,10 @@ export function splitPickStream(text: string): Array<{ type: 'text'; value: stri
 }
 export function parsePicks(text: string): { refs: PickRef[]; rest: string } {
   const refs: PickRef[] = []
-  PICK_TAG.lastIndex = 0
+  PICK_ANY.lastIndex = 0
   const rest = text
-    .replace(PICK_TAG, (_all, raw: string) => {
-      const ref = parsePickAttrs(raw)
+    .replace(PICK_ANY, (all, jsonBody: string | undefined, attrBody: string | undefined) => {
+      const ref = parsePickToken(jsonBody, attrBody)
       if (ref) refs.push(ref)
       return '\n'
     })
@@ -168,36 +187,25 @@ export function parsePicks(text: string): { refs: PickRef[]; rest: string } {
   return { refs: dedupePicks(refs), rest }
 }
 
-function escapeAttr(value: string) {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/\n/g, '&#10;')
-}
-
 export function lineSpanLabel(ref: PickRef) {
   if (ref.start_line == null) return ''
-  if (ref.end_line != null && ref.end_line !== ref.start_line) return `L${ref.start_line}–${ref.end_line}`
-  return `L${ref.start_line}`
+  if (ref.end_line != null && ref.end_line !== ref.start_line) return `${ref.start_line}-${ref.end_line}`
+  return String(ref.start_line)
+}
+
+function pickChipName(ref: PickRef) {
+  const file = ref.path?.split('/').filter(Boolean).pop() ?? ''
+  if (file.includes('.')) return file
+  if (ref.kind === 'text') {
+    return pickPreview(ref.selection || ref.text || ref.label, 24) || file || '选区'
+  }
+  return ref.label || file || ref.id
 }
 
 export function chipLabel(ref: PickRef) {
-  if (ref.kind === 'text') {
-    if (ref.insert != null && !ref.selection) {
-      const line = lineSpanLabel(ref) || 'L?'
-      return `${line}:${ref.insert}`
-    }
-    const snippet = pickPreview(ref.selection || ref.text || ref.label, 24)
-    return snippet || '选区'
-  }
-  const lines = lineSpanLabel(ref)
-  const where = ref.path
-  if (ref.action) return `${ref.label} · ${ref.action}`
-  if (lines && where) return `${lines} ${where}`
-  if (lines) return `${lines} ${ref.label}`
-  return ref.label
+  const name = ref.action ? `${ref.label} · ${ref.action}` : pickChipName(ref)
+  const span = lineSpanLabel(ref)
+  return span ? `${name} (${span})` : name
 }
 
 export function pickPreview(text: string, max = 48) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
芯片展示改成名称后面跟行号括号：多行 `README.md (9-10)`，一行 `(9)`。

传递上原来用 `<pick start_line="9" text="...">` 属性字符串。`text` 里一旦有引号、`>` 或高亮 HTML，正则会截断标签，行号其实写进去了却解析丢了。现在写成 `<pick>{"kind":"...","start_line":9,"end_line":10,"text":"..."}</pick>`，行号是 JSON 数字；`<` 写成 `\u003c`，不会提前结束标签。旧属性写法仍能读。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

