### PR TITLE
fix(page-block): 宿主给已注册 View 注入插件 id

### DIFF
--- a/.plugin-dev/page-algorithm/web.tsx
+++ b/.plugin-dev/page-algorithm/web.tsx
@@ -66,7 +66,6 @@ function DraftField({
     <Tag
       data-testid={testId}
       data-page-block-capture=""
-      data-biu-ignore
       readOnly={readOnly}
       spellCheck={Tag === 'textarea' ? false : undefined}
       value={draft}
@@ -117,7 +116,6 @@ function AlgorithmCard({
   return (
     <div
       data-testid="page-algorithm-card"
-      data-biu-plugin={name}
       style={{
         display: 'flex',
         flexWrap: 'wrap',

--- a/packages/core-editor/src/web/page-block-plugin-host.test.ts
+++ b/packages/core-editor/src/web/page-block-plugin-host.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { injectPageBlockPlugin } from './page-block-plugin-host.ts'
+
+test('page-block host stamps plugin on inner surfaces that plugins did not tag', () => {
+  const host = document.createElement('div')
+  host.className = 'page-block'
+  const title = document.createElement('input')
+  title.setAttribute('data-testid', 'page-algorithm-title')
+  const html = document.createElement('div')
+  html.setAttribute('data-biu-kind', 'html')
+  html.setAttribute('data-biu-id', 'html:0/1')
+  host.append(title, html)
+  document.body.append(host)
+  injectPageBlockPlugin(host, 'page-algorithm')
+  assert.equal(host.getAttribute('data-biu-plugin'), 'page-algorithm')
+  assert.equal(title.getAttribute('data-biu-plugin'), 'page-algorithm')
+  assert.equal(title.getAttribute('data-biu-kind'), 'plugin')
+  assert.equal(html.getAttribute('data-biu-plugin'), 'page-algorithm')
+  assert.equal(html.getAttribute('data-biu-kind'), 'html')
+  assert.equal(html.getAttribute('data-biu-id'), 'html:0/1')
+  host.remove()
+})

--- a/packages/core-editor/src/web/page-block-plugin-host.ts
+++ b/packages/core-editor/src/web/page-block-plugin-host.ts
@@ -1,0 +1,76 @@
+const PLUGIN_ATTR = 'data-biu-plugin'
+const KIND_ATTR = 'data-biu-kind'
+const ID_ATTR = 'data-biu-id'
+const LABEL_ATTR = 'data-biu-label'
+const SKIP = new Set(['SCRIPT', 'STYLE', 'LINK', 'META', 'NOSCRIPT', 'BR', 'HR'])
+const SURFACE = new Set([
+  'DIV',
+  'SPAN',
+  'SECTION',
+  'ARTICLE',
+  'INPUT',
+  'TEXTAREA',
+  'SELECT',
+  'BUTTON',
+  'A',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'P',
+  'PRE',
+  'CODE',
+  'LI',
+  'TABLE',
+  'IMG',
+  'CANVAS',
+  'IFRAME',
+])
+
+function surfaceLabel(el: HTMLElement) {
+  return (
+    el.getAttribute('aria-label') ||
+    el.getAttribute('data-testid') ||
+    el.getAttribute('title') ||
+    el.tagName.toLowerCase()
+  )
+}
+
+/** Page Block 宿主把登记插件 id 打进整棵子树；已有 kind 的内部节点只补 plugin。 */
+export function injectPageBlockPlugin(host: HTMLElement, plugin: string) {
+  const id = plugin.trim()
+  if (!id) return
+  host.setAttribute(PLUGIN_ATTR, id)
+  host.setAttribute('data-page-block-plugin', id)
+  const walk = (el: Element, path: string) => {
+    if (!(el instanceof HTMLElement) || SKIP.has(el.tagName)) return
+    if (el !== host) {
+      el.setAttribute(PLUGIN_ATTR, id)
+      if (!el.getAttribute(KIND_ATTR) && SURFACE.has(el.tagName)) {
+        el.setAttribute(KIND_ATTR, 'plugin')
+        el.setAttribute(ID_ATTR, `${id}:${path}`)
+        if (!el.getAttribute(LABEL_ATTR)) el.setAttribute(LABEL_ATTR, surfaceLabel(el))
+      }
+    }
+    let i = 0
+    for (const child of el.children) {
+      walk(child, `${path}/${i}`)
+      i += 1
+    }
+  }
+  walk(host, '0')
+}
+
+export function bindPageBlockPlugin(host: HTMLElement | null, plugin: string) {
+  if (!host || typeof MutationObserver === 'undefined') {
+    if (host) injectPageBlockPlugin(host, plugin)
+    return () => {}
+  }
+  const run = () => injectPageBlockPlugin(host, plugin)
+  run()
+  const mo = new MutationObserver(run)
+  mo.observe(host, { subtree: true, childList: true })
+  return () => mo.disconnect()
+}

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -1,9 +1,10 @@
-import { useEffect, type MouseEvent } from 'react'
+import { useEffect, useLayoutEffect, useRef, type MouseEvent } from 'react'
 import type { NodeViewProps } from '@tiptap/react'
 import { NodeViewWrapper } from '@tiptap/react'
 import { PlayIcon } from '@heroicons/react/16/solid'
 import { getPageEditor, usePageEditorVersion } from './service.ts'
 import { formatPageBlockFence, requestEnablePageBlockPlugin } from './page-block-meta.ts'
+import { bindPageBlockPlugin } from './page-block-plugin-host.ts'
 
 function assetName(file: string) {
   return file.replace(/^assets\//, '')
@@ -75,6 +76,8 @@ export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeVi
     updateAttributes({ data: opts?.replace ? patch : { ...data, ...patch } })
   }
   const View = spec?.View
+  const hostRef = useRef<HTMLElement | null>(null)
+  useLayoutEffect(() => bindPageBlockPlugin(hostRef.current, plugin), [plugin, kind, View, data])
 
   useEffect(() => {
     if (!cloneFrom || !file) return
@@ -98,6 +101,7 @@ export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeVi
 
   return (
     <NodeViewWrapper
+      ref={hostRef}
       className="page-block"
       data-page-block={kind}
       data-page-block-plugin={plugin}

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -292,6 +292,7 @@ test('pageBlock capture includes every registered block shell', async () => {
   assert.match(src, /closest\('\.page-block/)
   assert.match(src, /data-page-block-capture/)
   assert.match(view, /data-page-block-capture=""/)
+  assert.match(view, /bindPageBlockPlugin/)
   assert.match(view, /data-biu-plugin=\{plugin \|\| undefined\}/)
   assert.match(view, /data-biu-kind="plugin"/)
   assert.match(view, /data-page-block-id=\{blockId \|\| undefined\}/)

--- a/packages/core-editor/src/web/page-blocks-view.test.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.test.tsx
@@ -33,12 +33,14 @@ test('page-blocks view paints the registered block View', () => {
     />,
   )
   assert.equal(container.querySelector('[data-testid="html-ui"]')?.textContent, '<b>hi</b>')
+  assert.equal(container.querySelector('[data-testid="html-ui"]')?.getAttribute('data-biu-plugin'), 'page-html-blocks')
   assert.ok(container.querySelector('[data-testid="page-block-missing"]'))
 })
 
 test('gallery block writes notify other surfaces', () => {
   const src = readFileSync(resolve(import.meta.dirname, './page-blocks-view.tsx'), 'utf8')
   assert.match(src, /window.dispatchEvent\(new Event\('fsdb:change'\)\)/)
+  assert.match(src, /bindPageBlockPlugin/)
 })
 
 test('page-block detail content paints the registered View', () => {

--- a/packages/core-editor/src/web/page-blocks-view.tsx
+++ b/packages/core-editor/src/web/page-blocks-view.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { RectangleGroupIcon } from '@heroicons/react/16/solid'
 import type { DbRecord } from '@biu/type-file-system'
 import type { CollectionViewType, FsContentProps, FsViewProps } from '@biu/type-file-system/ui'
 import { PageBlockMissing } from './page-block-view.tsx'
+import { bindPageBlockPlugin } from './page-block-plugin-host.ts'
 import { getPageEditor, usePageEditorVersion } from './service.ts'
 
 export const PAGE_BLOCKS_VIEW_ID = 'blocks'
@@ -59,8 +60,11 @@ export function PageBlockStage({
     if (onChange) onChange(next)
     else void writeBlockData(String(row.id), next)
   }
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  useLayoutEffect(() => bindPageBlockPlugin(hostRef.current, plugin), [plugin, kind, View, packed])
   return (
     <div
+      ref={hostRef}
       className="page-block"
       data-page-block={kind || undefined}
       data-page-block-plugin={plugin || undefined}

--- a/packages/core-plugin-system/src/web/index.test.ts
+++ b/packages/core-plugin-system/src/web/index.test.ts
@@ -283,4 +283,6 @@ test('algorithm card drafts locally and saves on blur like html source', async (
   assert.doesNotMatch(src, /onChange=\{\(event\) => update\(\{ title:/)
   assert.doesNotMatch(src, /onChange=\{\(event\) => update\(\{ prompt:/)
   assert.doesNotMatch(src, /onChange=\{\(event\) => update\(\{ code:/)
+  assert.doesNotMatch(src, /data-biu-ignore/)
+  assert.doesNotMatch(src, /data-biu-plugin=\{name\}/)
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
原先策略是各插件自己打 `data-biu-plugin`，算法还在输入上标了 `data-biu-ignore`，选取点内部会直接丢掉。

现在改成 **Page Block 宿主注入**：View 挂上后遍历子树，把登记时的 plugin id 打到每个节点；没有 kind 的表面（input/div 等）顺手补 pick 句柄。HTML 已 stamp 的节点只补 plugin，不改它自己的 kind。算法字段不再 ignore。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

