### PR TITLE
Render page-block View in record detail

### DIFF
--- a/packages/core-editor/src/web/index.test.ts
+++ b/packages/core-editor/src/web/index.test.ts
@@ -13,6 +13,11 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
   }
   decorate(path: string, chrome: CollectionChrome) {
     this.paths.push(path)
+    if (path === '/page-blocks') {
+      assert.ok(chrome.Content)
+      assert.notEqual(chrome.Content, PageEditor)
+      return { dispose() {} }
+    }
     assert.equal(chrome.Content, PageEditor)
     assert.ok(chrome.DetailTools)
     return { dispose() {} }
@@ -38,11 +43,11 @@ class FakeDatabaseUi extends Service implements DatabaseUi {
   }
 }
 
-test('core-editor paints Content on pages, tasks, plugins and facets, not sessions', async () => {
+test('core-editor paints Content on pages, tasks, plugins, facets and page-blocks, not sessions', async () => {
   const ctx = new Context()
   const ui = new FakeDatabaseUi(ctx)
   await ctx.plugin(editorUi)
-  assert.deepEqual(ui.paths, ['/pages', '/tasks', '/plugins', '/facets'])
+  assert.deepEqual(ui.paths, ['/pages', '/tasks', '/plugins', '/facets', '/page-blocks'])
   assert.deepEqual(ui.registered, [{ path: '/page-blocks', id: 'blocks', label: '组件' }])
   assert.ok(ctx.pageEditor)
 })

--- a/packages/core-editor/src/web/index.ts
+++ b/packages/core-editor/src/web/index.ts
@@ -6,7 +6,7 @@ import { PageEditor } from './page-editor.tsx'
 import { PageEditorService } from './service.ts'
 import { PAGE_EDITOR_STYLE } from './style.ts'
 import { SourceToggle } from './source-toggle.tsx'
-import { pageBlocksCollectionView } from './page-blocks-view.tsx'
+import { pageBlocksCollectionView, PageBlockContent } from './page-blocks-view.tsx'
 
 export { PageEditor, PageEditor as RecordEditor } from './page-editor.tsx'
 export { SourceToggle } from './source-toggle.tsx'
@@ -14,7 +14,7 @@ export { PageEditorService, BASIC_BLOCK_TYPE, getPageEditor, usePageEditorVersio
 export type { HeadingReplacement, PageBlockSpec, PageBlockViewProps, SlashCommandSpec, SlashInsert } from './service.ts'
 export { pageEditorExtensions } from './kit.ts'
 export { markdownLocusFromRange, markdownLocusFromSelection, markdownLocusFromElement } from './markdown-locus.ts'
-export { PageBlocksView, pageBlocksCollectionView, PAGE_BLOCKS_VIEW_ID } from './page-blocks-view.tsx'
+export { PageBlocksView, PageBlockContent, PageBlockStage, pageBlocksCollectionView, PAGE_BLOCKS_VIEW_ID } from './page-blocks-view.tsx'
 
 export const name = 'core-editor-ui'
 export const inject = ['databaseUi']
@@ -27,6 +27,7 @@ export function apply(ctx: Context) {
   for (const path of EDITOR_COLLECTIONS) {
     ctx.effect(() => ui.decorate(path, { Content: PageEditor, DetailTools: SourceToggle }).dispose)
   }
+  ctx.effect(() => ui.decorate('/page-blocks', { Content: PageBlockContent }).dispose)
   ctx.effect(() => ui.registerView('/page-blocks', pageBlocksCollectionView).dispose)
 }
 

--- a/packages/core-editor/src/web/page-blocks-view.test.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.test.tsx
@@ -3,7 +3,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context } from 'cordis'
 import { PageEditorService } from './service.ts'
-import { parsePageBlockRowData, PageBlocksView } from './page-blocks-view.tsx'
+import { parsePageBlockRowData, PageBlocksView, PageBlockContent } from './page-blocks-view.tsx'
 
 test('parsePageBlockRowData reads json string or object', () => {
   assert.deepEqual(parsePageBlockRowData('{"html":"<p>a</p>"}'), { html: '<p>a</p>' })
@@ -32,4 +32,26 @@ test('page-blocks view paints the registered block View', () => {
   )
   assert.equal(container.querySelector('[data-testid="html-ui"]')?.textContent, '<b>hi</b>')
   assert.ok(container.querySelector('[data-testid="page-block-missing"]'))
+})
+
+test('page-block detail content paints the registered View', () => {
+  const ctx = new Context()
+  new PageEditorService(ctx)
+  ctx.pageEditor.registerBlock({
+    kind: 'html',
+    plugin: 'page-html-blocks',
+    label: '静态HTML',
+    View: ({ data }) => <div data-testid="html-detail">{String(data.html ?? '')}</div>,
+  })
+  const { container } = render(
+    <PageBlockContent
+      record={{ id: 'p1::a1', title: '刊头', blockKind: 'html', plugin: 'page-html-blocks' }}
+      field="data"
+      spec={{ type: 'string', writable: true }}
+      value={{ html: '<i>detail</i>' }}
+      writable
+    />,
+  )
+  assert.ok(container.querySelector('[data-testid="page-blocks-detail"]'))
+  assert.equal(container.querySelector('[data-testid="html-detail"]')?.textContent, '<i>detail</i>')
 })

--- a/packages/core-editor/src/web/page-blocks-view.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { RectangleGroupIcon } from '@heroicons/react/16/solid'
 import type { DbRecord } from '@biu/type-file-system'
-import type { CollectionViewType, FsViewProps } from '@biu/type-file-system/ui'
+import type { CollectionViewType, FsContentProps, FsViewProps } from '@biu/type-file-system/ui'
 import { PageBlockMissing } from './page-block-view.tsx'
 import { getPageEditor, usePageEditorVersion } from './service.ts'
 
@@ -30,6 +30,64 @@ async function writeBlockData(id: string, data: Record<string, unknown>) {
   if (!res.ok) throw new Error(body.error || res.statusText)
 }
 
+export function PageBlockStage({
+  row,
+  raw,
+  writable = true,
+  onChange,
+}: {
+  row: DbRecord
+  raw?: unknown
+  writable?: boolean
+  onChange?: (next: Record<string, unknown>) => void
+}) {
+  usePageEditorVersion()
+  const kind = String(row.blockKind ?? row.kind ?? '').trim()
+  const plugin = String(row.plugin ?? '').trim()
+  const spec = getPageEditor()?.block(kind)
+  const View = spec?.View
+  const source = raw ?? row.data
+  const packed = typeof source === 'string' ? source : JSON.stringify(source ?? {})
+  const [data, setData] = useState(() => parsePageBlockRowData(source))
+  useEffect(() => {
+    setData(parsePageBlockRowData(source))
+  }, [packed])
+  const update = (patch: Record<string, unknown>, opts?: { replace?: boolean }) => {
+    const next = opts?.replace ? patch : { ...data, ...patch }
+    setData(next)
+    if (onChange) onChange(next)
+    else void writeBlockData(String(row.id), next)
+  }
+  return (
+    <div
+      className="page-block"
+      data-page-block={kind || undefined}
+      data-page-block-plugin={plugin || undefined}
+      data-page-block-id={String(row.blockId ?? '') || undefined}
+      data-testid="page-block-stage"
+    >
+      {View ? (
+        <View data={data} update={update} writable={writable} />
+      ) : (
+        <PageBlockMissing kind={kind || 'unknown'} plugin={plugin} data={data} />
+      )}
+    </div>
+  )
+}
+
+export function PageBlockContent({ record, value, writable, onChange }: FsContentProps) {
+  return (
+    <div className="page-editor page-blocks-view page-blocks-detail" data-testid="page-blocks-detail">
+      <PageBlockStage
+        row={record}
+        raw={value ?? record.data}
+        writable={writable}
+        onChange={(next) => onChange?.(next)}
+      />
+    </div>
+  )
+}
+
 function BlockCard({
   row,
   onOpen,
@@ -39,36 +97,14 @@ function BlockCard({
 }) {
   usePageEditorVersion()
   const kind = String(row.blockKind ?? row.kind ?? '').trim()
-  const plugin = String(row.plugin ?? '').trim()
   const spec = getPageEditor()?.block(kind)
-  const View = spec?.View
-  const [data, setData] = useState(() => parsePageBlockRowData(row.data))
-  useEffect(() => {
-    setData(parsePageBlockRowData(row.data))
-  }, [row.data])
   const title = String(row.title ?? spec?.label ?? kind)
-  const update = (patch: Record<string, unknown>, opts?: { replace?: boolean }) => {
-    const next = opts?.replace ? patch : { ...data, ...patch }
-    setData(next)
-    void writeBlockData(String(row.id), next)
-  }
   return (
     <article className="page-blocks-view-card" data-testid="page-blocks-view-card">
       <button type="button" className="page-blocks-view-title" onClick={() => onOpen(row)}>
         {title}
       </button>
-      <div
-        className="page-block"
-        data-page-block={kind || undefined}
-        data-page-block-plugin={plugin || undefined}
-        data-page-block-id={String(row.blockId ?? '') || undefined}
-      >
-        {View ? (
-          <View data={data} update={update} writable />
-        ) : (
-          <PageBlockMissing kind={kind || 'unknown'} plugin={plugin} data={data} />
-        )}
-      </div>
+      <PageBlockStage row={row} />
     </article>
   )
 }

--- a/packages/core-editor/src/web/style.ts
+++ b/packages/core-editor/src/web/style.ts
@@ -115,4 +115,5 @@ export const PAGE_EDITOR_STYLE = `
 .page-blocks-view-title:hover{color:var(--dsw-business)}
 .page-blocks-view .page-block{margin:0}
 .page-blocks-view .page-block iframe{pointer-events:auto}
+.page-blocks-detail{padding:0 0 32px}
 `

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -158,6 +158,8 @@ function contentKey(spec: CollectionSpec) {
 function withoutContent(spec: CollectionSpec, row: DbRecord): DbRecord {
   const key = contentKey(spec)
   if (!Object.prototype.hasOwnProperty.call(row, key)) return row
+  const field = schemaFor(spec).fields[key]
+  if (field && field.type !== 'file') return row
   const next = { ...row }
   delete next[key]
   return next

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -68,6 +68,7 @@ test('page plugin stores pages in SQLite under .page', async () => {
   assert.equal(registered[1]?.view?.route, '/page-blocks')
   assert.notEqual(registered[1]?.view?.moduleId, registered[0]?.view?.moduleId)
   assert.deepEqual(registered[1]?.records, { update: true })
+  assert.equal(registered[1]?.schema.contentField, 'data')
 
   const spec = registered[0]!
   assert.equal((await spec.list()).length, 0)

--- a/packages/core-page/src/host/page-blocks-collection.ts
+++ b/packages/core-page/src/host/page-blocks-collection.ts
@@ -43,6 +43,7 @@ export function pageBlocksCollection(store: PagesStore, index: PageBlocksIndex):
     },
     schema: {
       labelField: 'title',
+      contentField: 'data',
       columns: ['title', 'blockKind', 'plugin', 'pageId'],
       fields: {
         ...REQUIRED_RECORD_FIELDS,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
打开「组件」记录详情时，主栏用该块在 `registerBlock` 里登记的 `View` 渲染（和组件画廊同一套），不再只显示 JSON 属性。

- `/page-blocks` 的 `contentField` 为 `data`
- core-editor 给该表 decorate `Content: PageBlockContent`
- 非 file 类型的正文不会从 list 里剥掉，画廊仍能拿到 `data`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

