### PR TITLE
feat(chat): Bash 折叠条显示输出字数

### DIFF
--- a/packages/core-chat/src/web/tool-card.test.ts
+++ b/packages/core-chat/src/web/tool-card.test.ts
@@ -25,4 +25,7 @@ test('tool panels match the step bar: sidebar fill, no border', () => {
   assert.match(css, /\.tool-call-chevron\.is-fail\s*\{[^}]*color:\s*#c4554d/s)
   assert.match(css, /\.tool-call-inspect\s*\{[^}]*opacity:\s*0/s)
   assert.match(css, /\.tool-call-head:hover \.tool-call-inspect/s)
+  assert.match(source, /tool-call-chars/)
+  assert.match(source, /toolOutputChars/)
+  assert.match(css, /\.tool-call-chars\s*\{[^}]*tabular-nums/s)
 })

--- a/packages/core-chat/src/web/tool-card.tsx
+++ b/packages/core-chat/src/web/tool-card.tsx
@@ -10,6 +10,7 @@ import {
   parseToolCall,
   prettyJsonString,
   shouldAutoOpenTool,
+  toolOutputChars,
   toolSummary,
   toolTitle,
   type DiffLine,
@@ -244,6 +245,11 @@ export function ToolCard({
           <span className="tool-call-title">{title}</span>
           {open ? null : <span className="tool-call-summary">{summary}</span>}
         </button>
+        {parsed.kind === 'bash' ? (
+          <span className="tool-call-chars" title="输出字数" data-testid="tool-call-chars">
+            {toolOutputChars(node.result?.detail, parsed.kind)}
+          </span>
+        ) : null}
         <button
           type="button"
           className="tool-call-inspect"

--- a/packages/core-chat/src/web/tool-format.test.ts
+++ b/packages/core-chat/src/web/tool-format.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { diffStats, formatToolDetail, lineDiff, parseToolCall, prettyJsonString, compactJsonSummary, toolSummary } from './tool-format.ts'
+import { diffStats, formatToolDetail, lineDiff, parseToolCall, prettyJsonString, compactJsonSummary, toolSummary, toolOutputChars } from './tool-format.ts'
 
 test('lineDiff marks removals and additions', () => {
   const lines = lineDiff('a\nb\nc', 'a\nx\nc')
@@ -64,6 +64,11 @@ test('formatToolDetail unwraps bash stdout/stderr json', () => {
   assert.equal(formatted.code, 0)
   assert.equal(formatted.stdout, 'hello\nworld\n')
   assert.equal(formatted.stderr, '')
+})
+
+test('toolOutputChars counts bash stdout and stderr', () => {
+  assert.equal(toolOutputChars(undefined, 'bash'), 0)
+  assert.equal(toolOutputChars(JSON.stringify({ code: 0, stdout: 'hello', stderr: 'err' }), 'bash'), 8)
 })
 
 test('formatToolDetail keeps bash artifacts for chat rendering', () => {

--- a/packages/core-chat/src/web/tool-format.ts
+++ b/packages/core-chat/src/web/tool-format.ts
@@ -150,6 +150,14 @@ export function formatToolDetail(detail: string | undefined, toolKind?: ParsedTo
   return { kind: 'text', text: detail }
 }
 
+/** Bash 回复字数：stdout+stderr；其它工具用 detail 全文。折叠时也能看它是否在涨。 */
+export function toolOutputChars(detail: string | undefined, kind?: ParsedToolCall['kind']): number {
+  if (!detail) return 0
+  const formatted = formatToolDetail(detail, kind)
+  if (formatted?.kind === 'bash') return formatted.stdout.length + formatted.stderr.length
+  return detail.length
+}
+
 export function prettyJsonString(raw: string): string {
   const parsed = parseJsonValue(raw)
   if (parsed === undefined) return raw

--- a/web/style.css
+++ b/web/style.css
@@ -4749,6 +4749,16 @@ body {
   color: var(--dsw-sidebar-fg);
 }
 
+.tool-call-chars {
+  flex-shrink: 0;
+  padding: 0 2px 0 6px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--dsw-label-3);
+  line-height: 24px;
+}
+
 .tool-call-inspect {
   display: grid;
   width: 24px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
折叠的 Bash 卡片在右侧轨迹图标左边显示 stdout+stderr 字数（等宽数字）。不用展开也能看输出有没有在涨。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

