### PR TITLE
fix(electron): 启动先编译 main.ts，并复用已占用端口

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ packages/**/*.d.ts
 packages/**/*.d.ts.map
 host/**/*.js
 host/**/*.js.map
+electron/out/
 web/**/*.js
 web/**/*.js.map
 # 沙箱源码是 ts/tsx；pack 产物在 .plugin。这里挡住误编译进沙箱的 js 和依赖

--- a/electron/README.md
+++ b/electron/README.md
@@ -18,7 +18,7 @@ CSP `frame-ancestors` 限制（那是 iframe 才有的约束）。
 ## 跑起来
 
 ```bash
-npm run electron:dev     # 起 host + vite，等 5173 就绪后开 Electron 窗口
+npm run electron:dev     # 编译 electron/main.ts，host/vite 已在跑就复用，否则自己起
 ```
 
 窗口里就是你现在的界面（**现有代码一行都没改**），右侧栏点 `+` 选「浏览器」即可。
@@ -27,7 +27,7 @@ npm run electron:dev     # 起 host + vite，等 5173 就绪后开 Electron 窗�
 
 ```bash
 npm run dev              # 原来的网页版，照常可用（面板会提示需要 Electron）
-npm run electron:build   # 先 vite build，再用 dist 起 Electron
+npm run electron:build   # 先 vite build，再用 dist 起 Electron（不依赖 5173）
 ```
 
 ## 文件
@@ -59,6 +59,8 @@ npm run electron:build   # 先 vite build，再用 dist 起 Electron
 'biu:browser:error'     // { code, desc, url } —— 来自 did-fail-load，是真实原因
 'biu:browser:inspected' // { tag, id, className, text, html }
 ```
+
+主进程是 TypeScript，启动前会 `tsc` 成 `electron/out/main.js` 再交给 Electron（它不能直接加载 `.ts`）。Linux 容器里会带 `no-sandbox`，否则 Chromium 沙箱起不来。
 
 ## 已知的粗糙处（要改就从这里下手）
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -9,14 +9,17 @@
  */
 
 import { app, BrowserWindow, BrowserView, ipcMain, shell, session } from 'electron'
+import { existsSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
+const electronRoot = join(__dirname, '..')
 
-/** dev：vite 起的地址；打包：本地 dist 文件。 */
+/** dev：vite 起的地址；打包 / 无 dev 标记：本地 dist 文件。 */
 const DEV_URL = process.env.BIU_DEV_URL || 'http://127.0.0.1:5173'
-const isDev = !app.isPackaged
+const distIndex = join(electronRoot, '..', 'dist', 'index.html')
+const isDev = process.env.BIU_ELECTRON_DEV === '1' || (!app.isPackaged && !existsSync(distIndex) && process.env.BIU_ELECTRON_DEV !== '0')
 
 /** 侧栏浏览器那块的原生视图。同一时间只开一个。 */
 let view: BrowserView | null = null
@@ -210,7 +213,7 @@ async function createWindow() {
     backgroundColor: '#191919',
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
-      preload: join(__dirname, 'preload.cjs'),
+      preload: join(electronRoot, 'preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: false,
@@ -234,13 +237,19 @@ async function createWindow() {
     await win.loadURL(DEV_URL)
     win.webContents.openDevTools({ mode: 'detach' })
   } else {
-    await win.loadFile(join(__dirname, '..', 'dist', 'index.html'))
+    await win.loadFile(join(electronRoot, '..', 'dist', 'index.html'))
   }
 }
 
 // 开发期开个 CDP 端口，方便自动化和排查（打包不加）
 if (isDev) {
   app.commandLine.appendSwitch('remote-debugging-port', '9222')
+}
+
+// 容器 / 无用户命名空间的 Linux 上 Chromium 沙箱会直接起不来
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('no-sandbox')
+  app.commandLine.appendSwitch('disable-gpu-sandbox')
 }
 
 app.whenReady().then(async () => {

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -1,12 +1,13 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true,
+    "rootDir": ".",
+    "outDir": "out",
     "types": ["node", "electron"]
   },
-  "include": ["."]
+  "include": ["main.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "build": "vite build",
     "start": "tsx host/index.ts",
     "test": "vitest run",
-    "electron:dev": "concurrently -k \"npm:dev:host\" \"npm:dev:web\" \"npm:electron:wait\"",
-    "electron:wait": "wait-on tcp:5173 && electron electron/main.ts",
-    "electron:build": "npm run build && electron electron/main.ts"
+    "electron:dev": "node scripts/electron-dev.mjs",
+    "electron:wait": "node scripts/electron-launch.mjs",
+    "electron:build": "npm run build && env BIU_ELECTRON_DEV=0 node scripts/electron-launch.mjs"
   },
   "dependencies": {
     "@codemirror/commands": "^6.11.0",

--- a/packages/core-plugin-system/src/host/gitignore.test.ts
+++ b/packages/core-plugin-system/src/host/gitignore.test.ts
@@ -21,4 +21,6 @@ test('compiled js beside package sources is ignored; grok-bot js stays tracked',
   assert.equal(ignored('.plugin-dev/page-algorithm/node_modules/foo/index.js'), true)
   assert.equal(ignored('public/grok-bot/src/character.js'), false)
   assert.equal(ignored('.plugin/page-html-blocks/web.js'), true)
+  assert.equal(ignored('electron/out/main.js'), true)
+  assert.equal(ignored('electron/preload.cjs'), false)
 })

--- a/scripts/electron-dev.mjs
+++ b/scripts/electron-dev.mjs
@@ -1,0 +1,62 @@
+import { spawn } from 'node:child_process'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { compileMain, launchElectron, portOpen } from './electron-launch.mjs'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function waitFor(port, ms = 60_000) {
+  const start = Date.now()
+  return new Promise((resolve, reject) => {
+    const tick = async () => {
+      if (await portOpen(port)) return resolve(undefined)
+      if (Date.now() - start > ms) return reject(new Error(`wait for :${port} timed out`))
+      setTimeout(tick, 200)
+    }
+    void tick()
+  })
+}
+
+function npmRun(script) {
+  return spawn('npm', ['run', script], { cwd: root, stdio: 'inherit', env: process.env })
+}
+
+export { portOpen }
+
+async function main() {
+  const kids = []
+  if (await portOpen(3141)) console.log('[electron] 已有 host :3141，复用')
+  else {
+    console.log('[electron] 启动 host :3141')
+    kids.push(npmRun('dev:host'))
+  }
+  if (await portOpen(5173)) console.log('[electron] 已有 vite :5173，复用')
+  else {
+    console.log('[electron] 启动 vite :5173')
+    kids.push(npmRun('dev:web'))
+  }
+
+  await waitFor(3141)
+  await waitFor(5173)
+  await compileMain()
+  const electron = launchElectron({ BIU_ELECTRON_DEV: '1' })
+
+  const shutdown = (signal) => {
+    electron.kill(signal)
+    for (const kid of kids) kid.kill(signal)
+  }
+
+  process.on('SIGINT', () => shutdown('SIGINT'))
+  process.on('SIGTERM', () => shutdown('SIGTERM'))
+
+  electron.on('exit', (code, signal) => {
+    for (const kid of kids) kid.kill('SIGTERM')
+    if (signal) process.kill(process.pid, signal)
+    process.exit(code ?? 0)
+  })
+}
+
+const entry = process.argv[1]
+if (entry && import.meta.url === pathToFileURL(resolve(entry)).href) {
+  await main()
+}

--- a/scripts/electron-dev.test.ts
+++ b/scripts/electron-dev.test.ts
@@ -1,0 +1,28 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:net'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { portOpen } from './electron-launch.mjs'
+
+test('electron scripts compile ts and reuse busy ports', async () => {
+  const pkg = JSON.parse(await readFile(resolve(import.meta.dirname, '../package.json'), 'utf8'))
+  assert.equal(pkg.scripts['electron:dev'], 'node scripts/electron-dev.mjs')
+  assert.equal(pkg.scripts['electron:wait'], 'node scripts/electron-launch.mjs')
+  assert.match(pkg.scripts['electron:build'], /electron-launch/)
+  assert.doesNotMatch(JSON.stringify(pkg.scripts), /electron\/main\.ts/)
+
+  const main = await readFile(resolve(import.meta.dirname, '../electron/main.ts'), 'utf8')
+  assert.match(main, /no-sandbox/)
+  assert.match(main, /BIU_ELECTRON_DEV/)
+
+  const tsconfig = await readFile(resolve(import.meta.dirname, '../electron/tsconfig.json'), 'utf8')
+  assert.doesNotMatch(tsconfig, /"noEmit": true/)
+
+  assert.equal(await portOpen(1), false)
+  const server = createServer()
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const port = server.address().port
+  assert.equal(await portOpen(port), true)
+  await new Promise((resolve) => server.close(resolve))
+})

--- a/scripts/electron-launch.mjs
+++ b/scripts/electron-launch.mjs
@@ -1,0 +1,60 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import net from 'node:net'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+export function portOpen(port, host = '127.0.0.1') {
+  return new Promise((resolve) => {
+    const sock = net.connect({ port, host })
+    sock.once('connect', () => {
+      sock.end()
+      resolve(true)
+    })
+    sock.once('error', () => resolve(false))
+  })
+}
+const tsc = join(root, 'node_modules', 'typescript', 'bin', 'tsc')
+const electron = join(root, 'node_modules', '.bin', 'electron')
+
+export function compileMain() {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsc, '-p', join(root, 'electron', 'tsconfig.json')], {
+      cwd: root,
+      stdio: 'inherit',
+    })
+    child.on('exit', (code) => {
+      if (code === 0 && existsSync(join(root, 'electron', 'out', 'main.js'))) resolve(undefined)
+      else reject(new Error(`electron tsc exited ${code}`))
+    })
+  })
+}
+
+export function launchElectron(extraEnv = {}) {
+  const child = spawn(electron, [join(root, 'electron', 'out', 'main.js')], {
+    cwd: root,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+  })
+  return child
+}
+
+function isMain() {
+  const entry = process.argv[1]
+  if (!entry) return false
+  return import.meta.url === pathToFileURL(resolve(entry)).href
+}
+
+if (isMain()) {
+  await compileMain()
+  const child = launchElectron()
+  child.on('exit', (code, signal) => {
+    if (signal) process.kill(process.pid, signal)
+    process.exit(code ?? 1)
+  })
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       ['packages/core-*/src/host/**', 'node'],
       ['packages/type-*/**', 'node'],
       ['packages/public-*/**/*.test.ts', 'node'],
+      ['scripts/**', 'node'],
     ],
   },
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npm run electron:dev` 原先直接 `electron electron/main.ts`，Electron 会立刻报 `Unknown file extension ".ts"` 退出。

这次改成：

- 启动前 `tsc -p electron/tsconfig.json`，跑 `electron/out/main.js`
- Linux 加上 `no-sandbox`，容器里 Chromium 沙箱起得来
- 3141 / 5173 已经在听就复用，不再自己再起一份撞 `EADDRINUSE`
- `BIU_ELECTRON_DEV=1` 才走 Vite；`electron:build` 走 `dist`

本地已用 `npm run electron:dev` 拉起窗口，host/vite 正常打 API，不再出现 `.ts` 加载错误。D-Bus `Failed to connect to the bus` 是无桌面 session 的噪音，不影响启动。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

