### PR TITLE
详情背景随 websocket 刷新，不进列表

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -831,6 +831,7 @@ export function CollectionBrowser({
   const detailIdRef = useRef<string | null>(null)
   detailIdRef.current = detailId
   const contentGen = useRef(0)
+  const recordGen = useRef(0)
   const pullDetailBody = useCallback(() => {
     const id = detailIdRef.current
     if (!id) {
@@ -847,6 +848,21 @@ export function CollectionBrowser({
         if (gen !== contentGen.current) return
         setDetailBody(null)
       })
+  }, [dataPath])
+  const pullDetailRecord = useCallback(() => {
+    const id = detailIdRef.current
+    if (!id) return
+    const gen = ++recordGen.current
+    void readJson<{ value?: DbRecord }>(`/api/db/read?path=${encodeURIComponent(`${dataPath}/${id}`)}`)
+      .then((data) => {
+        const row = data.value
+        if (gen !== recordGen.current || !row?.id) return
+        setDetailRow((prev) => {
+          if (prev?.id && prev.id !== row.id) return prev
+          return { ...prev, ...row, banner: row.banner ?? null }
+        })
+      })
+      .catch(() => undefined)
   }, [dataPath])
   const steppingView = useRef(false)
 
@@ -928,7 +944,10 @@ export function CollectionBrowser({
         const viewsTouched = pendingViews
         pendingViews = false
         void reloadRef.current()
-        if (detailIdRef.current) pullDetailBody()
+        if (detailIdRef.current) {
+          pullDetailBody()
+          pullDetailRecord()
+        }
         if (viewsTouched) void syncViewsRef.current()
       }, 120)
     }
@@ -944,7 +963,7 @@ export function CollectionBrowser({
       window.clearInterval(timer)
       window.removeEventListener('fsdb:change', onChange)
     }
-  }, [collectionPath, dataPath, nested, pullDetailBody])
+  }, [collectionPath, dataPath, nested, pullDetailBody, pullDetailRecord])
 
   useEffect(() => {
     void pullFacets()

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -577,7 +577,10 @@ test('list polling pauses while a record is open', () => {
 })
 
 test('open detail still reloads body when the collection changes', () => {
-  assert.match(browser, /if \(detailIdRef\.current\) pullDetailBody/)
+  assert.match(browser, /if \(detailIdRef\.current\) \{/)
+  assert.match(browser, /pullDetailBody\(\)/)
+  assert.match(browser, /pullDetailRecord\(\)/)
+  assert.match(browser, /banner: row\.banner \?\? null/)
   assert.match(browser, /window.dispatchEvent\(new Event\('fsdb:change'\)\)/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Agent 改 banner 时本来就会走和 `db_content` 同一条 websocket（`database/change` → `fsdb:change`）。缺的是详情侧：正文会 `pullDetailBody`，背景没有再读这一条记录。

打开的页面详情现在会顺带 `db_read` 这一行，只更新封面，列表仍然不带 banner。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

