### PR TITLE
fix: db_update 把页面合集属性真正写入 stamp

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.test.ts
+++ b/packages/core-file-system/src/host/agent-payload.test.ts
@@ -31,7 +31,12 @@ test('compact schema drops identical builtins and user-only actions', () => {
   const compact = pack.schema(notesSchema())
   assert.equal('id' in ((compact.fields as object) ?? {}), false)
   assert.equal('createdAt' in ((compact.fields as object) ?? {}), false)
-  assert.equal('facet' in ((compact.fields as object) ?? {}), false)
+  assert.deepEqual((compact.fields as Record<string, unknown>).facet, {
+    type: 'facet',
+    label: '合集',
+    description:
+      '贴合集并填属性。一个合集：{tags:["facet-2"],values:{导演:"查泽雷"}}。多个合集 values 必须按 id 分组：{tags:["facet-2","awards"],values:{"facet-2":{导演:"查泽雷"},awards:{oscar:true}}}。省略 tags 只合并属性，不撕掉其它合集。',
+  })
   assert.equal('title' in ((compact.fields as object) ?? {}), false)
   assert.deepEqual((compact.fields as Record<string, unknown>).status, {
     type: 'string',

--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -17,7 +17,7 @@ export class AgentDbCompact {
     const fields: Record<string, unknown> = {}
     for (const [key, field] of Object.entries(schema.fields)) {
       const builtin = defaults[key]
-      if (builtin && this.specsMatch(field, builtin)) continue
+      if (key !== 'facet' && builtin && this.specsMatch(field, builtin)) continue
       fields[key] = this.field(key, field)
     }
     const actions = (schema.actions ?? []).map((item) => this.action(item)).filter(Boolean)

--- a/packages/core-file-system/src/host/facets-collection.ts
+++ b/packages/core-file-system/src/host/facets-collection.ts
@@ -110,7 +110,7 @@ export function facetsCollection(
       route: '/db-facets',
       title: '合集',
       inspector: true,
-      blurb: '工作区全局合集定义，可贴到任意表的记录。列表 db_list /facets；某合集已贴过哪些记录用 filter.facetId。新建 db_create /facets records=[{title}]（id 由标题 slug）。改名或属性 db_update /facets/<id>，fields 为 JSON 数组 [{key,type,label}]。正文 notes 用 db_content（和页面、任务一样的编辑器）。把合集贴到某条记录：db_update 那条记录的 facet 字段。本表没有 db_action。',
+      blurb: '工作区全局合集定义，可贴到任意表的记录。列表 db_list /facets；某合集已贴过哪些记录用 filter.facetId。新建 db_create /facets records=[{title}]（id 由标题 slug）。改名或属性 db_update /facets/<id>，fields 为 JSON 数组 [{key,type,label}]。正文 notes 用 db_content。把合集贴到某条记录并填属性：db_update 那条记录，content.facet={tags:[合集id],values:{导演:"查泽雷"}}（扁平属性名即可）。本表没有 db_action。',
       order: 31,
       icon: 'rectangle-stack',
     },

--- a/packages/core-file-system/src/host/facets-collection.ts
+++ b/packages/core-file-system/src/host/facets-collection.ts
@@ -110,7 +110,7 @@ export function facetsCollection(
       route: '/db-facets',
       title: '合集',
       inspector: true,
-      blurb: '工作区全局合集定义，可贴到任意表的记录。列表 db_list /facets；某合集已贴过哪些记录用 filter.facetId。新建 db_create /facets records=[{title}]（id 由标题 slug）。改名或属性 db_update /facets/<id>，fields 为 JSON 数组 [{key,type,label}]。正文 notes 用 db_content。把合集贴到某条记录并填属性：db_update 那条记录，content.facet={tags:[合集id],values:{导演:"查泽雷"}}（扁平属性名即可）。本表没有 db_action。',
+      blurb: '工作区全局合集定义，可贴到任意表的记录。列表 db_list /facets；某合集已贴过哪些记录用 filter.facetId。新建 db_create /facets records=[{title}]（id 由标题 slug）。改名或属性 db_update /facets/<id>，fields 为 JSON 数组 [{key,type,label}]。正文 notes 用 db_content。把合集贴到记录并填属性：db_update 那条记录的 facet。一个合集 values 可扁平；多个合集 values 必须按合集 id 分子对象。省略 tags 只改属性，不会撕掉其它合集。本表没有 db_action。',
       order: 31,
       icon: 'rectangle-stack',
     },

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -1098,6 +1098,28 @@ test('db_update page facet stores flat property values on the stamp', async () =
   const merged = await db.update('/pages/p1', { facet: { values: { 导演: 'Damien Chazelle' } } })
   assert.equal(merged.value.facet.values[id].director, 'Damien Chazelle')
   assert.equal(merged.value.facet.values[id].year, 2016)
+
+  const awards = await db.create('/facets', [{ title: '奖项' }])
+  const awardId = String(awards.items[0]?.value.id)
+  await db.update(`/facets/${awardId}`, {
+    fields: JSON.stringify([{ key: 'oscar', type: 'boolean', label: '奥斯卡' }]),
+  })
+  const both = await db.update('/pages/p1', {
+    facet: {
+      tags: [id, awardId],
+      values: {
+        [id]: { 导演: '查泽雷' },
+        [awardId]: { 奥斯卡: true },
+      },
+    },
+  })
+  assert.deepEqual(both.value.facet.tags, [id, awardId])
+  assert.equal(both.value.facet.values[id].director, '查泽雷')
+  assert.equal(both.value.facet.values[id].year, 2016)
+  assert.equal(both.value.facet.values[awardId].oscar, true)
+  const onlyAward = await db.update('/pages/p1', { facet: { values: { [awardId]: { oscar: false } } } })
+  assert.equal(onlyAward.value.facet.values[awardId].oscar, false)
+  assert.equal(onlyAward.value.facet.values[id].director, '查泽雷')
 })
 
 test('tables without records.create/delete reject create and delete', async () => {

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -654,7 +654,7 @@ test('agent db_stat omits builtin fields; service stat and list still include th
     caps?: string[]
   }
   assert.equal(agentStat.schema?.fields && 'id' in agentStat.schema.fields, false)
-  assert.equal(agentStat.schema?.fields && 'facet' in agentStat.schema.fields, false)
+  assert.equal((agentStat.schema?.fields as { facet?: { type?: string } } | undefined)?.facet?.type, 'facet')
   assert.ok(agentStat.schema?.fields && 'status' in agentStat.schema.fields)
   assert.equal(agentStat.schema?.records, undefined)
   assert.ok(agentStat.caps?.includes('list'))

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -1060,6 +1060,46 @@ test('db_update /facets writes facet field packs', async () => {
   assert.equal(read.value, '# 合集说明')
 })
 
+test('db_update page facet stores flat property values on the stamp', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  const pages = new Map<string, Record<string, unknown>>([['p1', { id: 'p1', title: '爱乐之城' }]])
+  db.register({
+    id: 'pages',
+    path: '/pages',
+    schema: { fields: { ...REQUIRED_RECORD_FIELDS, title: { type: 'string', writable: true } } },
+    records: { update: true },
+    list: () => [...pages.values()] as { id: string }[],
+    get: (id) => pages.get(id) as { id: string } | undefined,
+    update: (id, patch) => {
+      const next = { ...pages.get(id), ...patch, id }
+      pages.set(id, next)
+      return next as { id: string }
+    },
+  })
+  db.register(facetsCollection(db.facets))
+  const created = await db.create('/facets', [{ title: '电影' }])
+  const id = String(created.items[0]?.value.id)
+  await db.update(`/facets/${id}`, {
+    fields: JSON.stringify([
+      { key: 'director', type: 'string', label: '导演' },
+      { key: 'year', type: 'number', label: '年份' },
+      { key: 'score', type: 'number', label: '评分' },
+    ]),
+  })
+  const tagged = await db.update('/pages/p1', {
+    facet: { tags: [id], values: { 导演: '查泽雷', 年份: 2016, 评分: 8.6 } },
+  })
+  assert.deepEqual(tagged.value.facet, {
+    tags: [id],
+    values: { [id]: { director: '查泽雷', year: 2016, score: 8.6 } },
+  })
+  assert.equal(db.facets.recordFacet('/pages', 'p1')?.values[id]?.director, '查泽雷')
+  const merged = await db.update('/pages/p1', { facet: { values: { 导演: 'Damien Chazelle' } } })
+  assert.equal(merged.value.facet.values[id].director, 'Damien Chazelle')
+  assert.equal(merged.value.facet.values[id].year, 2016)
+})
+
 test('tables without records.create/delete reject create and delete', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -12,6 +12,8 @@ import {
   asImageSrc,
   asImageSrcList,
   isFacetFieldType,
+  bindSchemaValue,
+  emptySchemaValue,
   normalizeSchemaValue,
   schemaSearchHaystack,
   withBuiltinFields,
@@ -28,6 +30,7 @@ import {
   type Database,
   type DbRecord,
   type FieldSpec,
+  type SchemaFieldValue,
   type ListPage,
   type PersonValue,
   parseContentJump,
@@ -301,6 +304,99 @@ function coerce(field: FieldSpec, value: unknown) {
     if (typeof rec.sessionId === 'string' || rec.kind === 'agent' || rec.kind === 'user') return value
   }
   return String(value ?? '')
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function packFieldKey(pack: CollectionSchemaPack | null | undefined, name: string) {
+  const want = String(name ?? '').trim()
+  if (!pack || !want) return want
+  for (const field of pack.fields) {
+    if (field.key === want || field.label === want) return field.key
+  }
+  return want
+}
+
+function remapFacetBag(pack: CollectionSchemaPack | null | undefined, bag: Record<string, unknown>) {
+  const out: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(bag)) {
+    const field = packFieldKey(pack, key)
+    if (!field) continue
+    if (value == null || value === '') {
+      delete out[field]
+      continue
+    }
+    out[field] = value
+  }
+  return out
+}
+
+/** Agent 常写成扁平 values（中文属性名），权威形状是 values[合集id][字段key]。 */
+function coerceFacetPatch(
+  raw: unknown,
+  current: SchemaFieldValue,
+  resolvePack: (idOrLabel: string) => CollectionSchemaPack | null,
+): SchemaFieldValue {
+  let parsed: unknown = raw
+  if (typeof parsed === 'string' && parsed.trim()) {
+    try {
+      parsed = JSON.parse(parsed) as unknown
+    } catch {
+      parsed = raw
+    }
+  }
+  if (Array.isArray(parsed)) {
+    const tags = parsed.map((item) => resolvePack(String(item))?.id ?? String(item).trim()).filter(Boolean)
+    return bindSchemaValue(tags, current.values)
+  }
+  if (!isPlainObject(parsed)) return normalizeSchemaValue(parsed)
+  const rec = parsed
+  const rawTags = Array.isArray(rec.tags)
+    ? rec.tags.map((item) => String(item).trim()).filter(Boolean)
+    : rec.tags == null
+      ? current.tags
+      : []
+  const tags = [...new Set(rawTags.map((item) => resolvePack(item)?.id ?? item).filter(Boolean))]
+  const bags: SchemaFieldValue['values'] = {}
+  for (const id of tags) bags[id] = { ...(current.values[id] ?? {}) }
+  const applyBag = (packId: string, bag: Record<string, unknown>) => {
+    const id = resolvePack(packId)?.id ?? packId
+    if (!tags.includes(id)) return
+    bags[id] = { ...bags[id], ...remapFacetBag(resolvePack(id), bag) }
+  }
+  if (isPlainObject(rec.values)) {
+    const nested: Array<[string, Record<string, unknown>]> = []
+    const flat: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(rec.values)) {
+      const pack = resolvePack(key)
+      const packId = pack?.id ?? (tags.includes(key) ? key : '')
+      if (packId && isPlainObject(value)) nested.push([packId, value])
+      else flat[key] = value
+    }
+    for (const [id, bag] of nested) applyBag(id, bag)
+    if (Object.keys(flat).length) {
+      if (tags.length === 1) applyBag(tags[0]!, flat)
+      else {
+        for (const [key, value] of Object.entries(flat)) {
+          const hit = tags
+            .map((id) => resolvePack(id))
+            .find((pack) => pack?.fields.some((field) => field.key === key || field.label === key))
+          if (hit) applyBag(hit.id, { [key]: value })
+        }
+      }
+    }
+  }
+  for (const [key, value] of Object.entries(rec)) {
+    if (key === 'tags' || key === 'values') continue
+    if (tags.length === 1) applyBag(tags[0]!, { [key]: value })
+    else {
+      const hit = tags.map((id) => resolvePack(id)).find((pack) => pack?.fields.some((field) => field.key === key || field.label === key))
+      if (hit) applyBag(hit.id, { [key]: value })
+    }
+  }
+  return bindSchemaValue(tags, bags)
 }
 
 function pickWritablePatch(schema: CollectionSchema, patch: Record<string, unknown>) {
@@ -709,6 +805,13 @@ export class DatabaseService extends Service implements Database {
     return Boolean(spec.records?.update && spec.update)
   }
 
+  private persistRecordFacet(spec: CollectionSpec, recordId: string, facet: unknown, record: DbRecord) {
+    const next = normalizeSchemaValue(facet)
+    const labelKey = schemaFor(spec).labelField ?? 'title'
+    this.facets.writeRecordFacet(spec.path, recordId, next, String(record[labelKey] ?? record.id))
+    return next
+  }
+
   private indexFacetRecord(spec: CollectionSpec, record: DbRecord) {
     if (!schemaFor(spec).fields.facet) return
     const labelKey = schemaFor(spec).labelField ?? 'title'
@@ -739,21 +842,24 @@ export class DatabaseService extends Service implements Database {
     if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
     const schema = schemaFor(spec)
     const raw = parseContent(content)
+    const current = await spec.get(parts[1]!)
+    if (!current) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
+    if ('facet' in raw && schema.fields.facet) {
+      if (!schema.fields.facet.writable || schema.fields.facet.computed) throw new Error(`field not writable: facet`)
+      raw.facet = coerceFacetPatch(raw.facet, normalizeSchemaValue(this.decorateRecord(spec, current).facet), (id) =>
+        this.facets.get(id),
+      )
+    }
     if (!this.collectionCanUpdate(spec)) {
       const keys = Object.keys(raw)
       const overlayKeys = new Set(['facet', 'emoji', 'tags'])
       if (!keys.length || keys.some((key) => !overlayKeys.has(key))) {
         throw new Error(`collection cannot update: ${spec.path}`)
       }
-      const current = await spec.get(parts[1]!)
-      if (!current) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
       let next: DbRecord = { ...this.decorateRecord(spec, current) }
       if ('facet' in raw) {
-        if (!schema.fields.facet?.writable || schema.fields.facet.computed) throw new Error(`field not writable: facet`)
         const nextSchema = coerce(schema.fields.facet, raw.facet)
-        const labelKey = schema.labelField ?? 'title'
-        this.facets.writeRecordFacet(spec.path, current.id, nextSchema, String(current[labelKey] ?? current.id))
-        next = { ...next, facet: nextSchema }
+        next = { ...next, facet: this.persistRecordFacet(spec, current.id, nextSchema, next) }
       }
       if ('emoji' in raw || 'tags' in raw) {
         if ('emoji' in raw && (!schema.fields.emoji?.writable || schema.fields.emoji.computed)) {
@@ -784,16 +890,8 @@ export class DatabaseService extends Service implements Database {
     await assertSameTableLinks(spec, patch, parts[1])
     let record = await spec.update(parts[1]!, patch)
     await this.stampActor(spec.path, record.id)
-    if (spec.path === '/facets' && schema.fields.facet && 'facet' in patch) {
-      const nextFacet = coerce(schema.fields.facet, patch.facet)
-      const labelKey = schema.labelField ?? 'title'
-      this.facets.writeRecordFacet(
-        spec.path,
-        record.id,
-        nextFacet as ReturnType<typeof normalizeSchemaValue>,
-        String(record[labelKey] ?? record.id),
-      )
-      record = { ...record, facet: nextFacet }
+    if (schema.fields.facet && 'facet' in patch) {
+      record = { ...record, facet: this.persistRecordFacet(spec, record.id, patch.facet, record) }
     }
     this.indexFacetRecord(spec, this.decorateRecord(spec, record))
     this.bump()
@@ -810,6 +908,9 @@ export class DatabaseService extends Service implements Database {
     const rows = parseRecords(content)
     const records: Record<string, unknown>[] = []
     for (const row of rows) {
+      if ('facet' in row && schema.fields.facet) {
+        row.facet = coerceFacetPatch(row.facet, emptySchemaValue(), (id) => this.facets.get(id))
+      }
       const patch = pickWritablePatch(schema, row)
       await assertSameTableLinks(spec, patch)
       records.push(patch)
@@ -817,6 +918,9 @@ export class DatabaseService extends Service implements Database {
     const created = await spec.create(records)
     for (const record of created) {
       await this.stampActor(spec.path, record.id)
+      if (schema.fields.facet) {
+        this.persistRecordFacet(spec, record.id, record.facet, record)
+      }
       this.indexFacetRecord(spec, record)
     }
     this.bump()
@@ -1234,7 +1338,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_update',
-    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。成功只返回 {ok, path}，不回整行。合集（facet 字段）在所有表都可写，包括 records.update 为 false 的表（如 /plugins）；其它字段仍看 caps。新建用 db_create，正文用 db_content。改合集属性用 db_update path=/facets/<id> content.fields。',
+    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。成功只返回 {ok, path}，不回整行。把合集贴到页面并填属性：content.facet={tags:["facet-2"],values:{导演:"查泽雷",年份:2016}}（values 用合集属性的中文名或 key 即可，不必再包一层合集 id）。改合集定义（名称、属性列表）用 db_update /facets/<id> content.fields。新建用 db_create，正文用 db_content。',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1343,7 +1343,10 @@ export function apply(ctx: Context) {
       type: 'object',
       properties: {
         path: { type: 'string' },
-        content: { description: '要更新的字段（对象或 JSON 字符串）' },
+        content: {
+          description:
+            '要更新的字段（对象或 JSON 字符串）。合集写 facet：一个合集 values 扁平，如 {facet:{tags:["facet-2"],values:{导演:"查泽雷"}}}；多个合集 values 按合集 id 分子对象。省略 tags 只改属性，不撕掉其它合集。',
+        },
       },
       required: ['path', 'content'],
     },

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1338,7 +1338,7 @@ export function apply(ctx: Context) {
   })
   ctx.tools.register({
     name: 'db_update',
-    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。成功只返回 {ok, path}，不回整行。把合集贴到页面并填属性：content.facet={tags:["facet-2"],values:{导演:"查泽雷",年份:2016}}（values 用合集属性的中文名或 key 即可，不必再包一层合集 id）。改合集定义（名称、属性列表）用 db_update /facets/<id> content.fields。新建用 db_create，正文用 db_content。',
+    description: '按表结构 schema 的可写字段更新一条已有记录，路径为 /<表>/<id>。成功只返回 {ok, path}，不回整行。合集 facet：可同时贴多个。一个合集用扁平 values，如 {tags:["facet-2"],values:{导演:"查泽雷"}}；多个合集必须按合集分子对象，如 {tags:["facet-2","awards"],values:{"facet-2":{导演:"查泽雷"},awards:{oscar:true}}}。省略 tags 则改当前已贴合集的属性（合并，不撕掉别的合集）。改合集定义用 db_update /facets/<id> content.fields。新建用 db_create，正文用 db_content。',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -16,7 +16,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
       route: '/pages',
       title: '页面',
       inspector: true,
-      blurb: '每页正文在工作区 .page/<id>.md（YAML 头 + Markdown）。.page/pages.sqlite 只做列表索引，不扫全部文件。正文用 db_content；改标题/标签等用 db_update。图片和附件在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
+      blurb: '每页正文在工作区 .page/<id>.md（YAML 头 + Markdown）。.page/pages.sqlite 只做列表索引，不扫全部文件。正文用 db_content；改标题/标签等用 db_update。合集用 db_update 写 facet：{tags:["facet-2"],values:{导演:"查泽雷"}}。图片和附件在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
       order: 25,
       icon: 'document',
     },

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -233,7 +233,13 @@ export const BUILTIN_FIELDS = {
   content: { type: 'file', label: '内容' },
   emoji: { type: 'string', label: '图标', writable: true },
   tags: { type: 'multi-select', label: '标签', writable: true },
-  facet: { type: 'facet', label: '合集', writable: true },
+  facet: {
+    type: 'facet',
+    label: '合集',
+    writable: true,
+    description:
+      '贴合集并填属性。一个合集：{tags:["facet-2"],values:{导演:"查泽雷"}}。多个合集 values 必须按 id 分组：{tags:["facet-2","awards"],values:{"facet-2":{导演:"查泽雷"},awards:{oscar:true}}}。省略 tags 只合并属性，不撕掉其它合集。',
+  },
   parentId: { type: 'ref', label: '父级', writable: true },
   dependsOn: { type: 'multi-ref', label: '依赖', writable: true },
   createdBy: { type: 'person', label: '创建人', writable: false },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
当时 Agent 猜错格式，是因为**没有真正提示过写法**：`db_stat` 会把内置 `facet` 字段省略掉，`db_update` 的 `content` 也只写「要更新的字段」。合集表 blurb 只说「写那条记录的 facet」，没有 JSON。

这次：

- 可更新表也会把属性写入 `facet_record_values`
- 接受一个合集的扁平 `values`（中文 label）
- 多个合集按 id 分子对象
- `db_update` 工具描述、`content` 参数、`db_stat` 的 `facet` 字段 description 都带上单合集/多合集样例

合集定义仍用 `/facets` 的 create/update。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

