### PR TITLE
fix(table): 勾选热区不要被 dnd-kit 的 CSS 挡住 CSS.escape

### DIFF
--- a/packages/core-file-system/src/web/browser.tsx
+++ b/packages/core-file-system/src/web/browser.tsx
@@ -11,7 +11,7 @@ import {
 } from '@dnd-kit/core'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
+import { CSS as DndCSS } from '@dnd-kit/utilities'
 import {
   ArrowPathIcon,
   ArrowsPointingOutIcon,
@@ -333,7 +333,7 @@ function ColumnDragRow({
     <ColumnRowShell
       rowRef={setNodeRef}
       className={isDragging ? 'is-drag' : undefined}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      style={{ transform: DndCSS.Transform.toString(transform), transition }}
       grip={
         <button type="button" className="fsdb-query-grip" aria-label="拖动调整列顺序" {...attributes} {...listeners}>
           <DndGrip />
@@ -1211,7 +1211,7 @@ export function CollectionBrowser({
         el.classList.remove('is-hover')
       }
       if (next) {
-        const hit = root.querySelector(`[data-check="${CSS.escape(next)}"]`)
+        const hit = root.querySelector(`[data-check="${typeof CSS !== 'undefined' && typeof CSS.escape === 'function' ? CSS.escape(next) : next}"]`)
         hit?.classList.add('is-hover')
       }
     }

--- a/packages/core-file-system/src/web/inspector-toggle.test.ts
+++ b/packages/core-file-system/src/web/inspector-toggle.test.ts
@@ -400,6 +400,8 @@ test('create record sits at the right of the toolbar with a blue label', () => {
   assert.match(css, /\.fsdb-check-slot\.is-hover \.fsdb-row-check/)
   assert.match(css, /\.fsdb-check-slot:hover \.fsdb-row-check/)
   assert.match(browser, /paintCheckHover/)
+  assert.match(browser, /CSS as DndCSS/)
+  assert.match(browser, /typeof CSS\.escape === 'function' \? CSS\.escape\(next\)/)
   assert.doesNotMatch(browser, /setCheckHover/)
   assert.match(browser, /data-check=\{slot\.kind === 'head' \? 'head' : slot\.id\}/)
   assert.match(css, /fsdb-check-rail/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
表格勾选热区 `paintCheckHover` 里写了 `CSS.escape`，但同文件 `import { CSS } from '@dnd-kit/utilities'` 把浏览器的 `CSS` 盖掉了，dnd-kit 那个对象没有 `escape`，所以报 `CSS.escape is not a function`。

把 dnd-kit 改成 `DndCSS`，选择器继续用 Web API 的 `CSS.escape`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

