### PR TITLE
fix(ui): 偏色字再亮一档

### DIFF
--- a/packages/core-file-system/src/web/fsdb-style.ts
+++ b/packages/core-file-system/src/web/fsdb-style.ts
@@ -227,7 +227,7 @@ const CSS = `
 .fsdb-page .tasks-table tbody tr:hover{position:relative;z-index:6}
 .fsdb-page .tasks-table [data-dock-tip]::after{z-index:80}
 .fsdb-page .tasks-table th{padding:6px 6px;color:var(--dsw-label-2);font-size:14px;font-weight:600;position:sticky;top:0;background:var(--dsw-surface);z-index:5;white-space:nowrap}
-.fsdb-page .tasks-table th.is-facet-col{color:color-mix(in srgb,var(--biu-tag) 16%,#fff);background:color-mix(in srgb,var(--biu-tag) 22%,var(--dsw-surface))}
+.fsdb-page .tasks-table th.is-facet-col{color:color-mix(in srgb,var(--biu-tag) 8%,#fff);background:color-mix(in srgb,var(--biu-tag) 22%,var(--dsw-surface))}
 .fsdb-page .tasks-table.is-cols-fixed{table-layout:fixed;width:max-content;min-width:0;max-width:none}
 .fsdb-page .tasks-table.is-cols-fixed.is-wrap{width:max-content;max-width:none;min-width:0}
 .fsdb-page .tasks-table.is-cols-fixed col,.fsdb-page .tasks-table.is-cols-fixed th,.fsdb-page .tasks-table.is-cols-fixed td{box-sizing:border-box}

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -415,7 +415,7 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(readFileSync(resolve(import.meta.dirname, './cell-pop-draft.tsx'), 'utf8'), /autoOpen/)
   assert.match(browser, /schemaTagTone\(flat\.packId\)/)
   assert.match(browser, /className=\{tone \? 'is-facet-col' : undefined\}/)
-  assert.match(css, /\.tasks-table th\.is-facet-col\{[^}]*color:color-mix\(in srgb,var\(--biu-tag\) 16%,#fff\)/)
+  assert.match(css, /\.tasks-table th\.is-facet-col\{[^}]*color:color-mix\(in srgb,var\(--biu-tag\) 8%,#fff\)/)
   assert.match(css, /\.tasks-table th\.is-facet-col\{[^}]*background:color-mix\(in srgb,var\(--biu-tag\) 22%,var\(--dsw-surface\)\)/)
   assert.match(css, /\.tasks-table\.is-wrap\{[^}]*white-space:normal/)
   assert.match(css, /\.tasks-table th,\.fsdb-page \.tasks-table\.is-wrap th\{[^}]*white-space:nowrap/)

--- a/packages/public-ui/src/tag-chip.test.ts
+++ b/packages/public-ui/src/tag-chip.test.ts
@@ -15,7 +15,7 @@ test('TagChip ships the tinted chip markup', () => {
   assert.match(src, /function TagChip/)
   assert.match(src, /className=\{\`biu-tag/)
   assert.match(src, /color-mix\(in srgb,var\(--biu-tag/)
-  assert.match(src, /16%,#fff/)
+  assert.match(src, /8%,#fff/)
   assert.match(src, /22%,transparent/)
   assert.match(src, /function tagTextColor/)
   assert.match(src, /icon\?: ReactNode/)

--- a/packages/public-ui/src/tag-chip.tsx
+++ b/packages/public-ui/src/tag-chip.tsx
@@ -4,7 +4,7 @@ const STYLE_ID = 'biu-public-ui-tag-chip'
 const CSS = `
 .biu-tag-wrap{border:0;background:transparent;padding:0;cursor:pointer;font:inherit}
 .biu-tags{display:inline-flex;flex-wrap:wrap;gap:4px;align-items:center;min-width:0;max-width:100%}
-.biu-tag{display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 6px;border-radius:4px;font-size:13px;font-weight:400;line-height:20px;background:color-mix(in srgb,var(--biu-tag,#5b9fd6) 22%,transparent);color:color-mix(in srgb,var(--biu-tag,#5b9fd6) 16%,#fff);max-width:160px}
+.biu-tag{display:inline-flex;align-items:center;gap:4px;height:20px;padding:0 6px;border-radius:4px;font-size:13px;font-weight:400;line-height:20px;background:color-mix(in srgb,var(--biu-tag,#5b9fd6) 22%,transparent);color:color-mix(in srgb,var(--biu-tag,#5b9fd6) 8%,#fff);max-width:160px}
 .biu-tag.is-btn{cursor:pointer}
 .biu-tag.is-on{background:color-mix(in srgb,var(--biu-tag,#5b9fd6) 34%,transparent)}
 .biu-tag-icon{display:inline-flex;width:12px;height:12px;flex:none;align-items:center;justify-content:center}
@@ -18,7 +18,7 @@ export const TAG_TONES = ['#5b9fd6', '#9a6dd7', '#d9730d', '#448361', '#c4554d',
 /** 字色叠在纯白上，少掺一点色相，保持偏亮的「白色偏红 / 白色偏橙」。 */
 export const TAG_INK_BASE = '#ffffff'
 
-export function tagTextColor(tone: string, strength = 16) {
+export function tagTextColor(tone: string, strength = 8) {
   return `color-mix(in srgb, ${tone} ${strength}%, ${TAG_INK_BASE})`
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
偏色字再提一档：色相从 16% 降到 8% 叠在纯白上。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

