### PR TITLE
源码选区改成 TipTap 同款蓝

### DIFF
--- a/packages/core-editor/src/web/source-editor.test.tsx
+++ b/packages/core-editor/src/web/source-editor.test.tsx
@@ -15,8 +15,8 @@ test('source editor uses CodeMirror markdown highlighting and line numbers', () 
   assert.match(src, /page-source-editor/)
   assert.match(src, /getLocus/)
   assert.match(src, /isAtStart/)
-  assert.match(src, /cm-selectionLayer \.cm-selectionBackground[\s\S]*background: 'Highlight'/)
-  assert.doesNotMatch(src, /cm-selectionBackground[\s\S]*dsw-business/)
+  assert.match(src, /cm-selectionLayer \.cm-selectionBackground[\s\S]*dsw-pick/)
+  assert.doesNotMatch(src, /background: 'Highlight'/)
 })
 
 test('source editor mounts a CodeMirror view for markdown', async () => {

--- a/packages/core-editor/src/web/source-editor.tsx
+++ b/packages/core-editor/src/web/source-editor.tsx
@@ -70,10 +70,10 @@ const theme = EditorView.theme({
   '.cm-activeLine': { background: 'color-mix(in srgb, var(--dsw-hover) 70%, transparent)' },
   '.cm-activeLineGutter': { background: 'transparent', color: '#F0EFED' },
   '.cm-cursor': { borderLeftColor: 'var(--dsw-label)' },
-  /* TipTap 用浏览器原生 ::selection（深色下是蓝）。不要用 --dsw-business，那是浅字色，混出来会过亮。 */
-  '.cm-content ::selection': { background: 'Highlight' },
+  /* 与正文 TipTap / --dsw-pick 同一蓝。系统 Highlight 在深色页会发白。 */
+  '.cm-content ::selection': { background: 'color-mix(in srgb, var(--dsw-pick) 40%, transparent)', color: 'inherit' },
   '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionLayer .cm-selectionBackground': {
-    background: 'Highlight',
+    background: 'color-mix(in srgb, var(--dsw-pick) 40%, transparent)',
   },
 })
 

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -6,7 +6,7 @@ export const PAGE_EDITOR_STYLE = `
 .page-source{min-width:0;width:100%}
 .page-source .cm-editor{background:transparent}
 .page-source .cm-focused{outline:none}
-.page-source .cm-editor.cm-focused>.cm-scroller>.cm-selectionLayer .cm-selectionBackground,.page-source .cm-selectionLayer .cm-selectionBackground{background:Highlight}
+.page-source .cm-editor.cm-focused>.cm-scroller>.cm-selectionLayer .cm-selectionBackground,.page-source .cm-selectionLayer .cm-selectionBackground{background:color-mix(in srgb,var(--dsw-pick) 40%,transparent)}
 .page-editor .tiptap{outline:none;min-height:240px}
 .page-block-handle{position:absolute;z-index:6;width:28px;display:flex;flex-direction:column;align-items:center;pointer-events:auto}
 .page-block-handle-grip{flex:none;display:flex;align-items:center;justify-content:center;width:22px;height:26px;margin:0;border:0;border-radius:6px;padding:0;background:transparent;color:#EFEEEC;cursor:grab}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
源码模式用 CodeMirror 的选区层，之前写成系统色 `Highlight`，深色页面上会发白。

改成 `color-mix(--dsw-pick 40%)`，和正文 TipTap / 产品选中蓝 `#5b9fd6` 一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

