### PR TITLE
组件表按块类型提供内置视图

### DIFF
--- a/packages/core-file-system/src/catalog-views.test.ts
+++ b/packages/core-file-system/src/catalog-views.test.ts
@@ -3,13 +3,17 @@ import assert from 'node:assert/strict'
 import {
   builtinAllView,
   builtinAllViewId,
+  builtinBlockKindViewId,
   builtinCatalogViewId,
   builtinCatalogViews,
+  isBuiltinBlockKindViewId,
   isBuiltinCatalogViewId,
   isReadOnlyViewId,
   mergeCatalogViews,
+  mergePageBlockViews,
   mergeTableViews,
   stubBuiltinAllView,
+  stubBuiltinBlockKindView,
   stubBuiltinCatalogView,
   catalogRowOpenTarget,
   builtinTagViewId,
@@ -97,4 +101,36 @@ test('stamp rows open the source record, not a tag view', () => {
 test('builtin all views are read-only', () => {
   assert.equal(isReadOnlyViewId(builtinAllViewId('/sessions')), true)
   assert.equal(isReadOnlyViewId('user-traj'), false)
+})
+
+test('each registered page block kind gets a builtin view', () => {
+  const table = { path: '/page-blocks', label: '组件', view: { title: '组件' } }
+  const merged = mergePageBlockViews(
+    table,
+    [
+      { kind: 'excalidraw', label: '画板' },
+      { kind: 'html', label: 'HTML' },
+      { kind: 'html', label: '重复' },
+      { kind: '', label: '空' },
+    ],
+    [
+      { id: builtinBlockKindViewId('html'), name: '旧的', mode: 'table', sortField: 'id', sortDir: 'asc', filters: {}, columns: [] },
+      { id: 'mine', name: '置顶', mode: 'table', sortField: 'id', sortDir: 'asc', filters: {}, columns: [] },
+    ],
+  )
+  assert.equal(merged[0]?.id, builtinAllViewId('/page-blocks'))
+  assert.equal(merged[0]?.name, '全部组件')
+  assert.equal(merged[1]?.id, builtinBlockKindViewId('excalidraw'))
+  assert.equal(merged[1]?.name, '画板')
+  assert.deepEqual(merged[1]?.filters, { blockKind: 'excalidraw' })
+  assert.equal(merged[1]?.builtin, true)
+  assert.equal(merged[2]?.id, builtinBlockKindViewId('html'))
+  assert.equal(merged[2]?.name, 'HTML')
+  assert.equal(merged.filter((view) => view.id === builtinBlockKindViewId('html')).length, 1)
+  assert.equal(merged.some((view) => view.id === 'mine'), true)
+  assert.equal(isReadOnlyViewId(builtinBlockKindViewId('html')), true)
+  assert.equal(isBuiltinCatalogViewId(builtinBlockKindViewId('html')), false)
+  assert.equal(isBuiltinBlockKindViewId(builtinBlockKindViewId('algorithm')), true)
+  assert.equal(stubBuiltinBlockKindView('builtin-block:html')?.filters.blockKind, 'html')
+  assert.equal(stubBuiltinBlockKindView('user-1'), null)
 })

--- a/packages/core-file-system/src/catalog-views.ts
+++ b/packages/core-file-system/src/catalog-views.ts
@@ -16,8 +16,15 @@ export function builtinCatalogViewId(collectionPath: string) {
 
 const TAG_PREFIX = 'builtin-tag:'
 
+const BLOCK_PREFIX = 'builtin-block:'
+
 export function isBuiltinCatalogViewId(id: string) {
-  return id.startsWith('builtin:') && !id.startsWith(ALL_PREFIX) && !id.startsWith(TAG_PREFIX)
+  return (
+    id.startsWith('builtin:') &&
+    !id.startsWith(ALL_PREFIX) &&
+    !id.startsWith(TAG_PREFIX) &&
+    !id.startsWith(BLOCK_PREFIX)
+  )
 }
 
 export function builtinTagViewId(tagId: string) {
@@ -41,7 +48,7 @@ export function isBuiltinAllViewId(id: string) {
 }
 
 export function isReadOnlyViewId(id: string) {
-  return isBuiltinAllViewId(id) || isBuiltinCatalogViewId(id) || isBuiltinTagViewId(id)
+  return isBuiltinAllViewId(id) || isBuiltinCatalogViewId(id) || isBuiltinTagViewId(id) || isBuiltinBlockKindViewId(id)
 }
 
 export function collectionNoun(table: TableRef) {
@@ -114,6 +121,62 @@ export function mergeTableViews(table: TableRef | undefined, user: SavedView[]):
   const extra = userViews(user)
   if (!table?.path || table.path === '/') return extra
   return [builtinAllView(table), ...extra]
+}
+
+export type BlockKindRef = { kind: string; label: string }
+
+export function builtinBlockKindViewId(kind: string) {
+  return `${BLOCK_PREFIX}${String(kind ?? '').trim()}`
+}
+
+export function isBuiltinBlockKindViewId(id: string) {
+  return id.startsWith(BLOCK_PREFIX)
+}
+
+export function blockKindFromViewId(id: string) {
+  return isBuiltinBlockKindViewId(id) ? id.slice(BLOCK_PREFIX.length) : ''
+}
+
+export function builtinBlockKindView(block: BlockKindRef): SavedView {
+  const kind = String(block.kind ?? '').trim()
+  return normalizeSavedView({
+    id: builtinBlockKindViewId(kind),
+    name: String(block.label ?? '').trim() || kind,
+    mode: 'table',
+    sortField: 'title',
+    sortDir: 'asc',
+    filters: { blockKind: kind },
+    columns: [],
+    groupBy: '',
+    tree: true,
+    wrap: false,
+    truncate: true,
+    query: '',
+    builtin: true,
+  })
+}
+
+export function stubBuiltinBlockKindView(id: string): SavedView | null {
+  if (!isBuiltinBlockKindViewId(id)) return null
+  const kind = blockKindFromViewId(id)
+  if (!kind) return null
+  return builtinBlockKindView({ kind, label: kind })
+}
+
+/** /page-blocks：全部组件 + 每种已登记块一条只读视图。 */
+export function mergePageBlockViews(table: TableRef | undefined, kinds: BlockKindRef[], user: SavedView[]): SavedView[] {
+  const extra = userViews(user)
+  const unique = new Map<string, BlockKindRef>()
+  for (const item of kinds) {
+    const kind = String(item.kind ?? '').trim()
+    if (!kind || unique.has(kind)) continue
+    unique.set(kind, { kind, label: String(item.label ?? '').trim() || kind })
+  }
+  const kindViews = [...unique.values()]
+    .sort((a, b) => a.kind.localeCompare(b.kind) || a.label.localeCompare(b.label))
+    .map(builtinBlockKindView)
+  if (!table?.path || table.path === '/') return [...kindViews, ...extra]
+  return [builtinAllView(table), ...kindViews, ...extra]
 }
 
 export type TagRef = { id: string; label: string }

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -35,6 +35,7 @@ export function databaseRecordPath(collection: string, recordId: string, viewId?
 export const VIEWS_COLLECTION_PATH = '/views'
 export const FACETS_COLLECTION_PATH = '/facets'
 export const EVENTS_COLLECTION_PATH = '/events'
+export const PAGE_BLOCKS_COLLECTION_PATH = '/page-blocks'
 
 const SYSTEM_COLLECTION_ORDER = [VIEWS_COLLECTION_PATH, EVENTS_COLLECTION_PATH] as const
 

--- a/packages/core-file-system/src/web/database-ui.test.ts
+++ b/packages/core-file-system/src/web/database-ui.test.ts
@@ -101,3 +101,14 @@ test('registerView is scoped to the collection that registered it', () => {
   first.dispose()
   assert.equal(ui.views('/tasks').length, 0)
 })
+
+test('refresh notifies chrome subscribers', () => {
+  const ctx = new Context()
+  const ui = new DatabaseUiService(ctx)
+  let n = 0
+  ui.subscribe(() => {
+    n += 1
+  })
+  ui.refresh()
+  assert.equal(n, 1)
+})

--- a/packages/core-file-system/src/web/database-ui.ts
+++ b/packages/core-file-system/src/web/database-ui.ts
@@ -124,6 +124,10 @@ export class DatabaseUiService extends Service implements DatabaseUi {
     }
   }
 
+  refresh() {
+    this.emit()
+  }
+
   private emit() {
     this.snapshot.clear()
     this.viewSnapshot.clear()

--- a/packages/core-file-system/src/web/index.tsx
+++ b/packages/core-file-system/src/web/index.tsx
@@ -17,10 +17,11 @@ import {
   collectionNavKey,
 } from './nav-boot.ts'
 import { defaultViewId, pullSavedViews, pushAllSavedViews } from './view-storage.ts'
-import { DATA_MODULE, DATA_MODULE_ID, DATA_MODULE_PATH, FACETS_COLLECTION_PATH, VIEWS_COLLECTION_PATH, sortDataCollections } from './database-path.ts'
+import { DATA_MODULE, DATA_MODULE_ID, DATA_MODULE_PATH, FACETS_COLLECTION_PATH, PAGE_BLOCKS_COLLECTION_PATH, VIEWS_COLLECTION_PATH, sortDataCollections } from './database-path.ts'
 import { pickMainDataRoute, readMainDataRoute, writeMainDataRoute } from './main-data-route.ts'
 import { facetsChrome } from './facet-chrome.tsx'
 import { viewsChrome } from './views-chrome.ts'
+import { pageBlocksChrome } from './page-blocks-chrome.ts'
 import { viewsForRegisteredCollection } from './collection-nav.ts'
 import { builtinAllViewId } from '../catalog-views.ts'
 import { normalizeCollectionPath } from '../paths.ts'
@@ -240,10 +241,36 @@ export function apply(ctx: Context) {
     if (!ui) return () => undefined
     const views = ui.decorate(VIEWS_COLLECTION_PATH, viewsChrome)
     const facetsUi = ui.decorate(FACETS_COLLECTION_PATH, facetsChrome)
+    const blocksUi = ui.decorate(
+      PAGE_BLOCKS_COLLECTION_PATH,
+      pageBlocksChrome(() => {
+        const editor = ctx.get('pageEditor') as { blocks?: () => Array<{ kind: string; label: string }> } | undefined
+        return editor?.blocks?.() ?? []
+      }),
+    )
     return () => {
       views.dispose()
       facetsUi.dispose()
+      blocksUi.dispose()
     }
+  })
+  ctx.inject(['pageEditor'], (inner) => {
+    const editor = inner.get('pageEditor') as {
+      subscribe: (fn: () => void) => () => void
+      blocks: () => Array<{ kind: string }>
+    }
+    let sig = ''
+    const stop = editor.subscribe(() => {
+      const next = editor
+        .blocks()
+        .map((item) => item.kind)
+        .sort()
+        .join('\0')
+      if (next === sig) return
+      sig = next
+      getDatabaseUi()?.refresh()
+    })
+    return () => stop()
   })
   const slots = ctx.get('slots') as SlotsService
   const appModules = ctx.get('appModules') as AppModulesService

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -129,6 +129,7 @@ test('table title opens record from the title-side button', () => {
   assert.doesNotMatch(browser, /stampRowOpenTarget/)
   const page = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
   assert.match(page, /viewsChrome/)
+  assert.match(page, /pageBlocksChrome/)
   assert.doesNotMatch(page, /openRegisteredRow/)
   assert.doesNotMatch(page, /onOpenRow=\{/)
   assert.doesNotMatch(page, /addSchemaTagField/)

--- a/packages/core-file-system/src/web/page-blocks-chrome.test.ts
+++ b/packages/core-file-system/src/web/page-blocks-chrome.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { builtinAllViewId, builtinBlockKindViewId } from '../catalog-views.ts'
+import { pageBlocksChrome } from './page-blocks-chrome.ts'
+import type { SavedView } from './saved-view.ts'
+
+test('page-blocks chrome lists all plus one view per kind', () => {
+  const chrome = pageBlocksChrome(() => [
+    { kind: 'algorithm', label: '算法题' },
+    { kind: 'html', label: 'HTML' },
+  ])
+  const listed = chrome.listViews?.(
+    [{ id: 'page-blocks', path: '/page-blocks', kind: 'collection', label: '组件', view: { title: '组件' } }],
+    [],
+  ) as SavedView[]
+  assert.equal(listed[0]?.id, builtinAllViewId('/page-blocks'))
+  assert.equal(listed.some((view) => view.id === builtinBlockKindViewId('html')), true)
+  assert.equal(listed.some((view) => view.id === builtinBlockKindViewId('algorithm')), true)
+})

--- a/packages/core-file-system/src/web/page-blocks-chrome.ts
+++ b/packages/core-file-system/src/web/page-blocks-chrome.ts
@@ -1,0 +1,19 @@
+import type { CollectionInfo } from '@biu/type-file-system'
+import type { CollectionChrome } from '@biu/type-file-system/ui'
+import { mergePageBlockViews, type BlockKindRef } from '../catalog-views.ts'
+import { PAGE_BLOCKS_COLLECTION_PATH } from './database-path.ts'
+import { normalizeCollectionPath } from '../paths.ts'
+import type { SavedView } from './saved-view.ts'
+
+export function pageBlocksChrome(kinds: () => BlockKindRef[]): CollectionChrome {
+  return {
+    listViews(tables: CollectionInfo[], user: unknown[]) {
+      const table = tables.find((item) => normalizeCollectionPath(item.path) === PAGE_BLOCKS_COLLECTION_PATH) ?? {
+        path: PAGE_BLOCKS_COLLECTION_PATH,
+        label: '组件',
+        view: { title: '组件' },
+      }
+      return mergePageBlockViews(table, kinds(), user as SavedView[])
+    },
+  }
+}

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -1,4 +1,4 @@
-import { builtinAllViewId, stubBuiltinAllView, stubBuiltinCatalogView, stubBuiltinTagView, isReadOnlyViewId } from '../catalog-views.ts'
+import { builtinAllViewId, stubBuiltinAllView, stubBuiltinBlockKindView, stubBuiltinCatalogView, stubBuiltinTagView, isReadOnlyViewId } from '../catalog-views.ts'
 import { listCollection } from './db-client.ts'
 import { looksLikeFilterTree, normalizeFilterGroup, parseSortsInput } from '../query-logic.ts'
 import { normalizeSavedView, type SavedView } from './saved-view.ts'
@@ -93,6 +93,7 @@ export function viewForPath(collectionPath: string, routeViewId?: string): Saved
       ? listed.find((item) => item.id === routeViewId) ??
         stubBuiltinCatalogView(routeViewId) ??
         stubBuiltinTagView(routeViewId) ??
+        stubBuiltinBlockKindView(routeViewId) ??
         stubBuiltinAllView(routeViewId)
       : undefined) ??
     listed.find((item) => item.id === loadActiveViewId(collectionPath, listed)) ??


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
组件（`/page-blocks`）除「全部组件」外，每种已 `registerBlock` 的类型各有一条只读内置视图（`builtin-block:<kind>`），筛选 `blockKind`。

- 标签用块的 `label`（HTML、画板、算法题等）
- 路由里即使本地视图列表尚未合并，也能用 stub 还原筛选
- 插件登记/卸载后刷新侧栏视图列表

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

