### PR TITLE
fix: 块菜单动作补上前置图标

### DIFF
--- a/packages/core-editor/src/web/page-block-handle.test.ts
+++ b/packages/core-editor/src/web/page-block-handle.test.ts
@@ -151,3 +151,16 @@ test('page block handle x uses the editor rail, not the node box', async () => {
   assert.match(src, /handleRailLeft\(hostBox\.left, contentBox\.left\)/)
   assert.doesNotMatch(src, /left: box\.left - hostBox\.left - HANDLE_RAIL/)
 })
+
+test('block handle menu puts an icon before each action', async () => {
+  const { readFile } = await import('node:fs/promises')
+  const { resolve } = await import('node:path')
+  const src = await readFile(resolve(import.meta.dirname, './page-block-handle.tsx'), 'utf8')
+  const css = await readFile(resolve(import.meta.dirname, './style.ts'), 'utf8')
+  assert.match(src, /<ArrowUpIcon[\s\S]*向上插入/)
+  assert.match(src, /<ArrowDownIcon[\s\S]*向下插入/)
+  assert.match(src, /<Square2StackIcon[\s\S]*复制/)
+  assert.match(src, /<TrashIcon[\s\S]*删除/)
+  assert.match(css, /\.page-block-handle-menu button\{[^}]*display:\s*flex/)
+  assert.match(css, /\.page-block-handle-menu button\{[^}]*gap:\s*8px/)
+})

--- a/packages/core-editor/src/web/page-block-handle.tsx
+++ b/packages/core-editor/src/web/page-block-handle.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type DragEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import type { Editor } from '@tiptap/core'
+import { ArrowDownIcon, ArrowUpIcon, Square2StackIcon, TrashIcon } from '@heroicons/react/16/solid'
 import { HeadlessDismiss } from '@biu/public-ui'
 import {
   beginHandleDrag,
@@ -144,15 +145,19 @@ export function PageBlockHandle({ editor }: { editor: Editor }) {
             data-testid="page-block-handle-menu"
           >
             <button type="button" role="menuitem" onMouseDown={run(() => insertParagraphBefore(editor, target.pos))}>
+              <ArrowUpIcon aria-hidden className="size-[14px]" />
               向上插入
             </button>
             <button type="button" role="menuitem" onMouseDown={run(() => insertParagraphAfter(editor, target.pos, target.node))}>
+              <ArrowDownIcon aria-hidden className="size-[14px]" />
               向下插入
             </button>
             <button type="button" role="menuitem" onMouseDown={run(() => duplicateHandleBlock(editor, target.pos, target.node))}>
+              <Square2StackIcon aria-hidden className="size-[14px]" />
               复制
             </button>
             <button type="button" role="menuitem" onMouseDown={run(() => deleteHandleBlock(editor, target.pos, target.node))}>
+              <TrashIcon aria-hidden className="size-[14px]" />
               删除
             </button>
           </div>

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -14,7 +14,7 @@ export const PAGE_EDITOR_STYLE = `
 .page-block-handle-grip:active{cursor:grabbing}
 .page-block-handle-dots{display:block;width:10px;height:16px;background-image:radial-gradient(circle,currentColor 1.35px,transparent 1.45px);background-size:5px 5.2px;background-position:0 0}
 .page-block-handle-menu{position:absolute;left:26px;top:0;z-index:40;min-width:132px;padding:4px;display:flex;flex-direction:column;gap:1px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 28px rgba(15,15,15,.12)}
-.page-block-handle-menu button{display:block;width:100%;margin:0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;text-align:left;cursor:pointer}
+.page-block-handle-menu button{display:flex;align-items:center;gap:8px;width:100%;margin:0;border:0;border-radius:6px;padding:6px 8px;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:600;text-align:left;cursor:pointer}
 .page-block-handle-menu button:hover{background:var(--dsw-hover)}
 .page-editor .tiptap>:first-child{margin-top:0}
 .page-editor .tiptap p,.page-editor .tiptap h1,.page-editor .tiptap h2,.page-editor .tiptap h3,.page-editor .tiptap ul,.page-editor .tiptap ol,.page-editor .tiptap blockquote,.page-editor .tiptap pre{margin:2px 0}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
块左侧把手菜单里，向上插入、向下插入、复制、删除四项在文字前面加上对应图标，并排成图标+文案一行。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

