### PR TITLE
聊天上滑不再和贴底抢滚动

### DIFF
--- a/packages/core-chat/src/web/thread-reveal.test.ts
+++ b/packages/core-chat/src/web/thread-reveal.test.ts
@@ -9,6 +9,8 @@ import {
   firstPaintStartIndex,
   groupNodesIntoTurns,
   isChatStuckToLatest,
+  isChatPinnedToBottom,
+  nextStickToLatest,
   pinChatToLatest,
   recalledChatScroll,
   rememberChatScroll,
@@ -193,6 +195,24 @@ describe('chat scroll memory per session', () => {
     parent.scrollTop = 200
     expect(isChatStuckToLatest(parent)).toBe(true)
   })
+
+  it('does not keep pin-follow when the user has already scrolled up a little', () => {
+    const parent = document.createElement('div')
+    Object.defineProperty(parent, 'scrollHeight', { value: 2400, configurable: true })
+    Object.defineProperty(parent, 'clientHeight', { value: 800, configurable: true })
+    Object.defineProperty(parent, 'scrollTop', { value: 1480, writable: true, configurable: true })
+    expect(isChatStuckToLatest(parent)).toBe(true)
+    expect(isChatPinnedToBottom(parent)).toBe(false)
+    expect(
+      nextStickToLatest({ stuck: true, distanceFromBottom: 120, scrollTop: 1480, scrollingUp: true }),
+    ).toBe(false)
+    expect(
+      nextStickToLatest({ stuck: true, distanceFromBottom: 120, scrollTop: 1480, scrollingUp: false }),
+    ).toBe(true)
+    expect(
+      nextStickToLatest({ stuck: false, distanceFromBottom: 20, scrollTop: 1580, scrollingUp: false }),
+    ).toBe(true)
+  })
 })
 
 describe('thread follows the latest message', () => {
@@ -202,5 +222,7 @@ describe('thread follows the latest message', () => {
     expect(src).toContain('ResizeObserver')
     expect(src).toContain('pinChatToLatest')
     expect(src).toContain('liveTurnId')
+    expect(src).toContain('event.deltaY < 0')
+    expect(src).toContain('nextStickToLatest')
   })
 })

--- a/packages/core-chat/src/web/thread-reveal.ts
+++ b/packages/core-chat/src/web/thread-reveal.ts
@@ -36,8 +36,10 @@ export function bumpRevealStart(startIndex: number, batch = CHAT_REVEAL_BATCH): 
   return Math.max(0, startIndex - Math.max(1, batch))
 }
 
-/** 输入栏垫了 pb-72 / 18rem，离真正 scroll 底还有一大截也算在看最新。 */
+/** 输入栏垫了 pb-72 / 18rem，离真正 scroll 底还有一大截也算在看最新（记忆用）。 */
 export const CHAT_NEAR_BOTTOM_PX = 360
+/** 只有贴着滚动条底边才跟着新内容钉住；宽阈值会把上滑拽回去、抖死。 */
+export const CHAT_PIN_BOTTOM_PX = 48
 export const PIN_TOP_SLACK_PX = 8
 
 /** 贴底，或当时贴在视口顶的那条用户消息。回来滚到它重新贴顶。 */
@@ -114,6 +116,26 @@ export function isChatStuckToLatest(parent: HTMLElement): boolean {
   // 内容刚好比视口高一点时，顶和底会同时落入 360px 阈值；钉在顶上时不要当成贴底。
   if (parent.scrollTop <= PIN_TOP_SLACK_PX) return false
   return true
+}
+
+/** 实时跟随最新：要比「还在底部一带」严，否则滚轮上滑会被 pin 回去。 */
+export function isChatPinnedToBottom(parent: HTMLElement): boolean {
+  if (distanceFromChatBottom(parent) > CHAT_PIN_BOTTOM_PX) return false
+  if (parent.scrollTop <= PIN_TOP_SLACK_PX) return false
+  return true
+}
+
+/** 上滑立刻松钉；只有滚回真正底边才重新钉住。 */
+export function nextStickToLatest(opts: {
+  stuck: boolean
+  distanceFromBottom: number
+  scrollTop: number
+  scrollingUp: boolean
+}): boolean {
+  if (opts.scrollingUp) return false
+  if (opts.scrollTop <= PIN_TOP_SLACK_PX) return false
+  if (opts.distanceFromBottom <= CHAT_PIN_BOTTOM_PX) return true
+  return opts.stuck
 }
 
 export function pinChatToLatest(parent: HTMLElement) {

--- a/packages/core-chat/src/web/thread.tsx
+++ b/packages/core-chat/src/web/thread.tsx
@@ -43,7 +43,8 @@ import {
   captureChatScroll,
   firstPaintStartIndex,
   groupNodesIntoTurns,
-  isChatStuckToLatest,
+  distanceFromChatBottom,
+  nextStickToLatest,
   pinChatToLatest,
   PIN_TOP_SLACK_PX,
   recalledChatScroll,
@@ -897,9 +898,23 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
         })
     }
 
+    let lastTop = parent.scrollTop
+    const applyStick = (scrollingUp: boolean) => {
+      stickToBottomRef.current = nextStickToLatest({
+        stuck: stickToBottomRef.current,
+        distanceFromBottom: distanceFromChatBottom(parent),
+        scrollTop: parent.scrollTop,
+        scrollingUp,
+      })
+    }
     const onScroll = () => {
-      stickToBottomRef.current = isChatStuckToLatest(parent)
+      applyStick(parent.scrollTop < lastTop - 0.5)
+      lastTop = parent.scrollTop
       maybePrefetchOlder()
+    }
+    const onWheel = (event: WheelEvent) => {
+      // 滚轮先于 scroll；必须立刻松钉，否则 ResizeObserver / 贴底 layout 会把位移拽回去。
+      if (event.deltaY < 0) stickToBottomRef.current = false
     }
     const onUserScroll = () => {
       onScroll()
@@ -912,8 +927,10 @@ export const ChatThread = memo(function ChatThread(props: SlotProps) {
     }
     onScroll()
     parent.addEventListener('scroll', onUserScroll, { passive: true })
+    parent.addEventListener('wheel', onWheel, { passive: true })
     return () => {
       parent.removeEventListener('scroll', onUserScroll)
+      parent.removeEventListener('wheel', onWheel)
     }
   }, [sessionId, scrollEpoch, hasMoreOlder, loadingOlder, sessionView])
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天贴底用了 360px 宽阈值（给输入栏 padding），滚轮往上滑几十像素仍被当成「还在看最新」，`ResizeObserver` / layout 又 `pinChatToLatest`，和手势抢 `scrollTop`，所以会抖。右侧滑块一下能拉出 360px，所以显得只有滑块顺。

改动：
- 滚轮 `deltaY < 0` 立刻松钉
- 只有离真正底边 ≤ 48px 才重新跟随最新
- 360px 仍只用于会话滚动记忆（是不是还在底部一带）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

