### PR TITLE
修复内置视图误请求 /views 导致 400

### DIFF
--- a/packages/core-file-system/src/catalog-views.test.ts
+++ b/packages/core-file-system/src/catalog-views.test.ts
@@ -10,6 +10,7 @@ import {
   mergeCatalogViews,
   mergeTableViews,
   stubBuiltinAllView,
+  isBuiltinAllViewForCollection,
   stubBuiltinCatalogView,
   catalogRowOpenTarget,
   builtinTagViewId,
@@ -47,6 +48,12 @@ test('stub builtin catalog view from route id', () => {
   assert.equal(stubBuiltinCatalogView('user-1'), null)
   assert.equal(isBuiltinCatalogViewId('builtin-all:/sessions'), false)
   assert.equal(stubBuiltinCatalogView('builtin-all:/sessions'), null)
+})
+
+test('builtin all view ids belong to one collection', () => {
+  assert.equal(isBuiltinAllViewForCollection('builtin-all:/sessions', '/sessions'), true)
+  assert.equal(isBuiltinAllViewForCollection('builtin-all:/sessions', '/pages'), false)
+  assert.equal(isBuiltinAllViewForCollection('mine', '/sessions'), false)
 })
 
 test('every registered table gets a read-only 全部xx view', () => {

--- a/packages/core-file-system/src/catalog-views.ts
+++ b/packages/core-file-system/src/catalog-views.ts
@@ -40,6 +40,11 @@ export function isBuiltinAllViewId(id: string) {
   return id.startsWith(ALL_PREFIX)
 }
 
+export function isBuiltinAllViewForCollection(id: string, collectionPath: string) {
+  if (!isBuiltinAllViewId(id)) return false
+  return normalizeCollectionPath(id.slice(ALL_PREFIX.length)) === normalizeCollectionPath(collectionPath)
+}
+
 export function isReadOnlyViewId(id: string) {
   return isBuiltinAllViewId(id) || isBuiltinCatalogViewId(id) || isBuiltinTagViewId(id)
 }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -135,7 +135,7 @@ import { listCollection, readJson } from './db-client.ts'
 import { savedViewRecordPath } from '../paths.ts'
 import { findViewNeighbor, indexOnPage } from './view-adjacent.ts'
 import { rememberPreviewTotal, viewTotalKey } from './sidebar-preview.ts'
-import { mergeTableViews } from '../catalog-views.ts'
+import { isReadOnlyViewId, mergeTableViews } from '../catalog-views.ts'
 import { SAVED_VIEW_EVENT, showRecordInInspector } from './inspector-db-route.ts'
 import { SchemaChips, SchemaFieldEditor, schemaTagTone } from './schema-field.tsx'
 import { CellPop, cellUsesPop } from './cell-pop.tsx'
@@ -1239,7 +1239,7 @@ export function CollectionBrowser({
   const activeView = views.find((view) => view.id === activeViewId)
   const [viewBanner, setViewBanner] = useState<unknown>(null)
   useEffect(() => {
-    if (sheet || !activeViewId) {
+    if (sheet || !activeViewId || isReadOnlyViewId(activeViewId)) {
       setViewBanner(null)
       return
     }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -506,6 +506,7 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(style, /\.fsdb-detail-title\{[^}]*font-size:32px/)
   assert.match(browser, /<h1 className="fsdb-detail-title">\{activeView\?\.name \?\? title\}<\/h1>/)
   assert.match(browser, /savedViewRecordPath\(collectionPath, activeViewId\)/)
+  assert.match(browser, /isReadOnlyViewId\(activeViewId\)/)
   assert.match(browser, /<PageBanner/)
   assert.match(browser, /<PageBanner[\s\S]*writable=\{Boolean\(activeViewId\)\}/)
   assert.doesNotMatch(browser, /<BannerTitleActions/)

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -23,6 +23,7 @@ test('tables default to the builtin 全部xx view', () => {
   assert.equal(defaultViewId(VIEWS_COLLECTION_PATH), builtinAllViewId(VIEWS_COLLECTION_PATH))
   assert.equal(viewForPath('/sessions')?.builtin, true)
   assert.deepEqual(viewForPath('/sessions')?.filters, {})
+  assert.equal(viewForPath('/pages', builtinAllViewId('/sessions'))?.id, builtinAllViewId('/pages'))
 })
 
 test('builtin view wrap is stored as display prefs and restored', () => {

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -1,4 +1,4 @@
-import { builtinAllViewId, stubBuiltinAllView, stubBuiltinCatalogView, stubBuiltinTagView, isReadOnlyViewId } from '../catalog-views.ts'
+import { builtinAllViewId, stubBuiltinAllView, stubBuiltinCatalogView, stubBuiltinTagView, isReadOnlyViewId, isBuiltinAllViewForCollection } from '../catalog-views.ts'
 import { listCollection } from './db-client.ts'
 import { looksLikeFilterTree, normalizeFilterGroup, parseSortsInput } from '../query-logic.ts'
 import { normalizeSavedView, type SavedView } from './saved-view.ts'
@@ -79,7 +79,7 @@ export function viewForPath(collectionPath: string, routeViewId?: string): Saved
       ? listed.find((item) => item.id === routeViewId) ??
         stubBuiltinCatalogView(routeViewId) ??
         stubBuiltinTagView(routeViewId) ??
-        stubBuiltinAllView(routeViewId)
+        (isBuiltinAllViewForCollection(routeViewId, collectionPath) ? stubBuiltinAllView(routeViewId) : null)
       : undefined) ??
     listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ??
     fallback ??


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/api/db/read?path=/views/pages::builtin-all:/sessions` 会 400：把会话的「全部」视图套到页面表上，id 里的 `/` 把路径拆成三段。

- `viewForPath` 不再接受其它表的 `builtin-all:` id
- 内置视图不再去拉封面（本来也没有 `/views` 行）

`startTime` 的 TypeError 不在本仓库，堆栈是匿名 VM 脚本，多半是浏览器扩展。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

