### PR TITLE
feat(chat): 输入框 @ 引用走 mention 菜单、插入 pick 芯片

### DIFF
--- a/packages/core-chat/package.json
+++ b/packages/core-chat/package.json
@@ -9,6 +9,7 @@
     "./web": "./src/web/index.ts"
   },
   "dependencies": {
+    "@biu/core-editor": "0.1.0",
     "@biu/public-ui": "0.1.0",
     "@biu/host-plugin-loader": "0.1.0"
   },

--- a/packages/core-chat/src/web/composer-kit.ts
+++ b/packages/core-chat/src/web/composer-kit.ts
@@ -1,7 +1,8 @@
 import StarterKit from '@tiptap/starter-kit'
+import { pageMention } from '@biu/core-editor/mention'
 import { PickChipNode } from './composer-pick-node.tsx'
 
-/** 输入栏与已发送气泡共用：纯段落 + 行内 pick 芯片。 */
+/** 输入栏：纯段落 + pick 芯片 + 与正文同一套 @mention。 */
 export function composerDocExtensions() {
   return [
     StarterKit.configure({
@@ -21,5 +22,6 @@ export function composerDocExtensions() {
       underline: false,
     }),
     PickChipNode,
+    pageMention,
   ]
 }

--- a/packages/core-chat/src/web/composer-stack.test.ts
+++ b/packages/core-chat/src/web/composer-stack.test.ts
@@ -226,9 +226,12 @@ describe('composer dock stacking above sticky user', () => {
 
   it('uses Tiptap for inline pick chips in the composer', () => {
     const composer = readFileSync(resolve(root, 'packages/core-chat/src/web/composer.tsx'), 'utf8')
+    const kit = readFileSync(resolve(root, 'packages/core-chat/src/web/composer-kit.ts'), 'utf8')
     const node = readFileSync(resolve(root, 'packages/core-chat/src/web/composer-pick-node.tsx'), 'utf8')
     expect(composer).toMatch(/useEditor/)
     expect(composer).toMatch(/composerDocExtensions/)
+    expect(composer).toMatch(/page-mention/)
+    expect(kit).toMatch(/pageMention/)
     expect(composer).toMatch(/EditorContent/)
     expect(composer).toMatch(/insertPickChips/)
     expect(composer).toMatch(/takeDraft/)

--- a/packages/core-chat/src/web/composer-tiptap.ts
+++ b/packages/core-chat/src/web/composer-tiptap.ts
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/react'
+import { mentionPickFromAttrs } from '@biu/core-editor/mention'
 import { formatPick, pickChipAttrs, pickKey, pickRefFromAttrs, splitPickStream, type PickRef } from '@biu/core-pick/web'
 
 function attrsToRef(attrs: Record<string, unknown>): PickRef | null {
@@ -28,8 +29,9 @@ export function serializeComposer(editor: Editor | null): { text: string; refs: 
         plain += '\n'
         return
       }
-      if (child.type.name === 'pickChip') {
-        const ref = attrsToRef(child.attrs)
+      if (child.type.name === 'pickChip' || child.type.name === 'mention') {
+        const ref =
+          child.type.name === 'mention' ? mentionPickFromAttrs(child.attrs) : attrsToRef(child.attrs)
         if (!ref) return
         refs.push(ref)
         text += formatPick(ref)
@@ -72,8 +74,8 @@ export function collectPickKeys(editor: Editor | null) {
   const keys = new Set<string>()
   if (!editor) return keys
   editor.state.doc.descendants((node) => {
-    if (node.type.name !== 'pickChip') return
-    const ref = attrsToRef(node.attrs)
+    if (node.type.name !== 'pickChip' && node.type.name !== 'mention') return
+    const ref = node.type.name === 'mention' ? mentionPickFromAttrs(node.attrs) : attrsToRef(node.attrs)
     if (ref) keys.add(pickKey(ref))
   })
   return keys

--- a/packages/core-chat/src/web/composer.tsx
+++ b/packages/core-chat/src/web/composer.tsx
@@ -472,6 +472,18 @@ export const ChatComposer = memo(function ChatComposer(props: SlotProps) {
         return true
       },
       handleKeyDown(_view, event) {
+        const mentionOpen =
+          typeof document !== 'undefined' && document.querySelector('[data-testid="page-mention"]')
+        if (
+          mentionOpen &&
+          (event.key === 'Enter' ||
+            event.key === 'Tab' ||
+            event.key === 'ArrowUp' ||
+            event.key === 'ArrowDown' ||
+            event.key === 'Escape')
+        ) {
+          return false
+        }
         const menu = live.current.slash
         const list = live.current.filtered
         if (menu?.open && list.length) {

--- a/packages/core-editor/package.json
+++ b/packages/core-editor/package.json
@@ -6,7 +6,8 @@
   "description": "Core-Editor：记录正文 Markdown 编辑器。不落盘，由各表经 File System 持久化。",
   "exports": {
     "./host": "./src/host/index.ts",
-    "./web": "./src/web/index.ts"
+    "./web": "./src/web/index.ts",
+    "./mention": "./src/web/mention.ts"
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8",

--- a/packages/core-editor/src/web/mention.test.ts
+++ b/packages/core-editor/src/web/mention.test.ts
@@ -12,6 +12,7 @@ import {
   fetchMentionItems,
   mentionHref,
   mentionReveal,
+  mentionSuggestionContent,
   openMention,
 } from './mention.ts'
 
@@ -22,6 +23,19 @@ test('mention id encodes collection kind for jump targets', () => {
   assert.equal(mentionHref('session/abc'), '/s/abc')
   assert.deepEqual(mentionReveal('facet/f1'), { collection: '/facets', recordId: 'f1', unique: true })
   assert.equal(decodeMentionId('nope'), null)
+})
+
+test('mention suggestion inserts pickChip when the schema has it', () => {
+  const withPick = mentionSuggestionContent(
+    { nodes: { pickChip: {}, mention: {} } },
+    { id: 'page/p1', label: '首页' },
+  )
+  assert.equal(withPick[0]?.type, 'pickChip')
+  assert.equal((withPick[0] as { attrs: { kind: string; id: string; label: string } }).attrs.kind, 'page')
+  assert.equal((withPick[0] as { attrs: { kind: string; id: string; label: string } }).attrs.id, 'p1')
+  assert.equal((withPick[0] as { attrs: { kind: string; id: string; label: string } }).attrs.label, '首页')
+  const mentionOnly = mentionSuggestionContent({ nodes: { mention: {} } }, { id: 'task/t1', label: '任务甲' })
+  assert.equal(mentionOnly[0]?.type, 'mention')
 })
 
 test('fetchMentionItems lists pages tasks facets and sessions', async () => {

--- a/packages/core-editor/src/web/mention.ts
+++ b/packages/core-editor/src/web/mention.ts
@@ -3,11 +3,17 @@ import type { Editor } from '@tiptap/core'
 import Mention from '@tiptap/extension-mention'
 import { ReactNodeViewRenderer, ReactRenderer } from '@tiptap/react'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
-import { pickKindTone } from '@biu/core-pick/web'
+import { pickChipAttrs, pickKindTone } from '@biu/core-pick/web'
 import { MentionList, type MentionPick } from './mention-list.tsx'
 import { mentionIconSpec } from './mention-kind.tsx'
 import { MentionChipView } from './mention-chip.tsx'
-import { MENTION_SCOPES, decodeMentionId, encodeMentionId, openMention } from './mention-ref.ts'
+import {
+  MENTION_SCOPES,
+  decodeMentionId,
+  encodeMentionId,
+  mentionPickFromAttrs,
+  openMention,
+} from './mention-ref.ts'
 import { placeSlashInWindow } from './slash-place.ts'
 import { slashMayOpen } from './editor-live.ts'
 
@@ -18,6 +24,7 @@ export {
   encodeMentionId,
   mentionCollection,
   mentionHref,
+  mentionPickFromAttrs,
   mentionReveal,
   openMention,
 } from './mention-ref.ts'
@@ -61,6 +68,24 @@ export async function fetchMentionItems(query: string, signal?: AbortSignal): Pr
     }),
   )
   return groups.flat()
+}
+
+/** 输入框 schema 有 pickChip 时插芯片；正文编辑器插 mention 节点。 */
+export function mentionSuggestionContent(
+  schema: { nodes: Record<string, unknown> },
+  props: { id: string; label: string },
+) {
+  const space = { type: 'text', text: ' ' }
+  if (schema.nodes.pickChip) {
+    return [
+      {
+        type: 'pickChip',
+        attrs: pickChipAttrs(mentionPickFromAttrs({ id: props.id, label: props.label })),
+      },
+      space,
+    ]
+  }
+  return [{ type: 'mention', attrs: { id: props.id, label: props.label } }, space]
 }
 
 function mentionAnchor(target: EventTarget | null, root: Element) {
@@ -170,8 +195,26 @@ export const pageMention = Mention.extend({
     allow: ({ editor, state, range }) => {
       if (!slashMayOpen(editor)) return false
       const $from = state.doc.resolve(range.from)
-      const type = state.schema.nodes.mention
-      return !!type && !!$from.parent.type.contentMatch.matchType(type)
+      const parent = $from.parent.type.contentMatch
+      const mention = state.schema.nodes.mention
+      const pick = state.schema.nodes.pickChip
+      return !!(mention && parent.matchType(mention)) || !!(pick && parent.matchType(pick))
+    },
+    command: ({ editor, range, props }) => {
+      const nodeAfter = editor.state.selection.$to.nodeAfter
+      const to = nodeAfter?.text?.startsWith(' ') ? range.to + 1 : range.to
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(
+          { from: range.from, to },
+          mentionSuggestionContent(editor.schema, {
+            id: String(props.id ?? ''),
+            label: String(props.label ?? props.id ?? ''),
+          }),
+        )
+        .run()
+      window.getSelection()?.collapseToEnd()
     },
     items: async ({ query, editor, signal }) => {
       if (!slashMayOpen(editor)) return []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对话输入框 TipTap 复用正文编辑器的 `@` mention：搜索页面 / 任务 / 合集 / 会话，点选后在输入栏插入 pick 芯片（与侧栏 pick 同一套序列化），发送逻辑不用改 mention 节点。

Enter 在 mention 菜单打开时不提交，交给菜单选用。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

