### PR TITLE
新建页面在右侧检查器新开，不覆盖视图页

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1608,11 +1608,7 @@ export function CollectionBrowser({
       quietUntil.current = 0
       await reload()
       const id = data.items?.[0]?.value?.id
-      if (id) {
-        setOpenDetailId(id)
-        if (data.items?.[0]?.value) setDetailRow(data.items[0]!.value)
-        onOpenRecord?.(id, activeViewId, dataPath)
-      }
+      if (id) showRecordInInspector(collectionPath, id)
     } catch (err) {
       setError(String(err))
     }

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -98,6 +98,15 @@ test('showRecordInInspector focuses an already-open pane for the same page', () 
   assert.equal(getInspectorDbPath('database:/pages'), '')
 })
 
+test('showRecordInInspector opens a new pane when the collection view is already open', () => {
+  setInspectorDbPath('database:/pages', '/database/pages')
+  showRecordInInspector('/pages', 'p-new')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages')
+  const extra = Object.keys(snapshotInspectorDbPaths()).filter((id) => id.startsWith('database:/pages::'))
+  assert.equal(extra.length, 1)
+  assert.equal(getInspectorDbPath(extra[0]!), '/database/pages/record/p-new')
+})
+
 test('showRecordInInspector opens the inspector on this record', async () => {
   const tabs: string[] = []
   const onTab = (event: Event) => {

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -342,6 +342,13 @@ test('deletable tables can pick rows and bulk-act over the table header', () => 
   assert.doesNotMatch(browser, /skipBoolean/)
 })
 
+test('creating a record opens a new inspector pane instead of covering the view', () => {
+  const createFn = browser.slice(browser.indexOf('async function createRecord'), browser.indexOf('async function executeDeleteRecord'))
+  assert.match(createFn, /showRecordInInspector\(collectionPath, id\)/)
+  assert.doesNotMatch(createFn, /setOpenDetailId/)
+  assert.doesNotMatch(createFn, /onOpenRecord/)
+})
+
 test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(browser, /aria-label="排序"[\s\S]*aria-label="筛选"[\s\S]*aria-label="分组"/)
   assert.match(browser, /className="fsdb-create-btn"/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
点「新建」或面包屑新建记录后，不再把中间视图页切成这条新记录的详情。

列表/视图留在原地；新记录用 `showRecordInInspector` 在右侧检查器打开。若该表的视图已经在检查器里，会再开一个 pane，而不是盖掉原来的视图栏。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

