### PR TITLE
fix(editor): Delete 回到标题时真正 focus 标题输入框

### DIFF
--- a/packages/core-editor/src/web/page-editor.test.tsx
+++ b/packages/core-editor/src/web/page-editor.test.tsx
@@ -90,6 +90,7 @@ test('page editor bridges cursor to the record title', async () => {
   assert.match(src, /handleKeyDown/)
   assert.match(src, /FOCUS_RECORD_TITLE/)
   assert.match(src, /focusRecordTitleNear/)
+  assert.doesNotMatch(src, /commands\.blur\(\)/)
   assert.match(src, /onKeyDownCapture/)
   assert.match(src, /FOCUS_RECORD_CONTENT/)
   assert.match(src, /jumpToPending/)

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -543,7 +543,6 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
     if (atDocStart && shouldLeaveContentForTitle(event.key, event, 0, true, 0)) {
       event.preventDefault()
       event.stopPropagation()
-      editor?.commands.blur()
       if (!focusRecordTitleNear(event.currentTarget)) {
         window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
       }

--- a/packages/core-editor/src/web/title-content-nav.test.ts
+++ b/packages/core-editor/src/web/title-content-nav.test.ts
@@ -129,6 +129,32 @@ test('focusRecordTitleNear targets the title above properties in the same detail
   main.remove()
 })
 
+test('Delete at doc start focuses the title above properties', () => {
+  const main = document.createElement('div')
+  main.className = 'fsdb-detail-main'
+  const title = document.createElement('textarea')
+  title.className = 'fsdb-detail-title-input'
+  title.value = '页面标题'
+  const host = document.createElement('div')
+  main.appendChild(title)
+  main.appendChild(host)
+  document.body.appendChild(main)
+  const editor = new Editor({
+    element: host,
+    extensions: pageEditorExtensions(),
+    content: 'hello',
+    contentType: 'markdown',
+    editorProps: { handleKeyDown: handleContentTitleNav },
+  })
+  editor.chain().focus().setTextSelection(Selection.atStart(editor.state.doc)).run()
+  press(editor, 'Delete')
+  assert.equal(document.activeElement, title)
+  assert.equal(title.selectionStart, '页面标题'.length)
+  assert.match(editor.getHTML(), /hello/)
+  editor.destroy()
+  main.remove()
+})
+
 test('Backspace at doc start focuses the title above properties', () => {
   const main = document.createElement('div')
   main.className = 'fsdb-detail-main'

--- a/packages/core-editor/src/web/title-content-nav.ts
+++ b/packages/core-editor/src/web/title-content-nav.ts
@@ -28,20 +28,39 @@ export function handleContentTitleNav(view: EditorView, event: KeyboardEvent) {
   const start = Selection.atStart(view.state.doc).from
   if (!shouldLeaveContentForTitle(event.key, event, sel.from, sel.empty, start)) return false
   event.preventDefault()
-  view.dom.blur()
   if (!focusRecordTitleNear(view.dom)) {
     window.dispatchEvent(new Event(FOCUS_RECORD_TITLE))
   }
   return true
 }
 
-/** 标题在属性上方：同一个详情主栏里的 `.fsdb-detail-title-input`，光标放到末尾。 */
-export function focusRecordTitleNear(from: Element | null | undefined) {
-  const root = from?.closest('.fsdb-detail-main') ?? from?.closest('.fsdb-detail-stage')
-  const el = root?.querySelector<HTMLTextAreaElement | HTMLInputElement>('.fsdb-detail-title-input')
-  if (!el) return false
+function titleInputNear(from: Element | null | undefined) {
+  const root =
+    from?.closest('.fsdb-detail-main') ??
+    from?.closest('.fsdb-detail-stage') ??
+    from?.closest('.fsdb-page')
+  return root?.querySelector<HTMLTextAreaElement | HTMLInputElement>('.fsdb-detail-title-input')
+}
+
+function placeTitleCaret(el: HTMLTextAreaElement | HTMLInputElement) {
+  if (!el.isConnected) return
   el.focus()
   const n = el.value.length
-  el.setSelectionRange(n, n)
+  try {
+    el.setSelectionRange(n, n)
+  } catch {
+    /* ignore */
+  }
+}
+
+/** 标题在属性上方：同一个详情主栏里的 `.fsdb-detail-title-input`，光标放到末尾。 */
+export function focusRecordTitleNear(from: Element | null | undefined) {
+  const el = titleInputNear(from)
+  if (!el) return false
+  placeTitleCaret(el)
+  if (document.activeElement !== el) {
+    requestAnimationFrame(() => placeTitleCaret(el))
+    setTimeout(() => placeTitleCaret(el), 0)
+  }
   return true
 }

--- a/packages/core-file-system/src/web/record-detail.tsx
+++ b/packages/core-file-system/src/web/record-detail.tsx
@@ -163,7 +163,9 @@ export function RecordDetail({
   const mainRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     const onTitle = () => {
-      focusRecordTitleNear(mainRef.current)
+      const go = () => focusRecordTitleNear(mainRef.current)
+      go()
+      requestAnimationFrame(go)
     }
     window.addEventListener(FOCUS_RECORD_TITLE, onTitle)
     return () => window.removeEventListener(FOCUS_RECORD_TITLE, onTitle)

--- a/packages/core-file-system/src/web/title-content-nav.ts
+++ b/packages/core-file-system/src/web/title-content-nav.ts
@@ -25,13 +25,33 @@ export function shouldLeaveContentForTitle(
   return isDocStartSelection(from, empty, docStart)
 }
 
-/** 标题在属性上方：同一个详情主栏里的 `.fsdb-detail-title-input`，光标放到末尾。 */
-export function focusRecordTitleNear(from: Element | null | undefined) {
-  const root = from?.closest('.fsdb-detail-main') ?? from?.closest('.fsdb-detail-stage')
-  const el = root?.querySelector<HTMLTextAreaElement | HTMLInputElement>('.fsdb-detail-title-input')
-  if (!el) return false
+function titleInputNear(from: Element | null | undefined) {
+  const root =
+    from?.closest('.fsdb-detail-main') ??
+    from?.closest('.fsdb-detail-stage') ??
+    from?.closest('.fsdb-page')
+  return root?.querySelector<HTMLTextAreaElement | HTMLInputElement>('.fsdb-detail-title-input')
+}
+
+function placeTitleCaret(el: HTMLTextAreaElement | HTMLInputElement) {
+  if (!el.isConnected) return
   el.focus()
   const n = el.value.length
-  el.setSelectionRange(n, n)
+  try {
+    el.setSelectionRange(n, n)
+  } catch {
+    /* ignore */
+  }
+}
+
+/** 标题在属性上方：同一个详情主栏里的 `.fsdb-detail-title-input`，光标放到末尾。 */
+export function focusRecordTitleNear(from: Element | null | undefined) {
+  const el = titleInputNear(from)
+  if (!el) return false
+  placeTitleCaret(el)
+  if (document.activeElement !== el) {
+    requestAnimationFrame(() => placeTitleCaret(el))
+    setTimeout(() => placeTitleCaret(el), 0)
+  }
   return true
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
正文开头按 Delete / Backspace 时，先前会先 `blur` 编辑器。keydown 过程中标题 `textarea.fsdb-detail-title-input` 经常抢不到焦点，结果光标消失、标题也不亮。

改为直接把光标放到标题末尾，若当时没贴上则在下一帧再试一次。不再先 blur TipTap。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

