### PR TITLE
Switch license to PolyForm Noncommercial 1.0.0

### DIFF
--- a/COMMERCIAL.md
+++ b/COMMERCIAL.md
@@ -1,0 +1,31 @@
+# Commercial / organization license
+
+Biu Agent OS source from this revision onward is licensed under the
+[PolyForm Noncommercial License 1.0.0](LICENSE).
+
+**Personal, noncommercial use is free.** Company, organization, production,
+SaaS, paid redistribution, and any other commercial use need a **separate
+written grant** before you start.
+
+`public/grok-bot/` is **not** covered by either license. See [NOTICE.md](NOTICE.md).
+
+Already-published MIT snapshots cannot be recalled. This change applies to new
+versions only.
+
+To request a commercial or organization license, open a GitHub issue on
+[helloooooooooooooo97/biu](https://github.com/helloooooooooooooo97/biu) with
+subject `commercial license` and describe the product, org, and intended use.
+
+---
+
+# 组织 / 商用授权
+
+从此版本起，Biu 源码使用 [PolyForm Noncommercial 1.0.0](LICENSE)。
+
+**个人 / 非商业免费。** 公司、组织、生产环境、SaaS、有偿再分发及其它商用，须事先取得书面授权。
+
+`public/grok-bot/` 不在本许可或任何 Biu 商用授权内。见 [NOTICE.md](NOTICE.md)。
+
+已经按 MIT 发布过的版本收不回来；收紧只对之后的版本生效。
+
+申请：在仓库开 Issue，标题写 `commercial license`，说明产品、组织与用途。

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,116 @@
-MIT License
+Required Notice: Copyright (c) 2026 Biu contributors (https://github.com/helloooooooooooooo97/biu)
 
-Copyright (c) 2026 Biu contributors
+# PolyForm Noncommercial License 1.0.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Acceptance
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+In order to get any license under these terms, you must agree to them as both
+strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything
+you might do with the software that would otherwise infringe the licensor's
+copyright in it for any permitted purpose.  However, you may only distribute
+the software according to [Distribution License](#distribution-license) and
+make changes or new works based on the software according to [Changes and New
+Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of
+the software.  Your license to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms or the URL for them above, as well as
+copies of any plain-text lines beginning with `Required Notice:` that the
+licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new
+works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public
+knowledge, personal study, private entertainment, hobby projects, amateur
+pursuits, or religious observance, without any anticipated commercial
+application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research
+organization, public safety or health organization, environmental protection
+organization, or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do
+not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to
+anyone else, or prevent the licensor from granting licenses to anyone else.
+These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted under
+these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these
+terms, or done anything with the software not covered by your licenses, your
+licenses can nonetheless continue if you come into full compliance with these
+terms, and take practical steps to correct past violations, within 32 days of
+receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the
+**software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or
+the power to direct its management and policies by vote, contract, or
+otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notice
 
-## Grok Bot 角色（不在 MIT 范围内）
+## Grok Bot 角色（不在本仓库许可范围内）
 
 侧栏 / 会话头像用的运行时脚本在 `public/grok-bot/`，改编自学习向副本
 [grok_bot-icon-study](https://github.com/w210548735-art/grok_bot-icon-study)
@@ -9,9 +9,9 @@
 该研究项目从 Grok Bot.app 抽出几何、配色和动画，仅供个人学习。
 **角色外形、商标、图标、几何数据及抽出材料归 xAI 及相应权利人所有。**
 本仓库把它们当作本地 UI 实验（按 session 区分头像），**不是** Biu 的原创品牌，
-**也不随 [LICENSE](LICENSE) 的 MIT 授权出去。**
+**也不随 [LICENSE](LICENSE) 的 PolyForm Noncommercial 或任何单独商用授权出去。**
 
 二次分发、公开部署或商用前，请自行确认版权与商标要求；有侵权风险。
-上游说明：仅供学习参考。
+上游说明：仅供学习参考。即便已取得 Biu 的商用授权，也不等于取得 xAI 角色授权。
 
 更细的包内说明见 [`packages/public-mascot/src/web/NOTICE.md`](packages/public-mascot/src/web/NOTICE.md)。

--- a/README.md
+++ b/README.md
@@ -336,7 +336,8 @@ biu
 ├── cordis.plugins.json        # Single plugin manifest (host / web / plugins tables)
 ├── Makefile                   # make / make stop / make restart
 ├── vite.config.ts
-├── LICENSE                    # MIT (excluding Grok Bot character assets)
+├── LICENSE                    # PolyForm Noncommercial 1.0.0 (excluding Grok Bot character assets)
+├── COMMERCIAL.md              # How to request a commercial / organization grant
 ├── NOTICE.md                  # Third-party character notice
 ├── docs/
 │   ├── plugin-packages.md     # Package prefix and entry conventions
@@ -349,7 +350,7 @@ biu
 │   ├── mascot-blue.svg        # README mascots (BMW M tricolor)
 │   ├── mascot-violet.svg
 │   ├── mascot-red.svg
-│   └── grok-bot/              # Non-MIT: xAI character geometry replica
+│   └── grok-bot/              # Not under LICENSE: xAI character geometry replica
 └── packages/
     ├── type-session/          # Contracts; not in json
     ├── type-http/
@@ -460,8 +461,13 @@ Alternatively: `npm run dev:host` and `npm run dev:web`.
 
 ## License
 
-Code and docs written by Biu Agent OS are under the [MIT License](LICENSE): learn, modify, distribute, and use commercially, provided the copyright notice and license text are retained.
+From this revision on, Biu-written code and docs use the [PolyForm Noncommercial License 1.0.0](LICENSE):
 
-**Exception: the Grok Bot.** `public/grok-bot/` — its geometry, animation, and character design — is **not MIT**. It is adapted from a learning extraction of Grok Bot.app and rights belong to xAI and other holders. It may be used for cloning and demos; before redistributing, shipping, or adopting it as a product mascot, assess the trademark/copyright risk yourself or replace it with your own character. This project grants no rights to this part. See [NOTICE.md](NOTICE.md).
+- **Personal / noncommercial use is free** (hobby, study, private experiments).
+- **Organization use, production, SaaS, paid redistribution, and any commercial use** need a **prior written grant**. See [COMMERCIAL.md](COMMERCIAL.md).
 
-The MIT software is provided "as is", without warranty of any kind.
+Already-published MIT copies cannot be recalled. The tighter terms apply to new versions only.
+
+**Exception: the Grok Bot.** `public/grok-bot/` — its geometry, animation, and character design — is **not** under LICENSE or any Biu commercial grant. It is adapted from a learning extraction of Grok Bot.app and rights belong to xAI and other holders. It may be used for cloning and demos; before redistributing, shipping, or adopting it as a product mascot, assess the trademark/copyright risk yourself or replace it with your own character. See [NOTICE.md](NOTICE.md).
+
+The software is provided "as is", without warranty of any kind.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -335,7 +335,8 @@ biu
 ├── cordis.plugins.json        # 唯一插件清单（host / web / plugins 三张表）
 ├── Makefile                   # make / make stop / make restart
 ├── vite.config.ts
-├── LICENSE                    # MIT（不含 Grok Bot 角色资产）
+├── LICENSE                    # PolyForm Noncommercial 1.0.0（不含 Grok Bot 角色资产）
+├── COMMERCIAL.md              # 组织 / 商用如何申请单独授权
 ├── NOTICE.md                  # 第三方角色声明
 ├── docs/
 │   ├── plugin-packages.md     # 包前缀与入口约定
@@ -348,7 +349,7 @@ biu
 │   ├── mascot-blue.svg        # README 吉祥物（BMW M 三色）
 │   ├── mascot-violet.svg
 │   ├── mascot-red.svg
-│   └── grok-bot/              # 非 MIT：xAI 角色几何副本
+│   └── grok-bot/              # 不在 LICENSE 内：xAI 角色几何副本
 └── packages/
     ├── type-session/          # 契约，不进 json
     ├── type-http/
@@ -459,8 +460,13 @@ export CHAT_MODEL=deepseek-chat # 可选
 
 ## 许可
 
-仓库里 **Biu Agent OS 自己写的代码和文档** 使用 [MIT License](LICENSE)：可以学习、修改、分发，**也可以商用**，保留版权声明和许可文本即可。
+从此版本起，仓库里 **Biu Agent OS 自己写的代码和文档** 使用 [PolyForm Noncommercial License 1.0.0](LICENSE)：
 
-**例外：Grok Bot 机器人。** `public/grok-bot/` 里的几何、动画和角色外形 **不是 MIT**。它们改编自对 Grok Bot.app 的学习向抽取，权利属于 xAI 等权利人。可用于克隆与演示；二次分发、打包上线或当产品吉祥物前，**有商标 / 版权侵权风险**，请自行评估，或替换为自有角色。本项目不授予这部分的任何权利。说明见 [NOTICE.md](NOTICE.md)。
+- **个人 / 非商业免费**（自学、兴趣、私有试验）。
+- **组织使用、生产部署、SaaS、有偿再分发及任何商用** 须 **事先取得书面授权**。申请方式见 [COMMERCIAL.md](COMMERCIAL.md)。
 
-MIT 软件「按原样」提供，作者不承担质量担保。
+已经按 MIT 发布过的版本收不回来。收紧只对之后的版本生效。
+
+**例外：Grok Bot 机器人。** `public/grok-bot/` 里的几何、动画和角色外形 **不在** LICENSE 或 Biu 商用授权之内。它们改编自对 Grok Bot.app 的学习向抽取，权利属于 xAI 等权利人。可用于克隆与演示；二次分发、打包上线或当产品吉祥物前，**有商标 / 版权侵权风险**，请自行评估，或替换为自有角色。说明见 [NOTICE.md](NOTICE.md)。
+
+软件「按原样」提供，作者不承担质量担保。

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "biu",
       "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "PolyForm-Noncommercial-1.0.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "biu",
   "version": "0.1.0",
   "private": true,
+  "license": "PolyForm-Noncommercial-1.0.0",
   "description": "Biu Agent OS：一切即插件，多 Agent 不靠群聊，而是通过任务看板协作。基于 Cordis，事件流驱动，一切可溯源。",
   "type": "module",
   "workspaces": [

--- a/packages/cap-logger/package.json
+++ b/packages/cap-logger/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/cap-logger",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/cap-mascot-easter-egg/package.json
+++ b/packages/cap-mascot-easter-egg/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/cap-mascot-easter-egg",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-chat/package.json
+++ b/packages/core-chat/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-chat",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-editor/package.json
+++ b/packages/core-editor/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-editor",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-file-system/package.json
+++ b/packages/core-file-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-file-system",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-page/package.json
+++ b/packages/core-page/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-page",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-pick/package.json
+++ b/packages/core-pick/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-pick",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-plugin-system/package.json
+++ b/packages/core-plugin-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-plugin-system",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/core-task-system/package.json
+++ b/packages/core-task-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/core-task-system",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/database-ui/package.json
+++ b/packages/database-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/database-ui",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-agent-loop/package.json
+++ b/packages/host-agent-loop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-agent-loop",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-agents/package.json
+++ b/packages/host-agents/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-agents",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-approvals/package.json
+++ b/packages/host-approvals/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-approvals",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-context/package.json
+++ b/packages/host-context/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-context",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-fs/package.json
+++ b/packages/host-fs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-fs",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-http/package.json
+++ b/packages/host-http/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-http",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-hub/package.json
+++ b/packages/host-hub/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-hub",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-jobs/package.json
+++ b/packages/host-jobs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-jobs",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-live-sessions/package.json
+++ b/packages/host-live-sessions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-live-sessions",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-llm/package.json
+++ b/packages/host-llm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-llm",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-lsp/package.json
+++ b/packages/host-lsp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-lsp",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-mcp/package.json
+++ b/packages/host-mcp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-mcp",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-plugin-loader/package.json
+++ b/packages/host-plugin-loader/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-plugin-loader",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-sandbox/package.json
+++ b/packages/host-sandbox/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-sandbox",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-session-store/package.json
+++ b/packages/host-session-store/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-session-store",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-sessions/package.json
+++ b/packages/host-sessions/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-sessions",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-shell/package.json
+++ b/packages/host-shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-shell",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-subagents/package.json
+++ b/packages/host-subagents/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-subagents",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-subprocess/package.json
+++ b/packages/host-subprocess/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-subprocess",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-system-prompt/package.json
+++ b/packages/host-system-prompt/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-system-prompt",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-terminal/package.json
+++ b/packages/host-terminal/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-terminal",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-tools/package.json
+++ b/packages/host-tools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-tools",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/host-update/package.json
+++ b/packages/host-update/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/host-update",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/public-mascot/package.json
+++ b/packages/public-mascot/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/public-mascot",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/public-mascot/src/web/NOTICE.md
+++ b/packages/public-mascot/src/web/NOTICE.md
@@ -9,11 +9,15 @@ replica in [grok_bot-icon-study](https://github.com/w210548735-art/grok_bot-icon
 That study project extracts geometry, palette, and animation logic from
 Grok Bot.app for personal research. **Character shapes, trademarks, icons,
 geometry data, and extracted materials belong to xAI / respective rights
-holders and are not covered by this repository's MIT license.** This harness uses them only as a local UI experiment for
-per-session avatars; do not treat the assets as original product branding.
+holders and are not covered by this repository's PolyForm Noncommercial
+license, nor by any separate Biu commercial grant.** This harness uses them
+only as a local UI experiment for per-session avatars; do not treat the
+assets as original product branding.
 
 Source disclaimer (upstream): for learning reference only; confirm copyright,
 trademark, and license requirements before further distribution.
+Redistributing or using the character commercially is a risk even if you
+have a Biu commercial license.
 
 ## CursorAvatar / OpenMausBot mascot (retired)
 

--- a/packages/public-ui/package.json
+++ b/packages/public-ui/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/public-ui",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-agent-loop/package.json
+++ b/packages/type-agent-loop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-agent-loop",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-file-system/package.json
+++ b/packages/type-file-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-file-system",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-host-context/package.json
+++ b/packages/type-host-context/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-host-context",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-http/package.json
+++ b/packages/type-http/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-http",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-session/package.json
+++ b/packages/type-session/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-session",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/type-slots/package.json
+++ b/packages/type-slots/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/type-slots",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-app-modules/package.json
+++ b/packages/web-app-modules/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-app-modules",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-app-shell/package.json
+++ b/packages/web-app-shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-app-shell",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-app-shell/src/web/index.test.ts
+++ b/packages/web-app-shell/src/web/index.test.ts
@@ -129,3 +129,14 @@ test('settings lists search and pick shortcuts', () => {
   assert.match(chrome, /⌘L/)
   assert.match(chrome, /选区送到对话/)
 })
+
+test('settings about states noncommercial license and grok-bot notice', () => {
+  const shell = readFileSync(resolve(import.meta.dirname, './index.tsx'), 'utf8')
+  const chrome = readFileSync(resolve(import.meta.dirname, './shell-chrome.tsx'), 'utf8')
+  assert.match(shell, /key: 'about'/)
+  assert.match(shell, /ShellSettingsAbout/)
+  assert.match(chrome, /data-testid="settings-about"/)
+  assert.match(chrome, /PolyForm Noncommercial/)
+  assert.match(chrome, /grok-bot/)
+  assert.match(chrome, /xAI/)
+})

--- a/packages/web-app-shell/src/web/index.tsx
+++ b/packages/web-app-shell/src/web/index.tsx
@@ -44,7 +44,7 @@ import { SessionInspector } from './session-inspector.tsx'
 import { SessionConfigDialog } from '@biu/web-session-view/dialog'
 import { FolderGlyph } from '@biu/web-session-view/folder-glyph'
 import { OverlayChatWindow } from './overlay-window.tsx'
-import { ShellSettingsShortcuts, ShellSettingsUpdate } from './shell-chrome.tsx'
+import { ShellSettingsAbout, ShellSettingsShortcuts, ShellSettingsUpdate } from './shell-chrome.tsx'
 import { ShellSearchPanel } from './shell-search.tsx'
 import { useSlotEntries } from '@biu/web-slots'
 import type { SlotsService } from '@biu/web-slots'
@@ -856,6 +856,7 @@ function Shell(props: SlotProps) {
                       { key: 'routes', label: '路由' },
                       { key: 'events', label: '事件' },
                       { key: 'update', label: '更新' },
+                      { key: 'about', label: '关于' },
                     ].map((item) => (
                       <li key={item.key}>
                         <button
@@ -881,6 +882,7 @@ function Shell(props: SlotProps) {
                     <section>{props.renderSlot('log')}</section>
                   ) : null}
                   {settingsTab === 'update' ? <ShellSettingsUpdate /> : null}
+                  {settingsTab === 'about' ? <ShellSettingsAbout /> : null}
                 </div>
               </div>
             </div>

--- a/packages/web-app-shell/src/web/shell-chrome.tsx
+++ b/packages/web-app-shell/src/web/shell-chrome.tsx
@@ -14,6 +14,21 @@ import { chromeIcon } from './chrome-icon.ts'
 import { applyNoticeClick, noticeIdOf } from './notice-open.ts'
 import { readMainDataRoute } from '@biu/core-file-system/main-data-route'
 
+export function ShellSettingsAbout() {
+  return (
+    <section data-testid="settings-about">
+      <p className="m-0 px-2 text-[14px] font-semibold text-(--dsw-label)">Biu Agent OS</p>
+      <p className="settings-muted m-0 px-2 pt-2">
+        个人 / 非商业免费。组织使用、生产部署与商用须事先取得书面授权。许可正文为 PolyForm Noncommercial 1.0.0，商用申请见仓库 COMMERCIAL.md。
+      </p>
+      <p className="settings-muted m-0 px-2 pt-2">
+        public/grok-bot/ 角色素材归 xAI，不在本许可或任何 Biu 商用授权内；二次分发与商用有侵权风险。详见 NOTICE.md。
+      </p>
+      <p className="settings-muted m-0 px-2 pt-2">已按 MIT 发布的旧版本收不回来；收紧只对当前及之后版本生效。</p>
+    </section>
+  )
+}
+
 export function ShellSettingsShortcuts() {
   return (
     <section data-testid="settings-shortcuts">

--- a/packages/web-event-log/package.json
+++ b/packages/web-event-log/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-event-log",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-plugin-tree/package.json
+++ b/packages/web-plugin-tree/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-plugin-tree",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-project-view/package.json
+++ b/packages/web-project-view/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-project-view",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-react-host/package.json
+++ b/packages/web-react-host/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-react-host",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-routes-panel/package.json
+++ b/packages/web-routes-panel/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-routes-panel",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-session-view/package.json
+++ b/packages/web-session-view/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-session-view",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-slots/package.json
+++ b/packages/web-slots/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-slots",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-snapshot/package.json
+++ b/packages/web-snapshot/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-snapshot",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/packages/web-ui-hub/package.json
+++ b/packages/web-ui-hub/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@biu/web-ui-hub",
+  "license": "PolyForm-Noncommercial-1.0.0",
   "version": "0.1.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace MIT with [PolyForm Noncommercial 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0) so personal / noncommercial use stays free, while organization, production, SaaS, and other commercial use need a prior written grant (`COMMERCIAL.md`).

- Root `LICENSE` is the official PolyForm NC text plus Required Notice.
- `package.json` (root + workspaces) and lockfile root entry set `"license": "PolyForm-Noncommercial-1.0.0"`.
- README / README.zh-CN license sections, tree, and settings **关于** tab (`ShellSettingsAbout`).
- `NOTICE.md` restates that `public/grok-bot/` belongs to xAI and is outside PolyForm NC and any Biu commercial grant.

Already-published MIT copies cannot be recalled; this applies going forward only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

