### PR TITLE
数据侧栏：页面和任务记录按 parentId 嵌套

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useLayoutEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { memo, useEffect, useLayoutEffect, useMemo, useState, useSyncExternalStore, type MouseEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { ChatCount, RecordEmojiBoard, SidebarFold } from '@biu/public-ui'
 import {
@@ -12,9 +12,10 @@ import {
 } from '@heroicons/react/16/solid'
 import { TrashGlyph } from '@biu/web-session-view/trash-glyph'
 import type { CollectionInfo, CollectionSchema, DbRecord } from '@biu/type-file-system'
-import { groupField, groupRecords } from './fields.ts'
+import { groupField, groupRecords, parentFieldKey, treeChildren } from './fields.ts'
 import { builtinAllViewId } from '../catalog-views.ts'
-import { isSystemCollection, sortDataCollections } from './database-path.ts'
+import { isRecordTreeCollection, isSystemCollection, sortDataCollections } from './database-path.ts'
+import { readJson } from './db-client.ts'
 import { viewsForRegisteredCollection } from './collection-nav.ts'
 import type { SavedView } from './saved-view.ts'
 import {
@@ -34,12 +35,18 @@ import {
 } from './sidebar-preview.ts'
 import {
   activeViewStorageKey,
+  getStarredRecords,
+  getStarredRecordsVersion,
   getStarredViews,
   getStarredViewsVersion,
+  isRecordStarred,
   isViewStarred,
   loadViews,
+  persistStarredRecords,
   persistStarredViews,
+  subscribeStarredRecords,
   subscribeStarredViews,
+  toggleStarredRecord,
   toggleStarredView,
   withViewDisplay,
 } from './view-storage.ts'
@@ -87,9 +94,13 @@ function ViewRecordPreview({
     error: '',
   }))
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({})
+  const [openKids, setOpenKids] = useState<Record<string, boolean>>({})
   const [pickerId, setPickerId] = useState<string | null>(null)
   const [pickerAnchor, setPickerAnchor] = useState<HTMLElement | null>(null)
   const chromeIcon = getDatabaseUi()?.chrome(path).Icon
+  const nested = isRecordTreeCollection(path)
+  useSyncExternalStore(subscribeStarredRecords, getStarredRecordsVersion, () => 0)
+  const starredRecords = getStarredRecords()
 
   useEffect(() => {
     if (!open) return
@@ -155,67 +166,185 @@ function ViewRecordPreview({
     if (!grouping) return null
     return groupRecords(state.items, state.schema, view.groupBy).filter((bucket) => bucket.rows.length)
   }, [grouping, state.items, state.schema, view.groupBy])
+  const parentKey = nested ? parentFieldKey(state.schema, state.items) ?? 'parentId' : null
 
-  function renderRecords(rows: DbRecord[]) {
+  function toggleKid(id: string) {
+    setOpenKids((prev) => ({ ...prev, [id]: !prev[id] }))
+  }
+
+  function toggleRecordStar(recordId: string) {
+    persistStarredRecords(toggleStarredRecord(getStarredRecords(), path, recordId))
+  }
+
+  async function createChild(row: DbRecord) {
+    if (!parentKey) return
+    try {
+      const data = await readJson<{ items?: Array<{ value?: DbRecord }> }>('/api/db/create', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path, records: [{ [parentKey]: row.id }] }),
+      })
+      const created = data.items?.[0]?.value
+      const items = created ? [...state.items, created] : state.items
+      const total = state.total + (created ? 1 : 0)
+      previewCache.set(key, { items, total, schema: state.schema })
+      rememberPreviewTotal(key, total)
+      setState((prev) => ({ ...prev, items, total }))
+      setOpenKids((prev) => ({ ...prev, [row.id]: true }))
+      window.dispatchEvent(new Event('fsdb:change'))
+      if (created?.id) onOpenRecord?.(created.id, created)
+    } catch (err) {
+      setState((prev) => ({ ...prev, error: String(err) }))
+    }
+  }
+
+  function recordFace(row: DbRecord) {
+    const emoji = recordPreviewEmoji(row)
+    return emoji ? <span className="fsdb-record-emoji">{emoji}</span> : <RecordMark record={row} tableIcon={tableIcon} Icon={chromeIcon} />
+  }
+
+  function emojiBoard(row: DbRecord) {
+    if (pickerId !== row.id || !pickerAnchor) return null
+    return (
+      <RecordEmojiBoard
+        anchor={pickerAnchor}
+        onPick={(next) => void saveEmoji(row, next)}
+        onClear={() => void saveEmoji(row, '')}
+        onClose={() => {
+          setPickerId(null)
+          setPickerAnchor(null)
+        }}
+      />
+    )
+  }
+
+  function openEmojiPicker(event: MouseEvent<HTMLElement>, row: DbRecord) {
+    event.preventDefault()
+    event.stopPropagation()
+    const btn = event.currentTarget
+    setPickerId((prev) => {
+      if (prev === row.id) {
+        setPickerAnchor(null)
+        return null
+      }
+      setPickerAnchor(btn)
+      return row.id
+    })
+  }
+
+  function renderRecords(scope: DbRecord[], parentId = '') {
+    const rows = parentKey ? treeChildren(scope, parentKey, parentId) : parentId ? [] : scope
     return rows.map((row) => {
-      const emoji = recordPreviewEmoji(row)
-      return (
-        <div
-          key={row.id}
-          className="chat-session-row"
-          role="listitem"
-          {...pickDomAttrs(recordKind, row.id, recordPreviewLabel(row))}
-        >
-          <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
-            <span className="fsdb-record-icon relative grid size-6 shrink-0 place-items-center">
+      const label = recordPreviewLabel(row)
+      const kids = parentKey ? treeChildren(scope, parentKey, row.id) : []
+      const kidCount = kids.length
+      const expanded = Boolean(openKids[row.id])
+      const starred = isRecordStarred(starredRecords, path, row.id)
+      if (!nested) {
+        return (
+          <div
+            key={row.id}
+            className="chat-session-row"
+            role="listitem"
+            {...pickDomAttrs(recordKind, row.id, label)}
+          >
+            <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+              <span className="fsdb-record-icon relative grid size-6 shrink-0 place-items-center">
+                <button
+                  type="button"
+                  className="grid size-6 place-items-center border-0 bg-transparent p-0 text-[16px] leading-none text-inherit"
+                  title={recordPreviewEmoji(row) ? '更换图标' : '设置图标'}
+                  aria-label={recordPreviewEmoji(row) ? `更换 ${label} 的图标` : `设置 ${label} 的图标`}
+                  onClick={(event) => openEmojiPicker(event, row)}
+                >
+                  {recordFace(row)}
+                </button>
+                {emojiBoard(row)}
+              </span>
               <button
                 type="button"
-                className="grid size-6 place-items-center border-0 bg-transparent p-0 text-[16px] leading-none text-inherit"
-                title={emoji ? '更换图标' : '设置图标'}
-                aria-label={emoji ? `更换 ${recordPreviewLabel(row)} 的图标` : `设置 ${recordPreviewLabel(row)} 的图标`}
+                className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                title={label}
                 onClick={(event) => {
                   event.stopPropagation()
-                  const btn = event.currentTarget
-                  setPickerId((prev) => {
-                    if (prev === row.id) {
-                      setPickerAnchor(null)
-                      return null
-                    }
-                    setPickerAnchor(btn)
-                    return row.id
-                  })
+                  onOpenRecord?.(row.id, row)
                 }}
               >
-                {emoji ? (
-                  <span className="fsdb-record-emoji">{emoji}</span>
-                ) : (
-                  <RecordMark record={row} tableIcon={tableIcon} Icon={chromeIcon} />
-                )}
+                {label}
               </button>
-              {pickerId === row.id && pickerAnchor ? (
-                <RecordEmojiBoard
-                  anchor={pickerAnchor}
-                  onPick={(next) => void saveEmoji(row, next)}
-                  onClear={() => void saveEmoji(row, '')}
-                  onClose={() => {
-                    setPickerId(null)
-                    setPickerAnchor(null)
-                  }}
-                />
-              ) : null}
-            </span>
+            </div>
+          </div>
+        )
+      }
+      return (
+        <div key={row.id} className="min-w-0" role="listitem">
+          <div
+            className={`chat-session-row group${starred ? ' is-pinned' : ''}`}
+            {...pickDomAttrs(recordKind, row.id, label)}
+          >
+            <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+              <button
+                type="button"
+                className="relative grid size-6 shrink-0 place-items-center border-0 bg-transparent p-0 text-inherit"
+                title={expanded ? '收起子记录' : '展开子记录'}
+                aria-expanded={expanded}
+                onClick={() => toggleKid(row.id)}
+                onContextMenu={(event) => openEmojiPicker(event, row)}
+              >
+                <span className="sidebar-rail-icon sidebar-group-fold">
+                  <span className="sidebar-group-fold-face">{recordFace(row)}</span>
+                  <span className="sidebar-group-fold-chevron">
+                    {expanded ? (
+                      <ChevronDownIcon className="size-4 shrink-0 opacity-80" />
+                    ) : (
+                      <ChevronRightIcon className="size-4 shrink-0 opacity-80" />
+                    )}
+                  </span>
+                </span>
+                {emojiBoard(row)}
+              </button>
+              <button
+                type="button"
+                className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                title={label}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenRecord?.(row.id, row)
+                }}
+              >
+                {label}
+              </button>
+            </div>
+            <ChatCount count={kidCount} title={`${kidCount} 个子记录`} />
             <button
               type="button"
-              className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
-              title={recordPreviewLabel(row)}
+              className="sidebar-add"
+              title={`在 ${label} 下添加子记录`}
+              aria-label={`在 ${label} 下添加子记录`}
               onClick={(event) => {
                 event.stopPropagation()
-                onOpenRecord?.(row.id, row)
+                void createChild(row)
               }}
             >
-              {recordPreviewLabel(row)}
+              <PlusIcon className="size-4 shrink-0" />
+            </button>
+            <button
+              type="button"
+              className={`chat-session-row-star${starred ? ' is-on' : ''}`}
+              aria-pressed={starred}
+              aria-label={starred ? `取消收藏 ${label}` : `收藏 ${label}`}
+              title={starred ? '取消收藏' : '收藏'}
+              onClick={(event) => {
+                event.stopPropagation()
+                toggleRecordStar(row.id)
+              }}
+            >
+              <StarIcon className={`size-4 shrink-0${starred ? ' text-[#f5b700]' : ''}`} />
             </button>
           </div>
+          <SidebarFold open={expanded}>
+            <div className="fsdb-record-kids">{renderRecords(scope, row.id)}</div>
+          </SidebarFold>
         </div>
       )
     })

--- a/packages/core-file-system/src/web/database-path.test.ts
+++ b/packages/core-file-system/src/web/database-path.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { parseAppPath } from '@biu/web-session-view'
-import { DATA_MODULE, databaseAllViewPath, databaseRecordPath, databaseViewPath, isSystemCollection, sortDataCollections, viewsCatalogSource } from './database-path.ts'
+import { DATA_MODULE, databaseAllViewPath, databaseRecordPath, databaseViewPath, isRecordTreeCollection, isSystemCollection, sortDataCollections, viewsCatalogSource } from './database-path.ts'
 
 const plugins = [DATA_MODULE]
 
@@ -50,6 +50,15 @@ test('table path without view still parses as a collection-view URL', () => {
     assert.equal(parsed.collection, '/tasks')
     assert.equal(parsed.viewId, undefined)
   }
+})
+
+test('only pages and tasks nest records in the data sidebar', () => {
+  assert.equal(isRecordTreeCollection('/pages'), true)
+  assert.equal(isRecordTreeCollection('/pages/'), true)
+  assert.equal(isRecordTreeCollection('/tasks'), true)
+  assert.equal(isRecordTreeCollection('/sessions'), false)
+  assert.equal(isRecordTreeCollection('/page-blocks'), false)
+  assert.equal(isRecordTreeCollection('/plugins'), false)
 })
 
 test('views catalog source is a query filter', () => {

--- a/packages/core-file-system/src/web/database-path.ts
+++ b/packages/core-file-system/src/web/database-path.ts
@@ -37,6 +37,14 @@ export const FACETS_COLLECTION_PATH = '/facets'
 export const EVENTS_COLLECTION_PATH = '/events'
 export const NOTICES_COLLECTION_PATH = '/notices'
 export const PAGE_BLOCKS_COLLECTION_PATH = '/page-blocks'
+export const PAGES_COLLECTION_PATH = '/pages'
+export const TASKS_COLLECTION_PATH = '/tasks'
+
+/** 数据侧栏记录行按 parentId 嵌套：只有页面和任务。 */
+export function isRecordTreeCollection(path: string) {
+  const normalized = normalizeCollectionPath(path)
+  return normalized === PAGES_COLLECTION_PATH || normalized === TASKS_COLLECTION_PATH
+}
 
 const SYSTEM_COLLECTION_ORDER = [VIEWS_COLLECTION_PATH, EVENTS_COLLECTION_PATH, NOTICES_COLLECTION_PATH] as const
 

--- a/packages/core-file-system/src/web/fields.test.ts
+++ b/packages/core-file-system/src/web/fields.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import type { CollectionSchema } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS, normalizeSchemaValue } from '@biu/type-file-system'
-import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, facetColumnTitle, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
+import { defaultColumnKeys, facetFlatColumnKey, flattenFacetColumns, facetColumnTitle, inferPackFieldType, listProjectionKeys, parseFacetFlatColumnKey, patchFacetFlatValue, pinLabelColumn, contentFieldKey, flattenTree, formatField, fieldHasValue, groupField, groupRecords, hasTreeLinks, treeChildren, isViewModeId, matchActionWhen, overlayListed, previewActionRecord, parentFieldKey, readFacetFlatValue, recordLinkIds, resolveFieldType, uniqueValues } from './fields'
 import { placedActions, visibleActions } from './fsdb-cells.tsx'
 
 test('isViewModeId accepts builtin and custom slugs', () => {
@@ -254,6 +254,28 @@ test('parentFieldKey reads schema then parentId then data links', () => {
       ],
     ),
     'folder',
+  )
+})
+
+test('treeChildren lists direct kids and treats missing parents as roots', () => {
+  const rows = [
+    { id: 'p', title: 'parent' },
+    { id: 'c2', title: 'second', parentId: 'p' },
+    { id: 'c1', title: 'first', parentId: 'p' },
+    { id: 'g', title: 'grand', parentId: 'c1' },
+    { id: 'orphan', title: 'orphan', parentId: 'gone' },
+  ]
+  assert.deepEqual(
+    treeChildren(rows, 'parentId', '').map((row) => row.id),
+    ['p', 'orphan'],
+  )
+  assert.deepEqual(
+    treeChildren(rows, 'parentId', 'p').map((row) => row.id),
+    ['c2', 'c1'],
+  )
+  assert.deepEqual(
+    treeChildren(rows, 'parentId', 'c1').map((row) => row.id),
+    ['g'],
   )
 })
 

--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -55,6 +55,16 @@ export function parentFieldKey(schema: CollectionSchema | undefined, rows: DbRec
   return null
 }
 
+/** 当前列表里某条记录的直接子行（parent 不在列表里的当根）。 */
+export function treeChildren(rows: DbRecord[], parentKey: string, parentId: string): DbRecord[] {
+  const ids = new Set(rows.map((row) => row.id))
+  return rows.filter((row) => {
+    const raw = String(row[parentKey] ?? '')
+    const parent = raw && raw !== row.id && ids.has(raw) ? raw : ''
+    return parent === parentId
+  })
+}
+
 /** 当前数据里是否真有父子链接；没有则不当树形表。 */
 export function hasTreeLinks(rows: DbRecord[], parentKey: string | null): boolean {
   if (!parentKey || !rows.length) return false

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -109,6 +109,25 @@ test('sidebar records paint detail immediately without reloading the view', () =
   assert.match(detail, /<RecordEmojiBoard/)
 })
 
+test('pages and tasks sidebar records nest by parentId; other tables stay flat', () => {
+  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  const css = readFileSync(resolve(import.meta.dirname, '../../../../web/style.css'), 'utf8')
+  const path = readFileSync(resolve(import.meta.dirname, './database-path.ts'), 'utf8')
+  assert.match(path, /PAGES_COLLECTION_PATH = '\/pages'/)
+  assert.match(path, /TASKS_COLLECTION_PATH = '\/tasks'/)
+  assert.match(path, /function isRecordTreeCollection/)
+  assert.match(sidebar, /isRecordTreeCollection\(path\)/)
+  assert.match(sidebar, /treeChildren\(scope, parentKey, parentId\)/)
+  assert.match(sidebar, /title=\{\`\$\{kidCount\} 个子记录\`\}/)
+  assert.match(sidebar, /在 \$\{label\} 下添加子记录/)
+  assert.match(sidebar, /toggleStarredRecord/)
+  assert.match(sidebar, /records: \[\{ \[parentKey\]: row\.id \}\]/)
+  assert.match(sidebar, /if \(!nested\)/)
+  assert.match(css, /\.chat-session-row:hover \.sidebar-add/)
+  assert.match(css, /\.fsdb-record-kids/)
+  assert.doesNotMatch(css, /\.chat-session-row:hover \.sidebar-group-fold-chevron/)
+})
+
 test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /data-testid="record-title-split"/)

--- a/packages/core-file-system/src/web/list-projection.test.ts
+++ b/packages/core-file-system/src/web/list-projection.test.ts
@@ -16,7 +16,7 @@ test('table list and previews pass view columns to /api/db/list', () => {
   assert.match(browser, /\/api\/db\/read\?path=/)
   assert.match(client, /if \(opts\.columns\?\.length\) params\.set\('columns'/)
   assert.match(host, /columns: parseListColumnsParam\(route\.query\.get\('columns'\)\)/)
-  assert.match(preview, /columns: \['title', 'emoji', 'mascot'\]/)
+  assert.match(preview, /columns: \['title', 'emoji', 'mascot', 'parentId'\]/)
   assert.match(people, /columns: \['title', 'mascot'\]/)
   assert.match(links, /columns: \['label'\]/)
 })

--- a/packages/core-file-system/src/web/sidebar-preview.ts
+++ b/packages/core-file-system/src/web/sidebar-preview.ts
@@ -113,6 +113,6 @@ export async function fetchViewPreview(
     sortField: view.sortField,
     sortDir: view.sortDir,
     filters: view.filters,
-    columns: ['title', 'emoji', 'mascot'],
+    columns: ['title', 'emoji', 'mascot', 'parentId'],
   })
 }

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -8,6 +8,8 @@ import {
   persistViewDisplay,
   rememberRecords,
   savedViewFromRecord,
+  toggleStarredRecord,
+  isRecordStarred,
   viewDisplayKey,
   viewForPath,
   withViewDisplay,
@@ -126,4 +128,11 @@ test('rememberRecords scopes crumb rows to the current view', () => {
   )
   assert.equal(loadRecords('/pages', 'mine').some((row) => row.id === 't1'), false)
   assert.equal(loadRecords('/pages', 'all').some((row) => row.id === 't1'), false)
+})
+
+test('starred records toggle by collection path and id', () => {
+  const next = toggleStarredRecord([], '/pages', 'home')
+  assert.equal(isRecordStarred(next, '/pages', 'home'), true)
+  assert.equal(isRecordStarred(next, '/tasks', 'home'), false)
+  assert.equal(isRecordStarred(toggleStarredRecord(next, '/pages', 'home'), '/pages', 'home'), false)
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -303,6 +303,62 @@ export function toggleStarredView(items: StarredView[], path: string, viewId: st
   return [...items, { path, viewId }]
 }
 
+export type StarredRecord = { path: string; recordId: string }
+
+const STARRED_RECORDS_KEY = 'fsdb.starredRecords'
+
+export function loadStarredRecords(): StarredRecord[] {
+  try {
+    const raw = localStorage.getItem(STARRED_RECORDS_KEY)
+    const parsed = raw ? (JSON.parse(raw) as unknown) : []
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((item) => {
+      if (!item || typeof item !== 'object') return []
+      const rec = item as Record<string, unknown>
+      const path = String(rec.path ?? '').trim()
+      const recordId = String(rec.recordId ?? '').trim()
+      return path && recordId ? [{ path, recordId }] : []
+    })
+  } catch {
+    return []
+  }
+}
+
+let starredRecords = loadStarredRecords()
+let starredRecordsVersion = 0
+const starredRecordListeners = new Set<() => void>()
+
+export function getStarredRecords() {
+  return starredRecords
+}
+
+export function subscribeStarredRecords(fn: () => void) {
+  starredRecordListeners.add(fn)
+  return () => {
+    starredRecordListeners.delete(fn)
+  }
+}
+
+export function getStarredRecordsVersion() {
+  return starredRecordsVersion
+}
+
+export function persistStarredRecords(items: StarredRecord[]) {
+  starredRecords = items
+  starredRecordsVersion += 1
+  localStorage.setItem(STARRED_RECORDS_KEY, JSON.stringify(items))
+  for (const fn of starredRecordListeners) fn()
+}
+
+export function isRecordStarred(items: StarredRecord[], path: string, recordId: string) {
+  return items.some((item) => item.path === path && item.recordId === recordId)
+}
+
+export function toggleStarredRecord(items: StarredRecord[], path: string, recordId: string): StarredRecord[] {
+  if (isRecordStarred(items, path, recordId)) return items.filter((item) => item.path !== path || item.recordId !== recordId)
+  return [...items, { path, recordId }]
+}
+
 const DISPLAY_KEYS = [
   'mode',
   'sortField',

--- a/web/style.css
+++ b/web/style.css
@@ -2275,6 +2275,7 @@ body {
 }
 
 .sidebar-group-head:hover .sidebar-add,
+.chat-session-row:hover .sidebar-add,
 .sidebar-add:focus {
   width: 24px;
   min-width: 24px;
@@ -2351,6 +2352,10 @@ body {
 
 .sidebar-session-list .fsdb-view-preview .fsdb-view-preview-records .chat-session-row > .chat-session-row-main {
   padding-left: 33px;
+}
+
+.fsdb-record-kids {
+  padding-left: 11px;
 }
 
 .fsdb-view-preview-hint,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据视图左侧边栏里，**只有 `/pages` 和 `/tasks`** 的记录行改成和视图行同一套交互：

- 左侧图标 hover 变成展开/收起（子记录树，按 `parentId`）
- 右侧数字 = **直接子记录数量**
- hover 显示添加（新建子记录并写入 parentId）和收藏（逻辑同视图星星）

会话、组件、插件等其它表仍是原来的扁平图标+标题列表。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

