### PR TITLE
fix(html): 海报式 HTML 块给默认高度，避免塌成黑块

### DIFF
--- a/.plugin-dev/page-html-blocks/html-deck.ts
+++ b/.plugin-dev/page-html-blocks/html-deck.ts
@@ -16,6 +16,17 @@ export function cssBoxSize(value: unknown): string | undefined {
   return text || undefined
 }
 
+/** 海报式 HTML：根节点 height:100% + overflow:hidden，子级全 absolute，百分比高度相对 auto 父级为 0。 */
+export const HTML_FILL_HOST_PX = 280
+
+export function htmlLooksFillLayout(html: string) {
+  const head = html.trim().slice(0, 1600)
+  const pct = /\bheight\s*:\s*100%\b/i.test(head) || /\bheight\s*:\s*100vh\b/i.test(head)
+  const clipped = /\boverflow\s*:\s*hidden\b/i.test(head)
+  const abs = (html.match(/\bposition\s*:\s*absolute\b/gi) ?? []).length >= 3
+  return (pct && clipped) || (pct && abs) || (clipped && abs)
+}
+
 export function htmlDeckEnabled(deck: unknown) {
   return deck !== false
 }

--- a/.plugin-dev/page-html-blocks/web.tsx
+++ b/.plugin-dev/page-html-blocks/web.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { bindHtmlSlide, collectHtmlSlides, cssBoxSize, htmlDeckEnabled, htmlDeckIndex, htmlDeckKeyAction, stepHtmlDeck } from './html-deck.ts'
+import { bindHtmlSlide, collectHtmlSlides, cssBoxSize, htmlDeckEnabled, htmlDeckIndex, htmlDeckKeyAction, htmlLooksFillLayout, HTML_FILL_HOST_PX, stepHtmlDeck } from './html-deck.ts'
 import { htmlBlockKey, stampHtmlPickSurfaces, stampHtmlSource } from './stamp-picks.ts'
 
 const React = globalThis.React
@@ -559,12 +559,16 @@ const HTML_EDITORIAL_SAMPLE = `<div style="box-sizing:border-box;min-height:100%
 
 const HTML_DIRECT_SAMPLE = HTML_EDITORIAL_SAMPLE
 
+const HTML_FILL_CSS = `.html-direct-fill-inner{height:100%;min-height:100%}.html-direct-fill-inner>:first-child{height:100%!important;min-height:100%;box-sizing:border-box}`
+
 function HtmlDirectCard({ data, update, writable }: BlockProps) {
   const ro = !writable
   const html = String(data.html ?? '')
   const width = data.width
   const height = data.height
-  const sized = (width != null && width !== '') || (height != null && height !== '')
+  const fill = htmlLooksFillLayout(html)
+  const fillHost = fill && (height == null || height === '')
+  const sized = (width != null && width !== '') || (height != null && height !== '') || fillHost
   const deckOn = htmlDeckEnabled(data.deck)
   const [editing, setEditing] = useState(false)
   const [hover, setHover] = useState(false)
@@ -579,10 +583,11 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
     <div
       ref={hostRef}
       data-testid="page-html-direct"
+      className={fill ? 'html-direct-fill' : undefined}
       style={{
         position: 'relative',
         width: cssBoxSize(width) ?? '100%',
-        height: cssBoxSize(height),
+        height: cssBoxSize(height) ?? (fillHost ? HTML_FILL_HOST_PX : undefined),
         maxWidth: '100%',
         overflow: sized ? 'auto' : undefined,
         boxSizing: 'border-box',
@@ -590,6 +595,7 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
       onPointerEnter={() => setHover(true)}
       onPointerLeave={() => setHover(false)}
     >
+      {fill ? <style>{HTML_FILL_CSS}</style> : null}
       {(hover || editing) && (
         <FloatBar
           editing={editing}
@@ -605,7 +611,11 @@ function HtmlDirectCard({ data, update, writable }: BlockProps) {
       {editing ? (
         <SourceEditor html={html} onChange={(v) => update({ html: v })} />
       ) : (
-        <div style={{ overflowX: sized ? undefined : 'auto' }} dangerouslySetInnerHTML={{ __html: stamped }} />
+        <div
+          className={fill ? 'html-direct-fill-inner' : undefined}
+          style={{ overflowX: sized ? undefined : 'auto', height: fill ? '100%' : undefined }}
+          dangerouslySetInnerHTML={{ __html: stamped }}
+        />
       )}
       {ro || editing ? null : <SizeGrip reveal={hover} boxRef={hostRef} onSize={(next) => update(next)} />}
       {deck.overlay}

--- a/packages/core-editor/src/page-block-fence.test.ts
+++ b/packages/core-editor/src/page-block-fence.test.ts
@@ -58,6 +58,20 @@ test('patchPageBlockMarkdown rejects missing or duplicate ids', () => {
   assert.throws(() => patchPageBlockMarkdown(dup, 'ab12cd34', { data: { html: 'x' } }), /not unique/)
 })
 
+test('html fence with inline styles still yields the poster html', () => {
+  const md = `:::pageBlock {kind=html plugin=page-html-blocks id=d6ac31a5}
+<div style="box-sizing:border-box;height:100%;width:100%;overflow:hidden;position:relative;background:linear-gradient(170deg,#f3ecd8 0%,#eadfc2 100%)">
+<div style="position:absolute;left:26px;top:22px">番附</div>
+</div>
+:::
+`
+  const fences = listPageBlockFences(md)
+  assert.equal(fences.length, 1)
+  assert.equal(fences[0]?.kind, 'html')
+  assert.match(String(pageBlockData(fences[0]!).html), /番附/)
+  assert.match(String(pageBlockData(fences[0]!).html), /height:100%/)
+})
+
 test('pageBlock record id is page::block', () => {
   assert.equal(pageBlockRecordId('p001', 'ab12cd34'), 'p001::ab12cd34')
   assert.deepEqual(parsePageBlockRecordId('p001::ab12cd34'), { pageId: 'p001', blockId: 'ab12cd34' })

--- a/packages/core-plugin-system/src/web/html-deck.test.ts
+++ b/packages/core-plugin-system/src/web/html-deck.test.ts
@@ -7,6 +7,8 @@ import {
   htmlDeckEnabled,
   htmlDeckIndex,
   htmlDeckKeyAction,
+  htmlLooksFillLayout,
+  HTML_FILL_HOST_PX,
   stepHtmlDeck,
 } from '../../../../.plugin-dev/page-html-blocks/html-deck.ts'
 
@@ -72,6 +74,14 @@ test('fullscreen deck fills the viewport', async () => {
   assert.doesNotMatch(src, /justifyContent: 'safe center'/)
   assert.doesNotMatch(src, /min\(100%, 960px\)/)
   assert.doesNotMatch(src, /padding: 32/)
+})
+
+test('poster html with height 100% and absolute children fills a host', () => {
+  const magazine = `<div style="min-height:100%;height:100%;display:flex"><p>刊</p></div>`
+  const poster = `<div style="height:100%;overflow:hidden;position:relative"><div style="position:absolute">初番</div><div style="position:absolute">二番</div><div style="position:absolute">三番</div></div>`
+  assert.equal(htmlLooksFillLayout(magazine), false)
+  assert.equal(htmlLooksFillLayout(poster), true)
+  assert.equal(HTML_FILL_HOST_PX, 280)
 })
 
 test('arrow keys drive the deck', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
番付这类 `kind=html` 块其实已经解析成功了。根节点写了 `height:100%; overflow:hidden`，子节点全是 `position:absolute`，在没有明确 `height=` 的宿主里百分比高度算成 0，再被裁掉，编辑器深色底看起来就是黑块。

检测这种 fill 布局后，宿主默认 280px，内层把首个子节点撑满。普通流式 HTML 不受影响。用户仍可用角上的尺寸手柄改高度。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

