### PR TITLE
数据改动 + 数据库图标

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.test.tsx
+++ b/packages/core-chat/src/web/content-edits-table.test.tsx
@@ -82,7 +82,7 @@ describe('ContentEditsTable', () => {
     ]
     render(<ChatNodeList nodes={nodes} sessionId="sess-1" onInspect={() => undefined} onFork={() => undefined} />)
     expect(screen.getByTestId('content-edits-table')).toBeTruthy()
-    expect(screen.getByText('本回合文件系统内容的改动')).toBeTruthy()
+    expect(screen.getByText('数据改动')).toBeTruthy()
     expect(screen.getByText('首页')).toBeTruthy()
     expect(screen.queryByLabelText('撤销 首页')).toBeNull()
     expect(fetchMock).not.toHaveBeenCalled()

--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from 'react'
-import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/16/solid'
+import { ChevronDownIcon, ChevronRightIcon, CircleStackIcon } from '@heroicons/react/16/solid'
 import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { lineDiff, type DiffLine } from './tool-format.ts'
 
@@ -204,7 +204,10 @@ export const ContentEditsTable = memo(function ContentEditsTable({
       data-testid="content-edits-table"
     >
       <div className="flex items-center justify-between gap-2 border-b border-(--dsw-border) px-3 py-2">
-        <div className="text-(length:--dsw-chat-ui-font-size) font-semibold text-(--dsw-label-2)">本回合文件系统内容的改动</div>
+        <div className="flex min-w-0 items-center gap-1.5 text-[12px] font-semibold text-(--dsw-label-2)">
+          <CircleStackIcon className="size-3.5 shrink-0" aria-hidden />
+          数据改动
+        </div>
         <div className="flex items-center gap-2 text-[12px] font-semibold tabular-nums">
           <span className="text-[#448361]">+{added}</span>
           <span className="text-[#c4554d]">−{removed}</span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
卡片标题改为「数据改动」，前面加上和检查器一样的数据库图标（CircleStack）。标题字号 12px，和文件名一致。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

