### PR TITLE
fix: HTML 块内部卡片也能被 Cap 抓到

### DIFF
--- a/.plugin-dev/page-html-blocks/stamp-picks.ts
+++ b/.plugin-dev/page-html-blocks/stamp-picks.ts
@@ -36,22 +36,39 @@ function surfaceLabel(el: HTMLElement) {
     el.getAttribute('alt') ||
     el.getAttribute('title') ||
     el.getAttribute('aria-label') ||
-    (el instanceof HTMLAnchorElement ? el.textContent : '') ||
-    el.textContent ||
-    el.tagName.toLowerCase()
-  return named.replace(/\s+/g, ' ').trim().slice(0, 80)
+    (el instanceof HTMLAnchorElement ? el.textContent : '')
+  const short = [...el.querySelectorAll('div, span, h1, h2, h3, h4, p, button, a')]
+    .map((node) => (node.childElementCount === 0 ? (node.textContent ?? '').replace(/\s+/g, ' ').trim() : ''))
+    .find((text) => text.length >= 2 && text.length <= 40)
+  return (named || short || el.textContent || el.tagName.toLowerCase()).replace(/\s+/g, ' ').trim().slice(0, 80)
 }
 
-/** 整块根、语义块、带 id、以及预览根下的直接子节点。不给每个 span/div 盖章。 */
+function isPeerChunk(el: HTMLElement) {
+  const parent = el.parentElement
+  if (!parent) return false
+  const peers = [...parent.children].filter(
+    (node): node is HTMLElement =>
+      node instanceof HTMLElement && node.tagName !== 'SPAN' && node.childElementCount >= 1,
+  )
+  if (peers.length < 2 || !peers.includes(el)) return false
+  const lengths = peers.map((node) => (node.textContent ?? '').replace(/\s+/g, ' ').trim().length)
+  const max = Math.max(...lengths)
+  const min = Math.min(...lengths)
+  if (max > 0 && min < max * 0.25) return false
+  return (el.textContent ?? '').replace(/\s+/g, ' ').trim().length >= 12
+}
+
+/** 整块根、语义块、带 id、并列卡片。不给每个 span/内层排版 div 盖章。 */
 export function isHtmlPickSurface(el: Element, root: Element) {
   if (!(el instanceof HTMLElement)) return false
   if (el === root) return true
-  if (SKIP.has(el.tagName)) return false
+  if (SKIP.has(el.tagName) || el.tagName === 'SPAN') return false
   if (SURFACE.has(el.tagName)) return true
   if (el.id.trim()) return true
   const role = el.getAttribute('role')
   if (role === 'button' || role === 'link' || role === 'img') return true
-  return el.parentElement === root
+  if (el.parentElement === root) return true
+  return isPeerChunk(el)
 }
 
 export function htmlBlockKey(host: Element | null, html: string) {
@@ -72,7 +89,7 @@ export function clearHtmlPickSurfaces(root: ParentNode) {
   }
 }
 
-export function stampHtmlPickSurfaces(root: HTMLElement, blockKey: string) {
+export function stampHtmlPickSurfaces(root: HTMLElement, blockKey: string, opts?: { includeRoot?: boolean }) {
   clearHtmlPickSurfaces(root)
   const prefix = `${HTML_PICK_KIND}:${blockKey}`
   const stamp = (el: HTMLElement, path: string) => {
@@ -82,7 +99,7 @@ export function stampHtmlPickSurfaces(root: HTMLElement, blockKey: string) {
     el.setAttribute('data-biu-id', `${prefix}:${path}`)
     if (label) el.setAttribute('data-biu-label', label)
   }
-  stamp(root, 'root')
+  if (opts?.includeRoot !== false) stamp(root, 'root')
   const walk = (el: Element, path: string) => {
     let i = 0
     for (const child of el.children) {
@@ -93,4 +110,12 @@ export function stampHtmlPickSurfaces(root: HTMLElement, blockKey: string) {
     }
   }
   walk(root, '0')
+}
+
+/** 把 pick 写进 HTML 字符串，避免 React 重绘 innerHTML 时冲掉内部属性。 */
+export function stampHtmlSource(html: string, blockKey: string) {
+  const wrap = document.createElement('div')
+  wrap.innerHTML = html
+  stampHtmlPickSurfaces(wrap, blockKey, { includeRoot: false })
+  return wrap.innerHTML
 }

--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -1,7 +1,7 @@
-import { htmlBlockKey, stampHtmlPickSurfaces } from './stamp-picks.ts'
+import { htmlBlockKey, stampHtmlPickSurfaces, stampHtmlSource } from './stamp-picks.ts'
 
 const React = globalThis.React
-const { useEffect, useRef, useState } = React
+const { useEffect, useMemo, useRef, useState } = React
 
 export const name = 'page-html-blocks'
 export const inject = ['pageEditor']
@@ -133,21 +133,11 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
   const html = String(data.html ?? '')
   const [editing, setEditing] = useState(false)
   const [hover, setHover] = useState(false)
-  const previewRef = useRef<HTMLDivElement | null>(null)
   const hostRef = useRef<HTMLDivElement | null>(null)
-
-  useEffect(() => {
-    if (editing) return
-    const preview = previewRef.current
-    if (!preview) return
-    const host = hostRef.current?.closest('[data-page-block]') ?? null
-    const key = htmlBlockKey(host, html)
-    const stamp = () => stampHtmlPickSurfaces(preview, key)
-    queueMicrotask(stamp)
-    return () => {
-      /* next html replace clears nodes */
-    }
-  }, [editing, html])
+  const stamped = useMemo(
+    () => stampHtmlSource(html, htmlBlockKey(hostRef.current?.closest('[data-page-block]') ?? null, html)),
+    [html],
+  )
 
   return (
     <div
@@ -163,7 +153,7 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
       {editing ? (
         <SourceEditor html={html} onChange={(v) => update({ html: v })} />
       ) : (
-        <div ref={previewRef} style={{ overflowX: 'auto' }} dangerouslySetInnerHTML={{ __html: html }} />
+        <div style={{ overflowX: 'auto' }} dangerouslySetInnerHTML={{ __html: stamped }} />
       )}
     </div>
   )

--- a/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
+++ b/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   isHtmlPickSurface,
   stampHtmlPickSurfaces,
+  stampHtmlSource,
   htmlBlockKey,
 } from '../../../../.plugin-dev/page-html-blocks/stamp-picks.ts'
 
@@ -52,4 +53,22 @@ test('htmlBlockKey is stable for the same host and source', () => {
   assert.equal(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(a, '<p>x</p>'))
   assert.notEqual(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(b, '<p>x</p>'))
   assert.notEqual(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(a, '<p>y</p>'))
+})
+
+test('stampHtmlSource marks peer slide cards inside a flex wrap', () => {
+  const html = `<div style="display:flex;gap:12px">
+    <div style="flex:1"><span>SLIDE 01 · 视听</span><div>视听盛宴</div><div>从山顶的黄昏共舞到天文馆。</div></div>
+    <div style="flex:1"><span>SLIDE 02 · 弧光</span><div>梦想与现实</div><div>塞巴斯蒂安守着爵士乐。</div></div>
+    <div style="flex:1"><span>SLIDE 03 · 假如</span><div>结局的假如</div><div>结尾那段蒙太奇。</div></div>
+  </div>`
+  const stamped = stampHtmlSource(html, '1-slide')
+  const wrap = document.createElement('div')
+  wrap.innerHTML = stamped
+  const picks = [...wrap.querySelectorAll('[data-biu-id]')]
+  assert.ok(picks.length >= 3)
+  const ids = picks.map((el) => el.getAttribute('data-biu-id') ?? '')
+  assert.ok(ids.some((id) => id.includes('1-slide')))
+  const slides = picks.filter((el) => (el.textContent ?? '').includes('视听盛宴') || (el.textContent ?? '').includes('梦想与现实') || (el.textContent ?? '').includes('结局的假如'))
+  assert.equal(slides.length >= 3, true)
+  assert.equal(wrap.querySelector('span')?.hasAttribute('data-biu-kind'), false)
 })

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -203,7 +203,7 @@ test('html and req page blocks register plugin id for slash', async () => {
   assert.match(html, /plugin: name/)
   assert.match(html, /kind: 'html'/)
   assert.match(html, /kind: 'htmlframe'/)
-  assert.match(html, /stampHtmlPickSurfaces/)
+  assert.match(html, /stampHtmlSource/)
   assert.match(html, /data-biu-ignore/)
   assert.match(req, /plugin: name/)
   assert.match(req, /kind: 'req'/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
你贴的 DOM 只有最外层有 `data-biu-id`，有两层原因：

1. hover/NodeView 重绘会重写 `dangerouslySetInnerHTML`，内部刚打上的属性被冲掉，外壳 React 节点上的还在。
2. 三张 slide 不是预览根的直接子节点，旧规则不会给它们盖章。

现在把 pick 写进 HTML 字符串再渲染，并列的卡片（像这三张 slide）也会打上独立 id。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

