### PR TITLE
feat: HTML 块给生成内容打可抓面，Agent 仍输出干净 HTML

### DIFF
--- a/.plugin-dev/page-html-blocks/stamp-picks.ts
+++ b/.plugin-dev/page-html-blocks/stamp-picks.ts
@@ -1,0 +1,96 @@
+const SKIP = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'NOSCRIPT', 'BR', 'HR'])
+const SURFACE = new Set([
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'P',
+  'BUTTON',
+  'A',
+  'IMG',
+  'TABLE',
+  'VIDEO',
+  'AUDIO',
+  'FIGURE',
+  'LI',
+  'ARTICLE',
+  'SECTION',
+])
+
+export const HTML_PICK_KIND = 'html'
+export const HTML_PICK_MARK = 'data-html-pick'
+
+function hashText(value: string) {
+  let hash = 2166136261
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).slice(0, 8)
+}
+
+function surfaceLabel(el: HTMLElement) {
+  const named =
+    el.getAttribute('alt') ||
+    el.getAttribute('title') ||
+    el.getAttribute('aria-label') ||
+    (el instanceof HTMLAnchorElement ? el.textContent : '') ||
+    el.textContent ||
+    el.tagName.toLowerCase()
+  return named.replace(/\s+/g, ' ').trim().slice(0, 80)
+}
+
+/** 整块根、语义块、带 id、以及预览根下的直接子节点。不给每个 span/div 盖章。 */
+export function isHtmlPickSurface(el: Element, root: Element) {
+  if (!(el instanceof HTMLElement)) return false
+  if (el === root) return true
+  if (SKIP.has(el.tagName)) return false
+  if (SURFACE.has(el.tagName)) return true
+  if (el.id.trim()) return true
+  const role = el.getAttribute('role')
+  if (role === 'button' || role === 'link' || role === 'img') return true
+  return el.parentElement === root
+}
+
+export function htmlBlockKey(host: Element | null, html: string) {
+  const scope = host?.closest('.tiptap, [data-testid="page-editor"]') ?? host?.parentElement
+  const blocks = scope?.querySelectorAll('[data-page-block="html"], [data-page-block="htmlframe"]')
+  const index = host && blocks ? [...blocks].indexOf(host as Element) : 0
+  return `${Math.max(0, index)}-${hashText(html)}`
+}
+
+export function clearHtmlPickSurfaces(root: ParentNode) {
+  const nodes = 'querySelectorAll' in root ? [...root.querySelectorAll(`[${HTML_PICK_MARK}]`)] : []
+  if (root instanceof Element && root.hasAttribute(HTML_PICK_MARK)) nodes.push(root)
+  for (const el of nodes) {
+    el.removeAttribute(HTML_PICK_MARK)
+    el.removeAttribute('data-biu-kind')
+    el.removeAttribute('data-biu-id')
+    el.removeAttribute('data-biu-label')
+  }
+}
+
+export function stampHtmlPickSurfaces(root: HTMLElement, blockKey: string) {
+  clearHtmlPickSurfaces(root)
+  const prefix = `${HTML_PICK_KIND}:${blockKey}`
+  const stamp = (el: HTMLElement, path: string) => {
+    const label = surfaceLabel(el)
+    el.setAttribute(HTML_PICK_MARK, '')
+    el.setAttribute('data-biu-kind', HTML_PICK_KIND)
+    el.setAttribute('data-biu-id', `${prefix}:${path}`)
+    if (label) el.setAttribute('data-biu-label', label)
+  }
+  stamp(root, 'root')
+  const walk = (el: Element, path: string) => {
+    let i = 0
+    for (const child of el.children) {
+      const next = `${path}/${i}`
+      if (child instanceof HTMLElement && isHtmlPickSurface(child, root)) stamp(child, next)
+      walk(child, next)
+      i += 1
+    }
+  }
+  walk(root, '0')
+}

--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -1,5 +1,7 @@
+import { htmlBlockKey, stampHtmlPickSurfaces } from './stamp-picks.ts'
+
 const React = globalThis.React
-const { useState } = React
+const { useLayoutEffect, useRef, useState } = React
 
 export const name = 'page-html-blocks'
 export const inject = ['pageEditor']
@@ -27,6 +29,7 @@ function SourceEditor({ html, onChange }: { html: string; onChange: (v: string) 
   return (
     <textarea
       data-testid="html-source"
+      data-biu-ignore
       spellCheck={false}
       value={html}
       onChange={(e) => onChange(e.target.value)}
@@ -85,6 +88,7 @@ function FloatBar({
   return (
     <div
       data-testid="html-floatbar"
+      data-biu-ignore
       style={{
         position: 'absolute',
         top: 6,
@@ -129,9 +133,20 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
   const html = String(data.html ?? '')
   const [editing, setEditing] = useState(false)
   const [hover, setHover] = useState(false)
+  const previewRef = useRef<HTMLDivElement | null>(null)
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    if (editing) return
+    const preview = previewRef.current
+    if (!preview) return
+    const host = hostRef.current?.closest('[data-page-block]') ?? null
+    stampHtmlPickSurfaces(preview, htmlBlockKey(host, html))
+  }, [editing, html])
 
   return (
     <div
+      ref={hostRef}
       data-testid="page-html-direct"
       style={{ position: 'relative', width: '100%' }}
       onMouseEnter={() => setHover(true)}
@@ -143,7 +158,7 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
       {editing ? (
         <SourceEditor html={html} onChange={(v) => update({ html: v })} />
       ) : (
-        <div style={{ overflowX: 'auto' }} dangerouslySetInnerHTML={{ __html: html }} />
+        <div ref={previewRef} style={{ overflowX: 'auto' }} dangerouslySetInnerHTML={{ __html: html }} />
       )}
     </div>
   )
@@ -183,9 +198,31 @@ function HtmlFrameCard({ data, update, writable }: BlockProps) {
   const height = Number(data.height) || 300
   const [editing, setEditing] = useState(false)
   const [hover, setHover] = useState(false)
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const frameRef = useRef<HTMLIFrameElement | null>(null)
+
+  const stampFrame = () => {
+    const frame = frameRef.current
+    if (!frame) return
+    const host = hostRef.current?.closest('[data-page-block]') ?? null
+    const key = htmlBlockKey(host, html)
+    stampHtmlPickSurfaces(frame, key)
+    try {
+      const body = frame.contentDocument?.body
+      if (body) stampHtmlPickSurfaces(body, `${key}-doc`)
+    } catch {
+      /* srcdoc + sandbox 可能读不到 contentDocument */
+    }
+  }
+
+  useLayoutEffect(() => {
+    if (editing) return
+    stampFrame()
+  }, [editing, html, height])
 
   return (
     <div
+      ref={hostRef}
       data-testid="page-html-frame"
       style={{ position: 'relative', width: '100%' }}
       onMouseEnter={() => setHover(true)}
@@ -209,10 +246,12 @@ function HtmlFrameCard({ data, update, writable }: BlockProps) {
         <SourceEditor html={html} onChange={(v) => update({ html: v })} />
       ) : (
         <iframe
+          ref={frameRef}
           data-testid="page-html-frame-preview"
           title="html-frame"
           srcDoc={html}
           sandbox="allow-scripts"
+          onLoad={stampFrame}
           style={{ display: 'block', width: '100%', height, border: 'none', background: '#15151f' }}
         />
       )}

--- a/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
+++ b/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  isHtmlPickSurface,
+  stampHtmlPickSurfaces,
+  htmlBlockKey,
+} from '../../../../.plugin-dev/page-html-blocks/stamp-picks.ts'
+
+test('stamps the preview root, semantic nodes, and top-level chunks only', () => {
+  const root = document.createElement('div')
+  root.innerHTML = `
+    <div class="card">
+      <h2>爱乐之城</h2>
+      <p>一部歌舞片</p>
+      <span class="chip">标签</span>
+      <button type="button">播放</button>
+      <a href="#x">预告</a>
+      <img alt="海报" src="about:blank" />
+      <div id="score">8.6</div>
+    </div>
+  `
+  document.body.append(root)
+  stampHtmlPickSurfaces(root, '0-abcd')
+  const stamped = [...root.querySelectorAll('[data-html-pick]')]
+  if (root.hasAttribute('data-html-pick') && !stamped.includes(root)) stamped.unshift(root)
+  const tags = stamped.map((el) => el.tagName)
+  assert.equal(root.getAttribute('data-biu-kind'), 'html')
+  assert.equal(root.getAttribute('data-biu-id'), 'html:0-abcd:root')
+  assert.ok(tags.includes('DIV'))
+  assert.ok(tags.includes('H2'))
+  assert.ok(tags.includes('P'))
+  assert.ok(tags.includes('BUTTON'))
+  assert.ok(tags.includes('A'))
+  assert.ok(tags.includes('IMG'))
+  assert.equal(stamped.some((el) => el.className === 'chip'), false)
+  const heading = root.querySelector('h2')
+  assert.equal(heading?.getAttribute('data-biu-label'), '爱乐之城')
+  const chip = root.querySelector('.chip')
+  assert.equal(chip?.hasAttribute('data-biu-kind'), false)
+  assert.equal(isHtmlPickSurface(chip!, root), false)
+  root.remove()
+})
+
+test('htmlBlockKey is stable for the same host and source', () => {
+  const editor = document.createElement('div')
+  editor.className = 'tiptap'
+  const a = document.createElement('div')
+  a.setAttribute('data-page-block', 'html')
+  const b = document.createElement('div')
+  b.setAttribute('data-page-block', 'htmlframe')
+  editor.append(a, b)
+  assert.equal(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(a, '<p>x</p>'))
+  assert.notEqual(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(b, '<p>x</p>'))
+  assert.notEqual(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(a, '<p>y</p>'))
+})

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -203,6 +203,8 @@ test('html and req page blocks register plugin id for slash', async () => {
   assert.match(html, /plugin: name/)
   assert.match(html, /kind: 'html'/)
   assert.match(html, /kind: 'htmlframe'/)
+  assert.match(html, /stampHtmlPickSurfaces/)
+  assert.match(html, /data-biu-ignore/)
   assert.match(req, /plugin: name/)
   assert.match(req, /kind: 'req'/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 生成的仍是干净 HTML，不写 `data-biu-*`。页面 HTML 插件在渲染后给有意义的面打 pick：

- 预览根
- 标题 / 段落 / 按钮 / 链接 / 图 / 表 / 列表项等语义标签
- 带 `id` 或 button/link/img role 的节点
- 预览根下的直接子块（整张卡片）

不给每个 `span`/`div` 盖章。工具条和源码框 `data-biu-ignore`。Cap 仍只认协议，不认识 HTML 块。

iframe 在父页打在 iframe 盒子上；沙箱里往往读不到 `contentDocument`，里面细节点目前点不到，只能整框抓。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

