### PR TITLE
合入剩余开放 PR：空段 &nbsp; 与正文开头回车

### DIFF
--- a/packages/core-editor/src/web/kit.ts
+++ b/packages/core-editor/src/web/kit.ts
@@ -7,6 +7,7 @@ import { BlockMath, InlineMath, Mathematics } from '@tiptap/extension-mathematic
 import Placeholder from '@tiptap/extension-placeholder'
 import { TableKit } from '@tiptap/extension-table'
 import StarterKit from '@tiptap/starter-kit'
+import { Paragraph } from '@tiptap/extension-paragraph'
 import { common, createLowlight } from 'lowlight'
 import { pageTextStyle, pageHighlight, Color } from './color-marks.ts'
 import { headingSkin } from './heading-skin.ts'
@@ -18,6 +19,27 @@ import { openMathPop } from './math-pop.ts'
 function latexFromMarkdown(raw: unknown) {
   return String(raw ?? '').trim().replace(/\\([`*_[\]~])/g, '$1')
 }
+
+function isBlankParagraph(node: { content?: unknown } | null | undefined) {
+  const content = Array.isArray(node?.content) ? node.content : []
+  if (content.length === 0) return true
+  if (content.length !== 1) return false
+  const item = content[0] as { type?: string; text?: string }
+  if (item?.type !== 'text') return false
+  const text = String(item.text ?? '')
+    .replace(/\u00a0/g, '')
+    .replace(/&nbsp;/gi, '')
+    .trim()
+  return !text
+}
+
+/** 官方空段会写成 &nbsp;，源码/正文里会直接看见这串字符。空段改成真正的空行。 */
+const pageParagraph = Paragraph.extend({
+  renderMarkdown: (node, h) => {
+    if (!node || isBlankParagraph(node)) return ''
+    return h.renderChildren(Array.isArray(node.content) ? node.content : [])
+  },
+})
 
 function mathAnchor(editor: Editor, pos: number) {
   const dom = editor.view.nodeDOM(pos)
@@ -177,7 +199,9 @@ export function pageEditorExtensions() {
     StarterKit.configure({
       heading: { levels: [1, 2, 3] },
       codeBlock: false,
+      paragraph: false,
     }),
+    pageParagraph,
     pageCodeBlock,
     Markdown,
     pageTextStyle,

--- a/packages/core-editor/src/web/markdown.test.ts
+++ b/packages/core-editor/src/web/markdown.test.ts
@@ -64,6 +64,35 @@ test('heading stays a native h1 without node-view wrappers', () => {
   editor.destroy()
 })
 
+test('empty paragraphs serialize as blank lines, not &nbsp;', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: {
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'hi' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+      ],
+    },
+  })
+  const md = editor.getMarkdown()
+  assert.doesNotMatch(md, /&nbsp;/)
+  assert.match(md, /hi/)
+  editor.destroy()
+  const loaded = new Editor({
+    extensions: pageEditorExtensions(),
+    content: 'a\n\n&nbsp;\n\n&nbsp;\n\nb',
+    contentType: 'markdown',
+  })
+  assert.doesNotMatch(loaded.getMarkdown(), /&nbsp;/)
+  assert.match(loaded.getHTML(), /<p>a<\/p>/)
+  assert.match(loaded.getHTML(), /<p>b<\/p>/)
+  loaded.destroy()
+})
+
 test('slash suggestion uses a fixed high stacking context', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')

--- a/packages/core-editor/src/web/title-content-nav.test.ts
+++ b/packages/core-editor/src/web/title-content-nav.test.ts
@@ -12,11 +12,11 @@ import {
 
 const none = { shiftKey: false }
 
-test('empty caret at doc start leaves for title on Backspace/Delete and ArrowUp', () => {
+test('empty caret at doc start leaves for title on Backspace/Delete, ArrowUp and Enter', () => {
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, true, 1), true)
   assert.equal(shouldLeaveContentForTitle('Delete', none, 1, true, 1), true)
   assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 1, true, 1), true)
-  assert.equal(shouldLeaveContentForTitle('Enter', none, 1, true, 1), false)
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 1, true, 1), true)
   assert.equal(shouldLeaveContentForTitle('Backspace', { shiftKey: true }, 1, true, 1), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 2, true, 1), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, false, 1), false)
@@ -96,13 +96,16 @@ test('Backspace in the middle of a paragraph does not jump to the title', () => 
   host.remove()
 })
 
-test('Enter at the start of TipTap stays in the document', () => {
+test('Enter at the start of TipTap focuses the title and does not insert a blank paragraph', () => {
   const { editor, host } = makeEditor('hello')
   editor.chain().focus().setTextSelection(Selection.atStart(editor.state.doc)).run()
   const title = listenTitle()
-  press(editor, 'Enter')
+  const before = editor.getMarkdown()
+  const event = press(editor, 'Enter')
   title.stop()
-  assert.equal(title.hits(), 0)
+  assert.equal(event.defaultPrevented, true)
+  assert.equal(title.hits(), 1)
+  assert.equal(editor.getMarkdown(), before)
   editor.destroy()
   host.remove()
 })

--- a/packages/core-editor/src/web/title-content-nav.ts
+++ b/packages/core-editor/src/web/title-content-nav.ts
@@ -8,7 +8,7 @@ export function isDocStartSelection(from: number, empty: boolean, docStart: numb
   return empty && from === docStart
 }
 
-/** 正文最开头空选区：上方向键或退格（Mac 上的 Delete）回到标题末尾。 */
+/** 正文最开头空选区：上方向键、回车或退格（Mac 上的 Delete）回到标题末尾。 */
 export function shouldLeaveContentForTitle(
   key: string,
   flags: { shiftKey: boolean; altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean; isComposing?: boolean },
@@ -18,7 +18,7 @@ export function shouldLeaveContentForTitle(
 ) {
   if (flags.isComposing) return false
   if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
-  if (key !== 'ArrowUp' && key !== 'Backspace' && key !== 'Delete') return false
+  if (key !== 'ArrowUp' && key !== 'Enter' && key !== 'Backspace' && key !== 'Delete') return false
   return isDocStartSelection(from, empty, docStart)
 }
 

--- a/packages/core-file-system/src/web/title-content-nav.test.ts
+++ b/packages/core-file-system/src/web/title-content-nav.test.ts
@@ -16,7 +16,7 @@ test('content start Backspace and ArrowUp leave for title', () => {
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 0, true, 0), true)
   assert.equal(shouldLeaveContentForTitle('Delete', none, 0, true, 0), true)
   assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 0, true, 0), true)
-  assert.equal(shouldLeaveContentForTitle('Enter', none, 0, true, 0), false)
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 0, true, 0), true)
   assert.equal(shouldLeaveContentForTitle('Backspace', { shiftKey: true }, 0, true, 0), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, true, 0), false)
 })

--- a/packages/core-file-system/src/web/title-content-nav.ts
+++ b/packages/core-file-system/src/web/title-content-nav.ts
@@ -21,7 +21,7 @@ export function shouldLeaveContentForTitle(
 ) {
   if (flags.isComposing) return false
   if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
-  if (key !== 'ArrowUp' && key !== 'Backspace' && key !== 'Delete') return false
+  if (key !== 'ArrowUp' && key !== 'Enter' && key !== 'Backspace' && key !== 'Delete') return false
   return isDocStartSelection(from, empty, docStart)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把尚未进 `file-system` 的开放 PR 合进来：

- #816 空段落不再写成 `&nbsp;`
- #806 正文开头回车回到标题（保留已有的退格/上方向键行为）

#787 / #788 的斜杠 plugin id 与表格拖块改动已经在主干上，无需再拣。

全屏放映底栏悬停显示（#840）此前已合入。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

