### PR TITLE
Fix page-block View writes to persist JSON data

### DIFF
--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -484,6 +484,39 @@ test('content is omitted from list/read and served on its own path', async () =>
   assert.deepEqual(written.value, { kind: 'note', body: { a: 2 } })
 })
 
+test('writeContent string fields keep JSON objects instead of [object Object]', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  const rows = new Map<string, Record<string, unknown>>([
+    ['b1', { id: 'b1', title: '块', data: '{"html":"old"}' }],
+  ])
+  db.register({
+    id: 'page-blocks',
+    path: '/page-blocks',
+    schema: {
+      contentField: 'data',
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string' },
+        data: { type: 'string', writable: true },
+      },
+    },
+    records: { update: true },
+    list: () => [...rows.values()] as { id: string }[],
+    get: (id) => rows.get(id) as { id: string } | undefined,
+    update: (id, patch) => {
+      const next = { ...rows.get(id), ...patch, id }
+      rows.set(id, next)
+      return next as { id: string }
+    },
+  })
+  const written = await db.writeContent('/page-blocks/b1', { html: '<p>new</p>', deck: false })
+  assert.equal(written.field, 'data')
+  assert.equal(written.value, '{"html":"<p>new</p>","deck":false}')
+  const updated = await db.update('/page-blocks/b1', { data: { html: '<b>via update</b>' } })
+  assert.equal(updated.value.data, '{"html":"<b>via update</b>"}')
+})
+
 test('editContent view/str_replace/replace_lines/insert/write', async () => {
   const ctx = new Context()
   const db = new DatabaseService(ctx)

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -309,6 +309,7 @@ function coerce(field: FieldSpec, value: unknown) {
   if (value && typeof value === 'object' && !Array.isArray(value)) {
     const rec = value as Record<string, unknown>
     if (typeof rec.sessionId === 'string' || rec.kind === 'agent' || rec.kind === 'user') return value
+    return JSON.stringify(value)
   }
   return String(value ?? '')
 }

--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -1650,7 +1650,7 @@ export function CollectionBrowser({
     try {
       const keys = Object.keys(content)
       quietUntil.current = Date.now() + 800
-      if (bodyKey && keys.length === 1 && keys[0] === bodyKey) {
+      if (bodyKey && keys.length === 1 && keys[0] === bodyKey && schema?.fields[bodyKey]?.type === 'file') {
         const data = await readJson<{ value?: unknown }>('/api/db/content', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },

--- a/packages/core-file-system/src/web/index.test.ts
+++ b/packages/core-file-system/src/web/index.test.ts
@@ -83,6 +83,7 @@ test('tag collect table lives on the record board, not as sidebar views', () => 
   assert.doesNotMatch(detail, /chrome\?\.Board \? null/)
   assert.match(detail, /key === contentFieldKey\(schema\) && resolveFieldType\(field\) === 'file'/)
   assert.doesNotMatch(detail, /key === 'id' \|\| key === 'emoji' \|\| key === schema.labelField \|\| key === contentFieldKey\(schema\)/)
+  assert.match(browser, /keys\[0\] === bodyKey && schema\?\.fields\[bodyKey\]\?\.type === 'file'/)
   assert.match(browser, /field\.type !== 'file'/)
   assert.match(browser, /setDetailRow\(\(prev\) => \(prev\?\.id === row.id \? merge\(prev\) : prev\)\)/)
   assert.match(chrome, /label: '属性'/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情里改块 View 时，`data` 是对象，但列类型是 string。原先 `String(obj)` 变成 `"[object Object]"`，落盘失败或写成垃圾，属性栏不会变。从属性格子改之所以能同步，是因为提交的已经是 JSON 字符串。

现在普通对象会 `JSON.stringify` 再写入；`data` 走和属性一样的 `db_update` 合并，不再当 file 正文走 `db_content`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

