### PR TITLE
Drop pages.notes from sqlite

### DIFF
--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
 import { mkdtemp, mkdir, readFile, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -191,6 +192,45 @@ test('page-block index scans a hot batch instead of every page', async () => {
   assert.ok((await index.lastRunAt()) > 0)
 })
 
+
+test('pages sqlite drops leftover notes column after flushing to markdown', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-drop-notes-'))
+  await ctx.plugin(fsPlugin, { root })
+  await mkdir(join(root, PAGE_ROOT), { recursive: true })
+  const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite') as typeof import('node:sqlite')
+  const db = new DatabaseSync(join(root, PAGE_ROOT, 'pages.sqlite'))
+  db.exec(`
+    CREATE TABLE pages (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      notes TEXT NOT NULL DEFAULT '',
+      parent_id TEXT,
+      depends_on_json TEXT NOT NULL DEFAULT '[]',
+      facet_json TEXT NOT NULL DEFAULT '{}',
+      emoji TEXT NOT NULL DEFAULT '',
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.prepare(`
+    INSERT INTO pages (id, title, tags_json, notes, parent_id, depends_on_json, facet_json, emoji, created_at, updated_at)
+    VALUES (?, ?, '[]', ?, NULL, '[]', '{}', '', 1, 2)
+  `).run('legacy', '旧页', '只在 sqlite 里的正文\n')
+  db.close()
+  const store = new PagesStore(ctx.fs.workspace as never, join(root, '.biu/assets'))
+  const listed = await store.list()
+  assert.equal(listed.length, 1)
+  assert.equal(listed[0]?.id, 'legacy')
+  assert.equal(listed[0]?.notes, '')
+  const loaded = await store.get('legacy')
+  assert.equal(loaded?.notes, '只在 sqlite 里的正文\n')
+  const sqlite = await store.sqlite()
+  const cols = (sqlite.prepare('PRAGMA table_info(pages)').all() as Array<{ name: string }>).map((col) => col.name)
+  assert.equal(cols.includes('notes'), false)
+})
 
 test('PagesStore reads existing markdown files from .page', async () => {
   const ctx = new Context()

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -20,7 +20,7 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
       route: '/pages',
       title: '页面',
       inspector: true,
-      blurb: '每页正文在工作区 .page/<id>.md（YAML 头 + Markdown）。.page/pages.sqlite 只做列表索引，不扫全部文件。正文用 db_content；改标题/标签等用 db_update。合集用 db_update 写 facet：{tags:["facet-2"],values:{导演:"查泽雷"}}。图片和附件在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
+      blurb: '每页正文在工作区 .page/<id>.md（YAML 头 + Markdown）。.page/pages.sqlite 只做列表索引（无 notes 列），不扫全部文件。正文用 db_content；改标题/标签等用 db_update。合集用 db_update 写 facet：{tags:["facet-2"],values:{导演:"查泽雷"}}。图片和附件在仓库 .biu/assets。树用 parentId。新建 db_create，删除 db_delete。本表没有 db_action。',
       order: 25,
       icon: 'document',
     },

--- a/packages/core-page/src/host/store.ts
+++ b/packages/core-page/src/host/store.ts
@@ -210,7 +210,6 @@ export class PagesStore {
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         tags_json TEXT NOT NULL DEFAULT '[]',
-        notes TEXT NOT NULL DEFAULT '',
         parent_id TEXT,
         depends_on_json TEXT NOT NULL DEFAULT '[]',
         facet_json TEXT NOT NULL DEFAULT '{}',
@@ -224,6 +223,7 @@ export class PagesStore {
       db.exec(`ALTER TABLE pages ADD COLUMN depends_on_json TEXT NOT NULL DEFAULT '[]'`)
     }
     this.db = db
+    await this.flushSqliteNotesThenDrop()
     return db
   }
 
@@ -259,7 +259,27 @@ export class PagesStore {
     await this.backfillMarkdown(mdIds)
   }
 
-  /** sqlite 里已有、磁盘还没有 `.page/<id>.md` 的页，把 notes 写回 Markdown。 */
+  /** 旧库 `pages.notes` 先落盘再删列。sqlite 只留列表字段。 */
+  private async flushSqliteNotesThenDrop() {
+    if (!this.db) return
+    const cols = this.db.prepare('PRAGMA table_info(pages)').all() as Array<{ name: string }>
+    if (!cols.some((col) => col.name === 'notes')) return
+    let names: string[] = []
+    try {
+      names = await this.fs.list(PAGE_ROOT)
+    } catch {
+      names = []
+    }
+    const mdIds = new Set(names.filter((name) => name.endsWith('.md')).map((name) => name.slice(0, -3)))
+    const rows = this.db.prepare('SELECT * FROM pages').all() as SqlPage[]
+    for (const sql of rows) {
+      if (mdIds.has(sql.id)) continue
+      await this.persistMarkdown(rowFromSql(sql))
+    }
+    this.db.exec('ALTER TABLE pages DROP COLUMN notes')
+  }
+
+  /** sqlite 里已有、磁盘还没有 `.page/<id>.md` 的页，用列表字段写回 Markdown（正文为空）。 */
   private async backfillMarkdown(mdIds: Set<string>) {
     if (!this.db) return
     const rows = this.db.prepare('SELECT * FROM pages').all() as SqlPage[]
@@ -277,12 +297,11 @@ export class PagesStore {
     if (!this.db) return
     this.db.prepare(`
       INSERT INTO pages (
-        id, title, tags_json, notes, parent_id,
+        id, title, tags_json, parent_id,
         depends_on_json, facet_json, emoji, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         title=excluded.title, tags_json=excluded.tags_json,
-        notes=excluded.notes,
         parent_id=excluded.parent_id, depends_on_json=excluded.depends_on_json, facet_json=excluded.facet_json, emoji=excluded.emoji,
         updated_at=excluded.updated_at
     `).run(...sqlValues(row))
@@ -301,7 +320,7 @@ export class PagesStore {
       return rows
     }
     const listed = db.prepare(`
-      SELECT id, title, tags_json, '' AS notes, parent_id,
+      SELECT id, title, tags_json, parent_id,
         depends_on_json, facet_json, emoji, created_at, updated_at
       FROM pages ORDER BY id
     `).all() as SqlPage[]
@@ -411,11 +430,21 @@ export class PagesStore {
     } catch {
       return
     }
-    const db = await this.openDb()
+    await this.openDb()
     const live = new Set<string>()
-    const bodies = db.prepare('SELECT notes FROM pages').all() as Array<{ notes: string }>
-    for (const body of bodies) {
-      for (const name of collectPageAssetNames(body.notes)) live.add(name)
+    let pages: string[] = []
+    try {
+      pages = await this.fs.list(PAGE_ROOT)
+    } catch {
+      pages = []
+    }
+    for (const name of pages) {
+      if (!name.endsWith('.md')) continue
+      try {
+        for (const asset of collectPageAssetNames(await this.fs.read(`${PAGE_ROOT}/${name}`))) live.add(asset)
+      } catch {
+        /* skip unreadable */
+      }
     }
     for (const name of names) {
       if (name === '.gitkeep' || live.has(name) || !isPageAssetFileName(name)) continue
@@ -441,7 +470,7 @@ type SqlPage = {
   id: string
   title: string
   tags_json: string
-  notes: string
+  notes?: string
   parent_id: string | null
   depends_on_json: string
   facet_json: string
@@ -463,7 +492,6 @@ function sqlValues(row: PageRow) {
     row.id,
     row.title,
     JSON.stringify(row.tags),
-    row.notes ?? '',
     row.parentId,
     JSON.stringify(row.dependsOn),
     JSON.stringify(row.facet),
@@ -478,7 +506,7 @@ function rowFromSql(row: SqlPage): PageRow {
     id: row.id,
     title: row.title,
     tags: asStringList(parseJson(row.tags_json, [])),
-    notes: row.notes,
+    notes: row.notes ?? '',
     parentId: row.parent_id == null || row.parent_id === '' ? null : String(row.parent_id),
     dependsOn: asStringList(parseJson(row.depends_on_json ?? '[]', [])),
     facet: normalizeSchemaValue(parseJson(row.facet_json, emptySchemaValue())),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面 sqlite 不再存正文。

- `pages` 表去掉 `notes` 列；旧库先把只有 sqlite、没有 `.md` 的正文写回文件，再 `DROP COLUMN`
- 附件 GC 改为扫 `.page/*.md`，不再读 sqlite notes
- `list` 仍只返回列表字段；正文继续来自 Markdown / `get`

`packages/core-page` host 测试已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

