### PR TITLE
fix(algorithm): 失焦才保存，避免光标跳到末尾

### DIFF
--- a/.plugin-dev/page-algorithm/web.tsx
+++ b/.plugin-dev/page-algorithm/web.tsx
@@ -26,7 +26,7 @@ const DIFF_COLOR: Record<string, string> = {
   Hard: '#ff375f',
 }
 
-/** 草稿在本地；组字时不写回，避免 IME 被 pageBlock 更新打断。 */
+/** 草稿在本地；失焦/点到外部才写回，避免每次按键 update 把光标甩到末尾。 */
 function DraftField({
   as: Tag,
   value,
@@ -44,7 +44,6 @@ function DraftField({
 }) {
   const [draft, setDraft] = useState(value)
   const focused = useRef(false)
-  const composing = useRef(false)
   const draftRef = useRef(draft)
   const valueRef = useRef(value)
   const onCommitRef = useRef(onCommit)
@@ -61,7 +60,6 @@ function DraftField({
     [],
   )
   const flush = () => {
-    if (composing.current) return
     if (draftRef.current !== valueRef.current) onCommitRef.current(draftRef.current)
   }
   return (
@@ -79,23 +77,10 @@ function DraftField({
         focused.current = false
         flush()
       }}
-      onCompositionStart={() => {
-        composing.current = true
-      }}
-      onCompositionEnd={(event) => {
-        composing.current = false
-        const next = event.currentTarget.value
-        setDraft(next)
-        if (next !== valueRef.current) onCommitRef.current(next)
-      }}
       onKeyDown={(event) => {
         event.stopPropagation()
       }}
-      onChange={(event) => {
-        const next = event.currentTarget.value
-        setDraft(next)
-        if (!composing.current && next !== valueRef.current) onCommitRef.current(next)
-      }}
+      onChange={(event) => setDraft(event.currentTarget.value)}
       style={style}
     />
   )

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -266,15 +266,15 @@ test('html and req page blocks register plugin id for slash', async () => {
   assert.match(req, /kind: 'req'/)
 })
 
-test('algorithm card keeps IME composition local until commit', async () => {
+test('algorithm card drafts locally and saves on blur like html source', async () => {
   const { readFile } = await import('node:fs/promises')
   const { resolve } = await import('node:path')
   const src = await readFile(resolve(import.meta.dirname, '../../../../.plugin-dev/page-algorithm/web.tsx'), 'utf8')
   assert.match(src, /function DraftField/)
-  assert.match(src, /onCompositionStart/)
-  assert.match(src, /onCompositionEnd/)
-  assert.match(src, /if \(composing\.current\) return/)
-  assert.match(src, /if \(!composing\.current && next !== valueRef\.current\)/)
+  assert.match(src, /onChange=\{\(event\) => setDraft\(event\.currentTarget\.value\)\}/)
+  assert.match(src, /onBlur=\{\(\) => \{[\s\S]*flush\(\)/)
+  assert.doesNotMatch(src, /onChange=\{\(event\) => \{[\s\S]*onCommitRef/)
+  assert.doesNotMatch(src, /onCompositionEnd/)
   assert.match(src, /testId="page-algorithm-title"/)
   assert.match(src, /testId="page-algorithm-prompt"/)
   assert.match(src, /testId="page-algorithm-code"/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
算法卡片 View 的 title / prompt / code 原先在每次 `onChange`（以及 IME 结束）时就 `update()`。pageBlock 写回后受控输入重绘，光标会被甩到末尾。

现在和 HTML 源码编辑一致：输入只改本地 draft，**blur / 点到外部 / 卸载** 才写回。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

