### PR TITLE
组件表增加组件视图，直接画登记的块 UI

### DIFF
--- a/packages/core-editor/src/web/index.test.ts
+++ b/packages/core-editor/src/web/index.test.ts
@@ -7,6 +7,7 @@ import { PageEditor } from './page-editor.tsx'
 
 class FakeDatabaseUi extends Service implements DatabaseUi {
   paths: string[] = []
+  registered: Array<{ path: string; id: string; label: string }> = []
   constructor(ctx: Context) {
     super(ctx, 'databaseUi')
   }
@@ -16,7 +17,8 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
     assert.ok(chrome.DetailTools)
     return { dispose() {} }
   }
-  registerView(_path: string, _view: CollectionViewType) {
+  registerView(path: string, view: CollectionViewType) {
+    this.registered.push({ path, id: view.id, label: view.label })
     return { dispose() {} }
   }
   chrome() {
@@ -35,5 +37,6 @@ test('core-editor paints Content on pages, tasks, plugins and facets, not sessio
   const ui = new FakeDatabaseUi(ctx)
   await ctx.plugin(editorUi)
   assert.deepEqual(ui.paths, ['/pages', '/tasks', '/plugins', '/facets'])
+  assert.deepEqual(ui.registered, [{ path: '/page-blocks', id: 'blocks', label: '组件' }])
   assert.ok(ctx.pageEditor)
 })

--- a/packages/core-editor/src/web/index.ts
+++ b/packages/core-editor/src/web/index.ts
@@ -6,6 +6,7 @@ import { PageEditor } from './page-editor.tsx'
 import { PageEditorService } from './service.ts'
 import { PAGE_EDITOR_STYLE } from './style.ts'
 import { SourceToggle } from './source-toggle.tsx'
+import { pageBlocksCollectionView } from './page-blocks-view.tsx'
 
 export { PageEditor, PageEditor as RecordEditor } from './page-editor.tsx'
 export { SourceToggle } from './source-toggle.tsx'
@@ -13,6 +14,7 @@ export { PageEditorService, BASIC_BLOCK_TYPE, getPageEditor, usePageEditorVersio
 export type { HeadingReplacement, PageBlockSpec, PageBlockViewProps, SlashCommandSpec, SlashInsert } from './service.ts'
 export { pageEditorExtensions } from './kit.ts'
 export { markdownLocusFromRange, markdownLocusFromSelection, markdownLocusFromElement } from './markdown-locus.ts'
+export { PageBlocksView, pageBlocksCollectionView, PAGE_BLOCKS_VIEW_ID } from './page-blocks-view.tsx'
 
 export const name = 'core-editor-ui'
 export const inject = ['databaseUi']
@@ -25,6 +27,7 @@ export function apply(ctx: Context) {
   for (const path of EDITOR_COLLECTIONS) {
     ctx.effect(() => ui.decorate(path, { Content: PageEditor, DetailTools: SourceToggle }).dispose)
   }
+  ctx.effect(() => ui.registerView('/page-blocks', pageBlocksCollectionView).dispose)
 }
 
 if (typeof document !== 'undefined') {

--- a/packages/core-editor/src/web/page-blocks-view.test.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@testing-library/react'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import { PageEditorService } from './service.ts'
+import { parsePageBlockRowData, PageBlocksView } from './page-blocks-view.tsx'
+
+test('parsePageBlockRowData reads json string or object', () => {
+  assert.deepEqual(parsePageBlockRowData('{"html":"<p>a</p>"}'), { html: '<p>a</p>' })
+  assert.deepEqual(parsePageBlockRowData({ html: '<p>b</p>' }), { html: '<p>b</p>' })
+  assert.deepEqual(parsePageBlockRowData(''), {})
+})
+
+test('page-blocks view paints the registered block View', () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  ctx.pageEditor.registerBlock({
+    kind: 'html',
+    plugin: 'page-html-blocks',
+    label: '静态HTML',
+    View: ({ data }) => <div data-testid="html-ui">{String(data.html ?? '')}</div>,
+  })
+  const { container } = render(
+    <PageBlocksView
+      path="/page-blocks"
+      rows={[
+        { id: 'p1::a1', title: '刊头', blockKind: 'html', plugin: 'page-html-blocks', data: '{"html":"<b>hi</b>"}' },
+        { id: 'p1::a2', title: '缺插件', blockKind: 'gone', plugin: 'missing-plugin', data: '{}' },
+      ]}
+      onOpen={() => undefined}
+    />,
+  )
+  assert.equal(container.querySelector('[data-testid="html-ui"]')?.textContent, '<b>hi</b>')
+  assert.ok(container.querySelector('[data-testid="page-block-missing"]'))
+})

--- a/packages/core-editor/src/web/page-blocks-view.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react'
+import { RectangleGroupIcon } from '@heroicons/react/16/solid'
+import type { DbRecord } from '@biu/type-file-system'
+import type { CollectionViewType, FsViewProps } from '@biu/type-file-system/ui'
+import { PageBlockMissing } from './page-block-view.tsx'
+import { getPageEditor, usePageEditorVersion } from './service.ts'
+
+export const PAGE_BLOCKS_VIEW_ID = 'blocks'
+
+export function parsePageBlockRowData(raw: unknown): Record<string, unknown> {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) return { ...(raw as Record<string, unknown>) }
+  if (typeof raw === 'string' && raw.trim()) {
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed as Record<string, unknown>
+    } catch {
+      /* ignore */
+    }
+  }
+  return {}
+}
+
+async function writeBlockData(id: string, data: Record<string, unknown>) {
+  const res = await fetch('/api/db/update', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ path: `/page-blocks/${id}`, content: { data } }),
+  })
+  const body = (await res.json()) as { error?: string }
+  if (!res.ok) throw new Error(body.error || res.statusText)
+}
+
+function BlockCard({
+  row,
+  onOpen,
+}: {
+  row: DbRecord
+  onOpen: (row: DbRecord) => void
+}) {
+  usePageEditorVersion()
+  const kind = String(row.blockKind ?? row.kind ?? '').trim()
+  const plugin = String(row.plugin ?? '').trim()
+  const spec = getPageEditor()?.block(kind)
+  const View = spec?.View
+  const [data, setData] = useState(() => parsePageBlockRowData(row.data))
+  useEffect(() => {
+    setData(parsePageBlockRowData(row.data))
+  }, [row.data])
+  const title = String(row.title ?? spec?.label ?? kind)
+  const update = (patch: Record<string, unknown>, opts?: { replace?: boolean }) => {
+    const next = opts?.replace ? patch : { ...data, ...patch }
+    setData(next)
+    void writeBlockData(String(row.id), next)
+  }
+  return (
+    <article className="page-blocks-view-card" data-testid="page-blocks-view-card">
+      <button type="button" className="page-blocks-view-title" onClick={() => onOpen(row)}>
+        {title}
+      </button>
+      <div
+        className="page-block"
+        data-page-block={kind || undefined}
+        data-page-block-plugin={plugin || undefined}
+        data-page-block-id={String(row.blockId ?? '') || undefined}
+      >
+        {View ? (
+          <View data={data} update={update} writable />
+        ) : (
+          <PageBlockMissing kind={kind || 'unknown'} plugin={plugin} data={data} />
+        )}
+      </div>
+    </article>
+  )
+}
+
+export function PageBlocksView({ rows, onOpen }: FsViewProps) {
+  usePageEditorVersion()
+  if (!rows.length) return <p className="fsdb-empty">暂无组件</p>
+  return (
+    <div className="page-editor page-blocks-view" data-testid="page-blocks-view">
+      {rows.map((row) => (
+        <BlockCard key={row.id} row={row} onOpen={onOpen} />
+      ))}
+    </div>
+  )
+}
+
+export const pageBlocksCollectionView: CollectionViewType = {
+  id: PAGE_BLOCKS_VIEW_ID,
+  label: '组件',
+  Icon: RectangleGroupIcon,
+  View: PageBlocksView,
+}

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -109,4 +109,10 @@ export const PAGE_EDITOR_STYLE = `
 .page-math-pop{position:fixed;z-index:10000;min-width:220px;max-width:min(360px,calc(100vw - 16px));padding:6px 8px;background:var(--dsw-sidebar);border:1px solid var(--dsw-border);border-radius:8px;box-shadow:0 8px 24px rgba(15,15,15,.16)}
 .page-math-pop-input{display:block;width:100%;margin:0;border:0;padding:2px 0;background:transparent;color:var(--dsw-label);font-family:var(--font-mono);font-size:13px;line-height:1.45;outline:none;resize:none}
 .page-editor .tiptap mark{border-radius:2px;padding:0 .08em}
+.page-blocks-view{min-width:0;flex:1;overflow:auto;padding:8px 12px 32px;display:flex;flex-direction:column;gap:20px}
+.page-blocks-view-card{min-width:0;display:flex;flex-direction:column;gap:8px}
+.page-blocks-view-title{align-self:flex-start;margin:0;border:0;padding:0;background:transparent;color:var(--dsw-label);font:inherit;font-size:13px;font-weight:650;cursor:pointer}
+.page-blocks-view-title:hover{color:var(--dsw-business)}
+.page-blocks-view .page-block{margin:0}
+.page-blocks-view .page-block iframe{pointer-events:auto}
 `

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -600,6 +600,7 @@ export function CollectionBrowser({
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({})
   const listColumns = useMemo(() => {
+    if (customView) return undefined
     if (chrome?.cells) return undefined
     const currentSchema = stat?.schema
     const fieldKeys = currentSchema
@@ -613,7 +614,7 @@ export function CollectionBrowser({
     const visible = requested.filter((key) => allowed.has(key) || Boolean(parseFacetFlatColumnKey(key)))
     if (!visible.length) return undefined
     return listProjectionKeys({ schema: currentSchema, columns: visible, groupBy })
-  }, [chrome, columnKeys, facetCatalog, groupBy, stat])
+  }, [chrome, columnKeys, customView, facetCatalog, groupBy, stat])
   const listColumnsKey = listColumns?.join('\0') ?? ''
   const [refreshing, setRefreshing] = useState(false)
   const [searchOpen, setSearchOpen] = useState(false)

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -437,6 +437,7 @@ test('filesystem list is table-only; extra modes come from registerView', () => 
   assert.match(browser, /className="fsdb-title-host"/)
   assert.doesNotMatch(browser, /<th>操作<\/th>/)
   assert.match(browser, /aria-label="查看模式"/)
+  assert.match(browser, /if \(customView\) return undefined/)
   assert.doesNotMatch(browser, /extraViews\.length \?/)
 })
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
组件表在表格之外多一种查看模式 **组件**（`blocks`）。

插件 `pageEditor.registerBlock({ View })` 时登记的就是 TipTap 里那套 UI；这个视图按行取出 `blockKind`，直接画同一个 `View`。插件未启用时仍用缺块提示。切到该模式时列表不再按表格列投影，以便带上 `data`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

