### PR TITLE
diff 行号对齐展开按钮

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -151,8 +151,8 @@ function FileDiffView({ sessionId, turn, path }: { sessionId: string; turn: numb
         if (line.type === 'skip') {
           const oldRange = line.oldFrom != null && line.oldTo != null ? `${line.oldFrom}–${line.oldTo}` : ''
           return (
-            <div key={`skip-${index}`} className="flex px-2 py-0.5 text-[#7B7B79]">
-              <span className="w-10 shrink-0 text-right tabular-nums">{oldRange}</span>
+            <div key={`skip-${index}`} className="flex px-3 py-0.5 text-[#7B7B79]">
+              <span className="w-7 shrink-0 text-right tabular-nums">{oldRange}</span>
               <span className="w-10 shrink-0" />
               <span className="min-w-0 flex-1 px-2 text-center">··· 未改 {line.count} 行</span>
             </div>
@@ -168,12 +168,12 @@ function FileDiffView({ sessionId, turn, path }: { sessionId: string; turn: numb
         return (
           <div
             key={`${index}-${line.type}`}
-            className={`flex whitespace-pre-wrap break-all px-2 ${rowClass}`}
+            className={`flex whitespace-pre-wrap break-all px-3 ${rowClass}`}
             data-old-line={line.oldLine ?? ''}
             data-new-line={line.newLine ?? ''}
           >
-            <span className="w-10 shrink-0 select-none text-right tabular-nums text-[#7B7B79]">{line.oldLine ?? ''}</span>
-            <span className="w-10 shrink-0 select-none text-right tabular-nums text-[#7B7B79]">{line.newLine ?? ''}</span>
+            <span className="w-7 shrink-0 select-none text-right tabular-nums text-[#7B7B79]">{line.oldLine ?? ''}</span>
+            <span className="w-7 shrink-0 select-none text-right tabular-nums text-[#7B7B79]">{line.newLine ?? ''}</span>
             <span className="w-4 shrink-0 select-none px-1 opacity-70">{prefix}</span>
             <span className="min-w-0 flex-1">{line.text || ' '}</span>
           </div>
@@ -221,7 +221,7 @@ export const ContentEditsTable = memo(function ContentEditsTable({
               <div className="flex items-center gap-2 px-3 py-1.5">
                 <button
                   type="button"
-                  className="shrink-0 text-(--dsw-label-3)"
+                  className="flex w-7 shrink-0 items-center justify-end text-(--dsw-label-3)"
                   aria-expanded={shown}
                   aria-label={shown ? `收起 ${contentEditLabel(file, visible)} 的 diff` : `查看 ${contentEditLabel(file, visible)} 的 diff`}
                   onClick={() => setDiffPath(shown ? null : file.path)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
展开 diff 后，旧行号和文件行左侧的展开按钮同一列：同一左右边距、同一列宽，数字和箭头都靠这一列的右缘对齐，不再往右缩进。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

