### PR TITLE
feat: 特殊块在编辑器里写入稳定 id

### DIFF
--- a/packages/core-editor/src/web/page-block-meta.test.tsx
+++ b/packages/core-editor/src/web/page-block-meta.test.tsx
@@ -8,11 +8,12 @@ test('page block fence keeps plugin id in the document', () => {
   assert.deepEqual(parsePageBlockMeta('kind=excalidraw plugin=page-excalidraw'), {
     kind: 'excalidraw',
     plugin: 'page-excalidraw',
+    id: '',
     extras: {},
   })
   assert.match(
-    formatPageBlockFence('excalidraw', 'page-excalidraw', { file: 'assets/a.json' }),
-    /:::pageBlock \{kind=excalidraw plugin=page-excalidraw\}/,
+    formatPageBlockFence('excalidraw', 'page-excalidraw', { file: 'assets/a.json' }, 'ab12cd34'),
+    /:::pageBlock \{kind=excalidraw plugin=page-excalidraw id=ab12cd34\}/,
   )
 })
 
@@ -36,6 +37,7 @@ test('html pageBlock fence stores raw html and deck on the header', () => {
   assert.deepEqual(parsePageBlockMeta('kind=html plugin=page-html-blocks deck=true'), {
     kind: 'html',
     plugin: 'page-html-blocks',
+    id: '',
     extras: { deck: true },
   })
   const src = formatPageBlockFence('html', 'page-html-blocks', {
@@ -66,10 +68,11 @@ test('html pageBlock fence stores raw html and deck on the header', () => {
   })
   assert.match(sized, /width=100%/)
   assert.match(sized, /height=100vh/)
-  assert.deepEqual(parsePageBlockMeta('kind=html plugin=page-html-blocks deck=true width=100% height=100vh').extras, {
-    deck: true,
-    width: '100%',
-    height: '100vh',
+  assert.deepEqual(parsePageBlockMeta('kind=html plugin=page-html-blocks id=ab12cd34 deck=true'), {
+    kind: 'html',
+    plugin: 'page-html-blocks',
+    id: 'ab12cd34',
+    extras: { deck: true },
   })
 })
 

--- a/packages/core-editor/src/web/page-block-meta.ts
+++ b/packages/core-editor/src/web/page-block-meta.ts
@@ -6,6 +6,7 @@ const HTML_KINDS = new Set(['html', 'htmlframe'])
 export function parsePageBlockMeta(raw: string) {
   const kind = raw.match(/\bkind=["']?([a-z0-9-]+)/i)?.[1] ?? 'card'
   const plugin = raw.match(/\bplugin=["']?([a-z][a-z0-9-]*)/i)?.[1] ?? ''
+  const id = raw.match(/\bid=["']?([a-z0-9]{6,32})/i)?.[1] ?? ''
   const extras: Record<string, unknown> = {}
   const deck = raw.match(/\bdeck=(true|false|1|0)\b/i)?.[1]
   if (deck) extras.deck = /^(true|1)$/i.test(deck)
@@ -19,7 +20,7 @@ export function parsePageBlockMeta(raw: string) {
     const parsed = parseFenceSize(height)
     if (parsed != null) extras.height = parsed
   }
-  return { kind, plugin, extras }
+  return { kind, plugin, id, extras }
 }
 
 function parseFenceSize(raw: string): string | number | undefined {
@@ -56,9 +57,10 @@ export function parsePageBlockData(kind: string, raw: string, extras: Record<str
   return { ...extras }
 }
 
-function formatMeta(kind: string, plugin: string, extras: string[]) {
+function formatMeta(kind: string, plugin: string, extras: string[], id = '') {
   const parts = [`kind=${kind}`]
   if (plugin) parts.push(`plugin=${plugin}`)
+  if (id) parts.push(`id=${id}`)
   parts.push(...extras)
   return `{${parts.join(' ')}}`
 }
@@ -73,15 +75,15 @@ function htmlFenceExtras(data: Record<string, unknown>) {
   return extras
 }
 
-export function formatPageBlockFence(kind: string, plugin: string, data: Record<string, unknown>) {
+export function formatPageBlockFence(kind: string, plugin: string, data: Record<string, unknown>, id = '') {
   const body = { ...data }
   delete body.cloneFrom
   if (HTML_KINDS.has(kind)) {
     const html = typeof body.html === 'string' ? body.html : ''
     const extras = htmlFenceExtras(body)
-    return `:::pageBlock ${formatMeta(kind, plugin, extras)}\n${html}\n:::`
+    return `:::pageBlock ${formatMeta(kind, plugin, extras, id)}\n${html}\n:::`
   }
-  const meta = formatMeta(kind, plugin, [])
+  const meta = formatMeta(kind, plugin, [], id)
   return `:::pageBlock ${meta}\n${JSON.stringify(body, null, 2)}\n:::`
 }
 

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -68,7 +68,8 @@ export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeVi
   const spec = getPageEditor()?.block(kind)
   const cloneFrom = typeof data.cloneFrom === 'string' ? data.cloneFrom : ''
   const file = typeof data.file === 'string' ? data.file : ''
-  const pickId = `${plugin || 'page-block'}:${kind}`
+  const blockId = String(node.attrs.id ?? '').trim()
+  const pickId = blockId || `${plugin || 'page-block'}:${kind}`
   const pickLabel = spec?.label || kind
   const update = (patch: Record<string, unknown>, opts?: { replace?: boolean }) => {
     updateAttributes({ data: opts?.replace ? patch : { ...data, ...patch } })
@@ -100,6 +101,7 @@ export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeVi
       className="page-block"
       data-page-block={kind}
       data-page-block-plugin={plugin}
+      data-page-block-id={blockId || undefined}
       data-page-block-capture=""
       data-biu-kind="plugin"
       data-biu-id={pickId}

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -38,17 +38,18 @@ test('registerBlock adds a slash item and inserts pageBlock', async () => {
   const block = json.content?.find((node) => node.type === 'pageBlock')
   assert.equal(block?.attrs?.kind, 'algorithm')
   assert.equal(block?.attrs?.plugin, 'page-algorithm')
+  assert.match(String(block?.attrs?.id ?? ''), /^[a-z0-9]{8}$/i)
   assert.equal((block?.attrs?.data as { title?: string })?.title, 'Two Sum')
   const md = editor.getMarkdown()
-  assert.match(md, /:::pageBlock \{kind=algorithm plugin=page-algorithm\}/)
+  assert.match(md, /:::pageBlock \{kind=algorithm plugin=page-algorithm id=[a-z0-9]+\}/)
   assert.match(md, /Two Sum/)
   editor.destroy()
   await fiber.dispose()
   assert.equal(filterSlashItems('leetcode').some((entry) => entry.id === 'algorithm'), false)
 })
 
-test('pageBlock markdown roundtrips kind, plugin and data', () => {
-  const src = `:::pageBlock {kind=algorithm plugin=page-algorithm}
+test('pageBlock markdown roundtrips kind, plugin, id and data', () => {
+  const src = `:::pageBlock {kind=algorithm plugin=page-algorithm id=ab12cd34}
 {"title":"Two Sum","lang":"python"}
 :::
 `
@@ -61,9 +62,10 @@ test('pageBlock markdown roundtrips kind, plugin and data', () => {
   const block = json.content?.find((node) => node.type === 'pageBlock')
   assert.equal(block?.attrs?.kind, 'algorithm')
   assert.equal(block?.attrs?.plugin, 'page-algorithm')
+  assert.equal(block?.attrs?.id, 'ab12cd34')
   assert.equal((block?.attrs?.data as { title?: string })?.title, 'Two Sum')
   const out = editor.getMarkdown()
-  assert.match(out, /:::pageBlock \{kind=algorithm plugin=page-algorithm\}/)
+  assert.match(out, /:::pageBlock \{kind=algorithm plugin=page-algorithm id=ab12cd34\}/)
   assert.match(out, /Two Sum/)
   editor.destroy()
 })
@@ -188,7 +190,41 @@ test('duplicate pageBlock file pointers get a cloneFrom copy', () => {
   assert.equal(first.file, 'assets/board.json')
   assert.ok(second.file && second.file !== first.file)
   assert.equal(second.cloneFrom, 'assets/board.json')
-  assert.doesNotMatch(editor.getMarkdown(), /cloneFrom/)
+  editor.destroy()
+})
+
+test('editor assigns a stable id when inserting or loading a pageBlock without one', async () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: `:::pageBlock {kind=html plugin=page-html-blocks}\n<div>x</div>\n:::\n`,
+    contentType: 'markdown',
+  })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  const block = editor.getJSON().content?.find((node) => node.type === 'pageBlock')
+  assert.match(String(block?.attrs?.id ?? ''), /^[a-z0-9]{8}$/i)
+  assert.match(editor.getMarkdown(), /:::pageBlock \{kind=html plugin=page-html-blocks id=[a-z0-9]+\}/)
+  editor.destroy()
+})
+
+test('copied pageBlocks do not share an id', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: { type: 'doc', content: [{ type: 'paragraph' }] },
+  })
+  editor.commands.setContent({
+    type: 'doc',
+    content: [
+      { type: 'pageBlock', attrs: { kind: 'html', id: 'ab12cd34', data: { html: '<div>a</div>' } } },
+      { type: 'pageBlock', attrs: { kind: 'html', id: 'ab12cd34', data: { html: '<div>b</div>' } } },
+    ],
+  })
+  const ids = (editor.getJSON().content ?? [])
+    .filter((node) => node.type === 'pageBlock')
+    .map((node) => String(node.attrs?.id ?? ''))
+  assert.equal(ids.length, 2)
+  assert.equal(ids[0], 'ab12cd34')
+  assert.notEqual(ids[1], ids[0])
+  assert.match(ids[1]!, /^[a-z0-9]{8}$/i)
   editor.destroy()
 })
 
@@ -196,7 +232,7 @@ test('pageBlock node view skips react update when attrs are unchanged', async ()
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, './page-block.ts'), 'utf8')
-  assert.match(src, /oldNode\.attrs\.plugin === newNode\.attrs\.plugin/)
+  assert.match(src, /oldNode\.attrs\.id === newNode\.attrs\.id/)
   assert.match(src, /oldNode\.attrs\.kind === newNode\.attrs\.kind/)
   assert.match(src, /JSON\.stringify\(oldNode\.attrs\.data\) === JSON\.stringify\(newNode\.attrs\.data\)/)
   assert.match(src, /return true/)
@@ -211,6 +247,7 @@ test('pageBlock capture includes every registered block shell', async () => {
   assert.match(src, /data-page-block-capture/)
   assert.match(view, /data-page-block-capture=""/)
   assert.match(view, /data-biu-kind="plugin"/)
+  assert.match(view, /data-page-block-id=\{blockId \|\| undefined\}/)
   assert.match(view, /data-biu-id=\{pickId\}/)
   assert.match(view, /setNodeSelection\(pos\)/)
   assert.doesNotMatch(src, /addKeyboardShortcuts/)

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -8,6 +8,7 @@ import { formatPageBlockFence, parsePageBlockData, parsePageBlockMeta } from './
 
 const metaKey = new PluginKey('page-block-meta')
 const uniqueFilesKey = new PluginKey('page-block-unique-files')
+const assignIdsKey = new PluginKey('page-block-ids')
 
 function parseData(raw: string | null) {
   if (!raw) return {}
@@ -36,8 +37,20 @@ export function duplicateAssetPath(file: string) {
   const ext = dot >= 0 ? raw.slice(dot) : '.json'
   let stem = dot >= 0 ? raw.slice(0, dot) : raw
   stem = stem.replace(/-copy-[0-9a-f]{8}$/i, '')
-  const id = crypto.randomUUID().replace(/-/g, '').slice(0, 8)
+  const id = createPageBlockId()
   return `assets/${stem}-copy-${id}${ext}`
+}
+
+export function createPageBlockId() {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
+}
+
+export function isPageBlockId(raw: unknown) {
+  return typeof raw === 'string' && /^[a-z0-9]{6,32}$/i.test(raw.trim())
+}
+
+function nodePageBlockId(node: PmNode) {
+  return isPageBlockId(node.attrs.id) ? String(node.attrs.id).trim() : ''
 }
 
 export const pageBlock = Node.create({
@@ -51,6 +64,7 @@ export const pageBlock = Node.create({
     return {
       kind: { default: 'card' },
       plugin: { default: '' },
+      id: { default: '' },
       data: { default: {}, rendered: false },
     }
   },
@@ -64,6 +78,7 @@ export const pageBlock = Node.create({
           return {
             kind: el.getAttribute('data-page-block') || 'card',
             plugin: el.getAttribute('data-page-block-plugin') || '',
+            id: el.getAttribute('data-page-block-id') || '',
             data: parseData(el.getAttribute('data-page-block-data')),
           }
         },
@@ -77,6 +92,7 @@ export const pageBlock = Node.create({
       mergeAttributes(HTMLAttributes, {
         'data-page-block': String(node.attrs.kind ?? 'card'),
         'data-page-block-plugin': String(node.attrs.plugin ?? ''),
+        'data-page-block-id': String(node.attrs.id ?? ''),
         'data-page-block-data': encodeURIComponent(JSON.stringify(node.attrs.data ?? {})),
       }),
     ]
@@ -85,19 +101,21 @@ export const pageBlock = Node.create({
   parseMarkdown: (token, helpers) => {
     const kind = String(token.attributes?.kind ?? 'card')
     const plugin = String(token.attributes?.plugin ?? '')
+    const id = isPageBlockId(token.attributes?.id) ? String(token.attributes.id) : ''
     const extras: Record<string, unknown> = {}
     if (typeof token.attributes?.deck === 'boolean') extras.deck = token.attributes.deck
     if (typeof token.attributes?.height === 'number') extras.height = token.attributes.height
     const data = parsePageBlockData(kind, String(token.content ?? ''), extras)
-    return helpers.createNode('pageBlock', { kind, plugin, data })
+    return helpers.createNode('pageBlock', { kind, plugin, id, data })
   },
 
   renderMarkdown: (node) => {
     const kind = String(node.attrs?.kind ?? 'card')
     const stored = String(node.attrs?.plugin ?? '').trim()
     const plugin = stored || getPageEditor()?.block(kind)?.plugin || ''
+    const id = nodePageBlockId(node as PmNode)
     const data = { ...((node.attrs?.data && typeof node.attrs.data === 'object' ? node.attrs.data : {}) as Record<string, unknown>) }
-    return formatPageBlockFence(kind, plugin, data)
+    return formatPageBlockFence(kind, plugin, data, id)
   },
 
   markdownTokenizer: {
@@ -109,11 +127,11 @@ export const pageBlock = Node.create({
     tokenize(src) {
       const match = src.match(/^:::pageBlock(?:\s+\{([^}]*)\})?\s*\n([\s\S]*?)\n:::/)
       if (!match) return undefined
-      const { kind, plugin, extras } = parsePageBlockMeta(match[1] ?? '')
+      const { kind, plugin, extras, id } = parsePageBlockMeta(match[1] ?? '')
       return {
         type: 'pageBlock',
         raw: match[0],
-        attributes: { kind, plugin, ...extras },
+        attributes: { kind, plugin, id, ...extras },
         content: match[2] ?? '',
       }
     },
@@ -130,6 +148,7 @@ export const pageBlock = Node.create({
         if (
           oldNode.attrs.kind === newNode.attrs.kind &&
           oldNode.attrs.plugin === newNode.attrs.plugin &&
+          oldNode.attrs.id === newNode.attrs.id &&
           JSON.stringify(oldNode.attrs.data) === JSON.stringify(newNode.attrs.data)
         ) {
           return true
@@ -172,6 +191,40 @@ export const pageBlock = Node.create({
             data.file = duplicateAssetPath(from)
             data.cloneFrom = from
             tr = tr.setNodeMarkup(pos, undefined, { ...node.attrs, data })
+          }
+          return tr
+        },
+      }),
+      new Plugin({
+        key: assignIdsKey,
+        view(editorView) {
+          queueMicrotask(() => {
+            if (editorView.isDestroyed) return
+            editorView.dispatch(editorView.state.tr.setMeta(assignIdsKey, true))
+          })
+          return {}
+        },
+        appendTransaction(transactions, _old, state) {
+          const force = transactions.some((item) => item.getMeta(assignIdsKey))
+          if (!force && !transactions.some((item) => item.docChanged)) return null
+          const seen = new Set<string>()
+          const patch: { pos: number; node: PmNode }[] = []
+          state.doc.descendants((node, pos) => {
+            if (node.type.name !== 'pageBlock') return
+            const id = nodePageBlockId(node)
+            if (!id || seen.has(id)) {
+              patch.push({ pos, node })
+              return
+            }
+            seen.add(id)
+          })
+          if (!patch.length) return null
+          let tr = state.tr
+          for (const { pos, node } of patch.slice().sort((a, b) => b.pos - a.pos)) {
+            let next = createPageBlockId()
+            while (seen.has(next)) next = createPageBlockId()
+            seen.add(next)
+            tr = tr.setNodeMarkup(pos, undefined, { ...node.attrs, id: next })
           }
           return tr
         },

--- a/packages/core-editor/src/web/slash.ts
+++ b/packages/core-editor/src/web/slash.ts
@@ -5,6 +5,7 @@ import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion'
 import { SlashList } from './slash-list.tsx'
 import { placeSlashInWindow } from './slash-place.ts'
 import { slashMayOpen } from './editor-live.ts'
+import { createPageBlockId } from './page-block.ts'
 import { BASIC_BLOCK_TYPE, getPageEditor, type SlashInsert } from './service.ts'
 
 export type SlashItem = {
@@ -232,6 +233,7 @@ export function slashCatalog(): SlashItem[] {
             attrs: {
               kind: block.kind,
               plugin: block.plugin,
+              id: createPageBlockId(),
               data: typeof block.defaults === 'function' ? block.defaults() : { ...(block.defaults ?? {}) },
             },
           })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
斜杠插入特殊块时写入稳定 `id`，围栏 markdown 带 `id=`。打开旧文档或复制块时补上/拆开重复 id，倒排和反向更新才有指针。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

