### PR TITLE
按 id 改 pageBlock 属性，并登记 /page-blocks

### DIFF
--- a/packages/core-editor/src/host/index.ts
+++ b/packages/core-editor/src/host/index.ts
@@ -3,5 +3,14 @@ import type { Context } from 'cordis'
 export const name = 'core-editor'
 export const inject: string[] = []
 
+export {
+  listPageBlockFences,
+  pageBlockData,
+  pageBlockRecordId,
+  parsePageBlockRecordId,
+  patchPageBlockMarkdown,
+} from '../page-block-fence.ts'
+export type { PageBlockAttrsPatch, PageBlockFence } from '../page-block-fence.ts'
+
 /** 编辑器只在 Web；Host 占位以便目录加载。 */
 export function apply(_ctx: Context) {}

--- a/packages/core-editor/src/page-block-fence.test.ts
+++ b/packages/core-editor/src/page-block-fence.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import {
+  listPageBlockFences,
+  pageBlockData,
+  pageBlockRecordId,
+  parsePageBlockRecordId,
+  patchPageBlockMarkdown,
+} from './page-block-fence.ts'
+
+const doc = `前言
+
+:::pageBlock {kind=html plugin=page-html-blocks id=ab12cd34 deck=true}
+<div>旧</div>
+:::
+
+中间
+
+:::pageBlock {kind=excalidraw plugin=page-excalidraw id=ef90ab12}
+{"file":"assets/board.json"}
+:::
+`
+
+test('listPageBlockFences reads id kind plugin and body', () => {
+  const fences = listPageBlockFences(doc)
+  assert.equal(fences.length, 2)
+  assert.equal(fences[0]?.id, 'ab12cd34')
+  assert.equal(fences[0]?.kind, 'html')
+  assert.equal(pageBlockData(fences[0]!).html, '<div>旧</div>')
+  assert.equal(pageBlockData(fences[0]!).deck, true)
+  assert.equal(fences[1]?.id, 'ef90ab12')
+  assert.equal(pageBlockData(fences[1]!).file, 'assets/board.json')
+})
+
+test('patchPageBlockMarkdown merges attrs of one id and leaves the rest', () => {
+  const next = patchPageBlockMarkdown(doc, 'ab12cd34', { data: { html: '<div>新</div>', deck: false } })
+  assert.match(next, /id=ab12cd34 deck=false/)
+  assert.match(next, /<div>新<\/div>/)
+  assert.match(next, /id=ef90ab12/)
+  assert.match(next, /assets\/board.json/)
+  assert.match(next, /前言/)
+})
+
+test('patchPageBlockMarkdown can replace data and change plugin', () => {
+  const next = patchPageBlockMarkdown(doc, 'ef90ab12', {
+    plugin: 'page-excalidraw',
+    replace: true,
+    data: { file: 'assets/other.json' },
+  })
+  assert.match(next, /id=ef90ab12/)
+  assert.match(next, /"file": "assets\/other.json"/)
+  assert.doesNotMatch(next, /board.json/)
+})
+
+test('patchPageBlockMarkdown rejects missing or duplicate ids', () => {
+  assert.throws(() => patchPageBlockMarkdown(doc, 'nope', { data: {} }), /unknown pageBlock/)
+  const dup = `:::pageBlock {kind=html id=ab12cd34}\na\n:::\n\n:::pageBlock {kind=html id=ab12cd34}\nb\n:::\n`
+  assert.throws(() => patchPageBlockMarkdown(dup, 'ab12cd34', { data: { html: 'x' } }), /not unique/)
+})
+
+test('pageBlock record id is page::block', () => {
+  assert.equal(pageBlockRecordId('p001', 'ab12cd34'), 'p001::ab12cd34')
+  assert.deepEqual(parsePageBlockRecordId('p001::ab12cd34'), { pageId: 'p001', blockId: 'ab12cd34' })
+  assert.equal(parsePageBlockRecordId('p001'), null)
+})

--- a/packages/core-editor/src/page-block-fence.ts
+++ b/packages/core-editor/src/page-block-fence.ts
@@ -1,0 +1,75 @@
+import { formatPageBlockFence, parsePageBlockData, parsePageBlockMeta } from './web/page-block-meta.ts'
+
+const FENCE = /^:::pageBlock(?:\s+\{([^}]*)\})?\s*\n([\s\S]*?)\n:::/gm
+
+export type PageBlockFence = {
+  id: string
+  kind: string
+  plugin: string
+  extras: Record<string, unknown>
+  body: string
+  start: number
+  end: number
+  raw: string
+}
+
+/** 正文里改某一块的属性。id / kind 不改；data 默认合并。 */
+export type PageBlockAttrsPatch = {
+  plugin?: string
+  data?: Record<string, unknown>
+  replace?: boolean
+}
+
+export function pageBlockRecordId(pageId: string, blockId: string) {
+  return `${pageId}::${blockId}`
+}
+
+export function parsePageBlockRecordId(id: string) {
+  const raw = String(id ?? '')
+  const at = raw.indexOf('::')
+  if (at <= 0) return null
+  const pageId = raw.slice(0, at).trim()
+  const blockId = raw.slice(at + 2).trim()
+  if (!pageId || !blockId) return null
+  return { pageId, blockId }
+}
+
+export function listPageBlockFences(markdown: string): PageBlockFence[] {
+  const re = new RegExp(FENCE.source, FENCE.flags)
+  const out: PageBlockFence[] = []
+  let match: RegExpExecArray | null
+  while ((match = re.exec(markdown))) {
+    const meta = parsePageBlockMeta(match[1] ?? '')
+    out.push({
+      id: meta.id,
+      kind: meta.kind,
+      plugin: meta.plugin,
+      extras: meta.extras,
+      body: match[2] ?? '',
+      start: match.index,
+      end: match.index + match[0].length,
+      raw: match[0],
+    })
+  }
+  return out
+}
+
+export function pageBlockData(fence: PageBlockFence) {
+  return parsePageBlockData(fence.kind, fence.body, fence.extras)
+}
+
+export function patchPageBlockMarkdown(markdown: string, id: string, patch: PageBlockAttrsPatch): string {
+  const needle = String(id ?? '').trim()
+  if (!needle) throw new Error('pageBlock id is required')
+  const hits = listPageBlockFences(markdown).filter((item) => item.id === needle)
+  if (!hits.length) throw new Error(`unknown pageBlock: ${needle}`)
+  if (hits.length > 1) throw new Error(`pageBlock id is not unique: ${needle}`)
+  const fence = hits[0]!
+  const current = pageBlockData(fence)
+  const data = patch.replace
+    ? { ...(patch.data ?? {}) }
+    : { ...current, ...(patch.data ?? {}) }
+  const plugin = patch.plugin !== undefined ? String(patch.plugin) : fence.plugin
+  const next = formatPageBlockFence(fence.kind, plugin, data, fence.id)
+  return markdown.slice(0, fence.start) + next + markdown.slice(fence.end)
+}

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -59,6 +59,8 @@ test('page plugin stores pages in SQLite under .page', async () => {
   assert.equal(registered[0]?.schema.fields.tags?.enum, undefined)
   assert.deepEqual(registered[0]?.schema.columns, ['title', 'tags', 'createdBy', 'updatedBy'])
   assert.deepEqual(registered[0]?.records, { update: true, create: true, delete: true })
+  assert.equal(registered[1]?.path, '/page-blocks')
+  assert.deepEqual(registered[1]?.records, { update: true })
 
   const spec = registered[0]!
   assert.equal((await spec.list()).length, 0)
@@ -112,6 +114,48 @@ test('page plugin stores pages in SQLite under .page', async () => {
   await assert.rejects(() => store.writeAsset('board.json', '{}'), (error) => error instanceof PageAssetConflictError)
   const overwritten = await store.writeAsset('board.json', '{}', { etag: asset.etag })
   assert.equal(overwritten.etag.length, 16)
+})
+
+test('page-blocks collection updates one fence by page::block id', async () => {
+  const ctx = new Context()
+  const registered: CollectionSpec[] = []
+  class FakeDb extends Service {
+    constructor(c: Context) {
+      super(c, 'database')
+    }
+    register(spec: CollectionSpec) {
+      registered.push(spec)
+    }
+  }
+  new FakeDb(ctx)
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-blocks-'))
+  await ctx.plugin(fsPlugin, { root })
+  await ctx.plugin(page)
+  const pages = registered.find((item) => item.path === '/pages')!
+  const blocks = registered.find((item) => item.path === '/page-blocks')!
+  const created = await pages.create!([{
+    title: '海报',
+    notes: `:::pageBlock {kind=html plugin=page-html-blocks id=ab12cd34 deck=true}
+<div>旧</div>
+:::
+`,
+  }])
+  const pageId = created[0]!.id
+  const listed = await blocks.list()
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0]?.id, `${pageId}::ab12cd34`)
+  assert.equal(listed[0]?.kind, 'html')
+  const updated = await blocks.update!(`${pageId}::ab12cd34`, {
+    data: { html: '<div>新</div>', deck: false },
+  })
+  assert.match(String(updated.data), /新/)
+  assert.match(String(updated.data), /"deck":false/)
+  const md = await readFile(join(root, `.page/${pageId}.md`), 'utf8')
+  assert.match(md, /id=ab12cd34 deck=false/)
+  assert.match(md, /<div>新<\/div>/)
+  assert.equal(blocks.create, undefined)
+  assert.equal(blocks.remove, undefined)
 })
 
 test('PagesStore reads existing markdown files from .page', async () => {

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -3,8 +3,10 @@ import type { Context } from 'cordis'
 import type { CollectionSpec } from '@biu/type-file-system'
 import { DATABASE_CHANNEL, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { PagesStore, PageAssetConflictError, type WorkspaceFs } from './store.ts'
+import { pageBlocksCollection } from './page-blocks-collection.ts'
 
 export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
+export { pageBlocksCollection } from './page-blocks-collection.ts'
 
 export function pagesCollection(store: PagesStore): CollectionSpec {
   return {
@@ -93,6 +95,7 @@ export function apply(ctx: Context) {
   // 否则工具调用（绑定项目）与 HTTP 请求（无 Session）会落到不同目录。
   const store = new PagesStore(ctx.fs.workspace as WorkspaceFs, dataPath(process.cwd(), 'assets'))
   ctx.database.register(pagesCollection(store))
+  ctx.database.register(pageBlocksCollection(store))
   servePageFile(ctx, store)
 }
 

--- a/packages/core-page/src/host/page-blocks-collection.ts
+++ b/packages/core-page/src/host/page-blocks-collection.ts
@@ -1,0 +1,141 @@
+import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
+import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import {
+  listPageBlockFences,
+  pageBlockData,
+  pageBlockRecordId,
+  parsePageBlockRecordId,
+  patchPageBlockMarkdown,
+  type PageBlockFence,
+} from '@biu/core-editor/host'
+import type { PagesStore, PageRow } from './store.ts'
+
+function asDataObject(raw: unknown): Record<string, unknown> | undefined {
+  if (raw == null) return undefined
+  if (typeof raw === 'object' && !Array.isArray(raw)) return raw as Record<string, unknown>
+  if (typeof raw === 'string' && raw.trim()) {
+    const parsed = JSON.parse(raw) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('data must be a JSON object')
+    return parsed as Record<string, unknown>
+  }
+  throw new Error('data must be a JSON object')
+}
+
+function blockTitle(kind: string, data: Record<string, unknown>) {
+  if (typeof data.title === 'string' && data.title.trim()) return data.title.trim()
+  if (typeof data.html === 'string' && data.html.trim()) {
+    const text = data.html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 48)
+    if (text) return text
+  }
+  if (typeof data.file === 'string' && data.file.trim()) return data.file.replace(/^assets\//, '')
+  return kind
+}
+
+function toRecord(page: PageRow, fence: PageBlockFence): DbRecord {
+  const data = pageBlockData(fence)
+  return {
+    id: pageBlockRecordId(page.id, fence.id),
+    title: blockTitle(fence.kind, data),
+    pageId: page.id,
+    blockId: fence.id,
+    kind: fence.kind,
+    plugin: fence.plugin,
+    data: JSON.stringify(data),
+    ...recordBuiltinValues({ createdAt: page.createdAt, updatedAt: page.updatedAt }),
+  }
+}
+
+async function fencesOn(store: PagesStore, pageId: string) {
+  const page = await store.get(pageId)
+  if (!page) return null
+  return {
+    page,
+    fences: listPageBlockFences(page.notes).filter((item) => item.id),
+  }
+}
+
+async function recordOf(store: PagesStore, id: string) {
+  const parsed = parsePageBlockRecordId(id)
+  if (!parsed) return null
+  const found = await fencesOn(store, parsed.pageId)
+  if (!found) return null
+  const fence = found.fences.find((item) => item.id === parsed.blockId)
+  if (!fence) return null
+  return toRecord(found.page, fence)
+}
+
+export function pageBlocksCollection(store: PagesStore): CollectionSpec {
+  return {
+    id: 'page-blocks',
+    path: '/page-blocks',
+    label: '特殊块',
+    view: {
+      moduleId: 'page',
+      route: '/page-blocks',
+      title: '特殊块',
+      inspector: true,
+      blurb:
+        '页面 :::pageBlock 的投影。记录 id 为 <pageId>::<blockId>。改属性用 db_update：data 为 JSON 对象（默认合并），也可写 plugin。不改 id/kind，不能从本表新建或删除块。正文仍在对应页面的 notes。',
+      order: 26,
+      icon: 'puzzle-piece',
+    },
+    schema: {
+      labelField: 'title',
+      columns: ['title', 'kind', 'plugin', 'pageId'],
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string', label: '标题' },
+        pageId: { type: 'ref', label: '页面' },
+        blockId: { type: 'string', label: '块 id' },
+        kind: { type: 'string', label: '类型' },
+        plugin: { type: 'string', label: '插件', writable: true },
+        data: {
+          type: 'string',
+          label: '属性',
+          writable: true,
+          description: '块 data 的 JSON。默认与现有字段合并；replace=true 时整份替换。',
+        },
+      },
+    },
+    records: { update: true },
+    list: async (query) => {
+      if (query?.ids?.length) {
+        const rows: DbRecord[] = []
+        for (const id of query.ids) {
+          const row = await recordOf(store, id)
+          if (row) rows.push(row)
+        }
+        return rows
+      }
+      const pages = await store.list()
+      const rows: DbRecord[] = []
+      for (const slim of pages) {
+        const found = await fencesOn(store, slim.id)
+        if (!found) continue
+        for (const fence of found.fences) rows.push(toRecord(found.page, fence))
+      }
+      return rows
+    },
+    get: (id) => recordOf(store, id),
+    update: async (id, patch) => {
+      const parsed = parsePageBlockRecordId(id)
+      if (!parsed) throw new Error(`unknown pageBlock: ${id}`)
+      const page = await store.get(parsed.pageId)
+      if (!page) throw new Error(`unknown page: ${parsed.pageId}`)
+      const data = asDataObject(patch.data)
+      const extras: Record<string, unknown> = { ...(data ?? {}) }
+      if ('deck' in patch) extras.deck = patch.deck
+      if ('width' in patch) extras.width = patch.width
+      if ('height' in patch) extras.height = patch.height
+      const notes = patchPageBlockMarkdown(page.notes, parsed.blockId, {
+        plugin: typeof patch.plugin === 'string' ? patch.plugin : undefined,
+        data: Object.keys(extras).length ? extras : undefined,
+        replace: patch.replace === true,
+      })
+      const next = await store.update(page.id, { notes })
+      const fence = listPageBlockFences(next.notes).find((item) => item.id === parsed.blockId)
+      if (!fence) throw new Error(`unknown pageBlock: ${id}`)
+      return toRecord(next, fence)
+    },
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
先前没有「按块 id 改属性」的宿主 API，只有编辑器里当前节点的 `update()`。

现在提供 `patchPageBlockMarkdown(markdown, id, { data, plugin, replace })`：只改那一条 `:::pageBlock`，id/kind 不动，data 默认合并。

并注册文件系统表 `/page-blocks`（投影，不是第二份正文）：
- 记录 id：`<pageId>::<blockId>`
- `db_update` 写回对应页面的 notes
- 不从本表新建或删除块

list 仍扫各页正文；倒排表可以下一步再加。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

