### PR TITLE
没有下一页时下一页置灰

### DIFF
--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -288,7 +288,7 @@ function HtmlDeckOverlay({
             pointerEvents: navHot ? 'auto' : 'none',
           }}
         >
-          <button type="button" style={barBtn} disabled={index <= 0} onClick={() => onIndex(stepHtmlDeck(index, -1, total))} aria-label="上一张">
+          <button type="button" style={{ ...barBtn, ...(index <= 0 ? { opacity: 0.35, cursor: 'default' } : {}) }} disabled={index <= 0} onClick={() => onIndex(stepHtmlDeck(index, -1, total))} aria-label="上一张">
             上一张
           </button>
           <span data-testid="html-deck-index" style={{ color: '#8b93a7', minWidth: 64, textAlign: 'center' }}>
@@ -296,7 +296,7 @@ function HtmlDeckOverlay({
           </span>
           <button
             type="button"
-            style={barBtn}
+            style={{ ...barBtn, ...(index >= total - 1 ? { opacity: 0.35, cursor: 'default' } : {}) }}
             disabled={index >= total - 1}
             onClick={() => onIndex(stepHtmlDeck(index, 1, total))}
             aria-label="下一张"

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -3182,7 +3182,7 @@ export function CollectionBrowser({
                 type="button"
                 className="tasks-icon-btn"
                 aria-label="下一页"
-                disabled={(page + 1) * pageSize >= total}
+                disabled={total <= 0 || (page + 1) * pageSize >= total || (items.length > 0 && items.length < pageSize)}
                 onClick={() => setPage((prev) => prev + 1)}
               >
                 <ChevronRightIcon aria-hidden className="size-[14px]" />

--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -263,7 +263,7 @@ const CSS = `
 .fsdb-page .tasks-row-actions{display:inline-flex;align-items:center;gap:2px;flex:none}
 .fsdb-page .tasks-icon-btn{border:0;border-radius:5px;padding:3px;background:transparent;color:var(--dsw-label-3);cursor:pointer;font:inherit;display:inline-flex;align-items:center;justify-content:center}
 .fsdb-page .tasks-row-tools .tasks-icon-btn,.fsdb-page .tasks-row-actions .tasks-icon-btn{color:#F0EFED}
-.fsdb-page .tasks-icon-btn:hover,.fsdb-page .tasks-icon-btn.is-active{background:var(--dsw-hover);color:var(--dsw-label)}
+.fsdb-page .tasks-icon-btn:hover:not(:disabled),.fsdb-page .tasks-icon-btn.is-active{background:var(--dsw-hover);color:var(--dsw-label)}
 .fsdb-page .tasks-row-tools .tasks-icon-btn:hover,.fsdb-page .tasks-row-tools .tasks-icon-btn.is-active,.fsdb-page .tasks-row-actions .tasks-icon-btn:hover,.fsdb-page .tasks-row-actions .tasks-icon-btn.is-active{color:#F0EFED}
 .fsdb-page .tasks-icon-btn.is-danger:hover{background:var(--dsw-danger-soft);color:var(--dsw-danger)}
 .fsdb-page .tasks-icon-btn:disabled{opacity:.4;cursor:default}
@@ -315,6 +315,7 @@ const CSS = `
 .fsdb-pager-size-option:hover{background:var(--dsw-hover)}
 .fsdb-pager-size-option.is-active{color:var(--dsw-business);font-weight:600}
 .fsdb-pager .tasks-icon-btn{color:var(--dsw-label-3);width:26px;height:26px}
+.fsdb-pager .tasks-icon-btn:disabled{opacity:.4;cursor:default;color:var(--dsw-label-3)}
 .fsdb-pager .fsdb-pager-size-btn{width:auto}
 .fsdb-stage{display:flex;min-width:0;min-height:0;flex:1;flex-direction:column;overflow:hidden}
 .fsdb-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));grid-auto-flow:row;grid-auto-rows:max-content;gap:10px;align-content:start;align-items:stretch;justify-items:stretch;overflow:auto;flex:1;min-width:0;min-height:0;position:relative;box-sizing:border-box;width:calc(100% + var(--fsdb-check-gutter));margin-left:calc(var(--fsdb-check-gutter) * -1);padding-left:var(--fsdb-check-gutter)}
@@ -342,6 +343,7 @@ const CSS = `
 .fsdb-detail-float-btn{display:flex;width:24px;height:24px;align-items:center;justify-content:center;margin:0;border:0;border-radius:6px;padding:0;background:transparent;color:#F0EFED;cursor:pointer}
 .fsdb-detail-float-btn svg{width:16px;height:16px}
 .fsdb-detail-float-btn:hover:not(:disabled){background:rgba(255,255,255,.08);color:#F0EFED}
+.fsdb-detail-float-btn:disabled{opacity:.35;cursor:default;color:#F0EFED}
 .fsdb-detail-more-menu{min-width:168px;padding:4px;display:flex;flex-direction:column;gap:1px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,.18)}
 .fsdb-detail-more-item{display:flex;align-items:center;gap:8px;width:100%;margin:0;border:0;border-radius:6px;padding:7px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;text-align:left;cursor:pointer}
 .fsdb-detail-more-item:hover,.fsdb-detail-more-item[aria-pressed=true]{background:var(--dsw-hover)}

--- a/packages/core-file-system/src/web/pager-size.test.ts
+++ b/packages/core-file-system/src/web/pager-size.test.ts
@@ -15,3 +15,15 @@ test('page-size menu is a local control, not CollectionBrowser state', () => {
   assert.match(pager, /HeadlessPopover/)
   assert.match(pager, /if \(next !== pageSize\) onChange\(next\)/)
 })
+
+test('pager next is disabled on the last page', () => {
+  const css = readFileSync(resolve(import.meta.dirname, './fsdb-style.ts'), 'utf8')
+  assert.match(browser, /aria-label="下一页"/)
+  assert.match(
+    browser,
+    /disabled=\{total <= 0 \|\| \(page \+ 1\) \* pageSize >= total \|\| \(items\.length > 0 && items\.length < pageSize\)\}/,
+  )
+  assert.match(css, /\.fsdb-page \.tasks-icon-btn:hover:not\(:disabled\)/)
+  assert.match(css, /\.fsdb-pager \.tasks-icon-btn:disabled\{[^}]*opacity:\.4/)
+  assert.match(css, /\.fsdb-detail-float-btn:disabled\{[^}]*opacity:\.35/)
+})

--- a/packages/core-plugin-system/src/web/html-deck.test.ts
+++ b/packages/core-plugin-system/src/web/html-deck.test.ts
@@ -64,6 +64,7 @@ test('fullscreen deck centers a slide that is smaller than the viewport', async 
   assert.match(src, /alignItems: 'safe center'/)
   assert.match(src, /justifyContent: 'safe center'/)
   assert.match(src, /data-testid="html-deck-slide"/)
+  assert.match(src, /index >= total - 1 \? \{ opacity: 0\.35/)
   assert.doesNotMatch(src, /justifyContent: 'stretch'/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
没有下一页时，「下一页」保持 disabled，并且真正置灰：不再套用 hover 高亮。末页条数不足一页时也会关掉下一页。详情上/下一条和 HTML 放映「下一张」同样在尽头变淡。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

