### PR TITLE
fix(pick): HTML 点选带上页面 path 和源码行

### DIFF
--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -2,6 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { pickSurfaceAtPoint, resolvePickFromNode, resolvePickAtPoint, resolvePicksInRect, visiblePickBox, editorBlockElFromNode } from './resolve.ts'
 import { formatPicks, parsePicks, splitPickStream, chipLabel, chipCaption, dedupePicks, textPickFromSelection } from './types.ts'
+import { bindEditorTextHost } from './editor-host.ts'
 
 test('splitPickStream keeps text and chips in order', () => {
   const parts = splitPickStream('看 <pick kind="task" id="t1" label="写需求" /> 和 <pick kind="plugin" id="p1" label="Hello" /> 吧')
@@ -514,5 +515,43 @@ test('editor paragraphs headings lists and plugin shells are pickable', () => {
   const kinds = hits.map((item) => item.ref.kind).sort()
   assert.ok(kinds.includes('block'))
   assert.ok(kinds.includes('plugin'))
+  root.remove()
+})
+
+test('html surface pick carries page path and markdown lines like a block', () => {
+  const root = document.createElement('div')
+  root.className = 'tiptap'
+  const block = document.createElement('div')
+  block.className = 'page-block'
+  block.setAttribute('data-page-block', 'html')
+  const card = document.createElement('div')
+  card.setAttribute('data-biu-kind', 'html')
+  card.setAttribute('data-biu-id', 'html:0-abcd:0/1')
+  card.setAttribute('data-biu-label', '静态富排版')
+  card.textContent = '静态富排版，不跑脚本'
+  block.append(card)
+  root.append(block)
+  document.body.append(root)
+  bindEditorTextHost(root, {
+    path: '/pages/p002',
+    locusFromSelection: () => null,
+    locusFromElement: (el) =>
+      el === block || block.contains(el)
+        ? { start_line: 14, end_line: 22, text: ':::html\n<div>静态富排版</div>\n:::' }
+        : null,
+  })
+  const hit = resolvePickFromNode(card, '/s/abc')
+  assert.ok(hit)
+  assert.equal(hit.ref.kind, 'html')
+  assert.equal(hit.ref.id, 'html:0-abcd:0/1')
+  assert.equal(hit.ref.path, '/pages/p002')
+  assert.equal(hit.ref.start_line, 14)
+  assert.equal(hit.ref.end_line, 22)
+  assert.equal(hit.ref.text, ':::html\n<div>静态富排版</div>\n:::')
+  assert.equal(hit.ref.selection, '静态富排版，不跑脚本')
+  const packed = formatPicks([hit.ref])
+  assert.match(packed, /"path":"\/pages\/p002"/)
+  assert.match(packed, /"start_line":14/)
+  bindEditorTextHost(root, null)
   root.remove()
 })

--- a/packages/core-pick/src/web/resolve.ts
+++ b/packages/core-pick/src/web/resolve.ts
@@ -73,14 +73,37 @@ export function resolvePickFromNode(
   if (!kind || !id || !highlight) return editorBlockPick(start, route, surface)
   return {
     el: highlight,
-    ref: {
-      kind,
-      id,
-      ...(action ? { action } : {}),
-      label: label || id,
-      route,
-    },
+    ref: withEditorPickContext(
+      {
+        kind,
+        id,
+        ...(action ? { action } : {}),
+        label: label || id,
+        route,
+      },
+      highlight,
+    ),
   }
+}
+
+/** 带 data-biu 的命中也挂上页面 path / markdown 行，和点选 block 一样；id 仍用节点自己的。 */
+function withEditorPickContext(ref: PickRef, el: HTMLElement): PickRef {
+  const sourced = withHostSource(ref, el)
+  const locus = editorLocusFromNode(el)
+  const next = locus ? { ...withPickLocus(sourced, locus), id: ref.id } : sourced
+  if (ref.kind !== 'html' || next.selection) return next
+  const snippet = pickPreview(el.textContent ?? '', 120)
+  return snippet ? { ...next, selection: snippet } : next
+}
+
+function editorLocusFromNode(el: HTMLElement) {
+  const host = editorHostFromNode(el)
+  if (!host) return null
+  const direct = host.locusFromElement(el)
+  if (direct) return direct
+  const block = el.closest('[data-page-block], .page-block')
+  if (block instanceof Element && block !== el) return host.locusFromElement(block)
+  return null
 }
 
 const EDITOR_ROOT = '.tiptap, [data-testid="page-editor"]'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点选 HTML 块里的 div/span 时，以前 `<pick>` 只有 `kind`/`id`/`label`，Agent 不知道这是哪一页、Markdown 第几行。

现在和点选段落/插件块一样，会带上：

- `path`：例如 `/pages/p002`
- `start_line` / `end_line`：这个 HTML 块在页面源码里的行
- `text`：对应那一段 Markdown
- `selection`：点到的那一层文字，方便区分卡片里的哪一块

内层 stamp 的 `id` 仍保留，不会被行号哈希冲掉。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

