### PR TITLE
正文开头回车不再跳到标题

### DIFF
--- a/packages/core-editor/src/web/title-content-nav.test.ts
+++ b/packages/core-editor/src/web/title-content-nav.test.ts
@@ -12,11 +12,11 @@ import {
 
 const none = { shiftKey: false }
 
-test('empty caret at doc start leaves for title on Backspace/Delete, ArrowUp and Enter', () => {
+test('empty caret at doc start leaves for title on Backspace/Delete and ArrowUp', () => {
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, true, 1), true)
   assert.equal(shouldLeaveContentForTitle('Delete', none, 1, true, 1), true)
   assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 1, true, 1), true)
-  assert.equal(shouldLeaveContentForTitle('Enter', none, 1, true, 1), true)
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 1, true, 1), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', { shiftKey: true }, 1, true, 1), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 2, true, 1), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, false, 1), false)
@@ -96,16 +96,11 @@ test('Backspace in the middle of a paragraph does not jump to the title', () => 
   host.remove()
 })
 
-test('Enter at the start of TipTap focuses the title and does not insert a blank paragraph', () => {
+test('Enter at the start of TipTap stays in the document', () => {
   const { editor, host } = makeEditor('hello')
   editor.chain().focus().setTextSelection(Selection.atStart(editor.state.doc)).run()
-  const title = listenTitle()
-  const before = editor.getMarkdown()
-  const event = press(editor, 'Enter')
-  title.stop()
-  assert.equal(event.defaultPrevented, true)
-  assert.equal(title.hits(), 1)
-  assert.equal(editor.getMarkdown(), before)
+  const event = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+  assert.equal(handleContentTitleNav(editor.view, event), false)
   editor.destroy()
   host.remove()
 })

--- a/packages/core-editor/src/web/title-content-nav.ts
+++ b/packages/core-editor/src/web/title-content-nav.ts
@@ -8,7 +8,7 @@ export function isDocStartSelection(from: number, empty: boolean, docStart: numb
   return empty && from === docStart
 }
 
-/** 正文最开头空选区：上方向键、回车或退格（Mac 上的 Delete）回到标题末尾。 */
+/** 正文最开头空选区：上方向键或退格（Mac 上的 Delete）回到标题末尾。回车只换行，不跳标题。 */
 export function shouldLeaveContentForTitle(
   key: string,
   flags: { shiftKey: boolean; altKey?: boolean; metaKey?: boolean; ctrlKey?: boolean; isComposing?: boolean },
@@ -18,7 +18,7 @@ export function shouldLeaveContentForTitle(
 ) {
   if (flags.isComposing) return false
   if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
-  if (key !== 'ArrowUp' && key !== 'Enter' && key !== 'Backspace' && key !== 'Delete') return false
+  if (key !== 'ArrowUp' && key !== 'Backspace' && key !== 'Delete') return false
   return isDocStartSelection(from, empty, docStart)
 }
 

--- a/packages/core-file-system/src/web/title-content-nav.test.ts
+++ b/packages/core-file-system/src/web/title-content-nav.test.ts
@@ -16,7 +16,7 @@ test('content start Backspace and ArrowUp leave for title', () => {
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 0, true, 0), true)
   assert.equal(shouldLeaveContentForTitle('Delete', none, 0, true, 0), true)
   assert.equal(shouldLeaveContentForTitle('ArrowUp', none, 0, true, 0), true)
-  assert.equal(shouldLeaveContentForTitle('Enter', none, 0, true, 0), true)
+  assert.equal(shouldLeaveContentForTitle('Enter', none, 0, true, 0), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', { shiftKey: true }, 0, true, 0), false)
   assert.equal(shouldLeaveContentForTitle('Backspace', none, 1, true, 0), false)
 })

--- a/packages/core-file-system/src/web/title-content-nav.ts
+++ b/packages/core-file-system/src/web/title-content-nav.ts
@@ -21,7 +21,7 @@ export function shouldLeaveContentForTitle(
 ) {
   if (flags.isComposing) return false
   if (flags.shiftKey || flags.altKey || flags.metaKey || flags.ctrlKey) return false
-  if (key !== 'ArrowUp' && key !== 'Enter' && key !== 'Backspace' && key !== 'Delete') return false
+  if (key !== 'ArrowUp' && key !== 'Backspace' && key !== 'Delete') return false
   return isDocStartSelection(from, empty, docStart)
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
正文首行最开头按回车不再跳到标题，只正常换行。回到标题只保留退格、Delete 和上方向键。标题里按回车进正文的行为不变。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

