### PR TITLE
fix(plugins): 只能先开沙箱再打包安装

### DIFF
--- a/packages/core-file-system/src/web/fields.ts
+++ b/packages/core-file-system/src/web/fields.ts
@@ -492,7 +492,7 @@ export function previewActionRecord(row: DbRecord, action: { id?: string; when?:
     if (row.installed === false && row.running !== true && row.enabled !== true) return row
     return { ...row, installed: false, running: false, enabled: false }
   }
-  if (action.id === 'pack' || action.id === 'create') {
+  if (action.id === 'pack') {
     if (row.installed === true) return row
     return { ...row, installed: true }
   }

--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -90,7 +90,7 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.equal(draft?.shellWidth, undefined)
   assert.deepEqual(
     spec.actions?.map((item) => item.id),
-    ['create', 'sandbox', 'start', 'stop', 'pack', 'uninstall'],
+    ['sandbox', 'start', 'stop', 'pack', 'uninstall'],
   )
   await spec.actions!.find((item) => item.id === 'start')!.run('demo', demo!)
   await spec.actions!.find((item) => item.id === 'pack')!.run('draft-hello', draft!)
@@ -113,7 +113,7 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { installed: true, running: false })
   assert.deepEqual(spec.actions?.find((item) => item.id === 'pack')?.when, { sandbox: true })
   assert.deepEqual(spec.actions?.find((item) => item.id === 'uninstall')?.when, { installed: true })
-  assert.equal(spec.actions?.find((item) => item.id === 'create')?.for, 'agent')
+  assert.equal(spec.actions?.find((item) => item.id === 'sandbox')?.for, 'agent')
   assert.equal(spec.actions?.find((item) => item.id === 'start')?.for, undefined)
 })
 

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -2,8 +2,6 @@ import type { CollectionSpec, DbRecord } from '@biu/type-file-system'
 import { recordBuiltinValues, REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
 import {
   createArgs,
-  PLUGIN_CREATE_DESCRIPTION,
-  PLUGIN_CREATE_PROPERTIES,
   PLUGIN_PACK_DESCRIPTION,
   PLUGIN_SANDBOX_DESCRIPTION,
   PLUGIN_SANDBOX_PROPERTIES,
@@ -110,7 +108,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       route: '/plugins',
       title: '插件',
       inspector: true,
-      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。本表动作（db_action path=/plugins/<插件id> action=…）：create=把小插件源码写进 .plugin（args：name，以及 hostJs/webJs；记录可以还不存在）；sandbox=只建 .plugin-dev/<id>/，多文件写完必须再 pack；pack=把沙箱打进 .plugin（when：sandbox）；start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
+      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。安装只能 sandbox 再 pack：先 db_action path=/plugins/<插件id> action=sandbox 建 .plugin-dev/<id>/（记录可以还不存在），写完代码再 action=pack 打进 .plugin。不要直写 .plugin。start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
       order: 30,
       icon: 'puzzle-piece',
     },
@@ -176,21 +174,6 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       return ids
     },
     actions: [
-      {
-        id: 'create',
-        label: '直写安装',
-        for: 'agent',
-        placement: [],
-        allowMissing: true,
-        description: PLUGIN_CREATE_DESCRIPTION,
-        parameters: {
-          type: 'object',
-          description: PLUGIN_CREATE_DESCRIPTION,
-          properties: PLUGIN_CREATE_PROPERTIES,
-          required: ['name'],
-        },
-        run: async (id, _record, args = {}) => store.create(createArgs({ ...args, id })),
-      },
       {
         id: 'sandbox',
         label: '开沙箱',

--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -54,17 +54,19 @@ test('restore skips a broken enabled plugin and continues', async () => {
     const ctx = new Context()
     const { adopted } = stubHub(ctx)
     const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
-    await store.create({
+    await store.initSandbox({
       id: 'store-ok',
       name: 'Ok',
       hostJs: `export const name = 'store-ok'\nexport function apply() {}\n`,
     })
+    await store.pack('store-ok')
     await store.openPlugin('store-ok')
-    await store.create({
+    await store.initSandbox({
       id: 'store-bad',
       name: 'Bad',
       hostJs: `export const name = 'store-bad'\nexport function apply() {}\n`,
     })
+    await store.pack('store-bad')
     await store.openPlugin('store-bad')
     await writeFile(join(pluginDir, 'store-bad', 'host.js'), 'throw new SyntaxError("nope")\n')
     const ctx2 = new Context()
@@ -89,18 +91,19 @@ test('missing .plugin lists no plugins', async () => {
   }
 })
 
-test('create writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<id>/', async () => {
+test('sandbox then pack writes .plugin/<id>/; close keeps code; uninstall deletes .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
   const pluginDir = join(dir, '.plugin')
   try {
     const ctx = new Context()
     const { adopted, dropped, forks } = stubHub(ctx)
     const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
-    const created = await store.create({
+    await store.initSandbox({
       id: 'store-echo',
       name: 'Echo',
       hostJs: `export const name = 'store-echo'\nexport function apply() {}\n`,
     })
+    const created = await store.pack('store-echo')
     assert.equal(created.pluginPath, join(pluginDir, 'store-echo'))
     const echo = (await store.list()).find((item) => item.id === 'store-echo')
     assert.ok(echo)

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -18,6 +18,11 @@ function stubHub(ctx: Context) {
   }
 }
 
+async function installViaSandbox(store: PluginStoreService, input: Parameters<PluginStoreService['initSandbox']>[0]) {
+  await store.initSandbox(input)
+  return store.pack(input.id)
+}
+
 test('list writes createdAt into old manifests and does not use directory ctime', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-created-at-'))
   try {
@@ -60,14 +65,14 @@ test('list writes createdAt into old manifests and does not use directory ctime'
   }
 })
 
-test('create compiles host source straight into .plugin/<id>/', async () => {
+test('sandbox then pack compiles host source into .plugin/<id>/', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-create-small-'))
   try {
     const ctx = new Context()
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
     const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
-    await store.create({
+    await installViaSandbox(store, {
       id: 'store-echo',
       name: 'Echo',
       tags: ['tool', 'demo'],
@@ -100,23 +105,21 @@ test('create compiles host source straight into .plugin/<id>/', async () => {
     assert.match(readme, /^# Echo\n/)
     await store.writeReadme('store-echo', '# Echo\n\n自定义介绍\n')
     assert.equal(await store.readReadme('store-echo'), '# Echo\n\n自定义介绍\n')
-    await assert.rejects(
-      () => store.create({ id: 'store-empty', name: 'Empty' }),
-      /hostJs and\/or webJs/,
-    )
+    await store.initSandbox({ id: 'store-empty', name: 'Empty' })
+    await assert.rejects(() => store.pack('store-empty'), /host\.ts/)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }
 })
 
-test('create writes manifest.shell from input', async () => {
+test('sandbox then pack writes manifest.shell from input', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-shell-'))
   try {
     const ctx = new Context()
     stubHub(ctx)
     const pluginDir = join(dir, '.plugin')
     const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
-    await store.create({
+    await installViaSandbox(store, {
       id: 'store-game',
       name: 'Game',
       shell: { width: 640, height: 480, resizable: false },
@@ -136,7 +139,7 @@ test('create writes manifest.shell from input', async () => {
   }
 })
 
-test('create with web rejects missing shell size', async () => {
+test('sandbox with web rejects missing shell size', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-shell-required-'))
   try {
     const ctx = new Context()
@@ -149,7 +152,7 @@ test('create with web rejects missing shell size', async () => {
     ).open()
     await assert.rejects(
       () =>
-        store.create({
+        store.initSandbox({
           id: 'store-game',
           name: 'Game',
           webJs: `export const name = 'store-game'\nexport function apply() {}`,
@@ -184,7 +187,7 @@ test('pack with web rejects sandbox manifest without shell size', async () => {
   }
 })
 
-test('create and pack allow web without shell when headless', async () => {
+test('sandbox and pack allow web without shell when headless', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'plugin-headless-'))
   try {
     const ctx = new Context()
@@ -195,7 +198,7 @@ test('create and pack allow web without shell when headless', async () => {
       join(dir, 'store.json'),
       join(dir, '.plugin-dev'),
     ).open()
-    await store.create({
+    await installViaSandbox(store, {
       id: 'store-skin',
       name: 'Skin',
       headless: true,
@@ -287,7 +290,7 @@ test('pack bundles relative imports from sandbox', async () => {
   }
 })
 
-test('create/sandbox/pack live on the plugins collection, not as tools', () => {
+test('sandbox/pack live on the plugins collection, not as tools', () => {
   const spec = pluginsCollection({
     list: () => Promise.resolve([]),
     listSandboxes: () => Promise.resolve([]),
@@ -297,17 +300,14 @@ test('create/sandbox/pack live on the plugins collection, not as tools', () => {
     close() {},
     pack() {},
     uninstall() {},
-    create: async () => ({ id: 'x', pluginPath: '/tmp/x' }),
     initSandbox: async () => ({ id: 'x', sandboxPath: '/tmp/x' }),
   } as Store)
   const ids = spec.actions?.map((item) => item.id) ?? []
-  assert.deepEqual(ids, ['create', 'sandbox', 'start', 'stop', 'pack', 'uninstall'])
-  const create = spec.actions?.find((item) => item.id === 'create')
+  assert.deepEqual(ids, ['sandbox', 'start', 'stop', 'pack', 'uninstall'])
   const sandbox = spec.actions?.find((item) => item.id === 'sandbox')
   const pack = spec.actions?.find((item) => item.id === 'pack')
-  assert.equal(create?.allowMissing, true)
+  assert.equal(spec.actions?.find((item) => item.id === 'create'), undefined)
   assert.equal(sandbox?.allowMissing, true)
-  assert.match(JSON.stringify(create?.parameters), /storeShellFromRecord/)
   assert.match(JSON.stringify(sandbox?.parameters), /listing\.shell/)
   assert.match(String(pack?.parameters?.description ?? ''), /host\.ts/)
 })

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -312,22 +312,16 @@ export async function readSandboxManifest(dir: string) {
 }
 
 const CONTRACT = [
-  '契约：id 与 export const name 相同。可以 import npm，pack 会打进 host.js/web.js。不要 import react / react-dom / @biu/*：Web 用宿主 globalThis.React、ReactDOM 与 ReactJSXRuntime；宿主服务用 inject。有 npm 依赖请用 db_action /plugins/<id> action=sandbox，再用 action=pack（create 只做单文件、不解析 node_modules）。不要改 packages/ 或 cordis.plugins.json。',
+  '契约：id 与 export const name 相同。可以 import npm，pack 会打进 host.js/web.js。不要 import react / react-dom / @biu/*：Web 用宿主 globalThis.React、ReactDOM 与 ReactJSXRuntime；宿主服务用 inject。安装路径只有 sandbox + pack：db_action /plugins/<id> action=sandbox 建 .plugin-dev/<id>/，写完再用 action=pack。不要直写 .plugin。不要改 packages/ 或 cordis.plugins.json。',
   '有窗口的 Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选。运行窗口会给 extras 套操纵栏（关/缩；resizable 才有全屏），key 尽量用插件 id。',
   '无头插件：manifest 写 headless: true。有 web 也不要 shell，不要 place plugin-store-extras，不要操纵栏。只在 apply 里登记服务（如 pageEditor、databaseUi）。pageEditor.registerBlock 必须带 plugin（与本插件 id / export const name 相同），并用 blockType 声明块类型：basic 进斜杠「基础模块」，其它值（如 excalidraw、algorithm）各自成组，不要混进基础。写入文档后编辑器按这个 id 引导启用，不要让编辑器猜插件。页面块插件的 README（介绍）必须含「示例写法」和完整 :::pageBlock 围栏（含 kind、plugin、体），让 agent 读 /plugins/<id> 介绍就知道语法。集合自定义整页模式用 databaseUi.registerView(path, { id, label, plugin, View })。只换每一行的样子用 databaseUi.registerRowView(path 或 "*", { id, label, plugin, Row })，plugin 填本插件 id，宿主会打 data-biu-plugin，选取内部元素也能改这个插件。外壳和可见列由 File System 绑；Row 收到 record、fields、onOpen。',
   '有窗口的 web 必须在 manifest / 本动作 shell 参数里写 width 与 height。无头插件不要写 shell。',
   '/plugins 列表没有 listing.shell 对象，只有扁平字段 shellWidth、shellHeight、shellMinWidth、shellMinHeight、shellResizable、headless。有窗口时用 storeShellFromRecord 读尺寸。',
 ].join(' ')
 
-export const PLUGIN_CREATE_DESCRIPTION = [
-  '这是安装插件，不是新建代理。用户说「再开一个 agent」请 db_create /sessions。',
-  '直写已安装插件：单文件小插件。把 host/web 源码放进 args，立刻编译进 .plugin/<id>/，插件列表就能看到。',
-  '适合一两百行、无相对 import、无多文件。更大或要拆文件请改用 sandbox + pack。',
-  CONTRACT,
-].join(' ')
-
 export const PLUGIN_SANDBOX_DESCRIPTION = [
-  '开沙箱：多文件/大插件。只建/更新 .plugin-dev/<id>/（manifest.json，可选起点 host.ts / web.tsx），不进已安装目录。',
+  '这是安装插件的第一步，不是新建代理。用户说「再开一个 agent」请 db_create /sessions。',
+  '开沙箱：只建/更新 .plugin-dev/<id>/（manifest.json，可选起点 host.ts / web.tsx），不进已安装目录。',
   '然后用 bash / 文件工具在沙箱里写代码、相对 import。调完必须 db_action action=pack 才会打进 .plugin/<id>/。',
   '卸载删 .plugin/<id>/，沙箱还在。',
   CONTRACT,
@@ -386,18 +380,6 @@ const ID_NAME_BLURB = {
       resizable: { type: 'boolean', description: 'false 则锁死尺寸，适合固定画布' },
     },
     required: ['width', 'height'],
-  },
-}
-
-export const PLUGIN_CREATE_PROPERTIES = {
-  ...ID_NAME_BLURB,
-  hostJs: {
-    type: 'string',
-    description: 'host.ts 源码，编译成 .plugin/<id>/host.js。可与 webJs 二选一或都给。',
-  },
-  webJs: {
-    type: 'string',
-    description: 'web.tsx 源码，编译成 .plugin/<id>/web.js。可与 hostJs 二选一或都给。',
   },
 }
 

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -7,7 +7,6 @@ import type { CatalogEntry } from '@biu/host-hub'
 import {
   buildStoreManifest,
   bundleStoreEntry,
-  compileStoreModule,
   findEntry,
   HOST_ENTRIES,
   persistStoreManifestCreatedAt,
@@ -206,31 +205,6 @@ export class PluginStoreService extends Service {
 
   sandboxPath(id: string) {
     return join(this.sandboxDir, id)
-  }
-
-  /** 小插件：把 host/web 源码直接编译进 .plugin/<id>/。 */
-  async create(input: PluginCreateInput) {
-    const id = String(input.id ?? '').trim()
-    const name = String(input.name ?? '').trim()
-    if (!isSafeId(id)) throw new Error(`invalid plugin id: ${id}`)
-    if (!name) throw new Error('plugin name required')
-    const hostJs = String(input.hostJs ?? '').trim()
-    const webSrc = input.webJs != null ? String(input.webJs).trim() : ''
-    if (!hostJs && !webSrc) throw new Error('create needs hostJs and/or webJs')
-    requireDeclaredShell(input.shell, Boolean(webSrc), 'create', Boolean(input.headless))
-    this.invalidateList()
-    const dest = this.pluginPath(id)
-    mkdirSync(dest, { recursive: true })
-    const existing = existsSync(join(dest, 'manifest.json')) ? await readManifest(dest).catch(() => undefined) : undefined
-    const manifest = buildStoreManifest(input, existing)
-    await writeFile(join(dest, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-    if (hostJs) await writeFile(join(dest, 'host.js'), await compileStoreModule(hostJs, 'host'))
-    else if (existsSync(join(dest, 'host.js'))) await rm(join(dest, 'host.js'))
-    if (webSrc) await writeFile(join(dest, 'web.js'), await compileStoreModule(webSrc, 'web'))
-    else if (existsSync(join(dest, 'web.js'))) await rm(join(dest, 'web.js'))
-    if (this.isEnabled(id)) await this.mountFromDisk(manifest, dest)
-    await this.ensureReadme(dest, manifest.name, manifest.blurb)
-    return { id, pluginPath: dest }
   }
 
   /** 在 .plugin-dev/<id>/ 开沙箱，不写入已安装目录。 */

--- a/packages/web-app-shell/src/web/shell-search.tsx
+++ b/packages/web-app-shell/src/web/shell-search.tsx
@@ -177,7 +177,7 @@ export function previewHitRecord(record: Record<string, unknown>, action: Search
     if (record.installed === false && record.running !== true && record.enabled !== true) return record
     return { ...record, installed: false, running: false, enabled: false }
   }
-  if (action.id === 'pack' || action.id === 'create') {
+  if (action.id === 'pack') {
     if (record.installed === true) return record
     return { ...record, installed: true }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉 `/plugins` 上的「直写安装」`create` action，以及底层 `store.create()`。

装插件只剩一条路：`sandbox` 写 `.plugin-dev/<id>/`，再 `pack` 打进 `.plugin/<id>/`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

