### PR TITLE
fix(search): 卸载插件后搜索里不再显示打开/关闭

### DIFF
--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -92,6 +92,11 @@ test('previewActionRecord flips running from action when', () => {
   assert.equal(previewActionRecord(row, { when: { installed: true, running: false } }).running, true)
   assert.equal(previewActionRecord({ ...row, running: true }, { when: { installed: true, running: true } }).running, false)
   assert.equal(previewActionRecord(row, { when: { installed: true } }), row)
+  const gone = previewActionRecord({ ...row, running: true, enabled: true }, { id: 'uninstall', when: { installed: true } })
+  assert.equal(gone.installed, false)
+  assert.equal(gone.running, false)
+  assert.equal(gone.enabled, false)
+  assert.equal(previewActionRecord({ id: 'draft', sandbox: true }, { id: 'pack', when: { sandbox: true } }).installed, true)
 })
 
 test('placedActions keeps start and stop so chrome.Actions can own the pair', () => {

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -477,7 +477,15 @@ export function groupRecords(rows: DbRecord[], schema: CollectionSchema | undefi
   return listed
 }
 
-export function previewActionRecord(row: DbRecord, action: { when?: Record<string, unknown> }): DbRecord {
+export function previewActionRecord(row: DbRecord, action: { id?: string; when?: Record<string, unknown> }): DbRecord {
+  if (action.id === 'uninstall' || action.id === 'delete' || action.id === 'remove') {
+    if (row.installed === false && row.running !== true && row.enabled !== true) return row
+    return { ...row, installed: false, running: false, enabled: false }
+  }
+  if (action.id === 'pack' || action.id === 'create') {
+    if (row.installed === true) return row
+    return { ...row, installed: true }
+  }
   const when = action.when
   if (!when || !('running' in when) || typeof when.running !== 'boolean') return row
   const running = when.running === false

--- a/packages/core-plugin-system/src/web/chrome.test.tsx
+++ b/packages/core-plugin-system/src/web/chrome.test.tsx
@@ -35,6 +35,24 @@ test('plugin run toggle stays hidden until the plugin is installed', () => {
   assert.ok(container.querySelector('[aria-label="停止"]'))
 })
 
+test('plugin run toggle hides after uninstall', () => {
+  const Actions = pluginsChrome.Actions
+  assert.ok(Actions)
+  const { container } = render(
+    <Actions
+      actions={[...actions, { id: 'uninstall', label: '卸载', when: { installed: true } }]}
+      record={{ id: 'demo', sandbox: true }}
+      busy={false}
+      place="row"
+      run={() => {}}
+    />,
+  )
+  assert.equal(container.querySelector('[aria-label="运行"]'), null)
+  assert.equal(container.querySelector('[aria-label="停止"]'), null)
+  assert.equal(container.querySelector('[aria-label="卸载"]'), null)
+  assert.ok(container.querySelector('[aria-label="打包"]'))
+})
+
 test('plugin title puts a green dot left of the name when enabled', () => {
   const Title = pluginsChrome.Title
   assert.ok(Title)

--- a/packages/web-app-shell/src/web/shell-search.test.ts
+++ b/packages/web-app-shell/src/web/shell-search.test.ts
@@ -12,6 +12,7 @@ import {
   tagsFromRecord,
   pluginRecordEnabled,
   visibleRowActions,
+  previewHitRecord,
 } from './shell-search.tsx'
 
 test('search opens inspector collections, not chat or database routes', () => {
@@ -182,7 +183,21 @@ test('search hit actions use collection chrome.Actions when registered', () => {
   assert.match(src, /getDatabaseUi\(\)\?\.chrome\(searchCollection\(hit\.kind\)\)\.Actions/)
   assert.match(src, /placedRowActions\(hit\.actions\)/)
   assert.match(src, /<Actions/)
-  assert.match(src, /previewRunningRecord\(record, action\.when\)/)
+  assert.match(src, /previewHitRecord\(record, action\)/)
+  assert.match(src, /addEventListener\('fsdb:change'/)
+})
+
+test('previewHitRecord drops start/stop after uninstall', () => {
+  const row = { id: 'p1', installed: true, running: true, enabled: true, sandbox: true }
+  const next = previewHitRecord(row, { id: 'uninstall', label: '卸载', when: { installed: true } })
+  assert.equal(next.installed, false)
+  assert.equal(next.running, false)
+  const start = { id: 'start', label: '运行', when: { installed: true, running: false } }
+  const stop = { id: 'stop', label: '停止', when: { installed: true, running: true } }
+  assert.deepEqual(
+    visibleRowActions([start, stop, { id: 'pack', label: '打包', when: { sandbox: true } }], next).map((item) => item.id),
+    ['pack'],
+  )
 })
 
 test('opening a session on the left closes search and focuses the composer', () => {

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -172,6 +172,18 @@ export function previewRunningRecord(record: Record<string, unknown>, when?: Rec
   return { ...record, running }
 }
 
+export function previewHitRecord(record: Record<string, unknown>, action: SearchAction) {
+  if (action.id === 'uninstall' || action.id === 'delete' || action.id === 'remove') {
+    if (record.installed === false && record.running !== true && record.enabled !== true) return record
+    return { ...record, installed: false, running: false, enabled: false }
+  }
+  if (action.id === 'pack' || action.id === 'create') {
+    if (record.installed === true) return record
+    return { ...record, installed: true }
+  }
+  return previewRunningRecord(record, action.when)
+}
+
 export function visibleRowActions(actions: SearchAction[] | undefined, record: Record<string, unknown> | undefined) {
   const row = record ?? {}
   return placedRowActions(actions).filter((action) => matchActionWhen(row, action.when))
@@ -301,11 +313,14 @@ function HitActions({ hit }: { hit: SearchHit }) {
   const Actions = getDatabaseUi()?.chrome(searchCollection(hit.kind)).Actions
   const placed = placedRowActions(hit.actions)
   const actions = visibleRowActions(hit.actions, record).filter((action) => actionGlyph(action.id))
+  useEffect(() => {
+    setRecord(hit.record ?? { id: hit.id })
+  }, [hit.id, hit.record])
   const run = async (action: SearchAction) => {
     if (acting.current) return
     if (action.confirm && !window.confirm(action.confirm)) return
     acting.current = true
-    const next = previewRunningRecord(record, action.when)
+    const next = previewHitRecord(record, action)
     if (next !== record) setRecord(next)
     try {
       await fetch('/api/db/action', {
@@ -406,6 +421,12 @@ export function ShellSearchPanel({
     if (!node) return
     node.focus()
   }, [focusSeq])
+
+  useEffect(() => {
+    const onChange = () => setReloadSeq((seq) => seq + 1)
+    window.addEventListener('fsdb:change', onChange)
+    return () => window.removeEventListener('fsdb:change', onChange)
+  }, [])
 
   const needle = query.trim().toLowerCase()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
卸载插件后，搜索命中还拿着旧的 `installed/running`，运行/停止（打开/关闭）按钮还在。

卸载后立刻按未安装预览（关掉 start/stop）；`fsdb:change` 时清缓存重拉列表，沙箱行只留打包。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

