### PR TITLE
检查器相同数据页自动合并

### DIFF
--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -19,6 +19,8 @@ import {
   isInspectorPaneAbandoned,
   snapshotInspectorDbPaths,
   restoreInspectorDbPaths,
+  inspectorPageKey,
+  reuseInspectorOfferPane,
 } from './inspector-db-route.ts'
 
 function clearInspectorPanes() {
@@ -122,6 +124,42 @@ test('showRecordInInspector opens the inspector on this record', async () => {
   assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
   assert.deepEqual(tabs, ['database:/pages'])
   window.removeEventListener('biu:inspector-tab', onTab)
+})
+
+test('duplicate inspector panes for the same data page collapse to one', () => {
+  const closed: string[] = []
+  const onClosed = (event: Event) => {
+    const id = (event as CustomEvent).detail
+    if (typeof id === 'string') closed.push(id)
+  }
+  window.addEventListener('biu:inspector-pane-closed', onClosed)
+  setInspectorDbPath('database:/pages', '/database/pages/record/p1')
+  setInspectorDbPath('database:/pages::dup', '/database/pages/record/p1?view=all')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
+  assert.equal(getInspectorDbPath('database:/pages::dup'), '')
+  assert.deepEqual(closed, ['database:/pages::dup'])
+  assert.equal(isInspectorPaneAbandoned('database:/pages::dup'), true)
+  window.removeEventListener('biu:inspector-pane-closed', onClosed)
+})
+
+test('plus offer reuses the default collection pane instead of opening another', () => {
+  setInspectorDbPath('database:/pages', databaseAllViewPath('/pages'))
+  assert.equal(reuseInspectorOfferPane('database:/pages', ['database:/pages', 'traj']), 'database:/pages')
+  assert.equal(reuseInspectorOfferPane('database:/pages', ['database:/pages::x']), 'database:/pages::x')
+  setInspectorDbPath('database:/pages', '/database/pages/record/p1')
+  assert.equal(reuseInspectorOfferPane('database:/pages', ['database:/pages']), undefined)
+})
+
+test('showInInspector does not copy the same href onto every collection pane', () => {
+  setInspectorDbPath('database:/notes', '/database/notes/record/n1')
+  setInspectorDbPath('database:/notes::b', '/database/notes/record/n2')
+  showInInspector('/notes', '/database/notes/record/n3')
+  assert.equal(getInspectorDbPath('database:/notes'), '/database/notes/record/n3')
+  assert.equal(getInspectorDbPath('database:/notes::b'), '/database/notes/record/n2')
+})
+
+test('inspectorPageKey ignores view query', () => {
+  assert.equal(inspectorPageKey('/database/pages/record/p1?view=all'), '/database/pages/record/p1')
 })
 
 test('unique inspector reveal focuses the same page and opens a new pane for a different page', () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -143,10 +143,14 @@ export function setInspectorDbPath(paneId: string, next?: string) {
   const path = next === undefined ? paneId : next
   const stored = isInspectorDatabasePath(path) ? path : ''
   if (stored) abandonedPanes.delete(id)
-  if ((paths.get(id) ?? '') === stored) return
+  if ((paths.get(id) ?? '') === stored) {
+    if (stored) mergeDuplicateInspectorPanes(id)
+    return
+  }
   if (!stored) paths.delete(id)
   else paths.set(id, stored)
   bump()
+  if (stored) mergeDuplicateInspectorPanes(id)
 }
 
 function listStoredPaneIds() {
@@ -178,6 +182,7 @@ export function restoreInspectorDbPaths(next?: Record<string, string>) {
   abandonedPanes.clear()
   for (const [paneId, path] of Object.entries(incoming)) paths.set(paneId, path)
   bump()
+  mergeDuplicateInspectorPanes()
 }
 
 /** 关掉检查器里这一栏时清掉路径，避免左侧再点同一页又把右侧弹回来。 */
@@ -195,13 +200,79 @@ export function inspectorCollectionTabId(collection: string) {
   return `database:${collection}`
 }
 
-function hrefPathKey(href: string) {
+/** 同一数据页：路径不含 query。 */
+export function inspectorPageKey(href: string) {
   return String(href || '').split('?')[0]
 }
 
 function paneWithHref(tabId: string, href: string) {
-  const key = hrefPathKey(href)
-  return paneIdsForTab(tabId).find((id) => hrefPathKey(getInspectorDbPath(id)) === key)
+  const key = inspectorPageKey(href)
+  if (!key) return undefined
+  return paneIdsForTab(tabId).find((id) => inspectorPageKey(getInspectorDbPath(id)) === key)
+}
+
+function paneWithPageKey(href: string) {
+  const key = inspectorPageKey(href)
+  if (!key) return undefined
+  for (const id of listStoredPaneIds()) {
+    if (inspectorPageKey(panePath(id)) === key) return id
+  }
+  return undefined
+}
+
+function pickCanonicalPane(ids: string[], prefer?: string) {
+  const base = ids.find((id) => !id.includes('::'))
+  if (base) return base
+  if (prefer && ids.includes(prefer)) return prefer
+  return ids.slice().sort()[0]!
+}
+
+function emitInspectorPanesClosed(ids: string[]) {
+  for (const id of ids) {
+    window.dispatchEvent(new CustomEvent('biu:inspector-pane-closed', { detail: id }))
+  }
+}
+
+/** 同一数据页只留一栏；关掉重复实例。 */
+export function mergeDuplicateInspectorPanes(prefer?: string) {
+  const groups = new Map<string, string[]>()
+  for (const paneId of listStoredPaneIds()) {
+    const key = inspectorPageKey(panePath(paneId))
+    if (!key) continue
+    const list = groups.get(key) ?? []
+    list.push(paneId)
+    groups.set(key, list)
+  }
+  const closed: string[] = []
+  for (const ids of groups.values()) {
+    if (ids.length < 2) continue
+    const keep = pickCanonicalPane(ids, prefer)
+    for (const id of ids) {
+      if (id === keep) continue
+      paths.delete(id)
+      abandonedPanes.add(id)
+      closed.push(id)
+    }
+  }
+  if (closed.length) {
+    bump()
+    emitInspectorPanesClosed(closed)
+  }
+  return closed
+}
+
+/** 加号再开同一张表的默认视图时，复用已有栏。 */
+export function reuseInspectorOfferPane(tabId: string, opened: string[]) {
+  const collection = tabId.startsWith('database:') ? tabId.slice('database:'.length) : ''
+  const defaultKey = collection ? inspectorPageKey(databaseAllViewPath(collection)) : ''
+  for (const id of opened) {
+    if (slotTabId(id) !== tabId) continue
+    const path = getInspectorDbPath(id)
+    if (!path) return id
+    const key = inspectorPageKey(path)
+    if (defaultKey && key === defaultKey) return id
+  }
+  return undefined
 }
 
 function revealInspectorPane(paneId: string, href: string) {
@@ -222,25 +293,23 @@ export function focusInspectorIfOpen(collection: string, href: string) {
   return true
 }
 
-/** 右侧检查器打开这条路径，中间主界面不动。默认同表实例一起改路径；unique 时同页只聚焦、不同页新开。 */
+/** 右侧检查器打开这条路径，中间主界面不动。同一数据页只聚焦；unique 时不同页才新开。 */
 export function showInInspector(collection: string, href: string, opts?: { unique?: boolean }) {
   const tabId = inspectorCollectionTabId(collection)
   const unique = opts?.unique === true
+  const same = paneWithHref(tabId, href) ?? paneWithPageKey(href)
+  if (same) {
+    revealInspectorPane(same, href)
+    return
+  }
   const paneIds = paneIdsForTab(tabId)
   if (unique) {
-    const same = paneWithHref(tabId, href)
-    if (same) {
-      revealInspectorPane(same, href)
-      return
-    }
     const live = paneIds.filter((id) => getInspectorDbPath(id))
     const target = live.length ? nextInspectorPaneId(tabId) : tabId
     revealInspectorPane(target, href)
     return
   }
-  for (const paneId of paneIds) setInspectorDbPath(paneId, href)
-  window.dispatchEvent(new Event('biu:inspector-open'))
-  window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: tabId }))
+  revealInspectorPane(tabId, href)
 }
 
 /** 右侧检查器打开这条记录。同一页已在检查器里则只聚焦。 */

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -32,8 +32,8 @@ test('inspector header keeps opened tabs on top and a plus menu on the right', (
 test('plus menu can add another database tab', () => {
   assert.match(inspector, /repeatable/)
   assert.match(inspector, /nextRepeatableTabId/)
+  assert.match(inspector, /reuseInspectorOfferPane/)
   assert.match(inspector, /slotTabId/)
-  assert.match(inspector, /paneId=\{item.id\}/)
   assert.match(inspector, /inspector-stage-pane/)
   assert.match(inspector, /headerTabs.map\(\(item\) => \{/)
   assert.doesNotMatch(inspector, /displayTabs.find\(\(item\) => item.id === tab\)/)

--- a/packages/web-app-shell/src/web/inspector-catalog.test.ts
+++ b/packages/web-app-shell/src/web/inspector-catalog.test.ts
@@ -34,6 +34,7 @@ test('plus menu can add another database tab', () => {
   assert.match(inspector, /nextRepeatableTabId/)
   assert.match(inspector, /reuseInspectorOfferPane/)
   assert.match(inspector, /slotTabId/)
+  assert.match(inspector, /paneId=\{item.id\}/)
   assert.match(inspector, /inspector-stage-pane/)
   assert.match(inspector, /headerTabs.map\(\(item\) => \{/)
   assert.doesNotMatch(inspector, /displayTabs.find\(\(item\) => item.id === tab\)/)

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -30,6 +30,7 @@ import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import {
   restoreInspectorDbPaths,
+  reuseInspectorOfferPane,
   snapshotInspectorDbPaths,
   subscribeInspectorDbPath,
 } from '@biu/core-file-system/inspector-db-route'
@@ -271,6 +272,18 @@ export const SessionInspector = memo(function SessionInspector({
   }, [allowedTabs.join('|'), opened, persistOpened, setTab])
 
   useEffect(() => {
+    const onClosed = (event: Event) => {
+      const id = (event as CustomEvent).detail
+      if (typeof id !== 'string' || !openedRef.current.includes(id)) return
+      const next = openedRef.current.filter((item) => item !== id)
+      persistOpened(next)
+      if (tabRef.current === id) setTab(next.at(-1) ?? '')
+    }
+    window.addEventListener('biu:inspector-pane-closed', onClosed)
+    return () => window.removeEventListener('biu:inspector-pane-closed', onClosed)
+  }, [persistOpened, setTab])
+
+  useEffect(() => {
     if (!open) return
     const current = extraTabs.find((item) => item.id === tab)
     if (current?.ensureTrajectory) void sessionView.ensureTrajectory()
@@ -331,6 +344,12 @@ export const SessionInspector = memo(function SessionInspector({
       return
     }
     if (item.repeatable) {
+      const existing = reuseInspectorOfferPane(item.id, opened)
+      if (existing) {
+        persistOpened(opened.includes(existing) ? opened : [...opened, existing])
+        setTab(existing)
+        return
+      }
       const instanceId = nextRepeatableTabId(item.id)
       persistOpened([...opened, instanceId])
       setTab(instanceId)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
右侧检查器不再叠两份一模一样的数据页。

- 同一记录 / 同一路径（忽略 query）已打开时只聚焦
- 已经重复的栏会自动并成一栏（留下不带 `::` 的那栏）
- 加号再点同一张表的默认视图会复用现有栏，而不是再开一份

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

