### PR TITLE
修好特殊块详情的页面引用和类型列

### DIFF
--- a/packages/core-file-system/src/host/agent-payload.ts
+++ b/packages/core-file-system/src/host/agent-payload.ts
@@ -192,6 +192,7 @@ export class AgentDbCompact {
     if (field.description) out.description = field.description
     if (field.action) out.action = field.action
     if (field.computed) out.computed = true
+    if (field.collection) out.collection = field.collection
     return out
   }
 

--- a/packages/core-file-system/src/web/record-link-cell.test.tsx
+++ b/packages/core-file-system/src/web/record-link-cell.test.tsx
@@ -49,6 +49,35 @@ test('depend chips resolve title from the same table when the row is off this pa
   }
 })
 
+test('cross-table ref chips load the title from field.collection', async () => {
+  const original = globalThis.fetch
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    assert.match(url, /\/api\/db\/read/)
+    assert.match(url, /%2Fpages%2Fp012/)
+    return new Response(JSON.stringify({ value: { id: 'p012', title: '算法笔记' } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as typeof fetch
+  try {
+    const { container } = render(
+      <RecordLinkChips
+        field={{ type: 'ref', collection: '/pages' }}
+        fieldKey="pageId"
+        value="p012"
+        collectionPath="/page-blocks"
+        records={[{ id: 'p012::aaaa', title: 'Two Sum' }]}
+      />,
+    )
+    await waitFor(() => {
+      assert.equal(container.querySelector('.fsdb-ref-chip-title')?.textContent, '算法笔记')
+    })
+  } finally {
+    globalThis.fetch = original
+  }
+})
+
 test('ref picker lists titles and does not print ids beside them', () => {
   const src = readFileSync(resolve(import.meta.dirname, './record-link-cell.tsx'), 'utf8')
   assert.match(src, /crumbRecordLabel/)

--- a/packages/core-file-system/src/web/record-link-cell.tsx
+++ b/packages/core-file-system/src/web/record-link-cell.tsx
@@ -44,6 +44,11 @@ async function readPeer(collectionPath: string, id: string, labelField?: string)
   }
 }
 
+function linkCollection(field: FieldSpec | undefined, fallback?: string) {
+  const raw = typeof field?.collection === 'string' ? field.collection.trim() : ''
+  return raw || fallback || ''
+}
+
 function jumpRecord(collectionPath: string | undefined, id: string) {
   if (!collectionPath || !id) return
   showRecordInInspector(collectionPath, id)
@@ -100,8 +105,9 @@ export function RecordLinkChips({
   labelField?: string
 }) {
   const ids = recordLinkIds(field, value, fieldKey)
+  const peerPath = linkCollection(field, collectionPath)
   const seed = useMemo(() => asPeers(records ?? [], labelField), [labelField, records])
-  const labelOfId = useResolvedPeerLabels(ids, seed, collectionPath, labelField)
+  const labelOfId = useResolvedPeerLabels(ids, seed, peerPath, labelField)
   if (!ids.length) return null
   return (
     <span className="fsdb-ref-chips">
@@ -115,7 +121,7 @@ export function RecordLinkChips({
             title={label ? `在右侧打开 ${label}` : '在右侧打开'}
             onClick={(event) => {
               event.stopPropagation()
-              jumpRecord(collectionPath, id)
+              jumpRecord(peerPath, id)
             }}
           >
             <span className="fsdb-ref-chip-title">{label || '…'}</span>
@@ -152,6 +158,7 @@ export function RecordPickPanel({
 }) {
   ensureDbSearchStyle()
   const multiple = !isSingleRefField(field, fieldKey)
+  const peerPath = linkCollection(field, collectionPath)
   const selected = recordLinkIds(field, value, fieldKey)
   const [query, setQuery] = useState('')
   const [peers, setPeers] = useState<RecordLinkPeer[]>(() => asPeers(seed ?? [], labelField))
@@ -160,7 +167,7 @@ export function RecordPickPanel({
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    void loadTablePeers(collectionPath, labelField)
+    void loadTablePeers(peerPath, labelField)
       .then((rows) => {
         if (!cancelled) setPeers(rows)
       })
@@ -173,7 +180,7 @@ export function RecordPickPanel({
     return () => {
       cancelled = true
     }
-  }, [collectionPath, labelField])
+  }, [peerPath, labelField])
 
   const byId = useMemo(() => new Map(peers.map((item) => [item.id, item.label])), [peers])
   const selectedKey = selected.join('\0')
@@ -185,7 +192,7 @@ export function RecordPickPanel({
       return
     }
     let cancelled = false
-    void Promise.all(missing.map((id) => readPeer(collectionPath, id, labelField))).then((rows) => {
+    void Promise.all(missing.map((id) => readPeer(peerPath, id, labelField))).then((rows) => {
       if (cancelled) return
       const next: Record<string, string> = {}
       missing.forEach((id, index) => {
@@ -197,7 +204,7 @@ export function RecordPickPanel({
     return () => {
       cancelled = true
     }
-  }, [byId, collectionPath, labelField, selectedKey])
+  }, [byId, peerPath, labelField, selectedKey])
   const titleOf = (id: string) => {
     const labeled = byId.get(id) || extra[id]
     return labeled && labeled.trim() ? labeled : ''
@@ -227,7 +234,7 @@ export function RecordPickPanel({
   }
 
   function jump(id: string) {
-    jumpRecord(collectionPath, id)
+    jumpRecord(peerPath, id)
     onJump?.()
   }
 

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -149,7 +149,7 @@ test('page-blocks collection updates one fence by page::block id', async () => {
   const listed = await blocks.list()
   assert.equal(listed.length, 1)
   assert.equal(listed[0]?.id, `${pageId}::ab12cd34`)
-  assert.equal(listed[0]?.kind, 'html')
+  assert.equal(listed[0]?.blockKind, 'html')
   const updated = await blocks.update!(`${pageId}::ab12cd34`, {
     data: { html: '<div>新</div>', deck: false },
   })

--- a/packages/core-page/src/host/page-blocks-collection.ts
+++ b/packages/core-page/src/host/page-blocks-collection.ts
@@ -43,13 +43,13 @@ export function pageBlocksCollection(store: PagesStore, index: PageBlocksIndex):
     },
     schema: {
       labelField: 'title',
-      columns: ['title', 'kind', 'plugin', 'pageId'],
+      columns: ['title', 'blockKind', 'plugin', 'pageId'],
       fields: {
         ...REQUIRED_RECORD_FIELDS,
         title: { type: 'string', label: '标题' },
-        pageId: { type: 'ref', label: '页面' },
+        pageId: { type: 'ref', label: '页面', collection: '/pages' },
         blockId: { type: 'string', label: '块 id' },
-        kind: { type: 'string', label: '类型' },
+        blockKind: { type: 'string', label: '类型' },
         plugin: { type: 'string', label: '插件', writable: true },
         data: {
           type: 'string',

--- a/packages/core-page/src/host/page-blocks-index.ts
+++ b/packages/core-page/src/host/page-blocks-index.ts
@@ -36,7 +36,7 @@ function toRecord(row: IndexRow): DbRecord {
     title: row.title,
     pageId: row.page_id,
     blockId: row.block_id,
-    kind: row.kind,
+    blockKind: row.kind,
     plugin: row.plugin,
     data: row.data_json,
     ...recordBuiltinValues({ createdAt: row.page_created_at, updatedAt: row.page_updated_at }),

--- a/packages/type-file-system/src/index.ts
+++ b/packages/type-file-system/src/index.ts
@@ -33,6 +33,8 @@ export type FieldSpec = {
   computed?: boolean
   /** person：创建人一人；编辑人可多人。 */
   multiple?: boolean
+  /** ref / multi-ref 指向的表路径，缺省为本表。 */
+  collection?: string
 }
 
 export type AttachmentValue = { name: string; href: string; bytes?: number }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
特殊块详情里「页面」chip 在本表查 `p012`，找不到就显示省略号。`pageId` 改为指向 `/pages`。列表接口会把每行的 `kind` 写成 `record`，盖掉块类型，类型列改名为 `blockKind`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

