### PR TITLE
按新增文字起止光标整段高亮

### DIFF
--- a/packages/core-editor/src/web/content-jump.test.ts
+++ b/packages/core-editor/src/web/content-jump.test.ts
@@ -8,6 +8,7 @@ import {
   clearContentJump,
   consumeContentJump,
   peekContentJump,
+  posRangeForJump,
   rememberContentJump,
   snippetAtLine,
   stripMarkdownLine,
@@ -67,6 +68,26 @@ test('applyContentJump navigate still moves the caret when asked', () => {
   const editor = editorOf(md)
   applyContentJump(editor, md, { path: '/pages/home', start_line: 5, end_line: 5 }, { navigate: true })
   assert.match(textAtCaret(editor), /UNIQUE_NAV_ANCHOR/)
+  editor.destroy()
+})
+
+test('applyContentJump marks the whole added span, not the first 48 characters', () => {
+  const md = '# 欢迎\n\n这是第一段很长的正文需要整段高亮\n\n这是第二段同样要被标出来'
+  const editor = editorOf(md)
+  applyContentJump(editor, md, {
+    path: '/pages/home',
+    start_line: 1,
+    end_line: 5,
+    text: '欢迎\n这是第一段很长的正文需要整段高亮\n这是第二段同样要被标出来',
+  })
+  const marked = [...editor.view.dom.querySelectorAll('.page-agent-edit')].map((node) => node.textContent ?? '').join('')
+  assert.match(marked, /第一段很长的正文需要整段高亮/)
+  assert.match(marked, /第二段同样要被标出来/)
+  const range = posRangeForJump(editor.state.doc, md, { path: '/pages/home', start_line: 1, end_line: 5, text: '欢迎\n这是第一段很长的正文需要整段高亮\n这是第二段同样要被标出来' })
+  assert.ok(range)
+  const span = editor.state.doc.textBetween(range!.from, range!.to, '\n')
+  assert.match(span, /第一段/)
+  assert.match(span, /第二段/)
   editor.destroy()
 })
 

--- a/packages/core-editor/src/web/content-jump.ts
+++ b/packages/core-editor/src/web/content-jump.ts
@@ -99,47 +99,85 @@ export function snippetAtLine(markdown: string, line: number) {
 }
 
 export function posAtSnippet(doc: PmNode, snippet: string): number | null {
-  const needle = snippet.slice(0, Math.min(48, snippet.length))
-  if (!needle) return null
-  let found: number | null = null
+  const range = posRangeForOverlap(doc, snippet)
+  return range?.from ?? null
+}
+
+function flattenVisible(doc: PmNode) {
+  const chars: Array<{ ch: string; pos: number }> = []
   doc.descendants((node, pos) => {
-    if (found != null || !node.isText || !node.text) return
-    const idx = node.text.indexOf(needle)
-    if (idx >= 0) found = pos + idx
+    if (!node.isText || !node.text) return
+    for (let i = 0; i < node.text.length; i++) {
+      const ch = node.text[i]!
+      if (/\s/.test(ch)) continue
+      chars.push({ ch, pos: pos + i })
+    }
   })
-  return found
+  return chars
+}
+
+function compactNeedle(raw: string) {
+  return raw.replace(/\s+/g, '')
+}
+
+/** 新增字符串与编辑器可见文字的重叠：起点到终点之间整段高亮。 */
+export function posRangeForOverlap(doc: PmNode, added: string): { from: number; to: number } | null {
+  const needle = compactNeedle(added)
+  if (!needle) return null
+  const chars = flattenVisible(doc)
+  if (!chars.length) return null
+  const hay = chars.map((item) => item.ch).join('')
+  const exact = hay.indexOf(needle)
+  if (exact >= 0) {
+    const last = chars[exact + needle.length - 1]
+    const first = chars[exact]
+    if (!first || !last) return null
+    return { from: first.pos, to: last.pos + 1 }
+  }
+  const headLen = Math.min(32, needle.length)
+  const tailLen = Math.min(32, needle.length)
+  const headAt = hay.indexOf(needle.slice(0, headLen))
+  if (headAt < 0) return null
+  let tailAt = hay.lastIndexOf(needle.slice(-tailLen))
+  if (tailAt < headAt) tailAt = hay.indexOf(needle.slice(-tailLen), headAt)
+  const first = chars[headAt]
+  const last = chars[tailAt >= headAt ? tailAt + tailLen - 1 : headAt + headLen - 1]
+  if (!first || !last || last.pos < first.pos) return null
+  return { from: first.pos, to: last.pos + 1 }
+}
+
+function jumpNeedle(markdown: string, jump: ContentJump) {
+  if (jump.text?.trim()) return jump.text
+  const lines = markdown.split('\n')
+  const last = Math.max(lines.length, 1)
+  const a = Math.min(Math.max(1, jump.start_line), last) - 1
+  const b = Math.min(Math.max(a, (jump.end_line ?? jump.start_line) - 1), last - 1)
+  return lines
+    .slice(a, b + 1)
+    .map((line) => stripMarkdownLine(line))
+    .filter(Boolean)
+    .join('\n')
 }
 
 export function tryContentJump(editor: Editor, markdown: string, recordId: string, force = false) {
   if (!pending || editor.isDestroyed) return false
   if (!jumpMatchesRecord(pending, recordId)) return false
   if (!jumpHostOk(editor)) return false
-  const snippet = snippetAtLine(markdown, pending.start_line)
-  if (!force && snippet && posAtSnippet(editor.state.doc, snippet) == null) return false
+  const needle = jumpNeedle(markdown, pending)
+  if (!force && needle && posRangeForOverlap(editor.state.doc, needle) == null) return false
   applyContentJump(editor, markdown, pending, { navigate: pending.navigate === true })
   scheduleConsume()
   return true
 }
 
 export function posRangeForJump(doc: PmNode, markdown: string, jump: ContentJump): { from: number; to: number } | null {
+  const needle = jumpNeedle(markdown, jump)
+  const overlap = posRangeForOverlap(doc, needle)
+  if (overlap) return overlap
   const startSnippet = snippetAtLine(markdown, jump.start_line)
-  const endSnippet = snippetAtLine(markdown, jump.end_line ?? jump.start_line)
   const from = posAtSnippet(doc, startSnippet)
   if (from == null) return null
-  const endAt = posAtSnippet(doc, endSnippet)
-  const endLen = Math.max(1, Math.min(48, endSnippet.length || startSnippet.length || 1))
-  let to = endAt != null ? endAt + endLen : from + Math.max(1, Math.min(48, startSnippet.length || 1))
-  if (to <= from) to = from + Math.max(1, Math.min(48, startSnippet.length || 1))
-  try {
-    const $from = doc.resolve(Math.min(from, doc.content.size))
-    const $to = doc.resolve(Math.min(to, doc.content.size))
-    const start = $from.start(Math.max(1, $from.depth))
-    const end = $to.end(Math.max(1, $to.depth))
-    if (end > start) return { from: start, to: end }
-  } catch {
-    /* resolve */
-  }
-  return { from, to: Math.min(doc.content.size, to) }
+  return { from, to: Math.min(doc.content.size, from + Math.max(1, compactNeedle(startSnippet).length || 1)) }
 }
 
 /** Agent 写正文：只标改动，不 focus、不滚视口。navigate 仅给用户主动跳转。 */

--- a/packages/core-file-system/src/host/content-edit.test.ts
+++ b/packages/core-file-system/src/host/content-edit.test.ts
@@ -53,7 +53,7 @@ test('mutationLocus reports 1-based lines in the new text', () => {
   )
   assert.deepEqual(
     mutationLocus('replace_lines', before, 'one\ntwo\nC\nD', { start_line: 3, end_line: 4, new_str: 'C\nD' }),
-    { start_line: 3, end_line: 4, text: 'C' },
+    { start_line: 3, end_line: 4, text: 'C\nD' },
   )
   assert.deepEqual(mutationLocus('insert', before, 'one\nmid\ntwo\nthree\nfour', { insert_line: 1, new_str: 'mid' }), {
     start_line: 2,
@@ -65,5 +65,10 @@ test('mutationLocus reports 1-based lines in the new text', () => {
     start_line: 3,
     end_line: 3,
     text: 'THREE',
+  })
+  assert.deepEqual(mutationLocus('write', '', '# 标题\n\n第一段全文\n\n第二段也在', { value: '# 标题\n\n第一段全文\n\n第二段也在' }), {
+    start_line: 1,
+    end_line: 5,
+    text: '标题\n第一段全文\n第二段也在',
   })
 })

--- a/packages/core-file-system/src/host/content-edit.ts
+++ b/packages/core-file-system/src/host/content-edit.ts
@@ -70,12 +70,24 @@ function stripJumpLine(line: string) {
 
 export function withJumpText(next: string, locus: ContentLocus): ContentLocus {
   const lines = next.split('\n')
-  const i = Math.min(Math.max(1, locus.start_line), Math.max(lines.length, 1)) - 1
-  for (let k = i; k < lines.length; k++) {
-    const text = stripJumpLine(lines[k] ?? '')
-    if (text) return { ...locus, text }
-  }
-  return locus
+  const last = Math.max(lines.length, 1)
+  const a = Math.min(Math.max(1, locus.start_line), last) - 1
+  const b = Math.min(Math.max(a, (locus.end_line ?? locus.start_line) - 1), last - 1)
+  const text = lines
+    .slice(a, b + 1)
+    .map((line) => stripJumpLine(line))
+    .filter(Boolean)
+    .join('\n')
+  return { ...locus, ...(text ? { text } : {}) }
+}
+
+export function changedOffsets(before: string, after: string) {
+  let i = 0
+  const min = Math.min(before.length, after.length)
+  while (i < min && before[i] === after[i]) i += 1
+  let j = 0
+  while (j < min - i && before[before.length - 1 - j] === after[after.length - 1 - j]) j += 1
+  return { start: i, end: after.length - j }
 }
 
 export function locusFromRange(text: string, start: number, end: number): ContentLocus {
@@ -114,13 +126,8 @@ export function mutationLocus(
     return withJumpText(next, { start_line, end_line: start_line + added.split('\n').length - 1 })
   }
   if (command === 'write') {
-    const a = before.split('\n')
-    const b = next.split('\n')
-    const n = Math.max(a.length, b.length, 1)
-    for (let i = 0; i < n; i++) {
-      if ((a[i] ?? '') !== (b[i] ?? '')) return withJumpText(next, { start_line: i + 1, end_line: i + 1 })
-    }
-    return withJumpText(next, { start_line: 1, end_line: 1 })
+    const { start, end } = changedOffsets(before, next)
+    return locusFromRange(next, start, end)
   }
   return null
 }

--- a/packages/core-file-system/src/host/index.ts
+++ b/packages/core-file-system/src/host/index.ts
@@ -1141,7 +1141,7 @@ export class DatabaseService extends Service implements Database {
       field: current.field,
       command,
       ok: true as const,
-      ...(locus ? { start_line: locus.start_line, end_line: locus.end_line } : {}),
+      ...(locus ? { start_line: locus.start_line, end_line: locus.end_line, ...(locus.text ? { text: locus.text } : {}) } : {}),
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
以前高亮只拿改动第一行的前 48 个字，整篇写入时只会粉前面一小截。

现在写入会算出新增片段在 markdown 里的起止行；TipTap 里把这段可见文字和正文做重叠匹配，用第一个命中字符到最后一个命中字符作为光标区间，中间全部标上。整段对不上时，用开头/结尾各一小段定位，仍然涂满中间。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

