### PR TITLE
查找 HTML 块：只给整框描粉，不标内部文字

### DIFF
--- a/packages/core-editor/src/web/find-ranges.ts
+++ b/packages/core-editor/src/web/find-ranges.ts
@@ -61,7 +61,7 @@ function posFromFlat(pieces: TextPiece[], offset: number) {
   return last.pos + last.text.length
 }
 
-/** 在同一段落内跨 mark 搜可见文字；HTML / htmlframe 块搜去掉标签后的正文。 */
+/** 在同一段落内跨 mark 搜可见文字；HTML / htmlframe 块只看整块是否含关键字。 */
 export function findInPmDoc(
   doc: {
     descendants: (
@@ -86,14 +86,9 @@ export function findInPmDoc(
   doc.descendants((node, pos) => {
     const htmlText = pageBlockHtmlText(node)
     if (htmlText) {
-      const hay = htmlText.toLowerCase()
-      const size = node.nodeSize ?? 1
-      let from = 0
-      while (from <= hay.length - q.length) {
-        const at = hay.indexOf(q, from)
-        if (at < 0) break
+      if (htmlText.toLowerCase().includes(q)) {
+        const size = node.nodeSize ?? 1
         hits.push({ from: pos, to: pos + size, node: true })
-        from = at + Math.max(q.length, 1)
       }
       return false
     }

--- a/packages/core-editor/src/web/find.test.ts
+++ b/packages/core-editor/src/web/find.test.ts
@@ -51,10 +51,10 @@ test('htmlVisibleText keeps inner copy', () => {
   assert.equal(htmlVisibleText('<script>x()</script><p>海报</p>'), '海报')
 })
 
-test('findInPmDoc matches text inside html pageBlocks', () => {
+test('findInPmDoc highlights an html pageBlock once, not each inner match', () => {
   const editor = new Editor({
     extensions: pageEditorExtensions(),
-    content: `正文\n\n:::pageBlock {kind=html plugin=page-html-blocks}\n{"html":"<div>爱乐之城海报</div>"}\n:::\n`,
+    content: `正文\n\n:::pageBlock {kind=html plugin=page-html-blocks}\n{"html":"<div>爱乐之城海报 爱乐之城</div>"}\n:::\n`,
     contentType: 'markdown',
   })
   const hits = findInPmDoc(editor.state.doc, '爱乐之城')
@@ -117,8 +117,10 @@ test('find bar pins to the inspector chrome, not the scrolling body', () => {
   assert.doesNotMatch(PAGE_EDITOR_STYLE, /\.page-find\{[^}]*position:sticky/)
 })
 
-test('find hits use rose tag text and wash', () => {
+test('find hits use rose tag text and wash; html blocks only get a pink frame', () => {
   assert.match(PAGE_EDITOR_STYLE, new RegExp(`\\.page-find-hit\\{[^}]*color:${TAG_TONE_ROSE}`))
   assert.match(PAGE_EDITOR_STYLE, /color-mix\(in srgb,#e255a1 22%,transparent\)/)
+  assert.match(PAGE_EDITOR_STYLE, /\.page-find-hit:not\(\.page-block\)/)
+  assert.match(PAGE_EDITOR_STYLE, /\.page-block\.page-find-hit\{[^}]*background:transparent/)
   assert.match(PAGE_EDITOR_STYLE, /\.page-block\.page-find-hit/)
 })

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -85,8 +85,8 @@ export const PAGE_EDITOR_STYLE = `
 .page-find-btn:hover{background:var(--dsw-hover)}
 .page-find-hit{color:${TAG_TONE_ROSE};background:color-mix(in srgb,${TAG_TONE_ROSE} 22%,transparent);border-radius:2px}
 .page-find-hit.is-current{background:color-mix(in srgb,${TAG_TONE_ROSE} 34%,transparent)}
-.page-editor .page-find-hit,.page-editor .page-find-hit *{color:${TAG_TONE_ROSE}}
-.page-editor .page-block.page-find-hit{box-shadow:0 0 0 2px color-mix(in srgb,${TAG_TONE_ROSE} 55%,transparent)}
+.page-editor .page-find-hit:not(.page-block),.page-editor .page-find-hit:not(.page-block) *{color:${TAG_TONE_ROSE}}
+.page-editor .page-block.page-find-hit{color:inherit;background:transparent;box-shadow:0 0 0 2px color-mix(in srgb,${TAG_TONE_ROSE} 55%,transparent)}
 .page-editor .page-block.page-find-hit.is-current{box-shadow:0 0 0 2px ${TAG_TONE_ROSE}}
 .page-bubble{display:flex;flex-wrap:wrap;align-items:center;gap:2px;padding:4px;max-width:min(420px,calc(100vw - 48px))}
 .page-bubble button{display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;margin:0;border:0;border-radius:6px;padding:0 7px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:700;cursor:pointer}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cmd/F 搜到 HTML / iframe 块时，不再给块内文字上粉。只要块里含关键字，整张卡片描一圈粉框，同一块只算一次命中。普通段落仍按字高亮。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

