### PR TITLE
特殊块倒排按热/温窗口增量更新

### DIFF
--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -10,6 +10,7 @@ import * as fsPlugin from '@biu/host-fs'
 import * as page from './index.ts'
 import { dumpMarkdown, splitMarkdown } from './markdown.ts'
 import { ASSET_GC_GRACE_MS, PAGE_ASSETS, PAGE_ROOT, PageAssetConflictError, PagesStore, collectPageAssetNames } from './store.ts'
+import { PageBlocksIndex } from './page-blocks-index.ts'
 
 test('markdown frontmatter roundtrips YAML properties and body', () => {
   const raw = dumpMarkdown({ title: '首页', tags: ['red', 'prod'] }, '正文第一段\n')
@@ -157,6 +158,33 @@ test('page-blocks collection updates one fence by page::block id', async () => {
   assert.equal(blocks.create, undefined)
   assert.equal(blocks.remove, undefined)
 })
+
+test('page-block index scans a hot batch instead of every page', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-block-index-'))
+  await ctx.plugin(fsPlugin, { root })
+  const store = new PagesStore(ctx.fs.workspace as never, join(root, '.biu/assets'))
+  const index = new PageBlocksIndex(store, { hotWindowMs: 60_000, hotLimit: 1, warmLimit: 0 })
+  const fence = (id: string) => `:::pageBlock {kind=html plugin=page-html-blocks id=${id}}\n<div>${id}</div>\n:::\n`
+  await store.create({ title: 'a', notes: fence('aaaaaa11') })
+  await store.create({ title: 'b', notes: fence('bbbbbb22') })
+  await store.create({ title: 'c', notes: fence('cccccc33') })
+  const first = await index.sync()
+  assert.equal(first.scanned, 1)
+  assert.equal(first.dirty, 3)
+  assert.equal((await index.list()).length, 1)
+  const second = await index.sync()
+  assert.equal(second.scanned, 1)
+  assert.equal((await index.list()).length, 2)
+  await index.sync()
+  assert.equal((await index.list()).length, 3)
+  const idle = await index.sync()
+  assert.equal(idle.scanned, 0)
+  assert.equal(idle.dirty, 0)
+  assert.ok((await index.lastRunAt()) > 0)
+})
+
 
 test('PagesStore reads existing markdown files from .page', async () => {
   const ctx = new Context()

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -4,9 +4,11 @@ import type { CollectionSpec } from '@biu/type-file-system'
 import { DATABASE_CHANNEL, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import { PagesStore, PageAssetConflictError, type WorkspaceFs } from './store.ts'
 import { pageBlocksCollection } from './page-blocks-collection.ts'
+import { PAGE_BLOCK_TICK_MS, PageBlocksIndex } from './page-blocks-index.ts'
 
 export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, PagesStore } from './store.ts'
 export { pageBlocksCollection } from './page-blocks-collection.ts'
+export { PageBlocksIndex, PAGE_BLOCK_TICK_MS } from './page-blocks-index.ts'
 
 export function pagesCollection(store: PagesStore): CollectionSpec {
   return {
@@ -94,8 +96,14 @@ export function apply(ctx: Context) {
   // 页面固定存到工作区根（defaultRoot），不随 Session 绑定项目路径漂移，
   // 否则工具调用（绑定项目）与 HTTP 请求（无 Session）会落到不同目录。
   const store = new PagesStore(ctx.fs.workspace as WorkspaceFs, dataPath(process.cwd(), 'assets'))
+  const index = new PageBlocksIndex(store)
   ctx.database.register(pagesCollection(store))
-  ctx.database.register(pageBlocksCollection(store))
+  ctx.database.register(pageBlocksCollection(store, index))
   servePageFile(ctx, store)
+  const tick = setInterval(() => {
+    void index.sync()
+  }, PAGE_BLOCK_TICK_MS)
+  tick.unref()
+  ctx.effect(() => () => clearInterval(tick))
 }
 

--- a/packages/core-page/src/host/page-blocks-collection.ts
+++ b/packages/core-page/src/host/page-blocks-collection.ts
@@ -1,14 +1,8 @@
 import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
-import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
-import {
-  listPageBlockFences,
-  pageBlockData,
-  pageBlockRecordId,
-  parsePageBlockRecordId,
-  patchPageBlockMarkdown,
-  type PageBlockFence,
-} from '@biu/core-editor/host'
-import type { PagesStore, PageRow } from './store.ts'
+import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
+import { parsePageBlockRecordId, patchPageBlockMarkdown } from '@biu/core-editor/host'
+import type { PagesStore } from './store.ts'
+import { PageBlocksIndex } from './page-blocks-index.ts'
 
 function asDataObject(raw: unknown): Record<string, unknown> | undefined {
   if (raw == null) return undefined
@@ -21,50 +15,18 @@ function asDataObject(raw: unknown): Record<string, unknown> | undefined {
   throw new Error('data must be a JSON object')
 }
 
-function blockTitle(kind: string, data: Record<string, unknown>) {
-  if (typeof data.title === 'string' && data.title.trim()) return data.title.trim()
-  if (typeof data.html === 'string' && data.html.trim()) {
-    const text = data.html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 48)
-    if (text) return text
-  }
-  if (typeof data.file === 'string' && data.file.trim()) return data.file.replace(/^assets\//, '')
-  return kind
-}
-
-function toRecord(page: PageRow, fence: PageBlockFence): DbRecord {
-  const data = pageBlockData(fence)
-  return {
-    id: pageBlockRecordId(page.id, fence.id),
-    title: blockTitle(fence.kind, data),
-    pageId: page.id,
-    blockId: fence.id,
-    kind: fence.kind,
-    plugin: fence.plugin,
-    data: JSON.stringify(data),
-    ...recordBuiltinValues({ createdAt: page.createdAt, updatedAt: page.updatedAt }),
-  }
-}
-
-async function fencesOn(store: PagesStore, pageId: string) {
-  const page = await store.get(pageId)
-  if (!page) return null
-  return {
-    page,
-    fences: listPageBlockFences(page.notes).filter((item) => item.id),
-  }
-}
-
-async function recordOf(store: PagesStore, id: string) {
+async function recordOf(store: PagesStore, index: PageBlocksIndex, id: string) {
+  const hit = await index.get(id)
+  if (hit) return hit
   const parsed = parsePageBlockRecordId(id)
   if (!parsed) return null
-  const found = await fencesOn(store, parsed.pageId)
-  if (!found) return null
-  const fence = found.fences.find((item) => item.id === parsed.blockId)
-  if (!fence) return null
-  return toRecord(found.page, fence)
+  const page = await store.get(parsed.pageId)
+  if (!page) return null
+  await index.reindexPage(page)
+  return index.get(id)
 }
 
-export function pageBlocksCollection(store: PagesStore): CollectionSpec {
+export function pageBlocksCollection(store: PagesStore, index: PageBlocksIndex): CollectionSpec {
   return {
     id: 'page-blocks',
     path: '/page-blocks',
@@ -75,7 +37,7 @@ export function pageBlocksCollection(store: PagesStore): CollectionSpec {
       title: '特殊块',
       inspector: true,
       blurb:
-        '页面 :::pageBlock 的投影。记录 id 为 <pageId>::<blockId>。改属性用 db_update：data 为 JSON 对象（默认合并），也可写 plugin。不改 id/kind，不能从本表新建或删除块。正文仍在对应页面的 notes。',
+        '页面 :::pageBlock 的增量倒排。记录 id 为 <pageId>::<blockId>。索引记 last_run_at，每拍只扫最近改过的页（热窗口优先，再少量补旧），不会一次重建全部。改属性用 db_update：data 为 JSON 对象（默认合并）。不能从本表新建或删除块。',
       order: 26,
       icon: 'puzzle-piece',
     },
@@ -99,24 +61,21 @@ export function pageBlocksCollection(store: PagesStore): CollectionSpec {
     },
     records: { update: true },
     list: async (query) => {
+      await index.sync()
       if (query?.ids?.length) {
         const rows: DbRecord[] = []
         for (const id of query.ids) {
-          const row = await recordOf(store, id)
+          const row = await recordOf(store, index, id)
           if (row) rows.push(row)
         }
         return rows
       }
-      const pages = await store.list()
-      const rows: DbRecord[] = []
-      for (const slim of pages) {
-        const found = await fencesOn(store, slim.id)
-        if (!found) continue
-        for (const fence of found.fences) rows.push(toRecord(found.page, fence))
-      }
-      return rows
+      return index.list()
     },
-    get: (id) => recordOf(store, id),
+    get: async (id) => {
+      await index.sync()
+      return recordOf(store, index, id)
+    },
     update: async (id, patch) => {
       const parsed = parsePageBlockRecordId(id)
       if (!parsed) throw new Error(`unknown pageBlock: ${id}`)
@@ -133,9 +92,10 @@ export function pageBlocksCollection(store: PagesStore): CollectionSpec {
         replace: patch.replace === true,
       })
       const next = await store.update(page.id, { notes })
-      const fence = listPageBlockFences(next.notes).find((item) => item.id === parsed.blockId)
-      if (!fence) throw new Error(`unknown pageBlock: ${id}`)
-      return toRecord(next, fence)
+      await index.reindexPage(next)
+      const row = await index.get(id)
+      if (!row) throw new Error(`unknown pageBlock: ${id}`)
+      return row
     },
   }
 }

--- a/packages/core-page/src/host/page-blocks-index.ts
+++ b/packages/core-page/src/host/page-blocks-index.ts
@@ -1,0 +1,194 @@
+import type { DbRecord } from '@biu/type-file-system'
+import { recordBuiltinValues } from '@biu/type-file-system'
+import { listPageBlockFences, pageBlockData, pageBlockRecordId, parsePageBlockRecordId } from '@biu/core-editor/host'
+import type { PagesStore, PageRow } from './store.ts'
+
+export const PAGE_BLOCK_HOT_WINDOW_MS = 5 * 60 * 1000
+export const PAGE_BLOCK_HOT_LIMIT = 24
+export const PAGE_BLOCK_WARM_LIMIT = 8
+export const PAGE_BLOCK_TICK_MS = 15_000
+
+type Cover = { page_id: string; page_updated_at: number }
+type IndexRow = {
+  page_id: string
+  block_id: string
+  kind: string
+  plugin: string
+  title: string
+  data_json: string
+  page_created_at: number
+  page_updated_at: number
+}
+
+function blockTitle(kind: string, data: Record<string, unknown>) {
+  if (typeof data.title === 'string' && data.title.trim()) return data.title.trim()
+  if (typeof data.html === 'string' && data.html.trim()) {
+    const text = data.html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 48)
+    if (text) return text
+  }
+  if (typeof data.file === 'string' && data.file.trim()) return data.file.replace(/^assets\//, '')
+  return kind
+}
+
+function toRecord(row: IndexRow): DbRecord {
+  return {
+    id: pageBlockRecordId(row.page_id, row.block_id),
+    title: row.title,
+    pageId: row.page_id,
+    blockId: row.block_id,
+    kind: row.kind,
+    plugin: row.plugin,
+    data: row.data_json,
+    ...recordBuiltinValues({ createdAt: row.page_created_at, updatedAt: row.page_updated_at }),
+  }
+}
+
+export type PageBlocksIndexOptions = {
+  hotWindowMs?: number
+  hotLimit?: number
+  warmLimit?: number
+}
+
+/** 倒排只扫脏页：先最近窗口，再少量补旧的；每拍有上限。 */
+export class PageBlocksIndex {
+  constructor(
+    private store: PagesStore,
+    private opts: PageBlocksIndexOptions = {},
+  ) {}
+
+  private hotWindowMs() {
+    return this.opts.hotWindowMs ?? PAGE_BLOCK_HOT_WINDOW_MS
+  }
+
+  private hotLimit() {
+    return this.opts.hotLimit ?? PAGE_BLOCK_HOT_LIMIT
+  }
+
+  private warmLimit() {
+    return this.opts.warmLimit ?? PAGE_BLOCK_WARM_LIMIT
+  }
+
+  private async db() {
+    const sqlite = await this.store.sqlite()
+    sqlite.exec(`
+      CREATE TABLE IF NOT EXISTS page_block_index (
+        page_id TEXT NOT NULL,
+        block_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        plugin TEXT NOT NULL DEFAULT '',
+        title TEXT NOT NULL,
+        data_json TEXT NOT NULL,
+        page_created_at INTEGER NOT NULL DEFAULT 0,
+        page_updated_at INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (page_id, block_id)
+      );
+      CREATE INDEX IF NOT EXISTS page_block_index_page ON page_block_index(page_id);
+      CREATE TABLE IF NOT EXISTS page_block_cover (
+        page_id TEXT PRIMARY KEY,
+        page_updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS page_block_index_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `)
+    return sqlite
+  }
+
+  lastRunAt() {
+    return this.readMeta('last_run_at').then((raw) => Number(raw) || 0)
+  }
+
+  private async readMeta(key: string) {
+    const db = await this.db()
+    const row = db.prepare('SELECT value FROM page_block_index_meta WHERE key = ?').get(key) as { value: string } | undefined
+    return row?.value ?? ''
+  }
+
+  private async writeMeta(key: string, value: string) {
+    const db = await this.db()
+    db.prepare('INSERT INTO page_block_index_meta(key, value) VALUES(?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value').run(key, value)
+  }
+
+  async reindexPage(page: PageRow) {
+    const db = await this.db()
+    const fences = listPageBlockFences(page.notes).filter((item) => item.id)
+    db.exec('BEGIN')
+    try {
+      db.prepare('DELETE FROM page_block_index WHERE page_id = ?').run(page.id)
+      const insert = db.prepare(`
+        INSERT INTO page_block_index(
+          page_id, block_id, kind, plugin, title, data_json, page_created_at, page_updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      for (const fence of fences) {
+        const data = pageBlockData(fence)
+        insert.run(
+          page.id,
+          fence.id,
+          fence.kind,
+          fence.plugin,
+          blockTitle(fence.kind, data),
+          JSON.stringify(data),
+          page.createdAt,
+          page.updatedAt,
+        )
+      }
+      db.prepare(
+        'INSERT INTO page_block_cover(page_id, page_updated_at) VALUES(?, ?) ON CONFLICT(page_id) DO UPDATE SET page_updated_at=excluded.page_updated_at',
+      ).run(page.id, page.updatedAt)
+      db.exec('COMMIT')
+    } catch (error) {
+      db.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  async dropPage(pageId: string) {
+    const db = await this.db()
+    db.prepare('DELETE FROM page_block_index WHERE page_id = ?').run(pageId)
+    db.prepare('DELETE FROM page_block_cover WHERE page_id = ?').run(pageId)
+  }
+
+  async sync(now = Date.now()) {
+    const db = await this.db()
+    const pages = await this.store.list()
+    const live = new Set(pages.map((item) => item.id))
+    const covers = (db.prepare('SELECT page_id, page_updated_at FROM page_block_cover').all() as Cover[])
+    const coverAt = new Map(covers.map((item) => [item.page_id, item.page_updated_at]))
+    for (const item of covers) {
+      if (!live.has(item.page_id)) await this.dropPage(item.page_id)
+    }
+    const dirty = pages.filter((page) => (coverAt.get(page.id) ?? -1) < page.updatedAt)
+    const hotCut = now - this.hotWindowMs()
+    const hot = dirty.filter((page) => page.updatedAt >= hotCut).sort((a, b) => b.updatedAt - a.updatedAt || a.id.localeCompare(b.id))
+    const takeHot = hot.slice(0, this.hotLimit())
+    const taken = new Set(takeHot.map((item) => item.id))
+    const warm = dirty
+      .filter((page) => !taken.has(page.id))
+      .sort((a, b) => b.updatedAt - a.updatedAt || a.id.localeCompare(b.id))
+      .slice(0, this.warmLimit())
+    const batch = [...takeHot, ...warm]
+    for (const slim of batch) {
+      const page = await this.store.get(slim.id)
+      if (page) await this.reindexPage(page)
+    }
+    await this.writeMeta('last_run_at', String(now))
+    await this.writeMeta('last_batch', String(batch.length))
+    return { scanned: batch.length, dirty: dirty.length, lastRunAt: now }
+  }
+
+  async list() {
+    const db = await this.db()
+    const rows = db.prepare('SELECT * FROM page_block_index ORDER BY page_id, block_id').all() as IndexRow[]
+    return rows.map(toRecord)
+  }
+
+  async get(id: string) {
+    const parsed = parsePageBlockRecordId(id)
+    if (!parsed) return null
+    const db = await this.db()
+    const row = db.prepare('SELECT * FROM page_block_index WHERE page_id = ? AND block_id = ?').get(parsed.pageId, parsed.blockId) as IndexRow | undefined
+    return row ? toRecord(row) : null
+  }
+}

--- a/packages/core-page/src/host/store.ts
+++ b/packages/core-page/src/host/store.ts
@@ -227,6 +227,10 @@ export class PagesStore {
     return db
   }
 
+  async sqlite() {
+    return this.openDb()
+  }
+
   private async migrateMarkdown() {
     if (!this.db) return
     let names: string[] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`/page-blocks` 不再每次 list 扫全部页面。SQLite 记下每页上次编入索引的 `updated_at` 和全局 `last_run_at`。

每拍分级：
- 热：最近 5 分钟改过的脏页，最多 24 页
- 温：其余脏页再补最多 8 页
- 删掉的页面从倒排里摘掉

15 秒后台 tick（`unref`，不拖住进程）。改某一块时只重编那一页。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

