### PR TITLE
本回合改动可展开看文件 diff

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.test.tsx
+++ b/packages/core-chat/src/web/content-edits-table.test.tsx
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { ChatNodeList } from './thread.tsx'
 import {
   INSPECTOR_REVEAL_EVENT,
+  compactEqualLines,
   contentEditLabel,
   revealContentEdit,
   type ContentEditRow,
@@ -81,6 +82,7 @@ describe('ContentEditsTable', () => {
     render(<ChatNodeList nodes={nodes} sessionId="sess-1" onInspect={() => undefined} onFork={() => undefined} />)
     expect(screen.getByTestId('content-edits-table')).toBeTruthy()
     expect(screen.getByText('本回合文件系统内容的改动')).toBeTruthy()
+    fireEvent.click(screen.getByText('本回合文件系统内容的改动'))
     expect(screen.getByText('首页')).toBeTruthy()
     expect(screen.queryByLabelText('撤销 首页')).toBeNull()
     expect(fetchMock).not.toHaveBeenCalled()
@@ -102,6 +104,7 @@ describe('ContentEditsTable', () => {
       },
     ]
     render(<ChatNodeList nodes={nodes} sessionId="sess-hide" onInspect={() => undefined} onFork={() => undefined} />)
+    fireEvent.click(screen.getByText('本回合文件系统内容的改动'))
     expect(screen.queryByText(/新建/)).toBeNull()
     expect(screen.getByText('首页')).toBeTruthy()
     expect(screen.getAllByText('+12').length).toBeGreaterThan(0)
@@ -125,6 +128,7 @@ describe('ContentEditsTable', () => {
       },
     ]
     render(<ChatNodeList nodes={nodes} sessionId="sess-2" onInspect={() => undefined} onFork={() => undefined} />)
+    fireEvent.click(screen.getByText('本回合文件系统内容的改动'))
     const table = screen.getByTestId('content-edits-table')
     expect(table.querySelectorAll('li')).toHaveLength(5)
     expect(screen.getByText('你好 · p1')).toBeTruthy()
@@ -134,4 +138,61 @@ describe('ContentEditsTable', () => {
     expect(seen).toEqual([{ collection: '/pages', recordId: 'p4', unique: true }])
     window.removeEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
   })
+
+  it('loads a file diff from content-turns when the row chevron is opened', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/content-turns/file')) {
+        return {
+          ok: true,
+          json: async () => ({ before: 'keep\na\nkeep2\n', after: 'keep\nb\nkeep2\n' }),
+        }
+      }
+      return { ok: true, json: async () => ({}) }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const nodes: ChatNode[] = [
+      { id: 'u-1', kind: 'user', text: '改' },
+      {
+        id: 'r-1',
+        kind: 'reply',
+        copyText: '好了',
+        turn: 7,
+        parts: [{ id: 'a-1', kind: 'assistant', text: '好了' }],
+        contentEdits: [{ path: '/pages/home', title: '首页', added: 1, removed: 1, jump_line: 2 }],
+      },
+    ]
+    render(<ChatNodeList nodes={nodes} sessionId="sess-diff" onInspect={() => undefined} onFork={() => undefined} />)
+    fireEvent.click(screen.getByText('本回合文件系统内容的改动'))
+    fireEvent.click(screen.getByLabelText('查看 首页 的 diff'))
+    await waitFor(() => expect(screen.getByTestId('content-edit-diff')).toBeTruthy())
+    expect(screen.getByTestId('content-edit-diff').textContent).toContain('a')
+    expect(screen.getByTestId('content-edit-diff').textContent).toContain('b')
+    expect(fetchMock.mock.calls.some((call) => String(call[0]).includes('session=sess-diff') && String(call[0]).includes('turn=7'))).toBe(true)
+  })
 })
+
+describe('compactEqualLines', () => {
+  it('keeps unchanged lines next to edits and skips the rest', () => {
+    const rows = compactEqualLines(
+      [
+        { type: 'equal', text: '1' },
+        { type: 'equal', text: '2' },
+        { type: 'equal', text: '3' },
+        { type: 'equal', text: '4' },
+        { type: 'equal', text: '5' },
+        { type: 'add', text: 'x' },
+        { type: 'equal', text: '6' },
+        { type: 'equal', text: '7' },
+        { type: 'equal', text: '8' },
+        { type: 'equal', text: '9' },
+        { type: 'equal', text: '10' },
+      ],
+      2,
+      3,
+    )
+    expect(rows.some((row) => row.type === 'skip')).toBe(true)
+    expect(rows.some((row) => row.type === 'add' && row.text === 'x')).toBe(true)
+  })
+})
+

--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -1,5 +1,7 @@
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/16/solid'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
+import { lineDiff, type DiffLine } from './tool-format.ts'
 
 export type ContentEditRow = {
   path: string
@@ -44,8 +46,109 @@ export function revealContentEdit(path: string, jumpLine: number) {
   )
 }
 
-export const ContentEditsTable = memo(function ContentEditsTable({ files }: { files: ContentEditRow[] }) {
+export type CompactDiffRow = DiffLine | { type: 'skip'; count: number }
+
+/** 改动附近留两行上下文，中间未改的行收成「未改 N 行」。 */
+export function compactEqualLines(lines: DiffLine[], context = 2, minSkip = 4): CompactDiffRow[] {
+  const keep = new Array(lines.length).fill(false)
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i]?.type !== 'equal') {
+      for (let k = Math.max(0, i - context); k <= Math.min(lines.length - 1, i + context); k++) keep[k] = true
+    }
+  }
+  if (!keep.some(Boolean)) return lines
+  const out: CompactDiffRow[] = []
+  let i = 0
+  while (i < lines.length) {
+    if (keep[i]) {
+      out.push(lines[i]!)
+      i += 1
+      continue
+    }
+    let n = 0
+    while (i < lines.length && !keep[i]) {
+      n += 1
+      i += 1
+    }
+    if (n >= minSkip) out.push({ type: 'skip', count: n })
+    else {
+      for (let k = i - n; k < i; k++) out.push(lines[k]!)
+    }
+  }
+  return out
+}
+
+function FileDiffView({ sessionId, turn, path }: { sessionId: string; turn: number; path: string }) {
+  const [state, setState] = useState<'load' | 'gone' | 'ok'>('load')
+  const [rows, setRows] = useState<CompactDiffRow[]>([])
+
+  useEffect(() => {
+    const ac = new AbortController()
+    setState('load')
+    const qs = new URLSearchParams({ session: sessionId, turn: String(turn), path })
+    void fetch(`/api/content-turns/file?${qs}`, { signal: ac.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          setState('gone')
+          return
+        }
+        const body = (await res.json()) as { before?: string; after?: string }
+        setRows(compactEqualLines(lineDiff(body.before ?? '', body.after ?? '')))
+        setState('ok')
+      })
+      .catch((error: unknown) => {
+        if ((error as { name?: string }).name === 'AbortError') return
+        setState('gone')
+      })
+    return () => ac.abort()
+  }, [sessionId, turn, path])
+
+  if (state === 'load') {
+    return <div className="px-3 py-2 text-[12px] text-(--dsw-label-3)">载入 diff…</div>
+  }
+  if (state === 'gone') {
+    return <div className="px-3 py-2 text-[12px] text-(--dsw-label-3)">这份正文已过期，点标题仍可跳到当前文件。</div>
+  }
+  return (
+    <pre className="max-h-80 overflow-auto border-t border-(--dsw-border) py-1 font-mono text-[12px] leading-5" data-testid="content-edit-diff">
+      {rows.map((line, index) => {
+        if (line.type === 'skip') {
+          return (
+            <div key={`skip-${index}`} className="px-3 py-0.5 text-center text-(--dsw-label-3)">
+              ··· 未改 {line.count} 行
+            </div>
+          )
+        }
+        const prefix = line.type === 'add' ? '+' : line.type === 'remove' ? '−' : ' '
+        const rowClass =
+          line.type === 'add'
+            ? 'bg-[color-mix(in_srgb,#448361_22%,transparent)] text-[#448361]'
+            : line.type === 'remove'
+              ? 'bg-[color-mix(in_srgb,#c4554d_22%,transparent)] text-[#c4554d]'
+              : 'text-(--dsw-label-2)'
+        return (
+          <div key={`${index}-${line.type}`} className={`flex whitespace-pre-wrap break-all px-2 ${rowClass}`}>
+            <span className="w-4 shrink-0 select-none opacity-70">{prefix}</span>
+            <span className="min-w-0 flex-1">{line.text || ' '}</span>
+          </div>
+        )
+      })}
+    </pre>
+  )
+}
+
+export const ContentEditsTable = memo(function ContentEditsTable({
+  files,
+  sessionId,
+  turn,
+}: {
+  files: ContentEditRow[]
+  sessionId?: string
+  turn?: number
+}) {
   const visible = files.filter((file) => (file.kind === 'content' || !file.kind) && (file.added || file.removed))
+  const [open, setOpen] = useState(false)
+  const [diffPath, setDiffPath] = useState<string | null>(null)
   if (!visible.length) return null
   const added = visible.reduce((n, file) => n + file.added, 0)
   const removed = visible.reduce((n, file) => n + file.removed, 0)
@@ -55,41 +158,66 @@ export const ContentEditsTable = memo(function ContentEditsTable({ files }: { fi
       className="overflow-hidden rounded-[10px] border border-(--dsw-border) bg-(color-mix(in_srgb,var(--dsw-sidebar)_65%,transparent))"
       data-testid="content-edits-table"
     >
-      <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) px-3 py-2">
-        <div className="text-(length:--dsw-chat-ui-font-size) font-semibold text-(--dsw-label-2)">本回合文件系统内容的改动</div>
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <div className="flex min-w-0 items-center gap-1.5">
+          {open ? <ChevronDownIcon className="size-3.5 shrink-0 text-(--dsw-label-3)" /> : <ChevronRightIcon className="size-3.5 shrink-0 text-(--dsw-label-3)" />}
+          <div className="text-(length:--dsw-chat-ui-font-size) font-semibold text-(--dsw-label-2)">本回合文件系统内容的改动</div>
+        </div>
         <div className="flex items-center gap-2 text-[12px] font-semibold tabular-nums">
           <span className="text-[#448361]">+{added}</span>
           <span className="text-[#c4554d]">−{removed}</span>
         </div>
-      </div>
-      <ul className="m-0 list-none p-0">
-        {visible.map((file) => (
-          <li key={file.path} className="flex items-center gap-2 border-t border-(--dsw-border) px-3 py-1.5 first:border-t-0">
-            <button
-              type="button"
-              className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-(--dsw-label) hover:underline"
-              title={file.path}
-              onClick={() => revealContentEdit(file.path, file.jump_line)}
-            >
-              {contentEditLabel(file, visible)}
-            </button>
-            <button
-              type="button"
-              className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
-              onClick={() => revealContentEdit(file.path, file.jump_line)}
-            >
-              +{file.added}
-            </button>
-            <button
-              type="button"
-              className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
-              onClick={() => revealContentEdit(file.path, file.jump_line)}
-            >
-              −{file.removed}
-            </button>
-          </li>
-        ))}
-      </ul>
+      </button>
+      {open ? (
+        <ul className="m-0 list-none border-t border-(--dsw-border) p-0">
+          {visible.map((file) => {
+            const shown = diffPath === file.path
+            return (
+              <li key={file.path} className="border-t border-(--dsw-border) first:border-t-0">
+                <div className="flex items-center gap-2 px-3 py-1.5">
+                  <button
+                    type="button"
+                    className="shrink-0 text-(--dsw-label-3)"
+                    aria-expanded={shown}
+                    aria-label={shown ? `收起 ${contentEditLabel(file, visible)} 的 diff` : `查看 ${contentEditLabel(file, visible)} 的 diff`}
+                    onClick={() => setDiffPath(shown ? null : file.path)}
+                  >
+                    {shown ? <ChevronDownIcon className="size-3.5" /> : <ChevronRightIcon className="size-3.5" />}
+                  </button>
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 truncate text-left text-[13px] font-semibold text-(--dsw-label) hover:underline"
+                    title={file.path}
+                    onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  >
+                    {contentEditLabel(file, visible)}
+                  </button>
+                  <button
+                    type="button"
+                    className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
+                    onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  >
+                    +{file.added}
+                  </button>
+                  <button
+                    type="button"
+                    className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
+                    onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  >
+                    −{file.removed}
+                  </button>
+                </div>
+                {shown && sessionId && turn != null ? <FileDiffView sessionId={sessionId} turn={turn} path={file.path} /> : null}
+              </li>
+            )
+          })}
+        </ul>
+      ) : null}
     </div>
   )
 })

--- a/packages/core-chat/src/web/thread.tsx
+++ b/packages/core-chat/src/web/thread.tsx
@@ -651,7 +651,7 @@ function NodeView({
             <LiveDispatchTable tasks={dispatchTasks} />
           ) : null}
           {sessionId && node.turn != null && node.contentEdits?.length ? (
-            <ContentEditsTable files={node.contentEdits} />
+            <ContentEditsTable files={node.contentEdits} sessionId={sessionId} turn={node.turn} />
           ) : null}
         </div>
         {!streaming ? (

--- a/packages/core-file-system/src/host/content-turn-service.ts
+++ b/packages/core-file-system/src/host/content-turn-service.ts
@@ -61,6 +61,10 @@ export class ContentTurnService extends Service {
     return this.store.summaries(sessionId, turn)
   }
 
+  snapshot(sessionId: string, turn: number, path: string) {
+    return this.store.snapshot(sessionId, turn, path)
+  }
+
   private openTurn(sessionId: string) {
     const peek = this.ctx.get('sessions') as { peek?: (id: string) => { events?: Array<{ type?: string; turn?: number }> } | undefined } | undefined
     const events = peek?.peek?.(sessionId)?.events ?? []

--- a/packages/core-file-system/src/host/content-turn-store.test.ts
+++ b/packages/core-file-system/src/host/content-turn-store.test.ts
@@ -38,6 +38,15 @@ test('trailing newline is not counted as a character', () => {
   assert.equal(sum[0]?.removed, 0)
 })
 
+test('snapshot returns before/after without putting them on summaries', () => {
+  const store = new ContentTurnStore().open(':memory:')
+  store.record({ sessionId: 's1', turn: 5, path: '/pages/p', title: '你好', before: '旧\n', after: '你好\n' })
+  const snap = store.snapshot('s1', 5, '/pages/p')
+  assert.equal(snap?.before, '旧\n')
+  assert.equal(snap?.after, '你好\n')
+  assert.equal(store.summaries('s1', 5)[0]?.added, 2)
+})
+
 test('summaries count characters and omit create ops', () => {
   const store = new ContentTurnStore().open(':memory:')
   store.recordOp('s1', 3, { op: 'create', path: '/pages/a', title: '你好' })

--- a/packages/core-file-system/src/host/content-turn-store.ts
+++ b/packages/core-file-system/src/host/content-turn-store.ts
@@ -122,6 +122,12 @@ export class ContentTurnStore {
     return files ? Object.values(files) : []
   }
 
+  /** 回合内某文件的 before/after；过期裁剪后没有。不进 session 事件，避免把全文再存一份。 */
+  snapshot(sessionId: string, turn: number, path: string) {
+    const files = this.data.sessions[sessionId.trim()]?.[String(turn)]?.files
+    return files?.[path.trim()] ?? null
+  }
+
   private trim(sessionId: string) {
     const ids = Object.keys(this.data.sessions)
     if (ids.length > MAX_SESSIONS) {

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1380,7 +1380,20 @@ export function apply(ctx: Context) {
   ctx.http.route('POST', '/api/db/notices/clear', (route) => {
     route.send(200, { ok: true, cleared: notices.clear() })
   })
-  new ContentTurnService(ctx).open(process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'content-turns.json'))
+  const contentTurns = new ContentTurnService(ctx).open(
+    process.env.VITEST ? ':memory:' : dataPath(process.cwd(), 'content-turns.json'),
+  )
+  ctx.http.route('GET', '/api/content-turns/file', (route) => {
+    const session = String(route.query.get('session') ?? '').trim()
+    const turn = Number(route.query.get('turn'))
+    const path = String(route.query.get('path') ?? '').trim()
+    const file = contentTurns.snapshot(session, turn, path)
+    if (!file) {
+      route.send(404, { error: 'missing' })
+      return
+    }
+    route.send(200, { before: file.before, after: file.after })
+  })
   ctx.tools.register({
     name: 'db_list',
     description: '列出 File System 路径：/ 为已登记表（path、中文名、view.blurb 说明书），/<表> 为列式记录（不含 content、默认不含 createdAt/updatedAt/createdBy/updatedBy）。默认每页 50，最多 200。columns 参数只取需要的列。表结构用 db_stat。',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
聊天里「本回合文件系统内容的改动」默认收起，只显示合计 +/−。展开后是文件列表；点文件左侧箭头按需拉取该文件本回合的 before/after，画出行级 diff（绿加、红删、灰未改；中间大段未改收成「未改 N 行」）。

会话事件里仍然只存路径和字数，不把全文 diff 写进聊天日志。正文只在已有的 `content-turns.json` 里（最多约 40 个会话 × 32 回合），点开时再读。过期则提示，标题仍可跳到当前文件。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

