### PR TITLE
pageBlock 重复 id 只在整篇替换时校准

### DIFF
--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -248,6 +248,32 @@ test('copied pageBlocks do not share an id', () => {
   editor.destroy()
 })
 
+test('duplicate ids are not rewritten until the whole document is replaced', () => {
+  const editor = new Editor({
+    extensions: pageEditorExtensions(),
+    content: {
+      type: 'doc',
+      content: [{ type: 'pageBlock', attrs: { kind: 'html', id: 'ab12cd34', data: { html: '<div>a</div>' } } }],
+    },
+  })
+  editor.commands.insertContentAt(editor.state.doc.content.size, {
+    type: 'pageBlock',
+    attrs: { kind: 'html', id: 'ab12cd34', data: { html: '<div>b</div>' } },
+  })
+  const live = (editor.getJSON().content ?? [])
+    .filter((node) => node.type === 'pageBlock')
+    .map((node) => String(node.attrs?.id ?? ''))
+  assert.deepEqual(live, ['ab12cd34', 'ab12cd34'])
+  editor.commands.setContent(editor.getMarkdown(), { contentType: 'markdown', emitUpdate: false })
+  const calibrated = (editor.getJSON().content ?? [])
+    .filter((node) => node.type === 'pageBlock')
+    .map((node) => String(node.attrs?.id ?? ''))
+  assert.equal(calibrated[0], 'ab12cd34')
+  assert.notEqual(calibrated[1], calibrated[0])
+  assert.match(calibrated[1]!, /^[a-z0-9]{8}$/i)
+  editor.destroy()
+})
+
 test('pageBlock node view skips react update when attrs are unchanged', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -2,6 +2,7 @@ import { mergeAttributes, Node } from '@tiptap/core'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state'
 import type { Node as PmNode } from '@tiptap/pm/model'
+import { ReplaceStep } from '@tiptap/pm/transform'
 import { PageBlockView } from './page-block-view.tsx'
 import { getPageEditor } from './service.ts'
 import { formatPageBlockFence, parsePageBlockData, parsePageBlockMeta } from './page-block-meta.ts'
@@ -53,7 +54,17 @@ function nodePageBlockId(node: PmNode) {
   return isPageBlockId(node.attrs.id) ? String(node.attrs.id).trim() : ''
 }
 
-/** 打开旧文档、agent 写入无 id / 坏 id 的块时，在编辑器里补合法且不重复的 id。 */
+/** 整篇换文档（打开、离开源码、setContent）时再扫；日常编辑不跟。 */
+function shouldAssignPageBlockIds(transactions: readonly Transaction[], oldDoc: PmNode) {
+  return transactions.some((item) => {
+    if (item.getMeta(assignIdsKey)) return true
+    if (!item.docChanged) return false
+    const size = oldDoc.content.size
+    return item.steps.some((step) => step instanceof ReplaceStep && step.from === 0 && step.to === size)
+  })
+}
+
+/** 打开旧文档、源码贴完切回、agent 整篇写入时：缺 id / 坏 id / 重复 id 各补一次。 */
 export function assignPageBlockIds(state: EditorState): Transaction | null {
   const seen = new Set<string>()
   const patch: { pos: number; node: PmNode }[] = []
@@ -221,18 +232,9 @@ export const pageBlock = Node.create({
       }),
       new Plugin({
         key: assignIdsKey,
-        appendTransaction(transactions, _old, state) {
-          if (!transactions.some((item) => item.docChanged)) return null
+        appendTransaction(transactions, oldState, state) {
+          if (!shouldAssignPageBlockIds(transactions, oldState.doc)) return null
           return assignPageBlockIds(state)
-        },
-        view(editorView) {
-          const apply = () => {
-            if (editorView.isDestroyed) return
-            const tr = assignPageBlockIds(editorView.state)
-            if (tr) editorView.dispatch(tr)
-          }
-          apply()
-          return {}
         },
       }),
     ]
@@ -245,11 +247,10 @@ export const pageBlock = Node.create({
       editor.view.dispatch(editor.state.tr.setMeta(metaKey, true))
     })
     this.storage.stop = stop
-    // 构造时的 markdown 已在 state 里，但此时 dispatch 会被丢掉；下一拍再补缺 id。
     queueMicrotask(() => {
       if (editor.isDestroyed) return
       const tr = assignPageBlockIds(editor.state)
-      if (tr) editor.view.dispatch(tr)
+      if (tr) editor.view.dispatch(tr.setMeta(assignIdsKey, true))
     })
   },
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
重复 id 不必跟着每一次编辑走。只在整篇换文档时扫一次并改掉：打开、离开源码（源码里粘贴的重复围栏会在切回正文时校准）、以及 `setContent`。日常插入、打字不再跑检测。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

