### PR TITLE
fix(editor): db_content 按行号跳转，不再找第一处同文

### DIFF
--- a/packages/core-editor/src/web/content-jump.test.ts
+++ b/packages/core-editor/src/web/content-jump.test.ts
@@ -58,6 +58,17 @@ test('applyContentJump puts caret on the replaced markdown line', () => {
   editor.destroy()
 })
 
+test('applyContentJump lands on the matching line when the snippet appears twice', () => {
+  const md = '第一段重复\n\n中间\n\n第一段重复'
+  const editor = editorOf(md)
+  applyContentJump(editor, md, { path: '/pages/home', start_line: 5, end_line: 5 })
+  const from = editor.state.selection.from
+  const before = editor.state.doc.textBetween(0, from, '\n')
+  assert.match(before, /中间/)
+  assert.match(textAtCaret(editor), /第一段重复/)
+  editor.destroy()
+})
+
 test('tryContentJump waits until new text is in the doc then jumps', () => {
   clearContentJump()
   const before = '# 欢迎\n\n旧段落'

--- a/packages/core-editor/src/web/content-jump.ts
+++ b/packages/core-editor/src/web/content-jump.ts
@@ -2,6 +2,7 @@ import type { Node as PmNode } from '@tiptap/pm/model'
 import type { Editor } from '@tiptap/core'
 import { CONTENT_JUMP_EVENT, parseContentJump, type ContentJump } from '@biu/type-file-system'
 import { editorHostIsLive } from './editor-live.ts'
+import { markdownLineText, posAfterMarkdownLine, posAtMarkdownLine } from './markdown-locus.ts'
 import { scrollOutlineTarget } from '@biu/public-ui'
 
 let pending: ContentJump | null = null
@@ -113,19 +114,20 @@ export function tryContentJump(editor: Editor, markdown: string, recordId: strin
   if (!pending || editor.isDestroyed) return false
   if (!jumpMatchesRecord(pending, recordId)) return false
   if (!jumpHostOk(editor)) return false
-  const snippet = snippetAtLine(markdown, pending.start_line)
-  if (!force && snippet && posAtSnippet(editor.state.doc, snippet) == null) return false
+  const want = markdownLineText(markdown, pending.start_line)
+  const live = markdownLineText(editor.getMarkdown(), pending.start_line)
+  if (!force && want.trim() && live !== want) return false
   applyContentJump(editor, markdown, pending)
   scheduleConsume()
   return true
 }
 
-export function applyContentJump(editor: Editor, markdown: string, jump: ContentJump) {
-  const startSnippet = snippetAtLine(markdown, jump.start_line)
-  const found = posAtSnippet(editor.state.doc, startSnippet)
-  const pos = safeTextPos(editor.state.doc, found ?? 1)
+export function applyContentJump(editor: Editor, _markdown: string, jump: ContentJump) {
+  const from = safeTextPos(editor.state.doc, posAtMarkdownLine(editor, jump.start_line))
+  const to = safeTextPos(editor.state.doc, posAfterMarkdownLine(editor, jump.end_line ?? jump.start_line))
   try {
-    editor.chain().focus().setTextSelection(pos).run()
+    if (to > from) editor.chain().focus().setTextSelection({ from, to }).run()
+    else editor.chain().focus().setTextSelection(from).run()
   } catch {
     editor.commands.focus()
   }
@@ -134,7 +136,7 @@ export function applyContentJump(editor: Editor, markdown: string, jump: Content
   } catch {
     /* jsdom 没有 layout */
   }
-  scrollCaret(editor, pos)
+  scrollCaret(editor, from)
 }
 
 function scrollCaret(editor: Editor, pos: number) {

--- a/packages/core-editor/src/web/markdown-locus.test.ts
+++ b/packages/core-editor/src/web/markdown-locus.test.ts
@@ -2,7 +2,7 @@ import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Editor } from '@tiptap/core'
 import { pageEditorExtensions } from './kit.ts'
-import { markdownLocusFromRange, markdownLocusFromSelection } from './markdown-locus.ts'
+import { markdownLocusFromRange, markdownLocusFromSelection, posAtMarkdownLine } from './markdown-locus.ts'
 
 function editorOf(markdown: string) {
   return new Editor({
@@ -124,5 +124,16 @@ test('block math node selection still has a markdown locus for ⌘L', () => {
   const locus = markdownLocusFromSelection(editor)
   assert.ok(locus)
   assert.match(locus.selection ?? locus.text, /\\sum x/)
+  editor.destroy()
+})
+
+test('posAtMarkdownLine inverts locus line numbers', () => {
+  const md = '# 欢迎\n\n第一段\n\nUNIQUESEL\n\n末段'
+  const editor = editorOf(md)
+  const pos = posAtMarkdownLine(editor, 5)
+  editor.commands.setTextSelection(Math.max(1, pos))
+  const locus = markdownLocusFromSelection(editor)
+  assert.equal(locus?.start_line, 5)
+  assert.match(locus?.text ?? '', /UNIQUESEL/)
   editor.destroy()
 })

--- a/packages/core-editor/src/web/markdown-locus.ts
+++ b/packages/core-editor/src/web/markdown-locus.ts
@@ -16,6 +16,35 @@ function serialize(editor: Editor, doc: PmNode) {
   return editor.getMarkdown()
 }
 
+export function markdownLineText(md: string, line: number) {
+  return linesOf(md, line, line)
+}
+
+/** 当前文档里，该 1-based markdown 行开头的 ProseMirror 位置。 */
+export function posAtMarkdownLine(editor: Editor, line: number): number {
+  const doc = editor.state.doc
+  const full = serialize(editor, doc)
+  const target = clampLine(line, full)
+  let lo = 0
+  let hi = Math.max(0, doc.content.size)
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2)
+    const prefix = serialize(editor, doc.cut(0, mid))
+    if (lineFromPrefix(prefix, full) < target) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+/** 该行之后（下一行开头；已是末行则文档末尾）。 */
+export function posAfterMarkdownLine(editor: Editor, line: number): number {
+  const doc = editor.state.doc
+  const full = serialize(editor, doc)
+  const last = clampLine(Number.MAX_SAFE_INTEGER, full)
+  if (line >= last) return doc.content.size
+  return posAtMarkdownLine(editor, line + 1)
+}
+
 function lineAtEnd(md: string) {
   if (!md) return 1
   return md.split('\n').length

--- a/packages/core-file-system/src/web/heading-outline.tsx
+++ b/packages/core-file-system/src/web/heading-outline.tsx
@@ -58,6 +58,7 @@ export function HeadingOutline({ enabled }: { enabled: boolean }) {
       const run = () => {
         const main = detailMain(mark.current)
         if (!main) return
+        if (main.querySelector('.page-editor, [data-testid="page-editor"]')) return
         scrollOutlineTarget(blockElBySnippet(main, text))
       }
       run()

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -537,6 +537,7 @@ test('database extras sit after the record detail, not in the inspector', () => 
   assert.match(outline, /scrollOutlineTarget/)
   assert.match(outline, /CONTENT_JUMP_EVENT/)
   assert.match(outline, /blockElBySnippet/)
+  assert.match(outline, /page-editor/)
   assert.doesNotMatch(outline, /document\.querySelector\('\.fsdb-detail-main'\)/)
   assert.match(style, /\.heading-outline-host\{[^}]*z-index:20/)
   assert.match(detail, /FOCUS_RECORD_CONTENT/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`db_content` 改完跳编辑器时，以前是拿那一行文字去文档里找**第一次出现**，重复段落就会跳错。现在按 markdown 的 `start_line` 映射到 TipTap 位置。页面编辑器自己滚，大纲不再抢滚动。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

