### PR TITLE
fix(overlay): 收缩时去掉包着输入框的大框

### DIFF
--- a/packages/core-chat/src/web/composer-stack.test.ts
+++ b/packages/core-chat/src/web/composer-stack.test.ts
@@ -38,6 +38,8 @@ describe('composer dock stacking above sticky user', () => {
     const composer = readFileSync(resolve(root, 'packages/core-chat/src/web/composer.tsx'), 'utf8')
     expect(css).toMatch(/\.chat-overlay-panel \{/)
     expect(css).toMatch(/\.chat-overlay-panel\.is-compose-only \.chat-overlay-thread\s*\{[^}]*display:\s*none/s)
+    expect(css).toMatch(/\.chat-overlay-panel\.is-compose-only\s*\{[^}]*background:\s*transparent/s)
+    expect(css).toMatch(/\.chat-overlay-panel\.is-compose-only\s*\{[^}]*border:\s*0/s)
     expect(css).not.toMatch(/chat-overlay-peek/)
     expect(composer).toContain('revealOverlayThread')
     expect(composer).toContain('isComposerFocusPending')

--- a/packages/web-app-shell/src/web/chat-decouple.test.ts
+++ b/packages/web-app-shell/src/web/chat-decouple.test.ts
@@ -22,7 +22,7 @@ test('overlay chat is a resident floating window off the agent page', () => {
   assert.doesNotMatch(shell, /toggleChatOverlay/)
   assert.doesNotMatch(shell, /chat-overlay-pin/)
   const overlayHead = shell.slice(shell.indexOf('const overlayHeader'))
-  assert.match(overlayHead.slice(0, 1800), /chat-overlay-thread-toggle/)
+  assert.match(overlayHead.slice(0, 2200), /chat-overlay-thread-toggle[\s\S]*FolderGlyph/)
   assert.match(overlayHead.slice(0, 1800), /chat-view-project/)
   assert.doesNotMatch(overlayHead.slice(0, 1600), /layoutTools/)
   assert.doesNotMatch(overlayHead.slice(0, 1600), /chat-overlay-layout/)

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -695,23 +695,25 @@ function Shell(props: SlotProps) {
   const overlayHeader = (
     <header className="chat-view-header" data-biu-ignore>
       <div className="chat-view-header-left">
-        <button
-          type="button"
-          className={`chat-view-header-expand${overlayThread ? ' is-active' : ''}`}
-          title={overlayThread ? '收起对话' : '查看对话'}
-          aria-label={overlayThread ? '收起对话' : '查看对话'}
-          aria-pressed={overlayThread}
-          data-testid="chat-overlay-thread-toggle"
-          onClick={() => toggleOverlayThread()}
-        >
-          <ChatBubbleLeftRightIcon {...chromeIcon} />
-        </button>
-        {project ? (
-          <div className="chat-view-project" title={project.path ?? project.name}>
-            <FolderGlyph className="chat-view-project-icon" />
-            <span className="chat-view-project-name">{project.name}</span>
-          </div>
-        ) : null}
+        <div className="chat-view-project" title={project ? (project.path ?? project.name) : undefined}>
+          <button
+            type="button"
+            className={`chat-view-header-expand${overlayThread ? ' is-active' : ''}`}
+            title={overlayThread ? '收起对话' : '查看对话'}
+            aria-label={overlayThread ? '收起对话' : '查看对话'}
+            aria-pressed={overlayThread}
+            data-testid="chat-overlay-thread-toggle"
+            onClick={() => toggleOverlayThread()}
+          >
+            <ChatBubbleLeftRightIcon {...chromeIcon} />
+          </button>
+          {project ? (
+            <>
+              <FolderGlyph className="chat-view-project-icon" />
+              <span className="chat-view-project-name">{project.name}</span>
+            </>
+          ) : null}
+        </div>
       </div>
       <ChatSessionTitle useSessionView={useSessionView} sessionView={sessionView} />
       <div className="chat-view-header-right">

--- a/web/style.css
+++ b/web/style.css
@@ -1646,7 +1646,12 @@ body {
   top: auto !important;
   bottom: 12px;
   height: auto !important;
+  min-width: 0;
   min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .chat-overlay-panel.is-compose-only .chat-overlay-thread {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
收缩态去掉悬浮窗外面那层深色大框，不再包住输入框，只留输入胶囊和标题栏。对话 icon 放在绑定项目文件夹 icon 左边，和文件夹同一组。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

