### PR TITLE
fix(chat): 最新消息更新时自动滚到最底

### DIFF
--- a/packages/core-chat/src/web/thread-reveal.test.ts
+++ b/packages/core-chat/src/web/thread-reveal.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 import type { ChatNode } from '@biu/web-session-view'
 import {
   bumpRevealStart,
@@ -6,6 +8,8 @@ import {
   CHAT_FIRST_PAINT_TURNS,
   firstPaintStartIndex,
   groupNodesIntoTurns,
+  isChatStuckToLatest,
+  pinChatToLatest,
   recalledChatScroll,
   rememberChatScroll,
   resetChatScrollMemoryForTests,
@@ -143,6 +147,14 @@ describe('chat scroll memory per session', () => {
     expect(captureChatScroll(parent)).toEqual({ kind: 'bottom' })
   })
 
+  it('still counts as latest inside the composer padding slack', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollHeight', { value: 2000, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 920, writable: true, configurable: true })
+    Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
+    expect(captureChatScroll(parent)).toEqual({ kind: 'bottom' })
+  })
+
   it('restores by scrolling the turn box to the top, ignoring sticky visual offset', () => {
     const parent = document.createElement('div')
     Object.defineProperty(parent, 'scrollTop', { value: 1800, writable: true, configurable: true })
@@ -159,5 +171,26 @@ describe('chat scroll memory per session', () => {
     parent.append(turn)
     expect(restoreChatScroll(parent, { kind: 'pin', nodeId: 'u-3' })).toBe(true)
     expect(parent.scrollTop).toBe(1720)
+  })
+
+  it('pins the scroller onto the latest edge', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollHeight', { value: 2400, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 100, writable: true, configurable: true })
+    Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
+    pinChatToLatest(parent)
+    expect(parent.scrollTop).toBe(2400)
+    parent.scrollTop = 2100
+    expect(isChatStuckToLatest(parent)).toBe(true)
+  })
+})
+
+describe('thread follows the latest message', () => {
+  it('pins on pending layout, resize, and does not skip-paint the live turn', () => {
+    const src = readFileSync(resolve(import.meta.dirname, './thread.tsx'), 'utf8')
+    expect(src).toMatch(/useLayoutEffect\(\(\) => \{\s*if \(pending\) stickToBottomRef\.current = true/s)
+    expect(src).toContain('ResizeObserver')
+    expect(src).toContain('pinChatToLatest')
+    expect(src).toContain('liveTurnId')
   })
 })

--- a/packages/core-chat/src/web/thread-reveal.ts
+++ b/packages/core-chat/src/web/thread-reveal.ts
@@ -36,7 +36,8 @@ export function bumpRevealStart(startIndex: number, batch = CHAT_REVEAL_BATCH): 
   return Math.max(0, startIndex - Math.max(1, batch))
 }
 
-export const CHAT_NEAR_BOTTOM_PX = 96
+/** 输入栏垫了 pb-72 / 18rem，离真正 scroll 底还有一大截也算在看最新。 */
+export const CHAT_NEAR_BOTTOM_PX = 360
 const PIN_TOP_SLACK_PX = 8
 
 /** 贴底，或当时贴在视口顶的那条用户消息。回来滚到它重新贴顶。 */
@@ -92,8 +93,7 @@ export function offsetInScroller(el: HTMLElement, scroller: HTMLElement): number
 
 /** 当前贴顶的用户消息：已经顶到视口上沿的最后一条。 */
 export function captureChatScroll(parent: HTMLElement): ChatScrollMemory {
-  const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
-  if (distance <= CHAT_NEAR_BOTTOM_PX) return { kind: 'bottom' }
+  if (isChatStuckToLatest(parent)) return { kind: 'bottom' }
   const parentTop = parent.getBoundingClientRect().top
   const users = parent.querySelectorAll<HTMLElement>('[data-chat-kind="user"][data-node-id]')
   let pin: HTMLElement | null = null
@@ -105,9 +105,21 @@ export function captureChatScroll(parent: HTMLElement): ChatScrollMemory {
   return { kind: 'pin', nodeId: id }
 }
 
+export function distanceFromChatBottom(parent: HTMLElement): number {
+  return parent.scrollHeight - parent.scrollTop - parent.clientHeight
+}
+
+export function isChatStuckToLatest(parent: HTMLElement): boolean {
+  return distanceFromChatBottom(parent) <= CHAT_NEAR_BOTTOM_PX
+}
+
+export function pinChatToLatest(parent: HTMLElement) {
+  parent.scrollTop = parent.scrollHeight
+}
+
 export function restoreChatScroll(parent: HTMLElement, memory: ChatScrollMemory): boolean {
   if (memory.kind === 'bottom') {
-    parent.scrollTop = parent.scrollHeight
+    pinChatToLatest(parent)
     return true
   }
   const turn = parent.querySelector(turnSelector(memory.nodeId))

--- a/packages/core-chat/src/web/thread.tsx
+++ b/packages/core-chat/src/web/thread.tsx
@@ -40,9 +40,10 @@ import { UsageInline } from './usage-inline.tsx'
 import {
   bumpRevealStart,
   captureChatScroll,
-  CHAT_NEAR_BOTTOM_PX,
   firstPaintStartIndex,
   groupNodesIntoTurns,
+  isChatStuckToLatest,
+  pinChatToLatest,
   recalledChatScroll,
   rememberChatScroll,
   restoreChatScroll,
@@ -54,7 +55,6 @@ import {
 
 export { groupNodesIntoTurns } from './thread-reveal.ts'
 
-const NEAR_BOTTOM_PX = CHAT_NEAR_BOTTOM_PX
 /** 提早预取更早消息，避免滑到顶才开始请求 */
 const PREFETCH_OLDER_PX = 720
 
@@ -687,6 +687,7 @@ export const ChatNodeList = memo(function ChatNodeList({
   }, [])
 
   const turns = useMemo(() => groupNodesIntoTurns(nodes), [nodes])
+  const liveTurnId = turns.at(-1)?.[0]?.id
 
   return (
     <div className="chat-node-list">
@@ -708,7 +709,7 @@ export const ChatNodeList = memo(function ChatNodeList({
                   ? 'sticky top-0 z-1 bg-transparent'
                   : ''
               const skipPaint =
-                node.kind === 'reply' || node.kind === 'turn'
+                (node.kind === 'reply' || node.kind === 'turn') && anchor.id !== liveTurnId
                   ? '[content-visibility:auto] [contain-intrinsic-size:auto_160px]'
                   : ''
               return (
@@ -839,7 +840,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       scrollRef.current = parent
       setScrollEpoch((value) => value + 1)
     }
-  }, [sessionId])
+  })
 
   useLayoutEffect(() => {
     const mem = recalledChatScroll(sessionId)
@@ -858,7 +859,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (pending) stickToBottomRef.current = true
   }, [pending])
 
@@ -886,8 +887,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
 
     const onScroll = () => {
-      const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight
-      stickToBottomRef.current = distance <= NEAR_BOTTOM_PX
+      stickToBottomRef.current = isChatStuckToLatest(parent)
       maybePrefetchOlder()
     }
     const onUserScroll = () => {
@@ -905,6 +905,19 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
       parent.removeEventListener('scroll', onUserScroll)
     }
   }, [sessionId, scrollEpoch, hasMoreOlder, loadingOlder, sessionView])
+
+  useEffect(() => {
+    const root = rootRef.current
+    const parent = scrollRef.current
+    if (!root || !parent) return
+    const pin = () => {
+      if (!stickToBottomRef.current) return
+      pinChatToLatest(parent)
+    }
+    const ro = new ResizeObserver(pin)
+    ro.observe(root)
+    return () => ro.disconnect()
+  }, [sessionId, scrollEpoch])
 
   useEffect(() => {
     if (revealStart <= 0) return
@@ -951,7 +964,7 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
     if (sessionId) restoredForRef.current = sessionId
     if (stickToBottomRef.current) {
-      if (mountedNodes.length > 0) parent.scrollTop = parent.scrollHeight
+      if (mountedNodes.length > 0) pinChatToLatest(parent)
     } else if (prependHeightRef.current) {
       const delta = parent.scrollHeight - prependHeightRef.current
       if (delta) parent.scrollTop += delta


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天区在最新消息更新后应该自动滚到最新。

原因：
- 发送后把「贴底」写在 `useEffect` 里，晚于滚动布局，新回合当时不会上滑。
- 输入栏 `pb-72` / 18rem 垫很高，「离底 96px 才算贴底」几乎永远对不上，流式增高也不跟。
- 最新一回合还开了 `content-visibility`，高度估不准。

现在：pending 在 layout 里立刻贴底；内容变高用 ResizeObserver 继续跟；输入栏那截空白也算在看最新。往上翻历史时仍然不抢滚动。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

