### PR TITLE
动态界面上下文注入 Prompt，Pick 带标题

### DIFF
--- a/packages/core-chat/src/host/index.ts
+++ b/packages/core-chat/src/host/index.ts
@@ -10,7 +10,7 @@ import type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, Thinki
 export type { ChatProvider, LlmModelDef, LlmEndpointDef, ReasoningEffort, ThinkingMode, ContextWindow, SpeedMode, ModelCapabilities } from './model-catalog.ts'
 export { LLM_ENDPOINT_PRESETS, LLM_MODEL_CATALOG } from './model-catalog.ts'
 import { currentSessionId } from '@biu/host-sessions/scope'
-import { isSessionCompactPoint, type SessionConfig, type SessionEvent } from '@biu/type-session'
+import { isSessionCompactPoint, sanitizeLiveUiContext, type SessionConfig, type SessionEvent } from '@biu/type-session'
 import { DEFAULT_TAIL_TURNS, sliceBeforeTurns, sliceTailTurns } from '@biu/host-sessions/window'
 import {
   DEFAULT_TRAJECTORY_TURNS,
@@ -1355,6 +1355,7 @@ export function apply(ctx: Context) {
       wait?: boolean
       extraTools?: string[]
       images?: Array<{ name?: string; mime?: string; url?: string }>
+      liveContext?: unknown
     }
     const agent = await ctx.agents.create(route.params.id)
     // re-sync in-memory LLM without rewriting disk
@@ -1371,11 +1372,13 @@ export function apply(ctx: Context) {
           }))
           .filter((img) => img.name && img.mime && img.url)
       : []
+    const liveContext = sanitizeLiveUiContext(payload.liveContext)
     const sendOpts = {
       ...(extraTools.length ? { extraTools } : {}),
       // 默认不等待整回合：聊天要靠 WS 推 chunk。显式 wait:true 才阻塞 HTTP。
       wait: payload.wait === true,
       ...(images.length ? { images } : {}),
+      ...(liveContext ? { liveContext } : {}),
     }
     if (payload.kind === 'inject') {
       agent.inject(payload.text ?? '', sendOpts)

--- a/packages/core-editor/src/web/editor-ask.test.ts
+++ b/packages/core-editor/src/web/editor-ask.test.ts
@@ -19,6 +19,9 @@ test('pickFromLocus keeps path and markdown lines', () => {
   assert.equal(ref?.end_line, 4)
   assert.equal(ref?.text, 'hello block')
   assert.equal(pickFromLocus('/pages/p1', { start_line: 1, end_line: 1, text: '   ' }), null)
+  const named = pickFromLocus('/pages/p002', { start_line: 1, end_line: 1, text: '海报', selection: '海报' }, '/pages/p002', '爱乐之城')
+  assert.equal(named?.title, '爱乐之城')
+  assert.equal(named?.path, '/pages/p002')
 })
 
 test('pickFromEditor uses the current selection', () => {

--- a/packages/core-editor/src/web/editor-ask.ts
+++ b/packages/core-editor/src/web/editor-ask.ts
@@ -27,7 +27,12 @@ export function isSendChatHotkey(event: {
   return chord(event, 'l')
 }
 
-export function pickFromLocus(path: string | undefined, locus: MarkdownLocus | null, route = typeof window === 'undefined' ? '' : window.location.pathname): PickRef | null {
+export function pickFromLocus(
+  path: string | undefined,
+  locus: MarkdownLocus | null,
+  route = typeof window === 'undefined' ? '' : window.location.pathname,
+  title?: string,
+): PickRef | null {
   if (!locus) return null
   const hasSel = Boolean(locus.selection?.trim())
   const hasInsert = locus.insert != null
@@ -41,12 +46,13 @@ export function pickFromLocus(path: string | undefined, locus: MarkdownLocus | n
       label,
       route,
       ...(path ? { path } : {}),
+      ...(title?.trim() ? { title: title.trim() } : {}),
     },
     locus,
   )
 }
 
-export function pickFromEditor(editor: Editor, path: string | undefined): PickRef | null {
+export function pickFromEditor(editor: Editor, path: string | undefined, title?: string): PickRef | null {
   if (editor.isDestroyed) return null
-  return pickFromLocus(path, markdownLocusFromSelection(editor))
+  return pickFromLocus(path, markdownLocusFromSelection(editor), undefined, title)
 }

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -55,6 +55,26 @@ function asMarkdown(value: unknown) {
   return String(value)
 }
 
+function recordTitle(record: { title?: unknown; name?: unknown; id?: unknown }) {
+  return String(record.title ?? record.name ?? '').trim()
+}
+
+function stampLiveEditor(
+  root: HTMLElement | null,
+  next: { path?: string; title?: string; line?: number; insert?: number },
+) {
+  if (!root) return
+  if (next.path) root.dataset.livePath = next.path
+  else delete root.dataset.livePath
+  if (next.title) root.dataset.liveTitle = next.title
+  else delete root.dataset.liveTitle
+  if (next.line != null) root.dataset.liveLine = String(next.line)
+  else delete root.dataset.liveLine
+  if (next.insert != null) root.dataset.liveInsert = String(next.insert)
+  else delete root.dataset.liveInsert
+  root.dataset.liveAt = String(Date.now())
+}
+
 function holdSelection(event: MouseEvent) {
   event.preventDefault()
 }
@@ -280,6 +300,8 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
   const editorRef = useRef<Editor | null>(null)
   const pathRef = useRef(path)
   pathRef.current = path
+  const titleRef = useRef(recordTitle(record))
+  titleRef.current = recordTitle(record)
   const [findOpen, setFindOpen] = useState(false)
   const [findQuery, setFindQuery] = useState('')
   const [findIndex, setFindIndex] = useState(0)
@@ -311,7 +333,7 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
           if (isSendChatHotkey(event)) {
             event.preventDefault()
             const current = editorRef.current
-            const ref = current ? pickFromEditor(current, pathRef.current) : null
+            const ref = current ? pickFromEditor(current, pathRef.current, titleRef.current) : null
             if (ref) getPick()?.attach([ref])
             return true
           }
@@ -324,6 +346,18 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
             return false
           },
         },
+      },
+      onSelectionUpdate: ({ editor: current }) => {
+        const host = current.view.dom.closest('.page-editor')
+        if (host instanceof HTMLElement) {
+          const locus = markdownLocusFromSelection(current)
+          stampLiveEditor(host, {
+            path: pathRef.current,
+            title: titleRef.current,
+            line: locus?.start_line,
+            insert: locus?.insert,
+          })
+        }
       },
       onUpdate: ({ editor: current }) => {
         if (hydratedId.current !== record.id) return
@@ -413,11 +447,12 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
     const el = editor.view.dom
     bindEditorTextHost(el, {
       path: path || undefined,
+      title: recordTitle(record) || undefined,
       locusFromSelection: () => markdownLocusFromSelection(editor),
       locusFromElement: (node) => markdownLocusFromElement(editor, node),
     })
     return () => bindEditorTextHost(el, null)
-  }, [editor, source, path])
+  }, [editor, source, path, record])
 
   useEffect(() => {
     if (!editor || editor.isDestroyed || !source) return
@@ -502,9 +537,9 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
   }, [findOpen, findQuery, source, editor])
 
   const currentPick = () => {
-    if (source) return pickFromLocus(path, sourceFind.current?.getLocus() ?? null)
+    if (source) return pickFromLocus(path, sourceFind.current?.getLocus() ?? null, undefined, recordTitle(record))
     if (!editor || editor.isDestroyed) return null
-    return pickFromEditor(editor, path)
+    return pickFromEditor(editor, path, recordTitle(record))
   }
 
   const sendToChat = () => {

--- a/packages/core-pick/src/host/index.test.ts
+++ b/packages/core-pick/src/host/index.test.ts
@@ -17,4 +17,5 @@ test('registers pick instructions on the system prompt', async () => {
   assert.match(text, /db_content/)
   assert.match(text, /selection/)
   assert.match(text, /insert/)
+  assert.match(text, /title/)
 })

--- a/packages/core-pick/src/host/index.ts
+++ b/packages/core-pick/src/host/index.ts
@@ -6,6 +6,6 @@ export const inject = ['systemPrompt']
 export function apply(ctx: Context) {
   ctx.systemPrompt.register(
     'pick',
-    '若用户消息含一条或多条 <pick>{"kind","id",...}</pick> JSON 句柄（旧的 <pick kind id ... /> 属性写法仍有效），必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区 kind=text 带 path（db_content 记录路径）、start_line/end_line（数字，定位行）、text（对应源码整行）。有高亮时带 selection；无选区时带 insert（该行 markdown 源码里的 0-based 插入点，插在 text 的第 insert 个字符之前，不是可视编辑器列）。改正文用 db_content 的 path，不要读工作区文件。',
+    '若用户消息含一条或多条 <pick>{"kind","id",...}</pick> JSON 句柄（旧的 <pick kind id ... /> 属性写法仍有效），必须针对这些 kind/id（及可选 action）操作，不要另找对象。这是界面选取的数据句柄，不是 UI 截图。kind 常见：session、task、plugin、page、collection、view、record、message、reply、tool、step、event（轨迹行 seq）、turn、usage。编辑器选区 kind=text 带 path（db_content 记录路径）、title（页面/记录标题）、start_line/end_line（数字，定位行）、text（对应源码整行）。有高亮时带 selection；无选区时带 insert（该行 markdown 源码里的 0-based 插入点，插在 text 的第 insert 个字符之前，不是可视编辑器列）。改正文用 db_content 的 path，不要读工作区文件。标题 title 用来理解「这是哪一页」，不要只盯着 path。',
   )
 }

--- a/packages/core-pick/src/web/editor-host.test.ts
+++ b/packages/core-pick/src/web/editor-host.test.ts
@@ -10,6 +10,7 @@ test('text pick from a bound editor includes markdown source lines', () => {
   document.body.append(root)
   bindEditorTextHost(root, {
     path: '/pages/home',
+    title: '主页',
     locusFromSelection: () => ({ start_line: 5, end_line: 5, text: 'UNIQUESEL', selection: '第一段' }),
     locusFromElement: () => null,
   })
@@ -26,6 +27,7 @@ test('text pick from a bound editor includes markdown source lines', () => {
   assert.equal(ref.text, 'UNIQUESEL')
   assert.equal(ref.selection, '第一段')
   assert.equal(ref.path, '/pages/home')
+  assert.equal(ref.title, '主页')
   bindEditorTextHost(root, null)
   root.remove()
 })

--- a/packages/core-pick/src/web/editor-host.ts
+++ b/packages/core-pick/src/web/editor-host.ts
@@ -3,6 +3,8 @@ export type EditorTextLocus = { start_line: number; end_line: number; text: stri
 export type EditorTextHost = {
   /** db_content 路径，如 /pages/p002 */
   path?: string
+  /** 记录标题，如「爱乐之城」 */
+  title?: string
   locusFromSelection: () => EditorTextLocus | null
   locusFromElement: (el: Element) => EditorTextLocus | null
 }

--- a/packages/core-pick/src/web/resolve.test.ts
+++ b/packages/core-pick/src/web/resolve.test.ts
@@ -69,6 +69,27 @@ test('formatPicks emits JSON handles only', () => {
   assert.doesNotMatch(text, /class=|svg|html/i)
 })
 
+test('formatPicks keeps page title for the agent', () => {
+  const text = formatPicks([
+    {
+      kind: 'text',
+      id: 't1',
+      label: '海报',
+      title: '爱乐之城',
+      route: '/database/pages/record/p002',
+      path: '/pages/p002',
+      start_line: 1,
+      end_line: 1,
+      text: '海报',
+      selection: '海报',
+    },
+  ])
+  const parsed = parsePicks(text)
+  assert.equal(parsed.refs[0]?.title, '爱乐之城')
+  assert.equal(parsed.refs[0]?.path, '/pages/p002')
+  assert.equal(chipLabel(parsed.refs[0]!), '爱乐之城 (1)')
+})
+
 test('chip caption keeps line span off the truncated preview', () => {
   const raw =
     '<pick>{"kind":"text","id":"4b33982e","route":"/s/b3b1d688-1e8b-45b1-ac56-b8747a14e842","path":"/pages/p004","start_line":1,"end_line":12,"text":"的的的\\n\\n我爱你\\n完成滕王阁序  \\n我爱你，谢谢  \\n我爱你  \\n我爱你 forever  \\n你好吗？？？  \\n我喜欢呢？？？  \\n非常好  \\n你好  \\n继续加","selection":"的的的\\n我爱你\\n完成滕王阁序我爱你，谢谢我爱你我爱你 forever你好吗？？？我喜欢呢？？？非常好你好继续加"}</pick>'

--- a/packages/core-pick/src/web/resolve.ts
+++ b/packages/core-pick/src/web/resolve.ts
@@ -79,6 +79,7 @@ export function resolvePickFromNode(
         id,
         ...(action ? { action } : {}),
         label: label || id,
+        title: label || id,
         route,
       },
       highlight,

--- a/packages/core-pick/src/web/types.ts
+++ b/packages/core-pick/src/web/types.ts
@@ -6,6 +6,8 @@ export type PickRef = {
   action?: string
   label: string
   route: string
+  /** 页面 / 记录 / Tab 标题，给 agent 认对象。 */
+  title?: string
   /** db_content 路径，如 /pages/p002。 */
   path?: string
   /** Markdown 源码行号（1-based），不是可视编辑器行。 */
@@ -41,6 +43,7 @@ export function dedupePicks(refs: PickRef[]): PickRef[] {
       kind: ref.kind,
       id: ref.id,
       label: ref.label || prev.label,
+      title: ref.title || prev.title,
       route: ref.route || prev.route,
       ...(ref.action || prev.action ? { action: ref.action || prev.action } : {}),
       ...locusFields(ref.start_line != null ? ref : prev),
@@ -60,6 +63,7 @@ function pickPayload(ref: PickRef) {
   const data: Record<string, unknown> = { kind: ref.kind, id: ref.id }
   if (ref.action) data.action = ref.action
   if (ref.route) data.route = ref.route
+  if (ref.title) data.title = ref.title
   if (ref.kind !== 'text' && ref.label) data.label = ref.label
   if (ref.path) data.path = ref.path
   if (ref.start_line != null) data.start_line = ref.start_line
@@ -107,6 +111,7 @@ function parsePickAttrs(raw: string): PickRef | null {
     ...(attrs.action?.trim() ? { action: attrs.action.trim() } : {}),
     label: attrs.label?.trim() || (kind === 'text' ? selection || text : '') || (Number.isInteger(Number(attrs.start_line)) ? `L${attrs.start_line}` : '') || id,
     route: attrs.route?.trim() || '',
+    ...(attrs.title?.trim() ? { title: attrs.title.trim() } : {}),
     ...sourceFields({ path: attrs.path?.trim() }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
@@ -118,10 +123,12 @@ function parsePickAttrs(raw: string): PickRef | null {
   }
 }
 
-function sourceFields(ref: { path?: string }) {
+function sourceFields(ref: { path?: string; title?: string }) {
   const path = ref.path?.trim()
+  const title = ref.title?.trim()
   return {
     ...(path ? { path } : {}),
+    ...(title ? { title } : {}),
   }
 }
 
@@ -194,6 +201,7 @@ export function lineSpanLabel(ref: PickRef) {
 }
 
 function pickChipName(ref: PickRef) {
+  if (ref.title?.trim()) return ref.title.trim()
   const file = ref.path?.split('/').filter(Boolean).pop() ?? ''
   if (file.includes('.')) return file
   if (ref.kind === 'text') {
@@ -241,7 +249,7 @@ export function withHostSource(ref: PickRef, node: Node | null): PickRef {
   const host = editorHostFromNode(node)
   return {
     ...ref,
-    ...sourceFields({ path: host?.path || ref.path }),
+    ...sourceFields({ path: host?.path || ref.path, title: host?.title || ref.title }),
   }
 }
 
@@ -271,6 +279,7 @@ export function pickChipAttrs(ref: PickRef) {
     route: ref.route,
     action: ref.action ?? null,
     path: ref.path ?? null,
+    title: ref.title ?? null,
     start_line: ref.start_line ?? null,
     end_line: ref.end_line ?? null,
     text: ref.text ?? null,
@@ -296,7 +305,7 @@ export function pickRefFromAttrs(attrs: Record<string, unknown>): PickRef | null
     label: String(attrs.label ?? '').trim() || (kind === 'text' ? selection || text : '') || id,
     route: String(attrs.route ?? ''),
     ...(action ? { action } : {}),
-    ...sourceFields({ path }),
+    ...sourceFields({ path, title: String(attrs.title ?? '').trim() }),
     ...locusFields({
       start_line: Number.isInteger(start) && start >= 1 ? start : undefined,
       end_line: Number.isInteger(end) && end >= 1 ? end : undefined,

--- a/packages/host-agent-loop/src/host/index.ts
+++ b/packages/host-agent-loop/src/host/index.ts
@@ -85,7 +85,8 @@ export class AgentLoop implements AgentRunner {
     }
 
     // 分段 prompt 只在 turn 开头写入一次，避免每 step 污染权威日志；derive 取最后一条 system/prompt。
-    await session.append(this.sessionId, { type: 'system/prompt', text: this.ctx.systemPrompt.assemble() })
+    const live = [...claimed].reverse().find((item) => item.liveContext)?.liveContext
+    await session.append(this.sessionId, { type: 'system/prompt', text: this.ctx.systemPrompt.assemble(live) })
 
     const steps: AgentTurn['steps'] = []
     let final = '（空回复）'

--- a/packages/host-agents/src/host/index.ts
+++ b/packages/host-agents/src/host/index.ts
@@ -1,7 +1,7 @@
 import { Service, type Context } from 'cordis'
 import type { LlmConfig } from '@biu/host-llm'
 import type { AgentTurn, ClaimedInput } from '@biu/type-agent-loop'
-import type { MessageSender } from '@biu/type-session'
+import type { MessageSender, LiveUiContext } from '@biu/type-session'
 
 export type { AgentTurn, LlmConfig }
 
@@ -12,6 +12,7 @@ export interface AgentSendOptions {
   /** 消息来源：Live 派工时传入 { type: 'session', sessionId } */
   sender?: MessageSender
   images?: Array<{ name: string; mime: string; url: string }>
+  liveContext?: LiveUiContext
 }
 
 export interface AgentHandle {
@@ -148,6 +149,7 @@ export class AgentsService extends Service {
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
           ...(images ? { images } : {}),
+          ...(opts?.liveContext ? { liveContext: opts.liveContext } : {}),
         }
 
         // Cursor 同款：忙碌且已有 wake 排队时，再发送 → inject（并入该 wake 的下一回合）
@@ -178,6 +180,7 @@ export class AgentsService extends Service {
           ...(extraTools.length ? { extraTools } : {}),
           ...(opts?.sender ? { sender: opts.sender } : {}),
           ...(images ? { images } : {}),
+          ...(opts?.liveContext ? { liveContext: opts.liveContext } : {}),
         })
         this.emitInbox(id)
       },

--- a/packages/host-system-prompt/package.json
+++ b/packages/host-system-prompt/package.json
@@ -7,6 +7,9 @@
   "exports": {
     ".": "./src/host/index.ts"
   },
+  "dependencies": {
+    "@biu/type-session": "0.1.0"
+  },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8"
   }

--- a/packages/host-system-prompt/src/host/index.test.ts
+++ b/packages/host-system-prompt/src/host/index.test.ts
@@ -14,3 +14,19 @@ test('system prompt sections assemble in id order', async () => {
   assert.match(text, /头部[\s\S]*尾部/)
   assert.match(text, /可用工具/)
 })
+
+test('assemble appends live ui context', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  await ctx.plugin(systemPrompt)
+  const text = ctx.systemPrompt.assemble({
+    sessionId: 's1',
+    sessionTitle: '配图',
+    route: '/database/pages/record/p002',
+    focusTitle: '爱乐之城',
+    focusPath: '/pages/p002',
+  })
+  assert.match(text, /当前界面/)
+  assert.match(text, /主会话：配图 id=s1/)
+  assert.match(text, /爱乐之城 \/pages\/p002/)
+})

--- a/packages/host-system-prompt/src/host/index.ts
+++ b/packages/host-system-prompt/src/host/index.ts
@@ -1,4 +1,5 @@
 import { Service, type Context } from 'cordis'
+import { formatLiveUiContext, type LiveUiContext } from '@biu/type-session'
 
 export class SystemPromptService extends Service {
   private sections = new Map<string, () => string>()
@@ -14,13 +15,15 @@ export class SystemPromptService extends Service {
     }, `systemPrompt.register ${id}`)
   }
 
-  assemble() {
+  assemble(live?: LiveUiContext) {
     const parts = [...this.sections.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([, source]) => source().trim())
       .filter(Boolean)
     const tools = this.ctx.tools?.names() ?? []
     parts.push(`可用工具会随插件装卸变化：${tools.join(', ') || '（无）'}。没有的工具不要调用。`)
+    const ui = formatLiveUiContext(live)
+    if (ui) parts.push(ui)
     return parts.join('\n')
   }
 }

--- a/packages/type-agent-loop/package.json
+++ b/packages/type-agent-loop/package.json
@@ -7,6 +7,9 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "dependencies": {
+    "@biu/type-session": "0.1.0"
+  },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8"
   }

--- a/packages/type-agent-loop/src/index.ts
+++ b/packages/type-agent-loop/src/index.ts
@@ -1,4 +1,4 @@
-import type { InboxKind, MessageSender } from '@biu/type-session'
+import type { InboxKind, MessageSender, LiveUiContext } from '@biu/type-session'
 
 export interface AgentTurn {
   text: string
@@ -12,6 +12,8 @@ export interface ClaimedInput {
   extraTools?: string[]
   sender?: MessageSender
   images?: Array<{ name: string; mime: string; url: string }>
+  /** 发送时的界面快照，写入本回合 system/prompt。 */
+  liveContext?: LiveUiContext
 }
 
 export interface PreStepReq {

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -1,6 +1,7 @@
 import { nameFromSessionMascot } from './session-mascot-name.ts'
 export { nameFromSessionMascot, MASCOT_COLOR_NAME, MASCOT_EYE_NAME, MASCOT_SHAPE_NAME } from './session-mascot-name.ts'
 export { isSessionCompactPoint, sessionCompactSummaryText } from './compact-point.ts'
+export { formatLiveUiContext, sanitizeLiveUiContext, type LiveUiContext } from './live-ui-context.ts'
 export const SESSION_FORMAT_VERSION = 1
 
 export type InboxKind = 'wake' | 'inject'

--- a/packages/type-session/src/live-ui-context.test.ts
+++ b/packages/type-session/src/live-ui-context.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { formatLiveUiContext, sanitizeLiveUiContext } from './live-ui-context.ts'
+
+test('sanitizeLiveUiContext drops empty and clips', () => {
+  assert.equal(sanitizeLiveUiContext(null), undefined)
+  assert.equal(sanitizeLiveUiContext({}), undefined)
+  const live = sanitizeLiveUiContext({
+    sessionId: ' s1 ',
+    sessionTitle: '爱乐之城',
+    route: '/database/pages/record/p002',
+    inspectorTab: 'database:/pages',
+    inspectorTabLabel: '页面',
+    focusPath: '/pages/p002',
+    focusTitle: '爱乐之城',
+    caretLine: 12,
+    caretInsert: 4,
+    junk: true,
+  })
+  assert.deepEqual(live, {
+    sessionId: 's1',
+    sessionTitle: '爱乐之城',
+    route: '/database/pages/record/p002',
+    inspectorTab: 'database:/pages',
+    inspectorTabLabel: '页面',
+    focusPath: '/pages/p002',
+    focusTitle: '爱乐之城',
+    caretLine: 12,
+    caretInsert: 4,
+  })
+})
+
+test('formatLiveUiContext is a short labeled block', () => {
+  const text = formatLiveUiContext({
+    sessionId: 's1',
+    sessionTitle: '配图',
+    route: '/database/pages/record/p002',
+    inspectorTabLabel: '页面',
+    inspectorTab: 'database:/pages',
+    focusPath: '/pages/p002',
+    focusTitle: '爱乐之城',
+    caretLine: 3,
+    caretInsert: 0,
+  })
+  assert.match(text, /当前界面/)
+  assert.match(text, /主会话：配图 id=s1/)
+  assert.match(text, /路由：\/database\/pages\/record\/p002/)
+  assert.match(text, /右侧栏：页面 \(database:\/pages\)/)
+  assert.match(text, /焦点记录：爱乐之城 \/pages\/p002/)
+  assert.match(text, /光标：第 3 行，插入点 0/)
+  assert.equal(formatLiveUiContext({}), '')
+})

--- a/packages/type-session/src/live-ui-context.ts
+++ b/packages/type-session/src/live-ui-context.ts
@@ -1,0 +1,73 @@
+/** 发送回合时的界面快照。进本回合 system/prompt，不写进用户原文。 */
+export type LiveUiContext = {
+  sessionId?: string
+  sessionTitle?: string
+  route?: string
+  inspectorTab?: string
+  inspectorTabLabel?: string
+  focusPath?: string
+  focusTitle?: string
+  caretLine?: number
+  caretInsert?: number
+}
+
+function clip(value: unknown, max: number) {
+  const text = String(value ?? '').trim()
+  if (!text) return undefined
+  return text.length > max ? text.slice(0, max) : text
+}
+
+export function sanitizeLiveUiContext(raw: unknown): LiveUiContext | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const src = raw as Record<string, unknown>
+  const next: LiveUiContext = {}
+  const sessionId = clip(src.sessionId, 80)
+  const sessionTitle = clip(src.sessionTitle, 80)
+  const route = clip(src.route, 240)
+  const inspectorTab = clip(src.inspectorTab, 160)
+  const inspectorTabLabel = clip(src.inspectorTabLabel, 80)
+  const focusPath = clip(src.focusPath, 240)
+  const focusTitle = clip(src.focusTitle, 80)
+  const caretLine = Number(src.caretLine)
+  const caretInsert = Number(src.caretInsert)
+  if (sessionId) next.sessionId = sessionId
+  if (sessionTitle) next.sessionTitle = sessionTitle
+  if (route) next.route = route
+  if (inspectorTab) next.inspectorTab = inspectorTab
+  if (inspectorTabLabel) next.inspectorTabLabel = inspectorTabLabel
+  if (focusPath) next.focusPath = focusPath
+  if (focusTitle) next.focusTitle = focusTitle
+  if (Number.isInteger(caretLine) && caretLine >= 1) next.caretLine = caretLine
+  if (Number.isInteger(caretInsert) && caretInsert >= 0) next.caretInsert = caretInsert
+  return Object.keys(next).length ? next : undefined
+}
+
+/** 给模型看的短动态上下文。空则返回空串。 */
+export function formatLiveUiContext(ctx: LiveUiContext | undefined): string {
+  const live = sanitizeLiveUiContext(ctx)
+  if (!live) return ''
+  const lines: string[] = [
+    '当前界面（发送时的动态画面，不是用户点名的对象。点名对象在 <pick> 里。）',
+  ]
+  if (live.sessionId || live.sessionTitle) {
+    const name = live.sessionTitle || '（未命名）'
+    const id = live.sessionId ? ` id=${live.sessionId}` : ''
+    lines.push(`- 主会话：${name}${id}`)
+  }
+  if (live.route) lines.push(`- 路由：${live.route}`)
+  if (live.inspectorTabLabel || live.inspectorTab) {
+    const tab = live.inspectorTabLabel || live.inspectorTab
+    const id = live.inspectorTab && live.inspectorTabLabel ? ` (${live.inspectorTab})` : ''
+    lines.push(`- 右侧栏：${tab}${id}`)
+  }
+  if (live.focusTitle || live.focusPath) {
+    const title = live.focusTitle || '（无标题）'
+    const path = live.focusPath ? ` ${live.focusPath}` : ''
+    lines.push(`- 焦点记录：${title}${path}`)
+  }
+  if (live.caretLine != null) {
+    const insert = live.caretInsert != null ? `，插入点 ${live.caretInsert}` : ''
+    lines.push(`- 光标：第 ${live.caretLine} 行${insert}`)
+  }
+  return lines.length > 1 ? lines.join('\n') : ''
+}

--- a/packages/web-session-view/src/web/index.ts
+++ b/packages/web-session-view/src/web/index.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from 'react'
 import { Service, type Context } from 'cordis'
 import { mergeInspectorBind, type SessionInspectorBind } from '@biu/type-session'
+import { captureLiveUiContext } from './live-ui-context.ts'
 import {
   compactSessionEvents,
   mergeDispatchedUsageIntoNodes,
@@ -1364,6 +1365,7 @@ export class SessionViewService extends Service {
     if (!content && !pics.length) return
     const sessionId = await this.ensureSession()
     const tools = [...new Set(extraTools.map((name) => name.trim()).filter(Boolean))]
+    const liveContext = captureLiveUiContext(this)
     const busy = this.value.pending || this.value.agentStatus === 'running'
     const hasWake = this.value.inbox.some((item) => item.kind === 'wake')
     // 忙碌且已有 wake：再发 → inject；否则 wake。
@@ -1374,11 +1376,12 @@ export class SessionViewService extends Service {
     const imagePayload = pics.length ? { images: pics } : {}
     const body: Record<string, unknown> =
       effectiveKind === 'inject'
-        ? { text: content || '（图片）', kind: 'inject', ...(tools.length ? { extraTools: tools } : {}), ...imagePayload }
+        ? { text: content || '（图片）', kind: 'inject', ...(tools.length ? { extraTools: tools } : {}), ...(liveContext ? { liveContext } : {}), ...imagePayload }
         : {
             text: content || '（图片）',
             wait: false,
             ...(tools.length ? { extraTools: tools } : {}),
+            ...(liveContext ? { liveContext } : {}),
             ...imagePayload,
           }
 

--- a/packages/web-session-view/src/web/live-ui-context.test.ts
+++ b/packages/web-session-view/src/web/live-ui-context.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { captureLiveUiContext } from './live-ui-context.ts'
+
+test('captureLiveUiContext snapshots the main session', () => {
+  const live = captureLiveUiContext({
+    get: () => ({
+      sessionId: 's1',
+      sessions: [{ id: 's1', title: '配图讨论' }],
+      sessionInspector: { tab: 'database:/pages' },
+    }),
+  })
+  assert.equal(live?.sessionId, 's1')
+  assert.equal(live?.sessionTitle, '配图讨论')
+  assert.equal(live?.inspectorTab, 'database:/pages')
+})

--- a/packages/web-session-view/src/web/live-ui-context.ts
+++ b/packages/web-session-view/src/web/live-ui-context.ts
@@ -1,0 +1,74 @@
+import { sanitizeLiveUiContext, type LiveUiContext } from '@biu/type-session'
+import { decodeCollectionSeg, normalizePath } from './session-route.ts'
+
+type LiveView = {
+  get(): {
+    sessionId: string | null
+    sessions: Array<{ id: string; title: string }>
+    sessionInspector?: { tab?: string }
+  }
+}
+
+const DATABASE_RECORD = /^\/database\/([^/]+)(?:\/view\/[^/]+)?\/record\/([^/]+)\/?$/
+
+export function captureLiveUiContext(view: LiveView): LiveUiContext | undefined {
+  const state = view.get()
+  const sessionId = state.sessionId?.trim() || undefined
+  const sessionTitle = state.sessions.find((item) => item.id === sessionId)?.title?.trim() || undefined
+  const route = typeof location === 'undefined' ? undefined : normalizePath(location.pathname)
+  const inspectorTab = state.sessionInspector?.tab?.trim() || undefined
+  const inspectorTabLabel = inspectorTabLabelFromDom(inspectorTab)
+  const fromRoute = focusFromRoute(route)
+  const fromDom = focusFromDom()
+  const live = sanitizeLiveUiContext({
+    sessionId,
+    sessionTitle,
+    route,
+    inspectorTab,
+    inspectorTabLabel,
+    focusPath: fromDom.path || fromRoute.path,
+    focusTitle: fromDom.title || fromRoute.title,
+    caretLine: fromDom.caretLine,
+    caretInsert: fromDom.caretInsert,
+  })
+  return live
+}
+
+function inspectorTabLabelFromDom(tabId?: string) {
+  if (typeof document === 'undefined') return undefined
+  const selected = document.querySelector('.session-inspector [role="tab"][aria-selected="true"]')
+  const label = selected?.textContent?.replace(/\s+/g, ' ').trim()
+  if (label) return label
+  if (!tabId) return undefined
+  const slot = tabId.startsWith('database:') ? tabId.slice('database:'.length) : tabId
+  const leaf = slot.split('/').filter(Boolean).pop()
+  return leaf || undefined
+}
+
+function focusFromRoute(pathname?: string) {
+  if (!pathname) return {}
+  const match = pathname.match(DATABASE_RECORD)
+  if (!match?.[1] || !match[2]) return {}
+  const collection = decodeCollectionSeg(match[1])
+  const recordId = decodeURIComponent(match[2])
+  const path = `${collection.replace(/\/$/, '')}/${recordId}`.replace(/\/{2,}/g, '/')
+  return { path, title: undefined as string | undefined }
+}
+
+function focusFromDom() {
+  if (typeof document === 'undefined') return {}
+  const editors = [...document.querySelectorAll<HTMLElement>('.page-editor[data-live-path], .page-editor[data-live-title]')]
+  const stamped = editors.sort((a, b) => Number(b.dataset.liveAt ?? 0) - Number(a.dataset.liveAt ?? 0))[0]
+  const titleInput = document.querySelector<HTMLTextAreaElement | HTMLInputElement>('.fsdb-detail-title-input')
+  const titleHead = document.querySelector('.fsdb-detail-title')
+  const title = titleInput?.value.trim() || titleHead?.textContent?.trim() || stamped?.dataset.liveTitle
+  const path = stamped?.dataset.livePath
+  const caretLine = Number(stamped?.dataset.liveLine)
+  const caretInsert = Number(stamped?.dataset.liveInsert)
+  return {
+    path,
+    title,
+    caretLine: Number.isInteger(caretLine) && caretLine >= 1 ? caretLine : undefined,
+    caretInsert: Number.isInteger(caretInsert) && caretInsert >= 0 ? caretInsert : undefined,
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
每回合把发送时的画面写进 system prompt（主会话 id/名称、当前路由、右侧栏 Tab、焦点记录标题、光标行），不混进用户原文。Pick 增加 title，芯片和句柄都带页面名，避免只看见 /pages/p002。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

