### PR TITLE
fix(pick): 长选区芯片也始终露出行号

### DIFF
--- a/packages/core-chat/src/web/composer-stack.test.ts
+++ b/packages/core-chat/src/web/composer-stack.test.ts
@@ -216,6 +216,8 @@ describe('composer dock stacking above sticky user', () => {
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*vertical-align:\s*middle/s)
     expect(css).toMatch(/\.composer-inline-chip\s*\{[^}]*line-height:\s*1/s)
     expect(css).toMatch(/\.composer-tool-chip\.is-pick,\s*\n\.user-pick-chip\s*\{[^}]*line-height:\s*20px/s)
+    expect(css).toMatch(/\.composer-tool-chip\.is-pick>span\.pick-chip-lines,\s*\n\.user-pick-chip>span\.pick-chip-lines\s*\{[^}]*flex:\s*none/s)
+    expect(css).toMatch(/\.composer-tool-chip\.is-pick>span\.pick-chip-lines,\s*\n\.user-pick-chip>span\.pick-chip-lines\s*\{[^}]*min-width:\s*max-content/s)
     expect(css).toMatch(/\.pick-kind-icon\s*\{[^}]*display:\s*block/s)
     expect(css).toMatch(
       /\.composer-pill\.has-chips \.composer-tiptap p,\s*\n\.composer-tiptap\.is-readonly p \{\s*line-height:\s*1\.45/,

--- a/packages/core-pick/src/web/chip.test.ts
+++ b/packages/core-pick/src/web/chip.test.ts
@@ -53,4 +53,6 @@ test('pick chips can show the facet close mark', () => {
   assert.match(src, /onRemove/)
   assert.match(src, /biu-tag-x/)
   assert.match(src, /TagChipCloseMark/)
+  assert.match(src, /pick-chip-name/)
+  assert.match(src, /pick-chip-lines/)
 })

--- a/packages/core-pick/src/web/chip.tsx
+++ b/packages/core-pick/src/web/chip.tsx
@@ -16,7 +16,7 @@ import {
 import type { ComponentType } from 'react'
 import { ensureTagChipStyle, TagChipCloseMark, tagTone } from '@biu/public-ui'
 import type { PickRef } from './types.ts'
-import { chipLabel } from './types.ts'
+import { chipCaption, chipLabel } from './types.ts'
 
 /** 注入侧可能写 tasks / sessions-db，芯片按规范 kind 取色和图标。 */
 const PICK_KIND_ALIAS: Record<string, string> = {
@@ -77,10 +77,12 @@ export function PickKindGlyph({ kind }: { kind: string }) {
 }
 
 export function PickChipLabel({ pick }: { pick: PickRef }) {
+  const { name, span } = chipCaption(pick)
   return (
     <>
       <PickKindGlyph kind={pick.kind} />
-      <span>{chipLabel(pick)}</span>
+      <span className="pick-chip-name">{name}</span>
+      {span ? <span className="pick-chip-lines">({span})</span> : null}
     </>
   )
 }

--- a/packages/core-pick/src/web/index.tsx
+++ b/packages/core-pick/src/web/index.tsx
@@ -5,7 +5,7 @@ import { PickService, getPick, usePickState } from './service.ts'
 import { PickOverlay } from './overlay.tsx'
 
 export { PickService, getPick, usePickState } from './service.ts'
-export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, pickKey, pickPreview, pickIdFromText, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, withHostSource, lineSpanLabel, type PickRef } from './types.ts'
+export { formatPicks, formatPick, parsePicks, splitPickStream, dedupePicks, chipLabel, chipCaption, pickKey, pickPreview, pickIdFromText, textPickFromSelection, pickDomAttrs, pickChipAttrs, pickRefFromAttrs, withPickLocus, withHostSource, lineSpanLabel, type PickRef } from './types.ts'
 export { bindEditorTextHost, editorHostFromNode } from './editor-host.ts'
 export { PickChip, PickChipLabel, PickKindGlyph, pickKindIcon, pickKindTone, canonicalPickKind } from './chip.tsx'
 export { resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, pickSurfaceFromNode, pickSurfaceAtPoint } from './resolve.ts'

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { pickSurfaceAtPoint, resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, editorBlockElFromNode } from './resolve.ts'
-import { formatPicks, parsePicks, splitPickStream, chipLabel, dedupePicks, textPickFromSelection } from './types.ts'
+import { formatPicks, parsePicks, splitPickStream, chipLabel, chipCaption, dedupePicks, textPickFromSelection } from './types.ts'
 
 test('splitPickStream keeps text and chips in order', () => {
   const parts = splitPickStream('看 <pick kind="task" id="t1" label="写需求" /> 和 <pick kind="plugin" id="p1" label="Hello" /> 吧')
@@ -66,6 +66,20 @@ test('formatPicks emits JSON handles only', () => {
   ])
   assert.equal(text, '<pick>{"kind":"session","id":"abc","route":"/s/abc","label":"聊天"}</pick>')
   assert.doesNotMatch(text, /class=|svg|html/i)
+})
+
+test('chip caption keeps line span off the truncated preview', () => {
+  const raw =
+    '<pick>{"kind":"text","id":"4b33982e","route":"/s/b3b1d688-1e8b-45b1-ac56-b8747a14e842","path":"/pages/p004","start_line":1,"end_line":12,"text":"的的的\\n\\n我爱你\\n完成滕王阁序  \\n我爱你，谢谢  \\n我爱你  \\n我爱你 forever  \\n你好吗？？？  \\n我喜欢呢？？？  \\n非常好  \\n你好  \\n继续加","selection":"的的的\\n我爱你\\n完成滕王阁序我爱你，谢谢我爱你我爱你 forever你好吗？？？我喜欢呢？？？非常好你好继续加"}</pick>'
+  const parsed = parsePicks(raw)
+  const ref = parsed.refs[0]
+  assert.ok(ref)
+  assert.equal(ref.start_line, 1)
+  assert.equal(ref.end_line, 12)
+  const { name, span } = chipCaption(ref)
+  assert.equal(span, '1-12')
+  assert.ok(name.length <= 25)
+  assert.match(chipLabel(ref), /\(1-12\)$/)
 })
 
 test('chip label puts line span in parentheses after the name', () => {

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -202,9 +202,12 @@ function pickChipName(ref: PickRef) {
   return ref.label || file || ref.id
 }
 
+export function chipCaption(ref: PickRef) {
+  return { name: ref.action ? `${ref.label} · ${ref.action}` : pickChipName(ref), span: lineSpanLabel(ref) }
+}
+
 export function chipLabel(ref: PickRef) {
-  const name = ref.action ? `${ref.label} · ${ref.action}` : pickChipName(ref)
-  const span = lineSpanLabel(ref)
+  const { name, span } = chipCaption(ref)
   return span ? `${name} (${span})` : name
 }
 

--- a/web/style.css
+++ b/web/style.css
@@ -5641,12 +5641,23 @@ body {
   vertical-align: middle;
 }
 
-.composer-tool-chip.is-pick>span,
-.user-pick-chip>span {
+.composer-tool-chip.is-pick>span.pick-chip-name,
+.user-pick-chip>span.pick-chip-name {
   min-width: 0;
   padding-right: 2px;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1;
+}
+
+.composer-tool-chip.is-pick>span.pick-chip-lines,
+.user-pick-chip>span.pick-chip-lines {
+  flex: none;
+  min-width: max-content;
+  overflow: visible;
+  text-overflow: unset;
+  padding-right: 0;
+  white-space: nowrap;
   line-height: 1;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
选区很长时，芯片把预览和 `(1-12)` 写在同一个 `ellipsis` 的 span 里，行号被裁掉。

正文预览照常省略；行号单独一段、不收缩，始终显示，例如 `的的的 我爱你… (1-12)`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

