### PR TITLE
Reindex page-blocks when the last fence is removed

### DIFF
--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -167,6 +167,27 @@ test('page-blocks collection updates one fence by page::block id', async () => {
   assert.equal(blocks.remove, undefined)
 })
 
+test('clearing the last pageBlock fence drops the index row immediately', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-block-last-'))
+  await ctx.plugin(fsPlugin, { root })
+  const store = new PagesStore(ctx.fs.workspace as never, join(root, '.biu/assets'))
+  const index = new PageBlocksIndex(store, { hotWindowMs: 60_000, hotLimit: 0, warmLimit: 0 })
+  const pages = page.pagesCollection(store, index)
+  const fence = (id: string) => `:::pageBlock {kind=html plugin=page-html-blocks id=${id}}\n<div>${id}</div>\n:::\n`
+  const created = await pages.create!([{ title: '一页', notes: fence('aaaaaa11') + fence('bbbbbb22') }])
+  const id = created[0]!.id
+  assert.equal((await index.list()).length, 2)
+  await pages.update!(id, { notes: fence('aaaaaa11') })
+  assert.equal((await index.list()).length, 1)
+  await pages.update!(id, { notes: '只剩正文\n' })
+  assert.equal((await index.list()).length, 0)
+  const idle = await index.sync()
+  assert.equal(idle.scanned, 0)
+  assert.equal((await index.list()).length, 0)
+})
+
 test('page-block index scans a hot batch instead of every page', async () => {
   const ctx = new Context()
   await ctx.plugin(tools)

--- a/packages/core-page/src/host/index.ts
+++ b/packages/core-page/src/host/index.ts
@@ -10,7 +10,7 @@ export { PAGE_ROOT, PAGE_ASSETS, ASSET_GC_GRACE_MS, collectPageAssetNames, Pages
 export { pageBlocksCollection } from './page-blocks-collection.ts'
 export { PageBlocksIndex, PAGE_BLOCK_TICK_MS } from './page-blocks-index.ts'
 
-export function pagesCollection(store: PagesStore): CollectionSpec {
+export function pagesCollection(store: PagesStore, index: PageBlocksIndex): CollectionSpec {
   return {
     id: 'pages',
     path: '/pages',
@@ -41,15 +41,26 @@ export function pagesCollection(store: PagesStore): CollectionSpec {
     records: { update: true, create: true, delete: true },
     list: (query) => store.list(query?.ids),
     get: (id) => store.get(id),
-    update: (id, patch) => store.update(id, patch),
+    update: async (id, patch) => {
+      const row = await store.update(id, patch)
+      if ('notes' in patch) await index.reindexPage(row)
+      return row
+    },
     create: async (rows) => {
       const out = []
-      for (const fields of rows) out.push(await store.create(fields))
+      for (const fields of rows) {
+        const row = await store.create(fields)
+        await index.reindexPage(row)
+        out.push(row)
+      }
       return out
     },
     remove: async (query) => {
       const ids = query.ids ?? []
-      for (const id of ids) await store.remove(id)
+      for (const id of ids) {
+        await index.dropPage(id)
+        await store.remove(id)
+      }
       return ids
     },
   }
@@ -97,7 +108,7 @@ export function apply(ctx: Context) {
   // 否则工具调用（绑定项目）与 HTTP 请求（无 Session）会落到不同目录。
   const store = new PagesStore(ctx.fs.workspace as WorkspaceFs, dataPath(process.cwd(), 'assets'))
   const index = new PageBlocksIndex(store)
-  ctx.database.register(pagesCollection(store))
+  ctx.database.register(pagesCollection(store, index))
   ctx.database.register(pageBlocksCollection(store, index))
   servePageFile(ctx, store)
   const tick = setInterval(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
删掉一页里「不是最后一个」的特殊块时，剩下的块 View 还会写 `/page-blocks`，整页索引会立刻重建。删掉最后一个 fence 时只保存了页面正文，组件表要等 15 秒 tick 或再打开列表。

现在 `pages` 在写入 `notes` 时立刻 `reindexPage`（空 fence 会清掉该页全部索引行），删除页面时 `dropPage`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

