### PR TITLE
fix: Esc 不再从详情退回列表面包屑

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1194,15 +1194,6 @@ export function CollectionBrowser({
   }, [collectionPath, dataPath, detailId, pullDetailBody])
 
   useEffect(() => {
-    if (nested || !detailId) return
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setDetailId(null)
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [detailId, nested])
-
-  useEffect(() => {
     if (dlg?.kind !== 'rename') return
     setDlgError('')
   }, [dlg])

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -649,6 +649,11 @@ test('inspector crumbs lock the first level to an icon', () => {
   assert.doesNotMatch(browser, /lockRootCrumb/)
 })
 
+test('Escape does not pop record detail back to the list crumb', () => {
+  assert.doesNotMatch(browser, /if \(event.key === 'Escape'\) setDetailId\(null\)/)
+  assert.doesNotMatch(browser, /window.addEventListener\('keydown', onKey\)/)
+})
+
 test('collection header has a layout config control next to the star', () => {
   assert.match(browser, /data-testid="fsdb-layout-toggle"/)
   assert.match(browser, /data-testid="fsdb-layout-menu"/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情打开时，`browser.tsx` 在 `window` 上听 Esc，会 `setDetailId(null)`，第三级面包屑退回列表。这是最早落地 Database 时加上的（steveacen，`e57cc21`），不是后来单独做的快捷键设置。

已去掉这条全局监听。弹层、搜索框自己的 Esc 关闭不受影响；用面包屑或关闭按钮离开详情。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

