### PR TITLE
数据侧栏收藏区同时列出已收藏的页面和任务

### DIFF
--- a/packages/core-file-system/src/web/data-sidebar.tsx
+++ b/packages/core-file-system/src/web/data-sidebar.tsx
@@ -42,8 +42,12 @@ import {
   isRecordStarred,
   isViewStarred,
   loadViews,
+  peekRecord,
   persistStarredRecords,
   persistStarredViews,
+  rememberRecords,
+  starredRecordEmoji,
+  starredRecordLabel,
   subscribeStarredRecords,
   subscribeStarredViews,
   toggleStarredRecord,
@@ -54,7 +58,7 @@ import { pickDomAttrs, recordPickKind, viewPickId } from './pick-dom.ts'
 import { toggleExpandedViewKey } from './sidebar-nav.ts'
 import { TableGlyph, ViewModeGlyph } from './nav-glyphs.tsx'
 import { getDatabaseUi } from './database-ui.ts'
-import { RecordMark } from './record-mark.tsx'
+import { RecordMark, recordMarkStub } from './record-mark.tsx'
 import { SidebarBrandLockup } from '@biu/public-mascot'
 
 type PreviewState = {
@@ -172,8 +176,11 @@ function ViewRecordPreview({
     setOpenKids((prev) => ({ ...prev, [id]: !prev[id] }))
   }
 
-  function toggleRecordStar(recordId: string) {
-    persistStarredRecords(toggleStarredRecord(getStarredRecords(), path, recordId))
+  function toggleRecordStar(row: DbRecord) {
+    const label = recordPreviewLabel(row)
+    const emoji = recordPreviewEmoji(row)
+    rememberRecords(path, [{ id: row.id, label, emoji }])
+    persistStarredRecords(toggleStarredRecord(getStarredRecords(), path, row.id, { label, emoji }))
   }
 
   async function createChild(row: DbRecord) {
@@ -336,7 +343,7 @@ function ViewRecordPreview({
               title={starred ? '取消收藏' : '收藏'}
               onClick={(event) => {
                 event.stopPropagation()
-                toggleRecordStar(row.id)
+                toggleRecordStar(row)
               }}
             >
               <StarIcon className={`size-4 shrink-0${starred ? ' text-[#f5b700]' : ''}`} />
@@ -460,7 +467,9 @@ export const DataSidebar = memo(function DataSidebar({
   const { user: userTables, system: systemTables } = useMemo(() => sortDataCollections(listedTables), [listedTables])
   const [openTables, setOpenTables] = useState<Record<string, boolean>>(() => ({ [collectionPath]: true }))
   useSyncExternalStore(subscribeStarredViews, getStarredViewsVersion, () => 0)
+  useSyncExternalStore(subscribeStarredRecords, getStarredRecordsVersion, () => 0)
   const starredViews = getStarredViews()
+  const starredRecords = getStarredRecords()
   const [favOpen, setFavOpen] = useState(() => {
     try {
       return localStorage.getItem('fsdb.favOpen') !== '0'
@@ -486,6 +495,12 @@ export const DataSidebar = memo(function DataSidebar({
     if (!table || !view) return []
     return [{ table, view }]
   })
+  const starredRecordRows = starredRecords.flatMap((item) => {
+    const table = listedTables.find((row) => row.path === item.path)
+    if (!table) return []
+    return [{ table, item }]
+  })
+  const favCount = starredRows.length + starredRecordRows.length
 
   const countJobs = useMemo(() => {
     const jobs: Array<{ path: string; view: SavedView }> = []
@@ -524,6 +539,36 @@ export const DataSidebar = memo(function DataSidebar({
       cancelled = true
     }
   }, [countJobKey, countJobs])
+
+  useEffect(() => {
+    let cancelled = false
+    void Promise.all(
+      starredRecords.map(async (item) => {
+        if (item.label || peekRecord(item.path, item.recordId)?.label) {
+          if (item.label) rememberRecords(item.path, [{ id: item.recordId, label: item.label, emoji: item.emoji }])
+          return
+        }
+        try {
+          const data = await readJson<{ value?: DbRecord }>(`/api/db/read?path=${encodeURIComponent(`${item.path}/${item.recordId}`)}`)
+          const row = data.value
+          if (cancelled || !row?.id) return
+          const label = recordPreviewLabel(row)
+          const emoji = recordPreviewEmoji(row)
+          rememberRecords(item.path, [{ id: row.id, label, emoji, mascot: row.mascot }])
+          persistStarredRecords(
+            getStarredRecords().map((entry) =>
+              entry.path === item.path && entry.recordId === item.recordId ? { ...entry, label, emoji } : entry,
+            ),
+          )
+        } catch {
+          /* ignore */
+        }
+      }),
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [starredRecords])
 
   function toggleStar(path: string, viewId: string) {
     persistStarredViews(toggleStarredView(getStarredViews(), path, viewId))
@@ -711,7 +756,7 @@ export const DataSidebar = memo(function DataSidebar({
   const body = (
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-3">
         <div className="mt-2 space-y-1.5">
-          {starredRows.length ? (
+          {favCount ? (
             <section className="min-w-0">
               <div className="sidebar-section-head min-w-0">
                 <div className="flex min-h-8 min-w-0 flex-1 items-center">
@@ -732,10 +777,63 @@ export const DataSidebar = memo(function DataSidebar({
                     <span className="min-w-0 flex-1 truncate tracking-normal">收藏</span>
                   </button>
                 </div>
-                <ChatCount count={starredRows.length} />
+                <ChatCount count={favCount} />
               </div>
               <SidebarFold open={favOpen}>
                 <div className="min-w-0 pt-0.5">
+                  {starredRecordRows.map(({ table, item }) => {
+                    const tableName = table.view?.title ?? table.label
+                    const label = starredRecordLabel(item)
+                    const emoji = starredRecordEmoji(item)
+                    const chromeIcon = getDatabaseUi()?.chrome(table.path).Icon
+                    const view = viewsFor(table.path).find((row) => row.id === builtinAllViewId(table.path)) ?? viewsFor(table.path)[0]
+                    return (
+                      <div key={`star-record:${table.path}:${item.recordId}`} className="min-w-0">
+                        <div
+                          className="chat-session-row group is-pinned"
+                          {...pickDomAttrs(recordPickKind(table.view?.moduleId || table.id), item.recordId, label)}
+                        >
+                          <div className="chat-session-row-main flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left text-[14px] leading-5">
+                            <span className="grid size-6 shrink-0 place-items-center" aria-hidden>
+                              <RecordMark
+                                record={recordMarkStub({ id: item.recordId, emoji, mascot: peekRecord(table.path, item.recordId)?.mascot })}
+                                tableIcon={table.view?.icon}
+                                Icon={chromeIcon}
+                              />
+                            </span>
+                            <button
+                              type="button"
+                              className="min-w-0 flex-1 truncate border-0 bg-transparent p-0 text-left font-medium text-inherit"
+                              title={label}
+                              onClick={() => {
+                                if (!view) return
+                                openRecord(table.path, view, item.recordId, {
+                                  id: item.recordId,
+                                  title: label,
+                                  emoji,
+                                })
+                              }}
+                            >
+                              {label}
+                            </button>
+                          </div>
+                          <span className="grid size-6 shrink-0 place-items-center" title={tableName} aria-label={tableName}>
+                            <TableGlyph icon={table.view?.icon} />
+                          </span>
+                          <button
+                            type="button"
+                            className="chat-session-row-star is-on"
+                            aria-pressed
+                            aria-label={`取消收藏 ${label}`}
+                            title="取消收藏"
+                            onClick={() => persistStarredRecords(toggleStarredRecord(getStarredRecords(), table.path, item.recordId))}
+                          >
+                            <StarIcon className="size-4 shrink-0 text-[#f5b700]" />
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  })}
                   {starredRows.map(({ table, view }) => {
                     const tableName = table.view?.title ?? table.label
                     const active = table.path === collectionPath && view.id === activeViewId

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -128,6 +128,16 @@ test('pages and tasks sidebar records nest by parentId; other tables stay flat',
   assert.doesNotMatch(css, /\.chat-session-row:hover \.sidebar-group-fold-chevron/)
 })
 
+test('starred pages and tasks also list in the sidebar favorites section', () => {
+  const sidebar = readFileSync(resolve(import.meta.dirname, './data-sidebar.tsx'), 'utf8')
+  assert.match(sidebar, /const favCount = starredRows\.length \+ starredRecordRows\.length/)
+  assert.match(sidebar, /\{favCount \?/)
+  assert.match(sidebar, /starredRecordRows\.map/)
+  assert.match(sidebar, /star-record:\$\{table\.path\}:\$\{item\.recordId\}/)
+  assert.match(sidebar, /starredRecordLabel\(item\)/)
+  assert.doesNotMatch(sidebar, /\{starredRows\.length \?/)
+})
+
 test('table title opens record from the title-side button', () => {
   assert.match(browser, /data-testid="record-title-open"/)
   assert.match(browser, /data-testid="record-title-split"/)

--- a/packages/core-file-system/src/web/view-storage.test.ts
+++ b/packages/core-file-system/src/web/view-storage.test.ts
@@ -131,8 +131,9 @@ test('rememberRecords scopes crumb rows to the current view', () => {
 })
 
 test('starred records toggle by collection path and id', () => {
-  const next = toggleStarredRecord([], '/pages', 'home')
+  const next = toggleStarredRecord([], '/pages', 'home', { label: '首页' })
   assert.equal(isRecordStarred(next, '/pages', 'home'), true)
+  assert.equal(next[0]?.label, '首页')
   assert.equal(isRecordStarred(next, '/tasks', 'home'), false)
   assert.equal(isRecordStarred(toggleStarredRecord(next, '/pages', 'home'), '/pages', 'home'), false)
 })

--- a/packages/core-file-system/src/web/view-storage.ts
+++ b/packages/core-file-system/src/web/view-storage.ts
@@ -303,7 +303,7 @@ export function toggleStarredView(items: StarredView[], path: string, viewId: st
   return [...items, { path, viewId }]
 }
 
-export type StarredRecord = { path: string; recordId: string }
+export type StarredRecord = { path: string; recordId: string; label?: string; emoji?: string }
 
 const STARRED_RECORDS_KEY = 'fsdb.starredRecords'
 
@@ -317,7 +317,10 @@ export function loadStarredRecords(): StarredRecord[] {
       const rec = item as Record<string, unknown>
       const path = String(rec.path ?? '').trim()
       const recordId = String(rec.recordId ?? '').trim()
-      return path && recordId ? [{ path, recordId }] : []
+      if (!path || !recordId) return []
+      const label = String(rec.label ?? '').trim()
+      const emoji = String(rec.emoji ?? '').trim()
+      return [{ path, recordId, ...(label ? { label } : {}), ...(emoji ? { emoji } : {}) }]
     })
   } catch {
     return []
@@ -354,9 +357,26 @@ export function isRecordStarred(items: StarredRecord[], path: string, recordId: 
   return items.some((item) => item.path === path && item.recordId === recordId)
 }
 
-export function toggleStarredRecord(items: StarredRecord[], path: string, recordId: string): StarredRecord[] {
+export function toggleStarredRecord(
+  items: StarredRecord[],
+  path: string,
+  recordId: string,
+  meta?: { label?: string; emoji?: string },
+): StarredRecord[] {
   if (isRecordStarred(items, path, recordId)) return items.filter((item) => item.path !== path || item.recordId !== recordId)
-  return [...items, { path, recordId }]
+  const label = String(meta?.label ?? '').trim()
+  const emoji = String(meta?.emoji ?? '').trim()
+  return [...items, { path, recordId, ...(label ? { label } : {}), ...(emoji ? { emoji } : {}) }]
+}
+
+export function starredRecordLabel(item: StarredRecord) {
+  const peeked = peekRecord(item.path, item.recordId)
+  const label = String(peeked?.label ?? item.label ?? '').trim()
+  return label && label !== item.recordId ? label : label || item.recordId
+}
+
+export function starredRecordEmoji(item: StarredRecord) {
+  return String(peekRecord(item.path, item.recordId)?.emoji ?? item.emoji ?? '').trim()
 }
 
 const DISPLAY_KEYS = [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
数据侧栏顶部「收藏」以前只列收藏的视图。页面和任务记录点星星后，现在也会出现在同一块收藏区：标题、表图标、点开记录、再点星星取消收藏。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

