### PR TITLE
fix(mascot): 忙完后呼吸灯关掉

### DIFF
--- a/packages/core-chat/src/web/approvals.tsx
+++ b/packages/core-chat/src/web/approvals.tsx
@@ -148,7 +148,7 @@ export function ApprovalsRail(props: SlotProps) {
   const sessionBusy = useSessionView((state) => {
     const id = state.sessionId
     if (!id) return false
-    return Boolean(state.busySessions[id]) || state.agentStatus === 'running' || Boolean(state.pending)
+    return Boolean(state.busySessions[id])
   })
   const dispatchedTasksByTurn = useSessionView((state) => state.dispatchedTasksByTurn)
   const workerAgents = useMemo(

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -70,6 +70,7 @@ export class AgentLoop implements AgentRunner {
     }
     if (!req.messages.length) {
       await session.append(this.sessionId, { type: 'turn/end', turn, reason: 'empty' })
+      this.ctx.emit('agent/status', { sessionId: this.sessionId, status: 'idle' })
       return { text: '（空回合）', steps: [] }
     }
 

--- a/packages/host-agents/src/host/index.ts
+++ b/packages/host-agents/src/host/index.ts
@@ -115,7 +115,10 @@ export class AgentsService extends Service {
           result = turn
         })
         .finally(() => {
-          if (live.running === running) live.running = undefined
+          if (live.running === running) {
+            live.running = undefined
+            this.ctx.emit('agent/status', { sessionId: id, status: 'idle' })
+          }
         })
       live.running = running
       this.ctx.emit('agent/status', { sessionId: id, status: 'running', step: 0 })

--- a/packages/web-app-shell/src/web/chat-sidebar.tsx
+++ b/packages/web-app-shell/src/web/chat-sidebar.tsx
@@ -203,9 +203,6 @@ export const ChatSidebar = memo(function ChatSidebar({
   const navigate = useNavigate()
   const sessions = useSessionView((state) => state.sessions)
   const sessionId = useSessionView((state) => state.sessionId)
-  const agentBusy = useSessionView(
-    (state) => state.agentStatus === 'running' || state.pending,
-  )
   // 用签名订阅，避免 busySessions 对象引用抖动导致整栏重渲
   const busySignature = useSessionView((state) =>
     Object.keys(state.busySessions)
@@ -381,7 +378,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                             key={`pinned:${item.id}`}
                             item={item}
                             active={item.id === highlightId}
-                            busy={Boolean(busySessions[item.id]) || (item.id === highlightId && agentBusy)}
+                            busy={Boolean(busySessions[item.id])}
                             dancing={dancing}
                             onDelete={requestDeleteChat}
                             onPin={pinChat}
@@ -457,7 +454,7 @@ export const ChatSidebar = memo(function ChatSidebar({
                                     key={`${group.key}:${item.id}`}
                                     item={item}
                                     active={item.id === highlightId}
-                                    busy={Boolean(busySessions[item.id]) || (item.id === highlightId && agentBusy)}
+                                    busy={Boolean(busySessions[item.id])}
                                     dancing={dancing}
                                     onDelete={requestDeleteChat}
                                     onPin={pinChat}

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -73,7 +73,7 @@ function DockSessionMascot({
   const busy = useSessionView((state) => {
     const id = state.sessionId
     if (!id) return false
-    return Boolean(state.busySessions[id]) || state.agentStatus === 'running' || Boolean(state.pending)
+    return Boolean(state.busySessions[id])
   })
   return (
     <BrandCornerMascot

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -269,6 +269,18 @@ function sessionsEqual(a: SessionListItem[], b: SessionListItem[]): boolean {
   return true
 }
 
+/** send 乐观 busy 后，列表短暂仍可能 busy:false；超过此时长以列表为准。 */
+export const BUSY_HOLD_MS = 1500
+
+export function turnInProgress(events: { type: string }[]) {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const type = events[i]?.type
+    if (type === 'turn/end') return false
+    if (type === 'turn/start') return true
+  }
+  return false
+}
+
 export class SessionViewService extends Service {
   private value: SessionViewState = empty
   private listeners = new Set<() => void>()
@@ -281,6 +293,7 @@ export class SessionViewService extends Service {
   private trajGen = 0
   private trajFetchSessionId: string | null = null
   private dispatchedPoll: ReturnType<typeof setInterval> | null = null
+  private busyHoldUntil = 0
 
   constructor(ctx: Context) {
     super(ctx, 'sessionView')
@@ -441,6 +454,9 @@ export class SessionViewService extends Service {
   }
 
   ingest(sessionId: string, event: SessionEvent) {
+    if (event.type === 'turn/end' || event.type === 'turn/start') {
+      this.applyTurnBusy(sessionId, event.type)
+    }
     if (this.value.sessionId && this.value.sessionId !== sessionId) {
       void this.refreshSessions()
       return
@@ -456,26 +472,12 @@ export class SessionViewService extends Service {
     }
     this.flushChunkFrame()
     const events = upsertEvent(this.value.sessionId === sessionId ? this.value.events : [], event)
-    const basePatch: Partial<SessionViewState> = {
+    this.replace({
       sessionId,
       events,
       nodes: this.buildNodes(events),
       error: undefined,
-    }
-    let patch: Partial<SessionViewState> = basePatch
-    // 回合真正结束(turn/end)：立即清掉该会话的 busy，并解除当前会话 pending/运行态，
-    // 让侧栏呼吸态及时转回；否则仅靠 refreshSessions 兜底会被 syncBusyFromSessions 的 pending 保护卡住。
-    if (event.type === 'turn/end') {
-      const busySessions = { ...this.value.busySessions }
-      if (busySessions[sessionId]) {
-        delete busySessions[sessionId]
-        patch = { ...patch, busySessions }
-      }
-      if (this.value.sessionId === sessionId) {
-        patch = { ...patch, pending: false, agentStatus: 'idle' }
-      }
-    }
-    this.replace(patch)
+    })
     this.stashCurrent()
     // 检查器打开后 trajectoryLive=true：即使 URL 仍是 chat 也要刷新右侧轨迹
     if (this.wantsTrajectory()) void this.refreshTrajectoryIndex()
@@ -526,6 +528,16 @@ export class SessionViewService extends Service {
     const isOther = Boolean(sessionId && this.value.sessionId && sessionId !== this.value.sessionId)
 
     if (status === 'running') {
+      const holdOpen = Date.now() < this.busyHoldUntil
+      if (
+        !isOther &&
+        !holdOpen &&
+        !turnInProgress(this.value.events) &&
+        this.value.events.some((item) => item.type === 'turn/end')
+      ) {
+        return
+      }
+      if (!holdOpen) this.markBusyHold()
       const alreadyBusy = Boolean(id && this.value.busySessions[id])
       if (isOther) {
         // worker 步进会连发 running：busy 集合没变就别 notify，避免侧栏跟着抖
@@ -588,10 +600,32 @@ export class SessionViewService extends Service {
     }
   }
 
+  private markBusyHold() {
+    this.busyHoldUntil = Date.now() + BUSY_HOLD_MS
+  }
+
+  private applyTurnBusy(sessionId: string, type: 'turn/start' | 'turn/end') {
+    const busySessions = { ...this.value.busySessions }
+    if (type === 'turn/start') {
+      busySessions[sessionId] = true
+      this.markBusyHold()
+    } else {
+      delete busySessions[sessionId]
+      if (sessionId === this.value.sessionId) this.busyHoldUntil = 0
+    }
+    const current = sessionId === this.value.sessionId
+    const running = Boolean(busySessions[sessionId])
+    this.replace({
+      busySessions,
+      ...(current ? { pending: running, agentStatus: running ? 'running' : 'idle' } : {}),
+    })
+  }
+
   private syncBusyFromSessions(sessions: SessionListItem[]) {
     const busySessions = { ...this.value.busySessions }
     let changed = false
     const currentId = this.value.sessionId
+    const holdOpen = Date.now() < this.busyHoldUntil
     for (const item of sessions) {
       if (item.busy) {
         if (!busySessions[item.id]) {
@@ -599,8 +633,7 @@ export class SessionViewService extends Service {
           changed = true
         }
       } else if (busySessions[item.id]) {
-        // 当前会话正在 pending 时别被列表抖动清掉（send 乐观更新早于 isBusy）
-        if (item.id === currentId && this.value.pending) continue
+        if (item.id === currentId && holdOpen) continue
         delete busySessions[item.id]
         changed = true
       }
@@ -1364,6 +1397,7 @@ export class SessionViewService extends Service {
       return
     }
 
+    this.markBusyHold()
     this.setAgentStatus('running', undefined, sessionId)
     this.replace({ error: undefined })
     try {
@@ -1433,6 +1467,7 @@ export class SessionViewService extends Service {
     const sessionId = this.value.sessionId
     if (!sessionId) return false
     if (!this.value.inbox.some((item) => item.kind === 'wake')) return false
+    this.markBusyHold()
     this.setAgentStatus('running', undefined, sessionId)
     try {
       const res = await fetch(`/api/sessions/${sessionId}/inbox/flush`, { method: 'POST' })

--- a/packages/web-session-view/src/web/session-view.test.ts
+++ b/packages/web-session-view/src/web/session-view.test.ts
@@ -167,6 +167,72 @@ test('turn/end clears current busy promptly (no stale breathing state)', async (
   assert.equal(view.get().pending, false)
 })
 
+test('stale agent/status running after turn/end does not restart breathing', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', busy: false, eventCount: 2, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.setAgentStatus('running', 1)
+  view.ingest('s1', { type: 'turn/end', turn: 1, reason: 'complete', seq: 2, ts: 2 })
+  view.setAgentStatus('running', 2)
+  assert.equal(view.get().busySessions.s1, undefined)
+  assert.equal(view.get().pending, false)
+})
+
+test('list not-busy clears current breathing after the send hold expires', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', busy: false, eventCount: 1, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.setAgentStatus('running', 1)
+  assert.equal(view.get().busySessions.s1, true)
+  ;(view as unknown as { busyHoldUntil: number }).busyHoldUntil = 0
+  await view.refreshSessions()
+  assert.equal(view.get().busySessions.s1, undefined)
+  assert.equal(view.get().pending, false)
+})
+
+test('stale agent/status running after turn/end does not restart breathing', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', busy: false, eventCount: 2, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.setAgentStatus('running', 1)
+  view.ingest('s1', { type: 'turn/end', turn: 1, reason: 'complete', seq: 2, ts: 2 })
+  view.setAgentStatus('running', 2)
+  assert.equal(view.get().busySessions.s1, undefined)
+  assert.equal(view.get().pending, false)
+})
+
+test('list not-busy clears current breathing after the send hold expires', async () => {
+  mockFetch({
+    '/api/sessions': () => ({ sessions: [{ id: 's1', title: 'a', busy: false, eventCount: 1, updatedAt: 1 }] }),
+    '/api/approvals': () => ({ mode: 'auto', pending: [] }),
+  })
+  const ctx = new Context()
+  await ctx.plugin(sessionView)
+  const view = ctx.sessionView as SessionViewService
+  view.ingest('s1', { type: 'session/open', version: 1, seq: 0, ts: 1 })
+  view.setAgentStatus('running', 1)
+  assert.equal(view.get().busySessions.s1, true)
+  ;(view as unknown as { busyHoldUntil: number }).busyHoldUntil = 0
+  await view.refreshSessions()
+  assert.equal(view.get().busySessions.s1, undefined)
+  assert.equal(view.get().pending, false)
+})
+
 test('worker session busy cleared once list reports not busy', async () => {
   mockFetch({
     '/api/sessions': () => ({ sessions: [{ id: 'worker-9', title: 'w', busy: false, eventCount: 1, updatedAt: 1 }] }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
忙完了还呼吸，是因为 `pending` 把 busy 钉死：列表已经 idle，乐观 pending 仍拦住清理；迟到的 `agent/status running` 还会把灯重新点上。

- `turn/end` / `turn/start` 直接改 busy，切会话时也清
- 列表 idle 只在发送后短窗口内不覆盖乐观 busy
- 回合已结束后忽略过期的 running
- 小人只看 `busySessions`，不再用卡住的 pending
- agent kick 结束时补发 idle

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

