### PR TITLE
修好 gitignore：包内编译出来的 js 不再进暂存区

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,21 @@ dist/
 *.log
 .DS_Store
 .vscode/
-src/**/*.js
-src/**/*.js.map
+*.tsbuildinfo
+
+# 中间带 / 的规则只相对仓库根。packages/foo/src 下的 tsc 旁路 js 要用 packages/**
+packages/**/*.js
+packages/**/*.js.map
+packages/**/*.d.ts
+packages/**/*.d.ts.map
+host/**/*.js
+host/**/*.js.map
+web/**/*.js
+web/**/*.js.map
+# 沙箱源码是 ts/tsx；pack 产物在 .plugin。这里挡住误编译进沙箱的 js 和依赖
+.plugin-dev/**/*.js
+.plugin-dev/**/*.js.map
+.plugin-dev/**/node_modules/
 
 # 页面数据（.page Markdown 存储），本地数据不纳入版本控制
 .page/

--- a/packages/core-plugin-system/src/host/gitignore.test.ts
+++ b/packages/core-plugin-system/src/host/gitignore.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '../../../../')
+
+function ignored(rel: string) {
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--no-index', rel], { cwd: root, stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+test('compiled js beside package sources is ignored; grok-bot js stays tracked', () => {
+  assert.equal(ignored('packages/core-file-system/src/web/browser.js'), true)
+  assert.equal(ignored('packages/core-editor/src/web/index.js.map'), true)
+  assert.equal(ignored('.plugin-dev/page-html-blocks/web.js'), true)
+  assert.equal(ignored('.plugin-dev/fs-task-rows/node_modules/foo/index.js'), true)
+  assert.equal(ignored('public/grok-bot/src/character.js'), false)
+  assert.equal(ignored('.plugin/page-html-blocks/web.js'), true)
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`.gitignore` 里原来的 `src/**/*.js` 带中间斜杠，只匹配仓库根下的 `src/`，**匹配不到** `packages/*/src`。tsc 一旦在包里源码旁吐出 js，就会全部进暂存区。

改为忽略：

- `packages/**/*.js`（及 map / d.ts）
- `host/`、`web/` 下同样产物
- `.plugin-dev` 里误编译的 js 和 `node_modules`

`public/grok-bot` 的 js 仍入库。`.plugin/` 本来就整目录忽略。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

