### PR TITLE
fix: HTML 块里每一段文字都能被 Cap 选中

### DIFF
--- a/.plugin-dev/page-html-blocks/stamp-picks.ts
+++ b/.plugin-dev/page-html-blocks/stamp-picks.ts
@@ -43,12 +43,31 @@ function surfaceLabel(el: HTMLElement) {
   return (named || short || el.textContent || el.tagName.toLowerCase()).replace(/\s+/g, ' ').trim().slice(0, 80)
 }
 
+const PHRASE = new Set(['SPAN', 'STRONG', 'EM', 'B', 'I', 'SMALL', 'MARK', 'CODE', 'BR'])
+
+function ownText(el: HTMLElement) {
+  let out = ''
+  for (const node of el.childNodes) {
+    if (node.nodeType === Node.TEXT_NODE) out += node.textContent ?? ''
+  }
+  return out.replace(/\s+/g, ' ').trim()
+}
+
+function isTextRun(el: HTMLElement) {
+  if (SKIP.has(el.tagName)) return false
+  const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim()
+  if (text.length < 2) return false
+  const kids = [...el.children]
+  if (kids.length === 0) return true
+  if (kids.every((node) => PHRASE.has(node.tagName))) return true
+  return ownText(el).length >= 2
+}
+
 function isPeerChunk(el: HTMLElement) {
   const parent = el.parentElement
   if (!parent) return false
   const peers = [...parent.children].filter(
-    (node): node is HTMLElement =>
-      node instanceof HTMLElement && node.tagName !== 'SPAN' && node.childElementCount >= 1,
+    (node): node is HTMLElement => node instanceof HTMLElement && node.childElementCount >= 1,
   )
   if (peers.length < 2 || !peers.includes(el)) return false
   const lengths = peers.map((node) => (node.textContent ?? '').replace(/\s+/g, ' ').trim().length)
@@ -58,16 +77,17 @@ function isPeerChunk(el: HTMLElement) {
   return (el.textContent ?? '').replace(/\s+/g, ' ').trim().length >= 12
 }
 
-/** 整块根、语义块、带 id、并列卡片。不给每个 span/内层排版 div 盖章。 */
+/** 卡片、语义块，以及每一段可见文字（一行/一枚标签），不拆到单字。 */
 export function isHtmlPickSurface(el: Element, root: Element) {
   if (!(el instanceof HTMLElement)) return false
   if (el === root) return true
-  if (SKIP.has(el.tagName) || el.tagName === 'SPAN') return false
+  if (SKIP.has(el.tagName)) return false
   if (SURFACE.has(el.tagName)) return true
   if (el.id.trim()) return true
   const role = el.getAttribute('role')
   if (role === 'button' || role === 'link' || role === 'img') return true
   if (el.parentElement === root) return true
+  if (isTextRun(el)) return true
   return isPeerChunk(el)
 }
 

--- a/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
+++ b/packages/core-plugin-system/src/web/html-stamp-picks.test.ts
@@ -7,7 +7,7 @@ import {
   htmlBlockKey,
 } from '../../../../.plugin-dev/page-html-blocks/stamp-picks.ts'
 
-test('stamps the preview root, semantic nodes, and top-level chunks only', () => {
+test('stamps the preview root, semantic nodes, and text runs', () => {
   const root = document.createElement('div')
   root.innerHTML = `
     <div class="card">
@@ -33,12 +33,11 @@ test('stamps the preview root, semantic nodes, and top-level chunks only', () =>
   assert.ok(tags.includes('BUTTON'))
   assert.ok(tags.includes('A'))
   assert.ok(tags.includes('IMG'))
-  assert.equal(stamped.some((el) => el.className === 'chip'), false)
   const heading = root.querySelector('h2')
   assert.equal(heading?.getAttribute('data-biu-label'), '爱乐之城')
   const chip = root.querySelector('.chip')
-  assert.equal(chip?.hasAttribute('data-biu-kind'), false)
-  assert.equal(isHtmlPickSurface(chip!, root), false)
+  assert.equal(chip?.getAttribute('data-biu-kind'), 'html')
+  assert.equal(isHtmlPickSurface(chip!, root), true)
   root.remove()
 })
 
@@ -55,7 +54,7 @@ test('htmlBlockKey is stable for the same host and source', () => {
   assert.notEqual(htmlBlockKey(a, '<p>x</p>'), htmlBlockKey(a, '<p>y</p>'))
 })
 
-test('stampHtmlSource marks peer slide cards inside a flex wrap', () => {
+test('stampHtmlSource marks peer slide cards and their text lines', () => {
   const html = `<div style="display:flex;gap:12px">
     <div style="flex:1"><span>SLIDE 01 · 视听</span><div>视听盛宴</div><div>从山顶的黄昏共舞到天文馆。</div></div>
     <div style="flex:1"><span>SLIDE 02 · 弧光</span><div>梦想与现实</div><div>塞巴斯蒂安守着爵士乐。</div></div>
@@ -66,9 +65,29 @@ test('stampHtmlSource marks peer slide cards inside a flex wrap', () => {
   wrap.innerHTML = stamped
   const picks = [...wrap.querySelectorAll('[data-biu-id]')]
   assert.ok(picks.length >= 3)
-  const ids = picks.map((el) => el.getAttribute('data-biu-id') ?? '')
-  assert.ok(ids.some((id) => id.includes('1-slide')))
-  const slides = picks.filter((el) => (el.textContent ?? '').includes('视听盛宴') || (el.textContent ?? '').includes('梦想与现实') || (el.textContent ?? '').includes('结局的假如'))
-  assert.equal(slides.length >= 3, true)
-  assert.equal(wrap.querySelector('span')?.hasAttribute('data-biu-kind'), false)
+  assert.ok(picks.some((el) => el.textContent?.includes('视听盛宴') && el.childElementCount === 0))
+  assert.ok(wrap.querySelector('span')?.hasAttribute('data-biu-kind'))
+})
+
+test('stampHtmlSource marks each poster text line, not only the card', () => {
+  const html = `<div style="min-height:340px">
+    <div style="pointer-events:none"></div>
+    <div>
+      <div>✻ a romantic musical · 达米恩·查泽雷</div>
+      <div>LA LA</div>
+      <div>LAND <span>爱乐之城</span></div>
+      <div>塞巴斯蒂安 · 米娅 —— 敬那些做梦的人</div>
+      <div><span>🏆 奥斯卡最佳导演</span><span>🎵 City of Stars</span></div>
+      <div><span>致所有做梦的人 · 2026</span><span>CITY OF STARS</span></div>
+    </div>
+  </div>`
+  const stamped = stampHtmlSource(html, '0-poster')
+  const wrap = document.createElement('div')
+  wrap.innerHTML = stamped
+  const labels = [...wrap.querySelectorAll('[data-biu-id]')].map((el) => el.getAttribute('data-biu-label') ?? '')
+  assert.ok(labels.some((label) => label.includes('LA LA')))
+  assert.ok(labels.some((label) => label.includes('爱乐之城')))
+  assert.ok(labels.some((label) => label.includes('奥斯卡最佳导演')))
+  assert.ok(labels.some((label) => label.includes('CITY OF STARS')))
+  assert.equal(wrap.querySelector('[style*="pointer-events:none"]')?.hasAttribute('data-biu-kind'), false)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
海报这类 HTML 里正文是嵌套的 `div`/`span`，不是标题标签，所以之前只打了最外层卡片。现在每一段可见文字（一行标题、一句旁白、一枚标签）都会打 `data-biu-*`，空的装饰层不打。不拆到单字。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

