### PR TITLE
回合回滚：修好正文撤销，并记下 create/update/delete

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.test.tsx
+++ b/packages/core-chat/src/web/content-edits-table.test.tsx
@@ -80,6 +80,7 @@ describe('ContentEditsTable', () => {
     ]
     render(<ChatNodeList nodes={nodes} sessionId="sess-1" onInspect={() => undefined} onFork={() => undefined} />)
     expect(screen.getByTestId('content-edits-table')).toBeTruthy()
+    expect(screen.getByText('本回合改动')).toBeTruthy()
     expect(screen.getByText('首页')).toBeTruthy()
     fireEvent.click(screen.getByLabelText('撤销 首页'))
     expect(JSON.parse(String((fetchMock.mock.calls[0] as [string, RequestInit])[1].body))).toEqual({

--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -9,6 +9,7 @@ export type ContentEditRow = {
   removed: number
   jump_line: number
   reverted?: boolean
+  kind?: 'content' | 'create' | 'update' | 'delete'
 }
 
 export const INSPECTOR_REVEAL_EVENT = 'biu:inspector-reveal'
@@ -19,7 +20,12 @@ export function recordParts(path: string) {
   return { collection: `/${parts[0]}`, recordId: parts.slice(1).join('/') }
 }
 
-/** 同名标题（比如五页都叫「你好」）带上 id，避免看起来像同一条。 */
+function kindLabel(kind: ContentEditRow['kind']) {
+  if (kind === 'create') return '新建'
+  if (kind === 'delete') return '删除'
+  if (kind === 'update') return '更新'
+  return ''
+}
 export function contentEditLabel(file: ContentEditRow, files: ContentEditRow[]) {
   const title = file.title.trim() || file.path
   const dup = files.filter((row) => (row.title.trim() || row.path) === title).length > 1
@@ -56,13 +62,13 @@ export const ContentEditsTable = memo(function ContentEditsTable({
 }) {
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState('')
-  const visible = files.filter((file) => file.added || file.removed || file.reverted)
+  const visible = files.filter((file) => file.added || file.removed || file.reverted || file.kind === 'create' || file.kind === 'update' || file.kind === 'delete')
   if (!visible.length) return null
   const added = visible.reduce((n, file) => n + (file.reverted ? 0 : file.added), 0)
   const removed = visible.reduce((n, file) => n + (file.reverted ? 0 : file.removed), 0)
   const active = visible.filter((file) => !file.reverted)
 
-  const revert = async (path?: string) => {
+  const revert = async (path?: string, kind?: ContentEditRow['kind']) => {
     const key = path ?? '*'
     setBusy(key)
     setError('')
@@ -70,7 +76,7 @@ export const ContentEditsTable = memo(function ContentEditsTable({
       const res = await fetch('/api/db/content-revert', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ sessionId, turn, ...(path ? { path } : {}) }),
+        body: JSON.stringify({ sessionId, turn, ...(path ? { path } : {}), ...(kind ? { kind } : {}) }),
       })
       const body = (await res.json().catch(() => null)) as
         | { ok?: boolean; results?: Array<{ path: string; ok: boolean; error?: string }> }
@@ -78,8 +84,16 @@ export const ContentEditsTable = memo(function ContentEditsTable({
       const failed = body?.results?.filter((row) => !row.ok) ?? []
       if (!res.ok || !body?.ok) {
         const first = failed[0]
-        setError(first?.error === 'diverged' ? '正文已改过，未撤销以免覆盖' : first?.error || '撤销失败')
+        const errorText =
+          first?.error === 'diverged'
+            ? '已经被人改过，未撤销以免覆盖'
+            : first?.error === 'missing'
+              ? '找不到这回合的快照'
+              : first?.error || '撤销失败'
+        setError(errorText)
+        return
       }
+      window.dispatchEvent(new Event('fsdb:change'))
     } finally {
       setBusy(null)
     }
@@ -91,7 +105,7 @@ export const ContentEditsTable = memo(function ContentEditsTable({
       data-testid="content-edits-table"
     >
       <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) px-3 py-2">
-        <div className="text-(length:--dsw-chat-ui-font-size) font-semibold text-(--dsw-label-2)">本回合正文</div>
+        <div className="text-(length:--dsw-chat-ui-font-size) font-semibold text-(--dsw-label-2)">本回合改动</div>
         <div className="flex items-center gap-2 text-[12px] font-semibold tabular-nums">
           <span className="text-[#448361]">+{added}</span>
           <span className="text-[#c4554d]">−{removed}</span>
@@ -111,38 +125,42 @@ export const ContentEditsTable = memo(function ContentEditsTable({
       {error ? <div className="px-3 py-1.5 text-[12px] font-semibold text-(--dsw-danger)">{error}</div> : null}
       <ul className="m-0 list-none p-0">
         {visible.map((file) => (
-          <li key={file.path} className="flex items-center gap-2 border-t border-(--dsw-border) px-3 py-1.5 first:border-t-0">
+          <li key={`${file.kind ?? 'content'}:${file.path}`} className="flex items-center gap-2 border-t border-(--dsw-border) px-3 py-1.5 first:border-t-0">
             <button
               type="button"
               className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-(--dsw-label) hover:underline"
               onClick={() => revealContentEdit(file.path, file.jump_line)}
             >
-              {contentEditLabel(file, visible)}
+              {kindLabel(file.kind) ? `${kindLabel(file.kind)} · ${contentEditLabel(file, visible)}` : contentEditLabel(file, visible)}
             </button>
             {file.reverted ? (
               <span className="text-[12px] font-semibold text-(--dsw-label-3)">已撤销</span>
             ) : (
               <>
-                <button
-                  type="button"
-                  className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
-                  onClick={() => revealContentEdit(file.path, file.jump_line)}
-                >
-                  +{file.added}
-                </button>
-                <button
-                  type="button"
-                  className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
-                  onClick={() => revealContentEdit(file.path, file.jump_line)}
-                >
-                  −{file.removed}
-                </button>
+                {file.kind === 'content' || !file.kind ? (
+                  <>
+                    <button
+                      type="button"
+                      className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
+                      onClick={() => revealContentEdit(file.path, file.jump_line)}
+                    >
+                      +{file.added}
+                    </button>
+                    <button
+                      type="button"
+                      className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
+                      onClick={() => revealContentEdit(file.path, file.jump_line)}
+                    >
+                      −{file.removed}
+                    </button>
+                  </>
+                ) : null}
                 <button
                   type="button"
                   className="inline-flex items-center rounded-md p-1 text-(--dsw-label-2) hover:bg-(--dsw-hover)"
                   aria-label={`撤销 ${contentEditLabel(file, visible)}`}
                   disabled={busy != null}
-                  onClick={() => void revert(file.path)}
+                  onClick={() => void revert(file.path, file.kind)}
                 >
                   <ArrowUturnLeftIcon className="size-3.5" aria-hidden />
                 </button>

--- a/packages/core-file-system/src/host/content-turn-service.test.ts
+++ b/packages/core-file-system/src/host/content-turn-service.test.ts
@@ -28,3 +28,79 @@ test('parallel recordEdit of five 你好 pages publishes every file', async () =
   assert.deepEqual(last.sort(), ['/pages/p1', '/pages/p2', '/pages/p3', '/pages/p4', '/pages/p5'])
   assert.equal(service.summaries('sess-hello', 1).length, 5)
 })
+
+test('revert writes the first before and rejects empty snapshots', async () => {
+  const pages = new Map<string, string>([['/pages/p1', '你好']])
+  const ctx = new Context()
+  const sessions = {
+    peek: () => ({ events: [{ type: 'turn/start', turn: 1 }] }),
+    append: async () => undefined,
+  }
+  const db = {
+    content: async (path: string) => ({ value: pages.get(path) ?? '' }),
+    writeContent: async (path: string, value: unknown) => {
+      pages.set(path, String(value ?? ''))
+      return { value: pages.get(path) }
+    },
+  }
+  const service = new ContentTurnService(ctx, db).open(':memory:')
+  const get = service.ctx.get.bind(service.ctx)
+  service.ctx.get = ((name: string) => (name === 'sessions' ? sessions : get(name))) as typeof service.ctx.get
+  await runWithSession('sess-hello', async () => {
+    await service.recordEdit('/pages/p1', '', '你好', '你好')
+  })
+  const miss = await service.revert('sess-hello', 9)
+  assert.equal(miss.ok, false)
+  assert.equal(miss.results[0]?.error, 'missing')
+  const done = await service.revert('sess-hello', 1, '/pages/p1', 'content')
+  assert.equal(done.ok, true)
+  assert.equal(pages.get('/pages/p1'), '')
+  assert.equal(service.summaries('sess-hello', 1)[0]?.reverted, true)
+})
+
+test('revert create/update/delete in reverse', async () => {
+  const rows = new Map<string, Record<string, unknown>>([
+    ['/pages/keep', { id: 'keep', title: 'keep', status: 'open' }],
+  ])
+  const created: string[] = []
+  const ctx = new Context()
+  const sessions = {
+    peek: () => ({ events: [{ type: 'turn/start', turn: 1 }] }),
+    append: async () => undefined,
+  }
+  const db = {
+    content: async () => ({ value: '' }),
+    writeContent: async () => undefined,
+    read: async (path: string) => ({ value: rows.get(path) }),
+    update: async (path: string, content: unknown) => {
+      const patch = content as Record<string, unknown>
+      const cur = rows.get(path)
+      if (!cur) throw new Error('missing')
+      rows.set(path, { ...cur, ...patch })
+    },
+    create: async (_path: string, records: unknown) => {
+      const rec = (records as Record<string, unknown>[])[0]!
+      created.push(String(rec.title ?? ''))
+      rows.set('/pages/new', { id: 'new', ...rec })
+    },
+    remove: async (_path: string, query: { ids: string[] }) => {
+      for (const id of query.ids) rows.delete(`/pages/${id}`)
+    },
+  }
+  const service = new ContentTurnService(ctx, db).open(':memory:')
+  const get = service.ctx.get.bind(service.ctx)
+  service.ctx.get = ((name: string) => (name === 'sessions' ? sessions : get(name))) as typeof service.ctx.get
+  await runWithSession('sess-ops', async () => {
+    await service.recordCreate('/pages/made', 'made', { id: 'made', title: 'made' })
+    rows.set('/pages/made', { id: 'made', title: 'made' })
+    await service.recordUpdate('/pages/keep', 'keep', { status: 'open' }, { status: 'done' })
+    rows.set('/pages/keep', { id: 'keep', title: 'keep', status: 'done' })
+    await service.recordDelete('/pages/gone', 'gone', { id: 'gone', title: 'gone' })
+    rows.delete('/pages/gone')
+  })
+  const done = await service.revert('sess-ops', 1)
+  assert.equal(done.ok, true)
+  assert.equal(rows.has('/pages/made'), false)
+  assert.equal(rows.get('/pages/keep')?.status, 'open')
+  assert.deepEqual(created, ['gone'])
+})

--- a/packages/core-file-system/src/host/content-turn-service.ts
+++ b/packages/core-file-system/src/host/content-turn-service.ts
@@ -1,12 +1,41 @@
 import { Service, type Context } from 'cordis'
 import { currentSessionId } from '@biu/host-sessions/scope'
-import type { ContentEditSummary } from './content-turn-store.ts'
+import type { ContentEditSummary, TurnOp } from './content-turn-store.ts'
 import { ContentTurnStore } from './content-turn-store.ts'
 import { asContentText } from './content-edit.ts'
 
 type ContentDb = {
   content: (path: string) => Promise<{ value: unknown }>
-  writeContent: (path: string, value: unknown) => Promise<unknown>
+  writeContent: (path: string, value: unknown) => Promise<{ value?: unknown } | unknown>
+  update?: (path: string, content: unknown) => Promise<unknown>
+  create?: (path: string, records: unknown) => Promise<unknown>
+  remove?: (path: string, query: { ids: string[] }) => Promise<unknown>
+  read?: (path: string) => Promise<{ value?: unknown }>
+}
+
+function sameText(left: string, right: string) {
+  return left.replace(/\r\n/g, '\n') === right.replace(/\r\n/g, '\n')
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  return value as Record<string, unknown>
+}
+
+function writableClone(row: Record<string, unknown>) {
+  const next = { ...row }
+  delete next.id
+  delete next.createdAt
+  delete next.updatedAt
+  delete next.createdBy
+  delete next.updatedBy
+  return next
+}
+
+function splitRecordPath(path: string) {
+  const parts = path.split('/').filter(Boolean)
+  if (parts.length < 2) return null
+  return { collection: `/${parts[0]}`, id: parts.slice(1).join('/') }
 }
 
 export class ContentTurnService extends Service {
@@ -26,49 +55,137 @@ export class ContentTurnService extends Service {
     return this
   }
 
-  async recordEdit(path: string, before: string, after: string, title: string) {
-    if (this.reverting || before === after) return
+  private scope() {
+    if (this.reverting) return null
     const sessionId = String(currentSessionId() ?? '').trim()
-    if (!sessionId) return
+    if (!sessionId) return null
     const turn = this.openTurn(sessionId)
-    if (turn == null) return
-    this.store.record({ sessionId, turn, path, title, before, after })
-    await this.publishLatest(sessionId, turn)
+    if (turn == null) return null
+    return { sessionId, turn }
   }
 
-  async revert(sessionId: string, turn: number, path?: string) {
+  async recordEdit(path: string, before: string, after: string, title: string) {
+    if (sameText(before, after)) return
+    const scope = this.scope()
+    if (!scope) return
+    this.store.record({ ...scope, path, title, before, after })
+    await this.publishLatest(scope.sessionId, scope.turn)
+  }
+
+  async recordCreate(path: string, title: string, record: Record<string, unknown>) {
+    const scope = this.scope()
+    if (!scope) return
+    this.store.recordOp(scope.sessionId, scope.turn, { op: 'create', path, title, record })
+    await this.publishLatest(scope.sessionId, scope.turn)
+  }
+
+  async recordUpdate(path: string, title: string, before: Record<string, unknown>, after: Record<string, unknown>) {
+    if (JSON.stringify(before) === JSON.stringify(after)) return
+    const scope = this.scope()
+    if (!scope) return
+    this.store.recordOp(scope.sessionId, scope.turn, { op: 'update', path, title, before, after })
+    await this.publishLatest(scope.sessionId, scope.turn)
+  }
+
+  async recordDelete(path: string, title: string, record: Record<string, unknown>) {
+    const scope = this.scope()
+    if (!scope) return
+    this.store.recordOp(scope.sessionId, scope.turn, { op: 'delete', path, title, record })
+    await this.publishLatest(scope.sessionId, scope.turn)
+  }
+
+  async revert(sessionId: string, turn: number, path?: string, kind?: ContentEditSummary['kind']) {
     const sid = sessionId.trim()
-    const files = path ? [this.store.getFile(sid, turn, path)].filter(Boolean) : this.store.listFiles(sid, turn)
+    const want = path?.trim()
     const results: Array<{ path: string; ok: boolean; error?: string }> = []
     this.reverting = true
     try {
-      for (const file of files) {
-        if (!file || file.reverted) {
-          if (file) results.push({ path: file.path, ok: true })
-          continue
+      const ops = this.store.listOps(sid, turn).slice().reverse()
+      for (const op of ops) {
+        if (op.reverted) continue
+        if (want && op.path !== want) continue
+        if (kind && kind !== 'content' && op.op !== kind) continue
+        if (kind === 'content') continue
+        results.push(await this.revertOp(sid, turn, op))
+      }
+      if (!kind || kind === 'content') {
+        const files = want ? [this.store.getFile(sid, turn, want)].filter(Boolean) : this.store.listFiles(sid, turn)
+        if (want && kind === 'content' && !files.length) {
+          results.push({ path: want, ok: false, error: 'missing' })
         }
-        try {
-          const current = asContentText((await this.db.content(file.path)).value)
-          if (current !== file.after && current !== file.before) {
-            results.push({ path: file.path, ok: false, error: 'diverged' })
+        for (const file of files) {
+          if (!file || file.reverted) {
+            if (file) results.push({ path: file.path, ok: true })
             continue
           }
-          if (current !== file.before) await this.db.writeContent(file.path, file.before)
-          this.store.markReverted(sid, turn, file.path)
-          results.push({ path: file.path, ok: true })
-        } catch (error) {
-          results.push({ path: file.path, ok: false, error: String(error) })
+          results.push(await this.revertContent(sid, turn, file.path, file.before, file.after))
         }
       }
     } finally {
       this.reverting = false
     }
     await this.publishLatest(sid, turn)
+    if (!results.length) return { ok: false, results: [{ path: want || '', ok: false, error: 'missing' }] }
     return { ok: results.every((row) => row.ok), results }
   }
 
   summaries(sessionId: string, turn: number): ContentEditSummary[] {
     return this.store.summaries(sessionId, turn)
+  }
+
+  private async revertContent(sessionId: string, turn: number, path: string, before: string, after: string) {
+    try {
+      const current = asContentText((await this.db.content(path)).value)
+      if (!sameText(current, after) && !sameText(current, before)) {
+        return { path, ok: false, error: 'diverged' }
+      }
+      if (!sameText(current, before)) await this.db.writeContent(path, before)
+      this.store.markReverted(sessionId, turn, path, 'content')
+      return { path, ok: true }
+    } catch (error) {
+      return { path, ok: false, error: String(error) }
+    }
+  }
+
+  private async revertOp(sessionId: string, turn: number, op: TurnOp) {
+    try {
+      const parts = splitRecordPath(op.path)
+      if (op.op === 'create') {
+        const live = await this.db.read?.(op.path).catch(() => null)
+        if (!live?.value) {
+          this.store.markReverted(sessionId, turn, op.path, 'create')
+          return { path: op.path, ok: true }
+        }
+        if (!parts || !this.db.remove) return { path: op.path, ok: false, error: 'cannot delete' }
+        await this.db.remove(parts.collection, { ids: [parts.id] })
+        this.store.markReverted(sessionId, turn, op.path, 'create')
+        return { path: op.path, ok: true }
+      }
+      if (op.op === 'update') {
+        const live = asRecord((await this.db.read?.(op.path))?.value)
+        if (!live) return { path: op.path, ok: false, error: 'missing' }
+        const keys = Object.keys(op.after)
+        const slice = (row: Record<string, unknown>) => {
+          const next: Record<string, unknown> = {}
+          for (const key of keys) next[key] = row[key] ?? null
+          return next
+        }
+        const now = JSON.stringify(slice(live))
+        if (now !== JSON.stringify(op.after) && now !== JSON.stringify(op.before)) {
+          return { path: op.path, ok: false, error: 'diverged' }
+        }
+        if (!this.db.update) return { path: op.path, ok: false, error: 'cannot update' }
+        if (now !== JSON.stringify(op.before)) await this.db.update(op.path, op.before)
+        this.store.markReverted(sessionId, turn, op.path, 'update')
+        return { path: op.path, ok: true }
+      }
+      if (!this.db.create || !parts) return { path: op.path, ok: false, error: 'cannot create' }
+      await this.db.create(parts.collection, [writableClone(op.record)])
+      this.store.markReverted(sessionId, turn, op.path, 'delete')
+      return { path: op.path, ok: true }
+    } catch (error) {
+      return { path: op.path, ok: false, error: String(error) }
+    }
   }
 
   private openTurn(sessionId: string) {

--- a/packages/core-file-system/src/host/content-turn-store.test.ts
+++ b/packages/core-file-system/src/host/content-turn-store.test.ts
@@ -41,3 +41,13 @@ test('content turn store summaries keep reverted rows', () => {
   assert.equal(sum[0]?.reverted, true)
   assert.equal(sum[0]?.added, 1)
 })
+
+test('create ops show up beside content edits', () => {
+  const store = new ContentTurnStore().open(':memory:')
+  store.recordOp('s1', 3, { op: 'create', path: '/pages/a', title: '你好', record: { title: '你好' } })
+  store.recordOp('s1', 3, { op: 'create', path: '/pages/b', title: '你好', record: { title: '你好' } })
+  store.record({ sessionId: 's1', turn: 3, path: '/pages/a', title: '你好', before: '', after: '你好' })
+  const sum = store.summaries('s1', 3)
+  assert.equal(sum.filter((row) => row.kind === 'create').length, 2)
+  assert.equal(sum.filter((row) => row.kind === 'content').length, 1)
+})

--- a/packages/core-file-system/src/host/content-turn-store.ts
+++ b/packages/core-file-system/src/host/content-turn-store.ts
@@ -10,6 +10,11 @@ export type ContentTurnFile = {
   reverted?: boolean
 }
 
+export type TurnOp =
+  | { op: 'create'; path: string; title: string; record: Record<string, unknown>; reverted?: boolean }
+  | { op: 'update'; path: string; title: string; before: Record<string, unknown>; after: Record<string, unknown>; reverted?: boolean }
+  | { op: 'delete'; path: string; title: string; record: Record<string, unknown>; reverted?: boolean }
+
 export type ContentEditSummary = {
   path: string
   title: string
@@ -17,14 +22,32 @@ export type ContentEditSummary = {
   removed: number
   jump_line: number
   reverted?: boolean
+  kind?: 'content' | 'create' | 'update' | 'delete'
+}
+
+type TurnBucket = {
+  files: Record<string, ContentTurnFile>
+  ops: TurnOp[]
 }
 
 type StoreShape = {
-  sessions: Record<string, Record<string, Record<string, ContentTurnFile>>>
+  sessions: Record<string, Record<string, TurnBucket>>
 }
 
 const MAX_SESSIONS = 40
 const MAX_TURNS = 32
+
+function asBucket(raw: unknown): TurnBucket {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { files: {}, ops: [] }
+  const rec = raw as { files?: unknown; ops?: unknown }
+  if (rec.files && typeof rec.files === 'object' && !Array.isArray(rec.files)) {
+    return {
+      files: rec.files as Record<string, ContentTurnFile>,
+      ops: Array.isArray(rec.ops) ? (rec.ops as TurnOp[]) : [],
+    }
+  }
+  return { files: raw as Record<string, ContentTurnFile>, ops: [] }
+}
 
 export class ContentTurnStore {
   private file = ''
@@ -37,53 +60,91 @@ export class ContentTurnStore {
       return this
     }
     try {
-      const raw = JSON.parse(readFileSync(path, 'utf8')) as StoreShape
-      this.data = raw?.sessions ? raw : { sessions: {} }
+      const raw = JSON.parse(readFileSync(path, 'utf8')) as { sessions?: Record<string, Record<string, unknown>> }
+      const sessions: StoreShape['sessions'] = {}
+      for (const [sid, turns] of Object.entries(raw?.sessions ?? {})) {
+        sessions[sid] = {}
+        for (const [turn, bucket] of Object.entries(turns ?? {})) {
+          sessions[sid]![turn] = asBucket(bucket)
+        }
+      }
+      this.data = { sessions }
     } catch {
       this.data = { sessions: {} }
     }
     return this
   }
 
+  private bucket(sessionId: string, turn: number) {
+    const sid = sessionId.trim()
+    if (!sid || !Number.isInteger(turn) || turn < 1) return null
+    const turns = (this.data.sessions[sid] ??= {})
+    return (turns[String(turn)] ??= { files: {}, ops: [] })
+  }
+
   record(input: { sessionId: string; turn: number; path: string; title: string; before: string; after: string }) {
-    const sessionId = input.sessionId.trim()
+    const bucket = this.bucket(input.sessionId, input.turn)
     const path = input.path.trim()
-    if (!sessionId || !path || !Number.isInteger(input.turn) || input.turn < 1) return
-    const turns = (this.data.sessions[sessionId] ??= {})
-    const files = (turns[String(input.turn)] ??= {})
-    const prev = files[path]
-    files[path] = {
+    if (!bucket || !path) return
+    const prev = bucket.files[path]
+    bucket.files[path] = {
       path,
       title: input.title || prev?.title || path,
       before: prev?.before ?? input.before,
       after: input.after,
     }
-    this.trim(sessionId)
+    this.trim(input.sessionId.trim())
     this.flush()
   }
 
-  markReverted(sessionId: string, turn: number, path?: string) {
+  recordOp(sessionId: string, turn: number, op: TurnOp) {
+    const bucket = this.bucket(sessionId, turn)
+    if (!bucket || !op.path.trim()) return
+    bucket.ops.push(op)
+    this.trim(sessionId.trim())
+    this.flush()
+  }
+
+  markReverted(sessionId: string, turn: number, path?: string, kind?: ContentEditSummary['kind']) {
     const files = this.data.sessions[sessionId.trim()]?.[String(turn)]
     if (!files) return
-    const keys = path ? [path] : Object.keys(files)
-    for (const key of keys) {
-      const row = files[key]
-      if (row) row.reverted = true
+    const want = path?.trim()
+    if (!kind || kind === 'content') {
+      const keys = want ? [want] : Object.keys(files.files)
+      for (const key of keys) {
+        const row = files.files[key]
+        if (row) row.reverted = true
+      }
+    }
+    if (!kind || kind !== 'content') {
+      for (const op of files.ops) {
+        if (op.reverted) continue
+        if (want && op.path !== want) continue
+        if (kind && kind !== 'content' && op.op !== kind) continue
+        op.reverted = true
+      }
     }
     this.flush()
   }
 
   getFile(sessionId: string, turn: number, path: string) {
-    return this.data.sessions[sessionId.trim()]?.[String(turn)]?.[path.trim()] ?? null
+    const want = path.trim()
+    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]?.files ?? {}
+    if (files[want]) return files[want]!
+    return Object.values(files).find((row) => row.path === want || row.path.endsWith(want) || want.endsWith(row.path)) ?? null
   }
 
   listFiles(sessionId: string, turn: number) {
-    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]
+    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]?.files
     return files ? Object.values(files) : []
   }
 
+  listOps(sessionId: string, turn: number) {
+    return this.data.sessions[sessionId.trim()]?.[String(turn)]?.ops ?? []
+  }
+
   summaries(sessionId: string, turn: number): ContentEditSummary[] {
-    return this.listFiles(sessionId, turn)
+    const content = this.listFiles(sessionId, turn)
       .map((row) => {
         const stats = diffLineStats(row.before, row.after)
         const item: ContentEditSummary = {
@@ -92,11 +153,25 @@ export class ContentTurnStore {
           added: stats.added,
           removed: stats.removed,
           jump_line: stats.jump_line,
+          kind: 'content',
         }
         if (row.reverted) item.reverted = true
         return item
       })
       .filter((row) => row.added > 0 || row.removed > 0 || row.reverted)
+    const ops = this.listOps(sessionId, turn).map((op) => {
+      const item: ContentEditSummary = {
+        path: op.path,
+        title: op.title,
+        added: op.op === 'create' ? 1 : 0,
+        removed: op.op === 'delete' ? 1 : 0,
+        jump_line: 1,
+        kind: op.op,
+      }
+      if (op.reverted) item.reverted = true
+      return item
+    })
+    return [...ops, ...content]
   }
 
   private trim(sessionId: string) {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -911,6 +911,17 @@ export class DatabaseService extends Service implements Database {
       }
       await this.stampActor(spec.path, current.id)
       this.bump()
+      const beforeRow = this.decorateRecord(spec, current)
+      const beforeSnap: Record<string, unknown> = {}
+      const afterSnap: Record<string, unknown> = {}
+      for (const key of Object.keys(raw)) {
+        beforeSnap[key] = beforeRow[key] ?? null
+        afterSnap[key] = next[key] ?? null
+      }
+      const title = String(next.title ?? next.name ?? current.id).trim() || current.id
+      if (Object.keys(beforeSnap).length) {
+        await this.ctx.get('contentTurns')?.recordUpdate(`${spec.path}/${current.id}`, title, beforeSnap, afterSnap)
+      }
       return {
         kind: 'record' as const,
         path: `${spec.path}/${current.id}`,
@@ -929,6 +940,16 @@ export class DatabaseService extends Service implements Database {
     }
     this.indexFacetRecord(spec, this.decorateRecord(spec, record))
     this.bump()
+    const beforeSnap: Record<string, unknown> = {}
+    const afterSnap: Record<string, unknown> = {}
+    for (const key of Object.keys(patch)) {
+      beforeSnap[key] = current[key] ?? null
+      afterSnap[key] = record[key] ?? null
+    }
+    const title = String(record.title ?? record.name ?? record.id).trim() || record.id
+    if (Object.keys(patch).length) {
+      await this.ctx.get('contentTurns')?.recordUpdate(`${spec.path}/${record.id}`, title, beforeSnap, afterSnap)
+    }
     return { kind: 'record' as const, path: `${spec.path}/${record.id}`, value: withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, record))) }
   }
 
@@ -963,14 +984,19 @@ export class DatabaseService extends Service implements Database {
       this.indexFacetRecord(spec, record)
     }
     this.bump()
+    const items = created.map((record) => ({
+      kind: 'record' as const,
+      path: `${spec.path}/${record.id}`,
+      value: withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, record))),
+    }))
+    for (const item of items) {
+      const title = String(item.value.title ?? item.value.name ?? '').trim() || item.path
+      await this.ctx.get('contentTurns')?.recordCreate(item.path, title, item.value)
+    }
     return {
       kind: 'created' as const,
       path: spec.path,
-      items: created.map((record) => ({
-        kind: 'record' as const,
-        path: `${spec.path}/${record.id}`,
-        value: withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, record))),
-      })),
+      items,
     }
   }
 
@@ -994,6 +1020,11 @@ export class DatabaseService extends Service implements Database {
     const matched = await this.matchCollectionRows(spec, listQuery, filter, q)
     const ids = [...new Set(matched.map((row) => row.id))]
     if (!ids.length) return { kind: 'deleted' as const, path: spec.path, ids }
+    for (const row of matched) {
+      const rec = withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, row)))
+      const title = String(rec.title ?? rec.name ?? row.id).trim() || row.id
+      await this.ctx.get('contentTurns')?.recordDelete(`${spec.path}/${row.id}`, title, rec)
+    }
     await spec.remove({ ids })
     for (const id of ids) this.facets.removeRecord(spec.path, id)
     this.bump()
@@ -1100,8 +1131,10 @@ export class DatabaseService extends Service implements Database {
             : replaceLinesText(text, args.start_line, args.end_line, args.new_str)
     await this.writeContent(path, next)
     const locus = mutationLocus(command, text, next, args)
+    const written = await this.content(current.path)
+    const after = asContentText(written.value)
     const title = await this.contentTitle(current.path)
-    await this.ctx.get('contentTurns')?.recordEdit(current.path, text, next, title)
+    await this.ctx.get('contentTurns')?.recordEdit(current.path, text, after, title)
     return {
       kind: 'content' as const,
       path: current.path,
@@ -1604,7 +1637,7 @@ export function apply(ctx: Context) {
   })
   ctx.http.route('POST', '/api/db/content-revert', async (route) => {
     try {
-      const body = (await route.json()) as { sessionId?: string; turn?: number; path?: string }
+      const body = (await route.json()) as { sessionId?: string; turn?: number; path?: string; kind?: string }
       const sessionId = String(body?.sessionId ?? '').trim()
       const turn = Number(body?.turn)
       if (!sessionId || !Number.isInteger(turn) || turn < 1) {
@@ -1612,7 +1645,10 @@ export function apply(ctx: Context) {
         return
       }
       const path = String(body?.path ?? '').trim()
-      route.send(200, await ctx.contentTurns.revert(sessionId, turn, path || undefined))
+      const kindRaw = String(body?.kind ?? '').trim()
+      const kind =
+        kindRaw === 'content' || kindRaw === 'create' || kindRaw === 'update' || kindRaw === 'delete' ? kindRaw : undefined
+      route.send(200, await ctx.contentTurns.revert(sessionId, turn, path || undefined, kind))
     } catch (error) {
       route.send(400, { error: String(error) })
     }

--- a/packages/type-session/src/index.ts
+++ b/packages/type-session/src/index.ts
@@ -53,6 +53,7 @@ export type SessionEventBody =
         removed: number
         jump_line: number
         reverted?: boolean
+        kind?: 'content' | 'create' | 'update' | 'delete'
       }>
     }
 
@@ -64,15 +65,15 @@ export type SessionEvent = SessionEventBody & {
 export type ContentEditFile = Extract<SessionEventBody, { type: 'content/edits' }>['files'][number]
 
 /** 同回合多次 content/edits 按 path 合并；后写覆盖同 path，其它 path 保留。 */
-export function mergeContentEditFiles<T extends { path: string }>(prev: T[], next: T[]): T[] {
+export function mergeContentEditFiles<T extends { path: string; kind?: string }>(prev: T[], next: T[]): T[] {
   const map = new Map<string, T>()
   for (const file of prev) {
     const path = String(file.path ?? '').trim()
-    if (path) map.set(path, file)
+    if (path) map.set(`${file.kind ?? 'content'}:${path}`, file)
   }
   for (const file of next) {
     const path = String(file.path ?? '').trim()
-    if (path) map.set(path, file)
+    if (path) map.set(`${file.kind ?? 'content'}:${path}`, file)
   }
   return [...map.values()]
 }

--- a/packages/web-session-view/src/web/session-project.ts
+++ b/packages/web-session-view/src/web/session-project.ts
@@ -44,6 +44,7 @@ export type SessionEvent = {
         removed: number
         jump_line: number
         reverted?: boolean
+        kind?: 'content' | 'create' | 'update' | 'delete'
       }>
     }
 )
@@ -133,6 +134,7 @@ export type ChatNode =
         removed: number
         jump_line: number
         reverted?: boolean
+        kind?: 'content' | 'create' | 'update' | 'delete'
       }>
     }
   | { id: string; kind: 'turn'; text: string }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
撤销原先会在快照为空时假装成功，正文比较也过严。现在同一回合把 `db_content` / create / update / delete 记进 journal，可按行或整回合回滚。删除恢复会新建记录，不能保证原来的 id。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

