### PR TITLE
文件系统 WAL：折叠、正文备份、删除可恢复

### DIFF
--- a/packages/core-file-system/src/host/content-turn-service.test.ts
+++ b/packages/core-file-system/src/host/content-turn-service.test.ts
@@ -78,10 +78,9 @@ test('revert create/update/delete in reverse', async () => {
       if (!cur) throw new Error('missing')
       rows.set(path, { ...cur, ...patch })
     },
-    create: async (_path: string, records: unknown) => {
-      const rec = (records as Record<string, unknown>[])[0]!
-      created.push(String(rec.title ?? ''))
-      rows.set('/pages/new', { id: 'new', ...rec })
+    restoreRecord: async (path: string, fields: Record<string, unknown>, content?: string) => {
+      created.push(String(fields.title ?? ''))
+      rows.set(path, { ...fields, notes: content ?? '' })
     },
     remove: async (_path: string, query: { ids: string[] }) => {
       for (const id of query.ids) rows.delete(`/pages/${id}`)
@@ -95,12 +94,27 @@ test('revert create/update/delete in reverse', async () => {
     rows.set('/pages/made', { id: 'made', title: 'made' })
     await service.recordUpdate('/pages/keep', 'keep', { status: 'open' }, { status: 'done' })
     rows.set('/pages/keep', { id: 'keep', title: 'keep', status: 'done' })
-    await service.recordDelete('/pages/gone', 'gone', { id: 'gone', title: 'gone' })
+    await service.recordDelete('/pages/gone', 'gone', { id: 'gone', title: 'gone' }, '正文还在')
     rows.delete('/pages/gone')
   })
   const done = await service.revert('sess-ops', 1)
   assert.equal(done.ok, true)
   assert.equal(rows.has('/pages/made'), false)
   assert.equal(rows.get('/pages/keep')?.status, 'open')
+  assert.equal(rows.get('/pages/gone')?.notes, '正文还在')
   assert.deepEqual(created, ['gone'])
+})
+
+test('human edits without a session still fold on the same path', async () => {
+  const ctx = new Context()
+  const service = new ContentTurnService(ctx, {
+    content: async () => ({ value: '' }),
+    writeContent: async () => undefined,
+  }).open(':memory:')
+  await service.recordEdit('/pages/p1', '', '一', 'p1')
+  await service.recordEdit('/pages/p1', '一', '一二', 'p1')
+  const head = service.store.headEntry('/pages/p1')
+  assert.equal(head?.seq, 1)
+  assert.equal(head?.folded, true)
+  assert.equal(service.store.getBlob(head?.afterBlob), '一二')
 })

--- a/packages/core-file-system/src/host/content-turn-service.ts
+++ b/packages/core-file-system/src/host/content-turn-service.ts
@@ -1,8 +1,10 @@
 import { Service, type Context } from 'cordis'
 import { currentSessionId } from '@biu/host-sessions/scope'
-import type { ContentEditSummary, TurnOp } from './content-turn-store.ts'
-import { ContentTurnStore } from './content-turn-store.ts'
+import type { ContentEditSummary, WalActor, WalEntry } from './wal-store.ts'
+import { WalStore } from './wal-store.ts'
 import { asContentText } from './content-edit.ts'
+
+export type { ContentEditSummary } from './wal-store.ts'
 
 type ContentDb = {
   content: (path: string) => Promise<{ value: unknown }>
@@ -11,6 +13,7 @@ type ContentDb = {
   create?: (path: string, records: unknown) => Promise<unknown>
   remove?: (path: string, query: { ids: string[] }) => Promise<unknown>
   read?: (path: string) => Promise<{ value?: unknown }>
+  restoreRecord?: (path: string, fields: Record<string, unknown>, content?: string) => Promise<unknown>
 }
 
 function sameText(left: string, right: string) {
@@ -22,24 +25,18 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>
 }
 
-function writableClone(row: Record<string, unknown>) {
-  const next = { ...row }
-  delete next.id
-  delete next.createdAt
-  delete next.updatedAt
-  delete next.createdBy
-  delete next.updatedBy
-  return next
-}
-
 function splitRecordPath(path: string) {
   const parts = path.split('/').filter(Boolean)
   if (parts.length < 2) return null
   return { collection: `/${parts[0]}`, id: parts.slice(1).join('/') }
 }
 
+function stableJson(value: unknown) {
+  return JSON.stringify(value ?? null)
+}
+
 export class ContentTurnService extends Service {
-  store = new ContentTurnStore()
+  store = new WalStore()
   private reverting = false
   private publishChain: Promise<void> = Promise.resolve()
 
@@ -55,43 +52,61 @@ export class ContentTurnService extends Service {
     return this
   }
 
-  private scope() {
-    if (this.reverting) return null
+  private actor(): WalActor {
     const sessionId = String(currentSessionId() ?? '').trim()
-    if (!sessionId) return null
+    if (!sessionId) return { kind: 'user' }
     const turn = this.openTurn(sessionId)
-    if (turn == null) return null
-    return { sessionId, turn }
+    if (turn == null) return { kind: 'agent', sessionId }
+    return { kind: 'agent', sessionId, turn }
+  }
+
+  private afterWrite(actor: WalActor) {
+    if (actor.kind === 'agent' && actor.sessionId && actor.turn != null) {
+      return this.publishLatest(actor.sessionId, actor.turn)
+    }
+    return Promise.resolve()
   }
 
   async recordEdit(path: string, before: string, after: string, title: string) {
-    if (sameText(before, after)) return
-    const scope = this.scope()
-    if (!scope) return
-    this.store.record({ ...scope, path, title, before, after })
-    await this.publishLatest(scope.sessionId, scope.turn)
+    if (this.reverting || sameText(before, after)) return
+    const actor = this.actor()
+    this.store.append({ path, op: 'content', actor, title, beforeText: before, afterText: after })
+    await this.afterWrite(actor)
   }
 
-  async recordCreate(path: string, title: string, record: Record<string, unknown>) {
-    const scope = this.scope()
-    if (!scope) return
-    this.store.recordOp(scope.sessionId, scope.turn, { op: 'create', path, title, record })
-    await this.publishLatest(scope.sessionId, scope.turn)
+  async recordCreate(path: string, title: string, record: Record<string, unknown>, content = '') {
+    if (this.reverting) return
+    const actor = this.actor()
+    this.store.append({
+      path,
+      op: 'create',
+      actor,
+      title,
+      afterText: content,
+      afterMeta: record,
+    })
+    await this.afterWrite(actor)
   }
 
   async recordUpdate(path: string, title: string, before: Record<string, unknown>, after: Record<string, unknown>) {
-    if (JSON.stringify(before) === JSON.stringify(after)) return
-    const scope = this.scope()
-    if (!scope) return
-    this.store.recordOp(scope.sessionId, scope.turn, { op: 'update', path, title, before, after })
-    await this.publishLatest(scope.sessionId, scope.turn)
+    if (this.reverting || stableJson(before) === stableJson(after)) return
+    const actor = this.actor()
+    this.store.append({ path, op: 'update', actor, title, beforeMeta: before, afterMeta: after })
+    await this.afterWrite(actor)
   }
 
-  async recordDelete(path: string, title: string, record: Record<string, unknown>) {
-    const scope = this.scope()
-    if (!scope) return
-    this.store.recordOp(scope.sessionId, scope.turn, { op: 'delete', path, title, record })
-    await this.publishLatest(scope.sessionId, scope.turn)
+  async recordDelete(path: string, title: string, record: Record<string, unknown>, content = '') {
+    if (this.reverting) return
+    const actor = this.actor()
+    this.store.append({
+      path,
+      op: 'delete',
+      actor,
+      title,
+      beforeText: content,
+      beforeMeta: record,
+    })
+    await this.afterWrite(actor)
   }
 
   async revert(sessionId: string, turn: number, path?: string, kind?: ContentEditSummary['kind']) {
@@ -100,27 +115,20 @@ export class ContentTurnService extends Service {
     const results: Array<{ path: string; ok: boolean; error?: string }> = []
     this.reverting = true
     try {
-      const ops = this.store.listOps(sid, turn).slice().reverse()
-      for (const op of ops) {
-        if (op.reverted) continue
-        if (want && op.path !== want) continue
-        if (kind && kind !== 'content' && op.op !== kind) continue
-        if (kind === 'content') continue
-        results.push(await this.revertOp(sid, turn, op))
+      const rows = this.store
+        .listTurn(sid, turn)
+        .filter((row) => {
+          if (row.reverted) return false
+          if (want && row.path !== want) return false
+          if (kind && row.op !== kind) return false
+          return true
+        })
+        .slice()
+        .sort((a, b) => b.seq - a.seq)
+      if (want && kind && !rows.length) {
+        return { ok: false, results: [{ path: want, ok: false, error: 'missing' }] }
       }
-      if (!kind || kind === 'content') {
-        const files = want ? [this.store.getFile(sid, turn, want)].filter(Boolean) : this.store.listFiles(sid, turn)
-        if (want && kind === 'content' && !files.length) {
-          results.push({ path: want, ok: false, error: 'missing' })
-        }
-        for (const file of files) {
-          if (!file || file.reverted) {
-            if (file) results.push({ path: file.path, ok: true })
-            continue
-          }
-          results.push(await this.revertContent(sid, turn, file.path, file.before, file.after))
-        }
-      }
+      for (const row of rows) results.push(await this.revertEntry(row))
     } finally {
       this.reverting = false
     }
@@ -133,58 +141,59 @@ export class ContentTurnService extends Service {
     return this.store.summaries(sessionId, turn)
   }
 
-  private async revertContent(sessionId: string, turn: number, path: string, before: string, after: string) {
+  private async revertEntry(row: WalEntry): Promise<{ path: string; ok: boolean; error?: string }> {
     try {
-      const current = asContentText((await this.db.content(path)).value)
-      if (!sameText(current, after) && !sameText(current, before)) {
-        return { path, ok: false, error: 'diverged' }
-      }
-      if (!sameText(current, before)) await this.db.writeContent(path, before)
-      this.store.markReverted(sessionId, turn, path, 'content')
-      return { path, ok: true }
-    } catch (error) {
-      return { path, ok: false, error: String(error) }
-    }
-  }
-
-  private async revertOp(sessionId: string, turn: number, op: TurnOp) {
-    try {
-      const parts = splitRecordPath(op.path)
-      if (op.op === 'create') {
-        const live = await this.db.read?.(op.path).catch(() => null)
-        if (!live?.value) {
-          this.store.markReverted(sessionId, turn, op.path, 'create')
-          return { path: op.path, ok: true }
+      if (row.op === 'content') {
+        const before = this.store.getBlob(row.beforeBlob)
+        const after = this.store.getBlob(row.afterBlob)
+        const current = asContentText((await this.db.content(row.path)).value)
+        if (!sameText(current, after) && !sameText(current, before)) {
+          return { path: row.path, ok: false, error: 'diverged' }
         }
-        if (!parts || !this.db.remove) return { path: op.path, ok: false, error: 'cannot delete' }
-        await this.db.remove(parts.collection, { ids: [parts.id] })
-        this.store.markReverted(sessionId, turn, op.path, 'create')
-        return { path: op.path, ok: true }
+        if (!sameText(current, before)) await this.db.writeContent(row.path, before)
+        this.store.markReverted(row.seq)
+        return { path: row.path, ok: true }
       }
-      if (op.op === 'update') {
-        const live = asRecord((await this.db.read?.(op.path))?.value)
-        if (!live) return { path: op.path, ok: false, error: 'missing' }
-        const keys = Object.keys(op.after)
-        const slice = (row: Record<string, unknown>) => {
+      const parts = splitRecordPath(row.path)
+      if (row.op === 'create') {
+        const live = await this.db.read?.(row.path).catch(() => null)
+        if (!live?.value) {
+          this.store.markReverted(row.seq)
+          return { path: row.path, ok: true }
+        }
+        if (!parts || !this.db.remove) return { path: row.path, ok: false, error: 'cannot delete' }
+        await this.db.remove(parts.collection, { ids: [parts.id] })
+        this.store.markReverted(row.seq)
+        return { path: row.path, ok: true }
+      }
+      if (row.op === 'update') {
+        const live = asRecord((await this.db.read?.(row.path))?.value)
+        if (!live) return { path: row.path, ok: false, error: 'missing' }
+        const keys = Object.keys(row.afterMeta ?? {})
+        const slice = (rec: Record<string, unknown>) => {
           const next: Record<string, unknown> = {}
-          for (const key of keys) next[key] = row[key] ?? null
+          for (const key of keys) next[key] = rec[key] ?? null
           return next
         }
-        const now = JSON.stringify(slice(live))
-        if (now !== JSON.stringify(op.after) && now !== JSON.stringify(op.before)) {
-          return { path: op.path, ok: false, error: 'diverged' }
+        const now = stableJson(slice(live))
+        if (now !== stableJson(row.afterMeta) && now !== stableJson(row.beforeMeta)) {
+          return { path: row.path, ok: false, error: 'diverged' }
         }
-        if (!this.db.update) return { path: op.path, ok: false, error: 'cannot update' }
-        if (now !== JSON.stringify(op.before)) await this.db.update(op.path, op.before)
-        this.store.markReverted(sessionId, turn, op.path, 'update')
-        return { path: op.path, ok: true }
+        if (!this.db.update) return { path: row.path, ok: false, error: 'cannot update' }
+        if (now !== stableJson(row.beforeMeta)) await this.db.update(row.path, row.beforeMeta)
+        this.store.markReverted(row.seq)
+        return { path: row.path, ok: true }
       }
-      if (!this.db.create || !parts) return { path: op.path, ok: false, error: 'cannot create' }
-      await this.db.create(parts.collection, [writableClone(op.record)])
-      this.store.markReverted(sessionId, turn, op.path, 'delete')
-      return { path: op.path, ok: true }
+      if (!this.db.restoreRecord && !this.db.create) return { path: row.path, ok: false, error: 'cannot create' }
+      const fields = row.beforeMeta ?? {}
+      const text = this.store.getBlob(row.beforeBlob)
+      if (this.db.restoreRecord) await this.db.restoreRecord(row.path, fields, text)
+      else if (parts) await this.db.create(parts.collection, [{ ...fields, ...(text ? { content: text } : {}) }])
+      else return { path: row.path, ok: false, error: 'cannot create' }
+      this.store.markReverted(row.seq)
+      return { path: row.path, ok: true }
     } catch (error) {
-      return { path: op.path, ok: false, error: String(error) }
+      return { path: row.path, ok: false, error: String(error) }
     }
   }
 

--- a/packages/core-file-system/src/host/content-turn-store.ts
+++ b/packages/core-file-system/src/host/content-turn-store.ts
@@ -1,7 +1,7 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { diffLineStats } from './line-diff.ts'
+import type { ContentEditSummary, WalActor, WalOp } from './wal-store.ts'
+import { WalStore } from './wal-store.ts'
 
+export type { ContentEditSummary } from './wal-store.ts'
 export type ContentTurnFile = {
   path: string
   title: string
@@ -15,185 +15,124 @@ export type TurnOp =
   | { op: 'update'; path: string; title: string; before: Record<string, unknown>; after: Record<string, unknown>; reverted?: boolean }
   | { op: 'delete'; path: string; title: string; record: Record<string, unknown>; reverted?: boolean }
 
-export type ContentEditSummary = {
-  path: string
-  title: string
-  added: number
-  removed: number
-  jump_line: number
-  reverted?: boolean
-  kind?: 'content' | 'create' | 'update' | 'delete'
+function agent(sessionId: string, turn: number): WalActor {
+  return { kind: 'agent', sessionId, turn }
 }
 
-type TurnBucket = {
-  files: Record<string, ContentTurnFile>
-  ops: TurnOp[]
-}
-
-type StoreShape = {
-  sessions: Record<string, Record<string, TurnBucket>>
-}
-
-const MAX_SESSIONS = 40
-const MAX_TURNS = 32
-
-function asBucket(raw: unknown): TurnBucket {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return { files: {}, ops: [] }
-  const rec = raw as { files?: unknown; ops?: unknown }
-  if (rec.files && typeof rec.files === 'object' && !Array.isArray(rec.files)) {
-    return {
-      files: rec.files as Record<string, ContentTurnFile>,
-      ops: Array.isArray(rec.ops) ? (rec.ops as TurnOp[]) : [],
-    }
-  }
-  return { files: raw as Record<string, ContentTurnFile>, ops: [] }
-}
-
+/** 兼容旧回合 API：底层已换成全局 WAL。 */
 export class ContentTurnStore {
-  private file = ''
-  private data: StoreShape = { sessions: {} }
+  private wal = new WalStore()
 
   open(path: string) {
-    this.file = path
-    if (path === ':memory:') {
-      this.data = { sessions: {} }
-      return this
-    }
-    try {
-      const raw = JSON.parse(readFileSync(path, 'utf8')) as { sessions?: Record<string, Record<string, unknown>> }
-      const sessions: StoreShape['sessions'] = {}
-      for (const [sid, turns] of Object.entries(raw?.sessions ?? {})) {
-        sessions[sid] = {}
-        for (const [turn, bucket] of Object.entries(turns ?? {})) {
-          sessions[sid]![turn] = asBucket(bucket)
-        }
-      }
-      this.data = { sessions }
-    } catch {
-      this.data = { sessions: {} }
-    }
+    this.wal.open(path)
     return this
   }
 
-  private bucket(sessionId: string, turn: number) {
-    const sid = sessionId.trim()
-    if (!sid || !Number.isInteger(turn) || turn < 1) return null
-    const turns = (this.data.sessions[sid] ??= {})
-    return (turns[String(turn)] ??= { files: {}, ops: [] })
-  }
-
   record(input: { sessionId: string; turn: number; path: string; title: string; before: string; after: string }) {
-    const bucket = this.bucket(input.sessionId, input.turn)
-    const path = input.path.trim()
-    if (!bucket || !path) return
-    const prev = bucket.files[path]
-    bucket.files[path] = {
-      path,
-      title: input.title || prev?.title || path,
-      before: prev?.before ?? input.before,
-      after: input.after,
-    }
-    this.trim(input.sessionId.trim())
-    this.flush()
+    this.wal.append({
+      path: input.path,
+      op: 'content',
+      actor: agent(input.sessionId, input.turn),
+      title: input.title,
+      beforeText: input.before,
+      afterText: input.after,
+    })
   }
 
   recordOp(sessionId: string, turn: number, op: TurnOp) {
-    const bucket = this.bucket(sessionId, turn)
-    if (!bucket || !op.path.trim()) return
-    bucket.ops.push(op)
-    this.trim(sessionId.trim())
-    this.flush()
+    if (op.op === 'create') {
+      this.wal.append({
+        path: op.path,
+        op: 'create',
+        actor: agent(sessionId, turn),
+        title: op.title,
+        afterMeta: op.record,
+      })
+      return
+    }
+    if (op.op === 'update') {
+      this.wal.append({
+        path: op.path,
+        op: 'update',
+        actor: agent(sessionId, turn),
+        title: op.title,
+        beforeMeta: op.before,
+        afterMeta: op.after,
+      })
+      return
+    }
+    this.wal.append({
+      path: op.path,
+      op: 'delete',
+      actor: agent(sessionId, turn),
+      title: op.title,
+      beforeMeta: op.record,
+    })
   }
 
   markReverted(sessionId: string, turn: number, path?: string, kind?: ContentEditSummary['kind']) {
-    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]
-    if (!files) return
     const want = path?.trim()
-    if (!kind || kind === 'content') {
-      const keys = want ? [want] : Object.keys(files.files)
-      for (const key of keys) {
-        const row = files.files[key]
-        if (row) row.reverted = true
-      }
+    for (const row of this.wal.listTurn(sessionId, turn)) {
+      if (row.reverted) continue
+      if (want && row.path !== want) continue
+      if (kind && row.op !== kind) continue
+      this.wal.markReverted(row.seq)
     }
-    if (!kind || kind !== 'content') {
-      for (const op of files.ops) {
-        if (op.reverted) continue
-        if (want && op.path !== want) continue
-        if (kind && kind !== 'content' && op.op !== kind) continue
-        op.reverted = true
-      }
-    }
-    this.flush()
   }
 
   getFile(sessionId: string, turn: number, path: string) {
     const want = path.trim()
-    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]?.files ?? {}
-    if (files[want]) return files[want]!
-    return Object.values(files).find((row) => row.path === want || row.path.endsWith(want) || want.endsWith(row.path)) ?? null
+    const row = [...this.wal.listTurn(sessionId, turn)].reverse().find((item) => {
+      if (item.op !== 'content') return false
+      return item.path === want || item.path.endsWith(want) || want.endsWith(item.path)
+    })
+    if (!row) return null
+    const file: ContentTurnFile = {
+      path: row.path,
+      title: row.title,
+      before: this.wal.getBlob(row.beforeBlob),
+      after: this.wal.getBlob(row.afterBlob),
+    }
+    if (row.reverted) file.reverted = true
+    return file
   }
 
   listFiles(sessionId: string, turn: number) {
-    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]?.files
-    return files ? Object.values(files) : []
+    return this.wal
+      .listTurn(sessionId, turn)
+      .filter((row) => row.op === 'content')
+      .map((row) => this.getFile(sessionId, turn, row.path)!)
+      .filter(Boolean)
   }
 
-  listOps(sessionId: string, turn: number) {
-    return this.data.sessions[sessionId.trim()]?.[String(turn)]?.ops ?? []
+  listOps(sessionId: string, turn: number): TurnOp[] {
+    return this.wal.listTurn(sessionId, turn).flatMap((row) => {
+      if (row.op === 'content') return []
+      if (row.op === 'create') {
+        const item: TurnOp = { op: 'create', path: row.path, title: row.title, record: row.afterMeta ?? {} }
+        if (row.reverted) item.reverted = true
+        return [item]
+      }
+      if (row.op === 'update') {
+        const item: TurnOp = {
+          op: 'update',
+          path: row.path,
+          title: row.title,
+          before: row.beforeMeta ?? {},
+          after: row.afterMeta ?? {},
+        }
+        if (row.reverted) item.reverted = true
+        return [item]
+      }
+      const item: TurnOp = { op: 'delete', path: row.path, title: row.title, record: row.beforeMeta ?? {} }
+      if (row.reverted) item.reverted = true
+      return [item]
+    })
   }
 
   summaries(sessionId: string, turn: number): ContentEditSummary[] {
-    const content = this.listFiles(sessionId, turn)
-      .map((row) => {
-        const stats = diffLineStats(row.before, row.after)
-        const item: ContentEditSummary = {
-          path: row.path,
-          title: row.title,
-          added: stats.added,
-          removed: stats.removed,
-          jump_line: stats.jump_line,
-          kind: 'content',
-        }
-        if (row.reverted) item.reverted = true
-        return item
-      })
-      .filter((row) => row.added > 0 || row.removed > 0 || row.reverted)
-    const ops = this.listOps(sessionId, turn).map((op) => {
-      const item: ContentEditSummary = {
-        path: op.path,
-        title: op.title,
-        added: op.op === 'create' ? 1 : 0,
-        removed: op.op === 'delete' ? 1 : 0,
-        jump_line: 1,
-        kind: op.op,
-      }
-      if (op.reverted) item.reverted = true
-      return item
-    })
-    return [...ops, ...content]
-  }
-
-  private trim(sessionId: string) {
-    const ids = Object.keys(this.data.sessions)
-    if (ids.length > MAX_SESSIONS) {
-      for (const id of ids.slice(0, ids.length - MAX_SESSIONS)) delete this.data.sessions[id]
-    }
-    const turns = this.data.sessions[sessionId]
-    if (!turns) return
-    const keys = Object.keys(turns)
-      .map(Number)
-      .filter((n) => Number.isInteger(n))
-      .sort((a, b) => a - b)
-    while (keys.length > MAX_TURNS) {
-      const drop = keys.shift()
-      if (drop != null) delete turns[String(drop)]
-    }
-  }
-
-  private flush() {
-    if (!this.file || this.file === ':memory:') return
-    mkdirSync(dirname(this.file), { recursive: true })
-    writeFileSync(this.file, JSON.stringify(this.data))
+    return this.wal.summaries(sessionId, turn)
   }
 }
+
+export type { WalOp }

--- a/packages/core-file-system/src/host/index.test.ts
+++ b/packages/core-file-system/src/host/index.test.ts
@@ -6,6 +6,8 @@ import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DatabaseService, apply as applyFileSystem } from './index.ts'
+import { ContentTurnService } from './content-turn-service.ts'
+import { asContentText } from './content-edit.ts'
 import { FileSystemAssets } from './assets-store.ts'
 import type { CollectionSpec } from '@biu/type-file-system'
 import { REQUIRED_RECORD_FIELDS } from '@biu/type-file-system'
@@ -1248,4 +1250,61 @@ test('tables without records.create/delete reject create and delete', async () =
       }),
     /必须提供 create/,
   )
+})
+
+test('wal delete revert restores the same id and file content', async () => {
+  const ctx = new Context()
+  const db = new DatabaseService(ctx)
+  const turns = new ContentTurnService(ctx, db).open(':memory:')
+  const rows = new Map<string, Record<string, unknown>>([
+    ['p1', { id: 'p1', title: '页', notes: '完整正文' }],
+  ])
+  db.register({
+    id: 'pages',
+    path: '/pages',
+    schema: {
+      contentField: 'notes',
+      fields: {
+        ...REQUIRED_RECORD_FIELDS,
+        title: { type: 'string', writable: true },
+        notes: { type: 'file', writable: true },
+      },
+    },
+    records: { update: true, create: true, delete: true },
+    list: () => [...rows.values()] as { id: string }[],
+    get: (id) => rows.get(id) as { id: string } | undefined,
+    update: (id, patch) => {
+      const next = { ...rows.get(id), ...patch, id }
+      rows.set(id, next)
+      return next as { id: string }
+    },
+    create: async (records) => {
+      const out = []
+      for (const fields of records) {
+        const id = typeof fields.id === 'string' && fields.id ? fields.id : `n${rows.size}`
+        const row = { ...fields, id }
+        rows.set(id, row)
+        out.push(row as { id: string })
+      }
+      return out
+    },
+    remove: async (query) => {
+      for (const id of query.ids ?? []) rows.delete(id)
+      return query.ids ?? []
+    },
+  })
+  const sessions = {
+    peek: () => ({ events: [{ type: 'turn/start', turn: 1 }] }),
+    append: async () => undefined,
+  }
+  const get = turns.ctx.get.bind(turns.ctx)
+  turns.ctx.get = ((name: string) => (name === 'sessions' ? sessions : get(name))) as typeof turns.ctx.get
+  await runWithSession('sess-wal', async () => {
+    await db.remove('/pages', { ids: ['p1'] })
+  })
+  assert.equal(rows.has('p1'), false)
+  const done = await turns.revert('sess-wal', 1, '/pages/p1', 'delete')
+  assert.equal(done.ok, true)
+  assert.equal(rows.get('p1')?.id, 'p1')
+  assert.equal(asContentText((await db.content('/pages/p1')).value), '完整正文')
 })

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -940,15 +940,26 @@ export class DatabaseService extends Service implements Database {
     }
     this.indexFacetRecord(spec, this.decorateRecord(spec, record))
     this.bump()
+    const contentField = schema.contentField ?? 'content'
     const beforeSnap: Record<string, unknown> = {}
     const afterSnap: Record<string, unknown> = {}
     for (const key of Object.keys(patch)) {
+      if (key === contentField) continue
       beforeSnap[key] = current[key] ?? null
       afterSnap[key] = record[key] ?? null
     }
     const title = String(record.title ?? record.name ?? record.id).trim() || record.id
-    if (Object.keys(patch).length) {
-      await this.ctx.get('contentTurns')?.recordUpdate(`${spec.path}/${record.id}`, title, beforeSnap, afterSnap)
+    const recordPath = `${spec.path}/${record.id}`
+    if (Object.keys(beforeSnap).length) {
+      await this.ctx.get('contentTurns')?.recordUpdate(recordPath, title, beforeSnap, afterSnap)
+    }
+    if (contentField in patch) {
+      await this.ctx.get('contentTurns')?.recordEdit(
+        recordPath,
+        asContentText(current[contentField]),
+        asContentText(record[contentField]),
+        title,
+      )
     }
     return { kind: 'record' as const, path: `${spec.path}/${record.id}`, value: withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, record))) }
   }
@@ -989,9 +1000,11 @@ export class DatabaseService extends Service implements Database {
       path: `${spec.path}/${record.id}`,
       value: withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, record))),
     }))
-    for (const item of items) {
+    for (const [index, item] of items.entries()) {
+      const raw = created[index]
       const title = String(item.value.title ?? item.value.name ?? '').trim() || item.path
-      await this.ctx.get('contentTurns')?.recordCreate(item.path, title, item.value)
+      const text = raw ? asContentText(raw[contentKey(spec)]) : ''
+      await this.ctx.get('contentTurns')?.recordCreate(item.path, title, item.value, text)
     }
     return {
       kind: 'created' as const,
@@ -1023,7 +1036,13 @@ export class DatabaseService extends Service implements Database {
     for (const row of matched) {
       const rec = withoutContent(spec, this.withBanner(spec, this.decorateRecord(spec, row)))
       const title = String(rec.title ?? rec.name ?? row.id).trim() || row.id
-      await this.ctx.get('contentTurns')?.recordDelete(`${spec.path}/${row.id}`, title, rec)
+      let text = asContentText(row[contentKey(spec)])
+      try {
+        text = asContentText((await this.content(`${spec.path}/${row.id}`)).value)
+      } catch {
+        /* 正文可能只在行上 */
+      }
+      await this.ctx.get('contentTurns')?.recordDelete(`${spec.path}/${row.id}`, title, rec, text)
     }
     await spec.remove({ ids })
     for (const id of ids) this.facets.removeRecord(spec.path, id)
@@ -1080,18 +1099,62 @@ export class DatabaseService extends Service implements Database {
     const schema = schemaFor(spec)
     const field = schema.contentField ?? 'content'
     if (!schema.fields[field]) throw new Error(`no content field: ${field}`)
+    const current = await spec.get(parts[1]!)
+    if (!current) throw new Error(`unknown record: ${spec.path}/${parts[1]}`)
+    const before = asContentText(current[field])
     const patch = this.collectionCanUpdate(spec)
       ? pickWritablePatch(schema, { [field]: value })
       : { [field]: value }
     const record = await spec.update(parts[1]!, patch)
     await this.stampActor(spec.path, record.id)
     this.bump()
+    const after = asContentText(record[field])
+    const title = String(record.title ?? record.name ?? record.id).trim() || record.id
+    await this.ctx.get('contentTurns')?.recordEdit(`${spec.path}/${record.id}`, before, after, title)
     return {
       kind: 'content' as const,
       path: `${spec.path}/${record.id}`,
       field,
       value: record[field] ?? null,
     }
+  }
+
+  async restoreRecord(path: string, fields: Record<string, unknown>, content?: string) {
+    const parts = splitPath(path)
+    if (parts.length !== 2) throw new Error(`cannot restore: ${normalizeCollectionPath(path)}`)
+    const spec = this.collection(`/${parts[0]}`)
+    if (!spec) throw new Error(`unknown collection: /${parts[0]}`)
+    const schema = schemaFor(spec)
+    const field = schema.contentField ?? 'content'
+    const id = parts[1]!
+    const patch: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(fields)) {
+      if (key === 'id' || key === 'createdAt' || key === 'updatedAt' || key === 'createdBy' || key === 'updatedBy') continue
+      if (key === field) continue
+      const specField = schema.fields[key]
+      if (!specField?.writable || specField.computed) continue
+      try {
+        patch[key] = coerce(specField, value)
+      } catch {
+        /* 旧快照里可能有已删字段 */
+      }
+    }
+    const existing = spec.get ? await spec.get(id) : null
+    if (existing) {
+      if (Object.keys(patch).length && spec.update) await spec.update(id, patch)
+    } else {
+      if (!spec.create) throw new Error(`collection cannot create: ${spec.path}`)
+      const row = { ...patch, id }
+      if (content != null && schema.fields[field]?.writable) row[field] = content
+      await spec.create([row])
+    }
+    if (content != null && schema.fields[field]) {
+      await this.writeContent(path, content)
+    } else {
+      await this.stampActor(spec.path, id)
+      this.bump()
+    }
+    return this.read(path)
   }
 
   async contentTitle(path: string) {
@@ -1131,10 +1194,6 @@ export class DatabaseService extends Service implements Database {
             : replaceLinesText(text, args.start_line, args.end_line, args.new_str)
     await this.writeContent(path, next)
     const locus = mutationLocus(command, text, next, args)
-    const written = await this.content(current.path)
-    const after = asContentText(written.value)
-    const title = await this.contentTitle(current.path)
-    await this.ctx.get('contentTurns')?.recordEdit(current.path, text, after, title)
     return {
       kind: 'content' as const,
       path: current.path,
@@ -1377,7 +1436,7 @@ export function apply(ctx: Context) {
   }))))
   const notices = new NoticesService(ctx).open(process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'notices.json'))
   db.register(noticesCollection(notices.store))
-  new ContentTurnService(ctx, db).open(process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'content-turns.json'))
+  new ContentTurnService(ctx, db).open(process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'wal.json'))
   ctx.tools.register({
     name: 'db_list',
     description: '列出 File System 路径：/ 为已登记表（path、中文名、view.blurb 说明书），/<表> 为列式记录（不含 content、默认不含 createdAt/updatedAt/createdBy/updatedBy）。默认每页 50，最多 200。columns 参数只取需要的列。表结构用 db_stat。',

--- a/packages/core-file-system/src/host/wal-store.test.ts
+++ b/packages/core-file-system/src/host/wal-store.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { WalStore, actorKey } from './wal-store.ts'
+
+test('folds same actor content and keeps first before', () => {
+  const store = new WalStore().open(':memory:')
+  const actor = { kind: 'user' as const }
+  store.append({ path: '/pages/p1', op: 'content', actor, title: '首页', beforeText: 'a\n', afterText: 'a\nb\n' })
+  const second = store.append({ path: '/pages/p1', op: 'content', actor, title: '首页', beforeText: 'a\nb\n', afterText: 'a\nb\nc\n' })
+  assert.equal(second?.folded, true)
+  assert.equal(second?.seq, 1)
+  assert.equal(store.getBlob(second?.beforeBlob), 'a\n')
+  assert.equal(store.getBlob(second?.afterBlob), 'a\nb\nc\n')
+})
+
+test('does not fold when actor switches to an agent', () => {
+  const store = new WalStore().open(':memory:')
+  store.append({ path: '/pages/p1', op: 'content', actor: { kind: 'user' }, title: 'p', beforeText: '', afterText: '人' })
+  store.append({
+    path: '/pages/p1',
+    op: 'content',
+    actor: { kind: 'agent', sessionId: 's1', turn: 1 },
+    title: 'p',
+    beforeText: '人',
+    afterText: '模型',
+  })
+  assert.equal(store.headSeq('/pages/p1'), 2)
+  assert.equal(actorKey({ kind: 'user' }), 'user')
+})
+
+test('does not fold create or delete', () => {
+  const store = new WalStore().open(':memory:')
+  const actor = { kind: 'agent' as const, sessionId: 's', turn: 1 }
+  store.append({ path: '/pages/a', op: 'create', actor, title: 'a', afterMeta: { title: 'a' } })
+  store.append({ path: '/pages/a', op: 'create', actor, title: 'a', afterMeta: { title: 'a2' } })
+  assert.equal(store.listTurn('s', 1).length, 2)
+})
+
+test('persists blobs beside the log file', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'wal-'))
+  const file = join(dir, 'wal.json')
+  const store = new WalStore().open(file)
+  store.append({ path: '/pages/p1', op: 'content', actor: { kind: 'user' }, title: 'p', beforeText: '', afterText: '你好' })
+  const again = new WalStore().open(file)
+  const head = again.headEntry('/pages/p1')
+  assert.equal(again.getBlob(head?.afterBlob), '你好')
+  const raw = JSON.parse(await readFile(file, 'utf8')) as { entries: unknown[] }
+  assert.equal(raw.entries.length, 1)
+})

--- a/packages/core-file-system/src/host/wal-store.ts
+++ b/packages/core-file-system/src/host/wal-store.ts
@@ -1,0 +1,277 @@
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { diffLineStats } from './line-diff.ts'
+
+export type WalActor = {
+  kind: 'user' | 'agent'
+  sessionId?: string
+  turn?: number
+}
+
+export type WalOp = 'create' | 'update' | 'delete' | 'content'
+
+export type WalEntry = {
+  seq: number
+  ts: number
+  path: string
+  op: WalOp
+  actor: WalActor
+  parentSeq: number | null
+  title: string
+  beforeBlob?: string
+  afterBlob?: string
+  beforeMeta?: Record<string, unknown>
+  afterMeta?: Record<string, unknown>
+  reverted?: boolean
+  folded?: boolean
+}
+
+export type ContentEditSummary = {
+  path: string
+  title: string
+  added: number
+  removed: number
+  jump_line: number
+  reverted?: boolean
+  kind?: WalOp
+}
+
+type StoreShape = {
+  seq: number
+  entries: WalEntry[]
+}
+
+const MAX_ENTRIES = 4000
+
+export function actorKey(actor: WalActor) {
+  if (actor.kind === 'agent' && actor.sessionId) return `agent:${actor.sessionId}:${actor.turn ?? 0}`
+  return 'user'
+}
+
+function hashText(text: string) {
+  return createHash('sha1').update(text).digest('hex')
+}
+
+function blobName(hash: string) {
+  return hash.replace(/[^a-f0-9]/gi, '') || 'empty'
+}
+
+export class WalStore {
+  private file = ''
+  private blobDir = ''
+  private memoryBlobs = new Map<string, string>()
+  private data: StoreShape = { seq: 0, entries: [] }
+  private head = new Map<string, number>()
+
+  open(path: string) {
+    this.file = path
+    this.blobDir = path === ':memory:' ? '' : path.replace(/\.json$/i, '') + '-blobs'
+    this.memoryBlobs = new Map()
+    this.head = new Map()
+    if (path === ':memory:') {
+      this.data = { seq: 0, entries: [] }
+      return this
+    }
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf8')) as StoreShape
+      this.data = {
+        seq: Number(raw.seq) || 0,
+        entries: Array.isArray(raw.entries) ? raw.entries : [],
+      }
+    } catch {
+      this.data = { seq: 0, entries: [] }
+    }
+    this.rebuildHead()
+    return this
+  }
+
+  putBlob(value: string) {
+    const text = value ?? ''
+    const hash = hashText(text)
+    if (this.file === ':memory:' || !this.blobDir) {
+      this.memoryBlobs.set(hash, text)
+      return hash
+    }
+    mkdirSync(this.blobDir, { recursive: true })
+    const dest = join(this.blobDir, blobName(hash))
+    if (!existsSync(dest)) writeFileSync(dest, text)
+    return hash
+  }
+
+  getBlob(hash?: string) {
+    if (!hash) return ''
+    if (this.memoryBlobs.has(hash)) return this.memoryBlobs.get(hash) ?? ''
+    if (this.blobDir) {
+      try {
+        return readFileSync(join(this.blobDir, blobName(hash)), 'utf8')
+      } catch {
+        return ''
+      }
+    }
+    return ''
+  }
+
+  headSeq(path: string) {
+    return this.head.get(path) ?? null
+  }
+
+  headEntry(path: string) {
+    const seq = this.headSeq(path)
+    if (seq == null) return null
+    return this.data.entries.find((row) => row.seq === seq) ?? null
+  }
+
+  get(seq: number) {
+    return this.data.entries.find((row) => row.seq === seq) ?? null
+  }
+
+  listTurn(sessionId: string, turn: number) {
+    const sid = sessionId.trim()
+    return this.data.entries.filter((row) => row.actor.kind === 'agent' && row.actor.sessionId === sid && row.actor.turn === turn)
+  }
+
+  append(input: {
+    path: string
+    op: WalOp
+    actor: WalActor
+    title: string
+    beforeText?: string
+    afterText?: string
+    beforeMeta?: Record<string, unknown>
+    afterMeta?: Record<string, unknown>
+  }) {
+    const path = input.path.trim()
+    if (!path) return null
+    const prev = this.headEntry(path)
+    if (this.canFold(prev, input)) {
+      const next = prev!
+      if (input.op === 'content') {
+        next.afterBlob = this.putBlob(input.afterText ?? '')
+      } else if (input.op === 'update') {
+        next.afterMeta = { ...(next.afterMeta ?? {}), ...(input.afterMeta ?? {}) }
+        if (input.beforeMeta) {
+          next.beforeMeta = { ...input.beforeMeta, ...(next.beforeMeta ?? {}) }
+        }
+      }
+      next.ts = Date.now()
+      next.folded = true
+      next.title = input.title || next.title
+      next.reverted = undefined
+      this.flush()
+      return next
+    }
+    this.data.seq += 1
+    const entry: WalEntry = {
+      seq: this.data.seq,
+      ts: Date.now(),
+      path,
+      op: input.op,
+      actor: input.actor,
+      parentSeq: prev && !prev.reverted ? prev.seq : prev?.parentSeq ?? null,
+      title: input.title || path,
+    }
+    if (input.op === 'content' || input.op === 'delete' || input.op === 'create') {
+      if (input.beforeText != null) entry.beforeBlob = this.putBlob(input.beforeText)
+      if (input.afterText != null) entry.afterBlob = this.putBlob(input.afterText)
+    }
+    if (input.beforeMeta) entry.beforeMeta = input.beforeMeta
+    if (input.afterMeta) entry.afterMeta = input.afterMeta
+    this.data.entries.push(entry)
+    this.head.set(path, entry.seq)
+    this.trim()
+    this.flush()
+    return entry
+  }
+
+  markReverted(seq: number) {
+    const row = this.get(seq)
+    if (!row) return
+    row.reverted = true
+    if (this.head.get(row.path) === seq) {
+      const prev = [...this.data.entries].reverse().find((item) => item.path === row.path && !item.reverted && item.seq !== seq)
+      if (prev) this.head.set(row.path, prev.seq)
+      else this.head.delete(row.path)
+    }
+    this.flush()
+  }
+
+  summaries(sessionId: string, turn: number): ContentEditSummary[] {
+    return this.listTurn(sessionId, turn).map((row) => this.toSummary(row))
+  }
+
+  toSummary(row: WalEntry): ContentEditSummary {
+    if (row.op === 'content') {
+      const stats = diffLineStats(this.getBlob(row.beforeBlob), this.getBlob(row.afterBlob))
+      const item: ContentEditSummary = {
+        path: row.path,
+        title: row.title,
+        added: stats.added,
+        removed: stats.removed,
+        jump_line: stats.jump_line,
+        kind: 'content',
+      }
+      if (row.reverted) item.reverted = true
+      return item
+    }
+    const item: ContentEditSummary = {
+      path: row.path,
+      title: row.title,
+      added: row.op === 'create' ? 1 : 0,
+      removed: row.op === 'delete' ? 1 : 0,
+      jump_line: 1,
+      kind: row.op,
+    }
+    if (row.reverted) item.reverted = true
+    return item
+  }
+
+  private canFold(prev: WalEntry | null, input: { path: string; op: WalOp; actor: WalActor }) {
+    if (!prev || prev.reverted) return false
+    if (prev.path !== input.path) return false
+    if (prev.op !== input.op) return false
+    if (input.op === 'create' || input.op === 'delete') return false
+    if (actorKey(prev.actor) !== actorKey(input.actor)) return false
+    if (this.head.get(input.path) !== prev.seq) return false
+    return true
+  }
+
+  private rebuildHead() {
+    this.head = new Map()
+    for (const row of this.data.entries) {
+      if (!row.reverted) this.head.set(row.path, row.seq)
+    }
+  }
+
+  private trim() {
+    const extra = this.data.entries.length - MAX_ENTRIES
+    if (extra <= 0) return
+    const dropped = this.data.entries.splice(0, extra)
+    const keep = new Set<string>()
+    for (const row of this.data.entries) {
+      if (row.beforeBlob) keep.add(row.beforeBlob)
+      if (row.afterBlob) keep.add(row.afterBlob)
+    }
+    for (const row of dropped) {
+      if (row.beforeBlob && !keep.has(row.beforeBlob)) this.dropBlob(row.beforeBlob)
+      if (row.afterBlob && !keep.has(row.afterBlob)) this.dropBlob(row.afterBlob)
+    }
+    this.rebuildHead()
+  }
+
+  private dropBlob(hash: string) {
+    this.memoryBlobs.delete(hash)
+    if (!this.blobDir) return
+    try {
+      unlinkSync(join(this.blobDir, blobName(hash)))
+    } catch {
+      /* missing */
+    }
+  }
+
+  private flush() {
+    if (!this.file || this.file === ':memory:') return
+    mkdirSync(dirname(this.file), { recursive: true })
+    writeFileSync(this.file, JSON.stringify(this.data))
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
全局 path WAL：人与 Agent 的 create/update/delete/content 都先记日志。同 actor 连续写会折叠；删除带正文 blob，恢复尽量用回同一 id。回合撤销走这条日志，head 对不上则 diverged。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

