### PR TITLE
fix(nav): 侧栏组件放到页面下面

### DIFF
--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -69,11 +69,12 @@ test('views and events are system collections; tags sort with user tables', () =
     { path: '/facets' },
     { path: '/sessions' },
     { path: '/pages' },
+    { path: '/page-blocks' },
     { path: '/tasks' },
   ])
   assert.deepEqual(
     user.map((item) => item.path),
-    ['/sessions', '/tasks', '/pages', '/plugins', '/facets'],
+    ['/sessions', '/tasks', '/pages', '/page-blocks', '/plugins', '/facets'],
   )
   assert.deepEqual(
     system.map((item) => item.path),

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -39,7 +39,8 @@ export const PAGE_BLOCKS_COLLECTION_PATH = '/page-blocks'
 
 const SYSTEM_COLLECTION_ORDER = [VIEWS_COLLECTION_PATH, EVENTS_COLLECTION_PATH] as const
 
-const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/plugins', '/facets'] as const
+/** 用户表侧栏顺序。组件是页面里嵌的块，紧挨页面下面。 */
+const USER_COLLECTION_ORDER = ['/sessions', '/tasks', '/pages', '/page-blocks', '/plugins', '/facets'] as const
 
 /** 视图、事件由系统自己记下，侧栏归在系统数据。分面跨所有表，排在插件后面。 */
 export function isSystemCollection(path: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
左侧栏用户表顺序改成：会话 → 任务 → **页面 → 组件** → 插件 → 分面。组件是页面里嵌的块，紧挨页面下面，不再掉到列表末尾。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

