### PR TITLE
补全旧文档与 agent 写入的 pageBlock id

### DIFF
--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -85,7 +85,7 @@ test('html pageBlock markdown keeps raw html and deck on the fence', () => {
   assert.equal((block?.attrs?.data as { html?: string; deck?: boolean })?.html, '<div style="color:#fff">爱乐之城</div>')
   assert.equal((block?.attrs?.data as { deck?: boolean })?.deck, true)
   const out = editor.getMarkdown()
-  assert.match(out, /:::pageBlock \{kind=html plugin=page-html-blocks deck=true\}/)
+  assert.match(out, /:::pageBlock \{kind=html plugin=page-html-blocks id=[a-z0-9]+ deck=true\}/)
   assert.match(out, /<div style="color:#fff">爱乐之城<\/div>/)
   assert.doesNotMatch(out, /"html":/)
   editor.destroy()
@@ -130,7 +130,7 @@ test('pageBlock markdown keeps old fences without plugin id', () => {
   assert.equal(block?.attrs?.plugin, '')
   assert.deepEqual(block?.attrs?.data, { file: 'assets/excalidraw-demo.json' })
   const out = editor.getMarkdown()
-  assert.match(out, /:::pageBlock \{kind=excalidraw\}/)
+  assert.match(out, /:::pageBlock \{kind=excalidraw id=[a-z0-9]+\}/)
   assert.match(out, /"file": "assets\/excalidraw-demo.json"/)
   assert.doesNotMatch(out, /"elements"/)
   assert.doesNotMatch(out, /"height"/)
@@ -199,10 +199,30 @@ test('editor assigns a stable id when inserting or loading a pageBlock without o
     content: `:::pageBlock {kind=html plugin=page-html-blocks}\n<div>x</div>\n:::\n`,
     contentType: 'markdown',
   })
-  await new Promise((resolve) => setTimeout(resolve, 0))
+  await Promise.resolve()
   const block = editor.getJSON().content?.find((node) => node.type === 'pageBlock')
   assert.match(String(block?.attrs?.id ?? ''), /^[a-z0-9]{8}$/i)
   assert.match(editor.getMarkdown(), /:::pageBlock \{kind=html plugin=page-html-blocks id=[a-z0-9]+\}/)
+  editor.destroy()
+})
+
+test('setContent from agent without id or with a bad id gets a valid id', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: 'hello',
+    contentType: 'markdown',
+  })
+  editor.commands.setContent(
+    `:::pageBlock {kind=html plugin=page-html-blocks}\n<div>a</div>\n:::\n\n:::pageBlock {kind=html plugin=page-html-blocks id=no}\n<div>b</div>\n:::\n`,
+    { contentType: 'markdown', emitUpdate: false },
+  )
+  const ids = (editor.getJSON().content ?? [])
+    .filter((node) => node.type === 'pageBlock')
+    .map((node) => String(node.attrs?.id ?? ''))
+  assert.equal(ids.length, 2)
+  assert.match(ids[0]!, /^[a-z0-9]{8}$/i)
+  assert.match(ids[1]!, /^[a-z0-9]{8}$/i)
+  assert.notEqual(ids[0], ids[1])
   editor.destroy()
 })
 

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -1,6 +1,6 @@
 import { mergeAttributes, Node } from '@tiptap/core'
 import { ReactNodeViewRenderer } from '@tiptap/react'
-import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state'
 import type { Node as PmNode } from '@tiptap/pm/model'
 import { PageBlockView } from './page-block-view.tsx'
 import { getPageEditor } from './service.ts'
@@ -53,6 +53,30 @@ function nodePageBlockId(node: PmNode) {
   return isPageBlockId(node.attrs.id) ? String(node.attrs.id).trim() : ''
 }
 
+/** 打开旧文档、agent 写入无 id / 坏 id 的块时，在编辑器里补合法且不重复的 id。 */
+export function assignPageBlockIds(state: EditorState): Transaction | null {
+  const seen = new Set<string>()
+  const patch: { pos: number; node: PmNode }[] = []
+  state.doc.descendants((node, pos) => {
+    if (node.type.name !== 'pageBlock') return
+    const id = nodePageBlockId(node)
+    if (!id || seen.has(id)) {
+      patch.push({ pos, node })
+      return
+    }
+    seen.add(id)
+  })
+  if (!patch.length) return null
+  let tr = state.tr
+  for (const { pos, node } of patch.slice().sort((a, b) => b.pos - a.pos)) {
+    let next = createPageBlockId()
+    while (seen.has(next)) next = createPageBlockId()
+    seen.add(next)
+    tr = tr.setNodeMarkup(pos, undefined, { ...node.attrs, id: next })
+  }
+  return tr
+}
+
 export const pageBlock = Node.create({
   name: 'pageBlock',
   group: 'block',
@@ -101,7 +125,7 @@ export const pageBlock = Node.create({
   parseMarkdown: (token, helpers) => {
     const kind = String(token.attributes?.kind ?? 'card')
     const plugin = String(token.attributes?.plugin ?? '')
-    const id = isPageBlockId(token.attributes?.id) ? String(token.attributes.id) : ''
+    const id = isPageBlockId(token.attributes?.id) ? String(token.attributes.id) : createPageBlockId()
     const extras: Record<string, unknown> = {}
     if (typeof token.attributes?.deck === 'boolean') extras.deck = token.attributes.deck
     if (typeof token.attributes?.height === 'number') extras.height = token.attributes.height
@@ -197,36 +221,18 @@ export const pageBlock = Node.create({
       }),
       new Plugin({
         key: assignIdsKey,
-        view(editorView) {
-          queueMicrotask(() => {
-            if (editorView.isDestroyed) return
-            editorView.dispatch(editorView.state.tr.setMeta(assignIdsKey, true))
-          })
-          return {}
-        },
         appendTransaction(transactions, _old, state) {
-          const force = transactions.some((item) => item.getMeta(assignIdsKey))
-          if (!force && !transactions.some((item) => item.docChanged)) return null
-          const seen = new Set<string>()
-          const patch: { pos: number; node: PmNode }[] = []
-          state.doc.descendants((node, pos) => {
-            if (node.type.name !== 'pageBlock') return
-            const id = nodePageBlockId(node)
-            if (!id || seen.has(id)) {
-              patch.push({ pos, node })
-              return
-            }
-            seen.add(id)
-          })
-          if (!patch.length) return null
-          let tr = state.tr
-          for (const { pos, node } of patch.slice().sort((a, b) => b.pos - a.pos)) {
-            let next = createPageBlockId()
-            while (seen.has(next)) next = createPageBlockId()
-            seen.add(next)
-            tr = tr.setNodeMarkup(pos, undefined, { ...node.attrs, id: next })
+          if (!transactions.some((item) => item.docChanged)) return null
+          return assignPageBlockIds(state)
+        },
+        view(editorView) {
+          const apply = () => {
+            if (editorView.isDestroyed) return
+            const tr = assignPageBlockIds(editorView.state)
+            if (tr) editorView.dispatch(tr)
           }
-          return tr
+          apply()
+          return {}
         },
       }),
     ]
@@ -239,6 +245,12 @@ export const pageBlock = Node.create({
       editor.view.dispatch(editor.state.tr.setMeta(metaKey, true))
     })
     this.storage.stop = stop
+    // 构造时的 markdown 已在 state 里，但此时 dispatch 会被丢掉；下一拍再补缺 id。
+    queueMicrotask(() => {
+      if (editor.isDestroyed) return
+      const tr = assignPageBlockIds(editor.state)
+      if (tr) editor.view.dispatch(tr)
+    })
   },
 
   onDestroy() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在 `pageBlock` 插件内给缺 id / 坏 id / 重复 id 的块补合法 8 位 id：

- 解析 markdown 围栏时直接赋 id
- `appendTransaction` 在文档变更后扫一遍
- `onCreate` / plugin view 对构造时的初始文档再补一次

不经过 `PageEditor` 的 hydrate/`onChange`，各 `registerBlock` 也不各自定义 id。`createPageBlockId()` 仍只在 `page-block.ts`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

