### PR TITLE
fix(editor): db_content 实时套入聚焦中的 TipTap

### DIFF
--- a/packages/core-editor/src/web/insert-sync.test.ts
+++ b/packages/core-editor/src/web/insert-sync.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
 import { pageEditorExtensions } from './kit.ts'
-import { shouldApplyRemoteMarkdown } from './page-editor.tsx'
+import { recentlyLocalEdit, shouldApplyRemoteMarkdown } from './page-editor.tsx'
 
 function insertAfter(text: string, insertLine: number, newStr: string) {
   const lines = text.split('\n')
@@ -30,8 +30,26 @@ test('tiptap paints an inserted markdown line as a paragraph', () => {
 })
 
 test('remote insert applies when the wysiwyg editor is not live', () => {
-  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: false, hasJump: false }), true)
-  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: false }), false)
-  assert.equal(shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: true }), true)
-  assert.equal(shouldApplyRemoteMarkdown({ focused: false, live: true, hasJump: false }), true)
+  assert.equal(
+    shouldApplyRemoteMarkdown({ focused: true, live: false, hasJump: false, recentlyLocal: false }),
+    true,
+  )
+  assert.equal(
+    shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: false, recentlyLocal: true }),
+    false,
+  )
+  assert.equal(
+    shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: false, recentlyLocal: false }),
+    true,
+  )
+  assert.equal(
+    shouldApplyRemoteMarkdown({ focused: true, live: true, hasJump: true, recentlyLocal: true }),
+    true,
+  )
+  assert.equal(
+    shouldApplyRemoteMarkdown({ focused: false, live: true, hasJump: false, recentlyLocal: true }),
+    true,
+  )
+  assert.equal(recentlyLocalEdit(Date.now()), true)
+  assert.equal(recentlyLocalEdit(Date.now() - 2000), false)
 })

--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -166,6 +166,7 @@ test('page editor applies later value when it is not focused', async () => {
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-editor.tsx'), 'utf8')
   assert.match(src, /shouldApplyRemoteMarkdown/)
+  assert.match(src, /recentlyLocal/)
   assert.match(src, /contentJumpForRecord/)
   assert.match(src, /editorHostIsLive\(editor\)/)
   assert.doesNotMatch(src, /if \(editor\.isFocused && !contentJumpForRecord\(record\.id\)\) return/)

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -21,15 +21,22 @@ import { applyEditorFind } from './find-plugin.ts'
 import { EDITOR_TONES, tagTextColor, tagWashColor } from './color-swatches.ts'
 import { isSendChatHotkey, pickFromEditor, pickFromLocus } from './editor-ask.ts'
 
-/** 本地正在打字时不要用远端正文盖掉；源码模式 / 未挂上的编辑器不算在打字。 */
+const LOCAL_EDIT_MS = 600
+
+/** 本地刚打过字时不要用远端正文盖掉光标；只看聚焦会挡住 db_content 的实时套入。 */
 export function shouldApplyRemoteMarkdown(args: {
   focused: boolean
   live: boolean
   hasJump: boolean
+  recentlyLocal: boolean
 }) {
   if (args.hasJump) return true
-  if (args.focused && args.live) return false
+  if (args.focused && args.live && args.recentlyLocal) return false
   return true
+}
+
+export function recentlyLocalEdit(typedAt: number, now = Date.now()) {
+  return now - typedAt < LOCAL_EDIT_MS
 }
 
 function jumpToPending(editor: Editor, markdown: string, recordId: string, force = false) {
@@ -264,6 +271,10 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
   const saved = useRef(asMarkdown(value))
   const sourceMode = useRef(source)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const remoteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const typedAt = useRef(0)
+  const valueRef = useRef(value)
+  valueRef.current = value
   const hydratedId = useRef<string | null>(null)
   const sourceFind = useRef<SourceEditorHandle>(null)
   const editorRef = useRef<Editor | null>(null)
@@ -316,6 +327,7 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
       },
       onUpdate: ({ editor: current }) => {
         if (hydratedId.current !== record.id) return
+        typedAt.current = Date.now()
         if (timer.current) clearTimeout(timer.current)
         timer.current = setTimeout(() => {
           queueMicrotask(() => {
@@ -362,19 +374,39 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
       jumpToPending(editor, md, record.id)
       return
     }
-    if (
-      !shouldApplyRemoteMarkdown({
+    const paint = (next: string) => {
+      saved.current = next
+      editor.commands.setContent(next, { contentType: 'markdown', emitUpdate: false })
+      jumpToPending(editor, next, record.id, true)
+    }
+    const canPaint = () =>
+      shouldApplyRemoteMarkdown({
         focused: editor.isFocused,
         live: editorHostIsLive(editor),
         hasJump: Boolean(contentJumpForRecord(record.id)),
+        recentlyLocal: recentlyLocalEdit(typedAt.current),
       })
-    ) {
+    if (!canPaint()) {
+      if (remoteTimer.current) clearTimeout(remoteTimer.current)
+      const wait = () => {
+        if (editor.isDestroyed) return
+        const next = asMarkdown(valueRef.current)
+        if (next === saved.current) return
+        if (!canPaint()) {
+          remoteTimer.current = setTimeout(wait, LOCAL_EDIT_MS)
+          return
+        }
+        paint(next)
+      }
+      remoteTimer.current = setTimeout(wait, LOCAL_EDIT_MS)
       return
     }
-    saved.current = md
-    editor.commands.setContent(md, { contentType: 'markdown', emitUpdate: false })
-    jumpToPending(editor, md, record.id, true)
+    paint(md)
   }, [editor, record.id, value])
+
+  useEffect(() => () => {
+    if (remoteTimer.current) clearTimeout(remoteTimer.current)
+  }, [])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed || source) return


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面开着、WYSIWYG 聚焦且 live 时，先前一律拒绝远端 `setContent`，agent `db_content` 改正文后 TipTap 不会更新。

改为：仅在本地刚打过字时暂缓覆盖光标；空闲或打字停 600ms 后套入最新 markdown。有 content jump 仍立即套入。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

