### PR TITLE
正文跳转进检查器；同名多页都进汇总表

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.test.tsx
+++ b/packages/core-chat/src/web/content-edits-table.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { ChatNodeList } from './thread.tsx'
+import {
+  INSPECTOR_REVEAL_EVENT,
+  contentEditLabel,
+  revealContentEdit,
+  type ContentEditRow,
+} from './content-edits-table.tsx'
 import type { ChatNode } from '@biu/web-session-view'
 
 afterEach(() => {
@@ -9,8 +15,56 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+function helloPages(): ContentEditRow[] {
+  return [1, 2, 3, 4, 5].map((n) => ({
+    path: `/pages/p${n}`,
+    title: '你好',
+    added: 1,
+    removed: 0,
+    jump_line: 1,
+  }))
+}
+
+describe('contentEditLabel', () => {
+  it('keeps a unique title as-is', () => {
+    expect(contentEditLabel({ path: '/pages/home', title: '首页', added: 1, removed: 0, jump_line: 1 }, helloPages().slice(0, 1))).toBe(
+      '首页',
+    )
+  })
+
+  it('disambiguates five pages that all share the title 你好', () => {
+    const files = helloPages()
+    expect(files.map((file) => contentEditLabel(file, files))).toEqual([
+      '你好 · p1',
+      '你好 · p2',
+      '你好 · p3',
+      '你好 · p4',
+      '你好 · p5',
+    ])
+  })
+})
+
+describe('revealContentEdit', () => {
+  it('opens the record in the right inspector and jumps, without navigating the chat route', () => {
+    const seen: Array<{ type: string; detail: unknown }> = []
+    const onReveal = (event: Event) => seen.push({ type: event.type, detail: (event as CustomEvent).detail })
+    const onJump = (event: Event) => seen.push({ type: event.type, detail: (event as CustomEvent).detail })
+    window.addEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
+    window.addEventListener(CONTENT_JUMP_EVENT, onJump)
+    const href = window.location.href
+    revealContentEdit('/pages/p3', 1)
+    expect(window.location.href).toBe(href)
+    expect(seen).toEqual([
+      { type: INSPECTOR_REVEAL_EVENT, detail: { collection: '/pages', recordId: 'p3', unique: true } },
+      { type: CONTENT_JUMP_EVENT, detail: { path: '/pages/p3', start_line: 1, end_line: 1, navigate: true } },
+    ])
+    window.removeEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
+    window.removeEventListener(CONTENT_JUMP_EVENT, onJump)
+  })
+})
+
 describe('ContentEditsTable', () => {
-  it('renders under the reply and jumps / reverts files', () => {
+  it('renders under the reply and reverts a single file', () => {
     const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true, results: [] }) }))
     vi.stubGlobal('fetch', fetchMock)
     const nodes: ChatNode[] = [
@@ -21,24 +75,44 @@ describe('ContentEditsTable', () => {
         copyText: '改好了',
         turn: 3,
         parts: [{ id: 'a-1', kind: 'assistant', text: '改好了' }],
-        contentEdits: [
-          { path: '/pages/home', title: '首页', added: 4, removed: 1, jump_line: 8 },
-        ],
+        contentEdits: [{ path: '/pages/home', title: '首页', added: 4, removed: 1, jump_line: 8 }],
       },
     ]
-    render(
-      <MemoryRouter>
-        <ChatNodeList nodes={nodes} sessionId="sess-1" onInspect={() => undefined} onFork={() => undefined} />
-      </MemoryRouter>,
-    )
+    render(<ChatNodeList nodes={nodes} sessionId="sess-1" onInspect={() => undefined} onFork={() => undefined} />)
     expect(screen.getByTestId('content-edits-table')).toBeTruthy()
     expect(screen.getByText('首页')).toBeTruthy()
-    expect(screen.getAllByText('+4').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('−1').length).toBeGreaterThan(0)
     fireEvent.click(screen.getByLabelText('撤销 首页'))
-    expect(fetchMock).toHaveBeenCalled()
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-    expect(String(fetchMock.mock.calls[0]?.[0])).toBe('/api/db/content-revert')
-    expect(JSON.parse(String(init.body))).toEqual({ sessionId: 'sess-1', turn: 3, path: '/pages/home' })
+    expect(JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))).toEqual({
+      sessionId: 'sess-1',
+      turn: 3,
+      path: '/pages/home',
+    })
+  })
+
+  it('lists all five 你好 pages as separate rows and reveals the clicked one in the inspector', () => {
+    const seen: unknown[] = []
+    const onReveal = (event: Event) => seen.push((event as CustomEvent).detail)
+    window.addEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
+    const href = window.location.href
+    const nodes: ChatNode[] = [
+      { id: 'u-1', kind: 'user', text: '五页都写你好' },
+      {
+        id: 'r-1',
+        kind: 'reply',
+        copyText: '写好了',
+        turn: 4,
+        parts: [{ id: 'a-1', kind: 'assistant', text: '写好了' }],
+        contentEdits: helloPages(),
+      },
+    ]
+    render(<ChatNodeList nodes={nodes} sessionId="sess-2" onInspect={() => undefined} onFork={() => undefined} />)
+    const table = screen.getByTestId('content-edits-table')
+    expect(table.querySelectorAll('li')).toHaveLength(5)
+    expect(screen.getByText('你好 · p1')).toBeTruthy()
+    expect(screen.getByText('你好 · p5')).toBeTruthy()
+    fireEvent.click(screen.getByText('你好 · p4'))
+    expect(window.location.href).toBe(href)
+    expect(seen).toEqual([{ collection: '/pages', recordId: 'p4', unique: true }])
+    window.removeEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
   })
 })

--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -1,8 +1,6 @@
 import { memo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { ArrowUturnLeftIcon } from '@heroicons/react/16/solid'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
-import { setChatOverlay } from '@biu/web-app-shell/chat-overlay'
 
 export type ContentEditRow = {
   path: string
@@ -13,16 +11,36 @@ export type ContentEditRow = {
   reverted?: boolean
 }
 
-function recordHref(path: string) {
+export const INSPECTOR_REVEAL_EVENT = 'biu:inspector-reveal'
+
+export function recordParts(path: string) {
   const parts = path.split('/').filter(Boolean)
-  if (parts.length < 2) return ''
-  return `/database/${parts[0]}/record/${encodeURIComponent(parts.slice(1).join('/'))}`
+  if (parts.length < 2) return null
+  return { collection: `/${parts[0]}`, recordId: parts.slice(1).join('/') }
 }
 
-function jumpTo(path: string, line: number) {
+/** 同名标题（比如五页都叫「你好」）带上 id，避免看起来像同一条。 */
+export function contentEditLabel(file: ContentEditRow, files: ContentEditRow[]) {
+  const title = file.title.trim() || file.path
+  const dup = files.filter((row) => (row.title.trim() || row.path) === title).length > 1
+  if (!dup) return title
+  const id = recordParts(file.path)?.recordId
+  return id ? `${title} · ${id}` : title
+}
+
+/** 右侧检查器打开记录并跳到改动行；不改中间主界面、不关聊天。 */
+export function revealContentEdit(path: string, jumpLine: number) {
+  const parts = recordParts(path)
+  if (parts) {
+    window.dispatchEvent(
+      new CustomEvent(INSPECTOR_REVEAL_EVENT, {
+        detail: { collection: parts.collection, recordId: parts.recordId, unique: true },
+      }),
+    )
+  }
   window.dispatchEvent(
     new CustomEvent(CONTENT_JUMP_EVENT, {
-      detail: { path, start_line: line, end_line: line, navigate: true },
+      detail: { path, start_line: jumpLine, end_line: jumpLine, navigate: true },
     }),
   )
 }
@@ -36,7 +54,6 @@ export const ContentEditsTable = memo(function ContentEditsTable({
   turn: number
   files: ContentEditRow[]
 }) {
-  const navigate = useNavigate()
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState('')
   const visible = files.filter((file) => file.added || file.removed || file.reverted)
@@ -66,13 +83,6 @@ export const ContentEditsTable = memo(function ContentEditsTable({
     } finally {
       setBusy(null)
     }
-  }
-
-  const openFile = (file: ContentEditRow) => {
-    const href = recordHref(file.path)
-    setChatOverlay(false)
-    if (href) navigate(href)
-    jumpTo(file.path, file.jump_line)
   }
 
   return (
@@ -105,9 +115,9 @@ export const ContentEditsTable = memo(function ContentEditsTable({
             <button
               type="button"
               className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-(--dsw-label) hover:underline"
-              onClick={() => openFile(file)}
+              onClick={() => revealContentEdit(file.path, file.jump_line)}
             >
-              {file.title || file.path}
+              {contentEditLabel(file, visible)}
             </button>
             {file.reverted ? (
               <span className="text-[12px] font-semibold text-(--dsw-label-3)">已撤销</span>
@@ -116,21 +126,21 @@ export const ContentEditsTable = memo(function ContentEditsTable({
                 <button
                   type="button"
                   className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
-                  onClick={() => openFile(file)}
+                  onClick={() => revealContentEdit(file.path, file.jump_line)}
                 >
                   +{file.added}
                 </button>
                 <button
                   type="button"
                   className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
-                  onClick={() => openFile(file)}
+                  onClick={() => revealContentEdit(file.path, file.jump_line)}
                 >
                   −{file.removed}
                 </button>
                 <button
                   type="button"
                   className="inline-flex items-center rounded-md p-1 text-(--dsw-label-2) hover:bg-(--dsw-hover)"
-                  aria-label={`撤销 ${file.title}`}
+                  aria-label={`撤销 ${contentEditLabel(file, visible)}`}
                   disabled={busy != null}
                   onClick={() => void revert(file.path)}
                 >

--- a/packages/core-file-system/src/host/content-turn-service.test.ts
+++ b/packages/core-file-system/src/host/content-turn-service.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import { runWithSession } from '@biu/host-sessions/scope'
+import { ContentTurnService } from './content-turn-service.ts'
+
+test('parallel recordEdit of five 你好 pages publishes every file', async () => {
+  const published: Array<Array<{ path: string }>> = []
+  const sessions = {
+    peek: () => ({ events: [{ type: 'turn/start', turn: 1 }] }),
+    append: async (_id: string, body: { files?: Array<{ path: string }> }) => {
+      await new Promise((resolve) => setTimeout(resolve, 8))
+      if (body.files) published.push(body.files)
+    },
+  }
+  const ctx = new Context()
+  const db = {
+    content: async () => ({ value: '' }),
+    writeContent: async () => undefined,
+  }
+  const service = new ContentTurnService(ctx, db).open(':memory:')
+  const get = service.ctx.get.bind(service.ctx)
+  service.ctx.get = ((name: string) => (name === 'sessions' ? sessions : get(name))) as typeof service.ctx.get
+  await runWithSession('sess-hello', async () => {
+    await Promise.all([1, 2, 3, 4, 5].map((n) => service.recordEdit(`/pages/p${n}`, '', '你好', '你好')))
+  })
+  const last = published.at(-1)?.map((file) => file.path) ?? []
+  assert.deepEqual(last.sort(), ['/pages/p1', '/pages/p2', '/pages/p3', '/pages/p4', '/pages/p5'])
+  assert.equal(service.summaries('sess-hello', 1).length, 5)
+})

--- a/packages/core-file-system/src/host/content-turn-service.ts
+++ b/packages/core-file-system/src/host/content-turn-service.ts
@@ -12,6 +12,7 @@ type ContentDb = {
 export class ContentTurnService extends Service {
   store = new ContentTurnStore()
   private reverting = false
+  private publishChain: Promise<void> = Promise.resolve()
 
   constructor(
     ctx: Context,
@@ -32,7 +33,7 @@ export class ContentTurnService extends Service {
     const turn = this.openTurn(sessionId)
     if (turn == null) return
     this.store.record({ sessionId, turn, path, title, before, after })
-    await this.publish(sessionId, turn)
+    await this.publishLatest(sessionId, turn)
   }
 
   async revert(sessionId: string, turn: number, path?: string) {
@@ -62,7 +63,7 @@ export class ContentTurnService extends Service {
     } finally {
       this.reverting = false
     }
-    await this.publish(sid, turn)
+    await this.publishLatest(sid, turn)
     return { ok: results.every((row) => row.ok), results }
   }
 
@@ -79,6 +80,14 @@ export class ContentTurnService extends Service {
       else if (event.type === 'turn/end') turn = null
     }
     return turn
+  }
+
+  private publishLatest(sessionId: string, turn: number) {
+    this.publishChain = this.publishChain.then(
+      () => this.publish(sessionId, turn),
+      () => this.publish(sessionId, turn),
+    )
+    return this.publishChain
   }
 
   private async publish(sessionId: string, turn: number) {

--- a/packages/core-file-system/src/host/content-turn-store.test.ts
+++ b/packages/core-file-system/src/host/content-turn-store.test.ts
@@ -15,6 +15,24 @@ test('content turn store keeps first before and latest after', () => {
   assert.equal(sum[0]?.removed, 0)
 })
 
+test('five pages that all write 你好 still produce five summary rows', () => {
+  const store = new ContentTurnStore().open(':memory:')
+  for (const id of ['p1', 'p2', 'p3', 'p4', 'p5']) {
+    store.record({ sessionId: 's1', turn: 2, path: `/pages/${id}`, title: '你好', before: '', after: '你好' })
+  }
+  const sum = store.summaries('s1', 2)
+  assert.equal(sum.length, 5)
+  assert.deepEqual(
+    sum.map((row) => row.path),
+    ['/pages/p1', '/pages/p2', '/pages/p3', '/pages/p4', '/pages/p5'],
+  )
+  for (const row of sum) {
+    assert.equal(row.title, '你好')
+    assert.equal(row.added, 1)
+    assert.equal(row.removed, 1)
+  }
+})
+
 test('content turn store summaries keep reverted rows', () => {
   const store = new ContentTurnStore().open(':memory:')
   store.record({ sessionId: 's1', turn: 1, path: '/pages/p1', title: '首页', before: 'a\n', after: 'b\n' })

--- a/packages/host-sessions/src/host/index.ts
+++ b/packages/host-sessions/src/host/index.ts
@@ -422,7 +422,7 @@ export class SessionsService extends Service {
     } else if (body.type === 'content/edits') {
       const existing = record.events.slice(0, -1).findLast((item) => item.type === 'content/edits' && item.turn === body.turn)
       if (existing && existing.type === 'content/edits') {
-        existing.files = body.files
+        existing.files = mergeContentEditFiles(existing.files, body.files)
         existing.ts = event.ts
         record.events.pop()
         this.schedulePersist(id)
@@ -605,6 +605,20 @@ async function resolveHostProject(input: string): Promise<SessionProject> {
   const info = await stat(real)
   if (!info.isDirectory()) throw new Error(`project path is not a directory: ${real}`)
   return { name: basename(real) || real, path: real, boundAt: Date.now() }
+}
+
+/** 同回合多次 content/edits 按 path 合并，避免并行发布用旧快照把后写的文件盖掉。 */
+export function mergeContentEditFiles<T extends { path: string }>(prev: T[], next: T[]): T[] {
+  const map = new Map<string, T>()
+  for (const file of prev) {
+    const path = String(file.path ?? '').trim()
+    if (path) map.set(path, file)
+  }
+  for (const file of next) {
+    const path = String(file.path ?? '').trim()
+    if (path) map.set(path, file)
+  }
+  return [...map.values()]
 }
 
 export { sessionsCollection } from './sessions-collection.ts'

--- a/packages/host-sessions/src/host/merge-content-edits.test.ts
+++ b/packages/host-sessions/src/host/merge-content-edits.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { mergeContentEditFiles } from './index.ts'
+
+test('mergeContentEditFiles keeps later files when a stale snapshot only has the first', () => {
+  const first = [{ path: '/pages/a', title: '你好', added: 1, removed: 0, jump_line: 1 }]
+  const all = [
+    { path: '/pages/a', title: '你好', added: 1, removed: 0, jump_line: 1 },
+    { path: '/pages/b', title: '你好', added: 1, removed: 0, jump_line: 1 },
+    { path: '/pages/c', title: '你好', added: 1, removed: 0, jump_line: 1 },
+    { path: '/pages/d', title: '你好', added: 1, removed: 0, jump_line: 1 },
+    { path: '/pages/e', title: '你好', added: 1, removed: 0, jump_line: 1 },
+  ]
+  const merged = mergeContentEditFiles(all, first)
+  assert.equal(merged.length, 5)
+  assert.deepEqual(
+    merged.map((file) => file.path),
+    ['/pages/a', '/pages/b', '/pages/c', '/pages/d', '/pages/e'],
+  )
+})
+
+test('mergeContentEditFiles lets a newer row for the same path win', () => {
+  const prev = [{ path: '/pages/a', title: '你好', added: 1, removed: 0, jump_line: 1 }]
+  const next = [{ path: '/pages/a', title: '你好', added: 2, removed: 1, jump_line: 3, reverted: true }]
+  const merged = mergeContentEditFiles(prev, next)
+  assert.equal(merged.length, 1)
+  assert.equal(merged[0]?.added, 2)
+  assert.equal(merged[0]?.reverted, true)
+})

--- a/packages/web-session-view/src/web/session-project.test.ts
+++ b/packages/web-session-view/src/web/session-project.test.ts
@@ -61,6 +61,32 @@ test('projectNodes attaches content/edits onto the turn reply', () => {
   assert.equal(reply.copyText, '已改')
 })
 
+test('projectNodes keeps all five 你好 content edits on the reply', () => {
+  const files = [1, 2, 3, 4, 5].map((n) => ({
+    path: `/pages/p${n}`,
+    title: '你好',
+    added: 1,
+    removed: 0,
+    jump_line: 1,
+  }))
+  const nodes = projectNodes([
+    { type: 'turn/start', turn: 3, seq: 1, ts: 1 },
+    { type: 'user/message', text: '五页你好', kind: 'wake', seq: 2, ts: 2 },
+    { type: 'content/edits', turn: 3, files: files.slice(0, 1), seq: 3, ts: 3 },
+    { type: 'content/edits', turn: 3, files, seq: 4, ts: 4 },
+    { type: 'assistant/message', text: '好了', seq: 5, ts: 5 },
+    { type: 'turn/end', turn: 3, reason: 'complete', seq: 6, ts: 6 },
+  ])
+  const reply = nodes.find((node) => node.kind === 'reply')
+  assert.equal(reply?.kind, 'reply')
+  if (reply?.kind !== 'reply') return
+  assert.equal(reply.contentEdits?.length, 5)
+  assert.deepEqual(
+    reply.contentEdits?.map((file) => file.path),
+    ['/pages/p1', '/pages/p2', '/pages/p3', '/pages/p4', '/pages/p5'],
+  )
+})
+
 test('projectNodes keeps streamed DeepSeek reasoning as a think part', () => {
   const nodes = projectNodes([
     { type: 'turn/start', turn: 1, seq: 1, ts: 1 },
@@ -519,22 +545,4 @@ test('reply & step histPct is token-weighted average over all llm.chat usage', (
   // 各 step 单独保留自身 histPct
   assert.equal(reply.steps?.[0]?.histPct, 0.2)
   assert.equal(reply.steps?.[1]?.histPct, 0.8)
-})
-
-test('projectNodes attaches content/edits onto the turn reply', () => {
-  const files = [
-    { path: '/pages/home', title: '首页', added: 3, removed: 1, jump_line: 4 },
-  ]
-  const nodes = projectNodes([
-    { type: 'turn/start', turn: 2, seq: 1, ts: 1 },
-    { type: 'user/message', text: '改文档', kind: 'wake', seq: 2, ts: 2 },
-    { type: 'content/edits', turn: 2, files, seq: 3, ts: 3 },
-    { type: 'assistant/message', text: '已改', seq: 4, ts: 4 },
-    { type: 'turn/end', turn: 2, reason: 'complete', seq: 5, ts: 5 },
-  ])
-  const reply = nodes.find((node) => node.kind === 'reply')
-  assert.equal(reply?.kind, 'reply')
-  if (reply?.kind !== 'reply') return
-  assert.deepEqual(reply.contentEdits, files)
-  assert.equal(reply.copyText, '已改')
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
两点：

1. 汇总表点击只在**右侧检查器**打开记录并跳到改动行，不 `navigate` 中间主界面，也不关聊天 overlay。
2. 同一回合并行写多份正文时，旧的 `content/edits` 快照会把后写的文件盖掉。现在按 path 合并，并串行发布。五页都写「你好」会显示五条（同名标题带 id：`你好 · p4`）。

测试覆盖五页同名、并行 recordEdit、stale snapshot 合并、检查器 reveal 不改 `location.href`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

