### PR TITLE
点文件跳转也套上改动高亮

### DIFF
--- a/packages/core-chat/src/web/content-edits-table.test.tsx
+++ b/packages/core-chat/src/web/content-edits-table.test.tsx
@@ -4,6 +4,7 @@ import { CONTENT_JUMP_EVENT } from '@biu/type-file-system'
 import { ChatNodeList } from './thread.tsx'
 import {
   INSPECTOR_REVEAL_EVENT,
+  addedJumpFromSnapshot,
   compactEqualLines,
   contentEditLabel,
   numberDiffLines,
@@ -43,6 +44,16 @@ describe('contentEditLabel', () => {
       '你好 · p4',
       '你好 · p5',
     ])
+  })
+})
+
+describe('addedJumpFromSnapshot', () => {
+  it('covers the whole added markdown, not the first line only', () => {
+    expect(addedJumpFromSnapshot('', '# 标题\n\n第一段\n\n第二段')).toEqual({
+      start_line: 1,
+      end_line: 5,
+      text: '# 标题\n\n第一段\n\n第二段',
+    })
   })
 })
 
@@ -110,10 +121,19 @@ describe('ContentEditsTable', () => {
     expect(screen.getAllByText('−3').length).toBeGreaterThan(0)
   })
 
-  it('lists all five 你好 pages as separate rows and reveals the clicked one in the inspector', () => {
+  it('lists all five 你好 pages as separate rows and reveals the clicked one in the inspector', async () => {
     const seen: unknown[] = []
+    const jumps: unknown[] = []
     const onReveal = (event: Event) => seen.push((event as CustomEvent).detail)
+    const onJump = (event: Event) => jumps.push((event as CustomEvent).detail)
     window.addEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
+    window.addEventListener(CONTENT_JUMP_EVENT, onJump)
+    vi.stubGlobal('fetch', async (input: RequestInfo | URL) => {
+      if (String(input).includes('/api/content-turns/file')) {
+        return { ok: true, json: async () => ({ before: '', after: '你好\n' }) }
+      }
+      return { ok: true, json: async () => ({}) }
+    })
     const href = window.location.href
     const nodes: ChatNode[] = [
       { id: 'u-1', kind: 'user', text: '五页都写你好' },
@@ -134,7 +154,13 @@ describe('ContentEditsTable', () => {
     fireEvent.click(screen.getByText('你好 · p4'))
     expect(window.location.href).toBe(href)
     expect(seen).toEqual([{ collection: '/pages', recordId: 'p4', unique: true }])
+    await waitFor(() =>
+      expect(jumps).toEqual([
+        { path: '/pages/p4', start_line: 1, end_line: 1, navigate: true, text: '你好\n' },
+      ]),
+    )
     window.removeEventListener(INSPECTOR_REVEAL_EVENT, onReveal)
+    window.removeEventListener(CONTENT_JUMP_EVENT, onJump)
   })
 
   it('loads a file diff from content-turns when the row chevron is opened', async () => {

--- a/packages/core-chat/src/web/content-edits-table.tsx
+++ b/packages/core-chat/src/web/content-edits-table.tsx
@@ -29,8 +29,32 @@ export function contentEditLabel(file: ContentEditRow, files: ContentEditRow[]) 
   return id ? `${title} · ${id}` : title
 }
 
+function lineAtOffset(text: string, offset: number) {
+  if (offset <= 0) return 1
+  return text.slice(0, offset).split('\n').length
+}
+
+export function addedJumpFromSnapshot(before: string, after: string) {
+  let i = 0
+  const min = Math.min(before.length, after.length)
+  while (i < min && before[i] === after[i]) i += 1
+  let j = 0
+  while (j < min - i && before[before.length - 1 - j] === after[after.length - 1 - j]) j += 1
+  const slice = after.slice(i, after.length - j)
+  const end = Math.max(i, after.length - j)
+  return {
+    start_line: lineAtOffset(after, i),
+    end_line: lineAtOffset(after, end > i ? end - 1 : i),
+    ...(slice.trim() ? { text: slice } : {}),
+  }
+}
+
 /** 右侧检查器打开记录并跳到改动行；不改中间主界面、不关聊天。 */
-export function revealContentEdit(path: string, jumpLine: number) {
+export function revealContentEdit(
+  path: string,
+  jumpLine: number,
+  scope?: { sessionId?: string; turn?: number },
+) {
   const parts = recordParts(path)
   if (parts) {
     window.dispatchEvent(
@@ -39,11 +63,36 @@ export function revealContentEdit(path: string, jumpLine: number) {
       }),
     )
   }
-  window.dispatchEvent(
-    new CustomEvent(CONTENT_JUMP_EVENT, {
-      detail: { path, start_line: jumpLine, end_line: jumpLine, navigate: true },
-    }),
-  )
+  const fire = (extra?: { start_line?: number; end_line?: number; text?: string }) => {
+    window.dispatchEvent(
+      new CustomEvent(CONTENT_JUMP_EVENT, {
+        detail: {
+          path,
+          start_line: extra?.start_line ?? jumpLine,
+          end_line: extra?.end_line ?? extra?.start_line ?? jumpLine,
+          navigate: true,
+          ...(extra?.text ? { text: extra.text } : {}),
+        },
+      }),
+    )
+  }
+  const sessionId = scope?.sessionId?.trim()
+  const turn = scope?.turn
+  if (!sessionId || turn == null) {
+    fire()
+    return
+  }
+  const qs = new URLSearchParams({ session: sessionId, turn: String(turn), path })
+  void fetch(`/api/content-turns/file?${qs}`)
+    .then(async (res) => {
+      if (!res.ok) {
+        fire()
+        return
+      }
+      const body = (await res.json()) as { before?: string; after?: string }
+      fire(addedJumpFromSnapshot(body.before ?? '', body.after ?? ''))
+    })
+    .catch(() => fire())
 }
 
 export type NumberedDiffLine = DiffLine & { oldLine?: number; newLine?: number }
@@ -231,21 +280,21 @@ export const ContentEditsTable = memo(function ContentEditsTable({
                   type="button"
                   className="min-w-0 flex-1 truncate text-left text-[12px] font-semibold text-(--dsw-label) hover:underline"
                   title={file.path}
-                  onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  onClick={() => revealContentEdit(file.path, file.jump_line, { sessionId, turn })}
                 >
                   {contentEditLabel(file, visible)}
                 </button>
                 <button
                   type="button"
                   className="text-[12px] font-semibold tabular-nums text-[#448361] hover:underline"
-                  onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  onClick={() => revealContentEdit(file.path, file.jump_line, { sessionId, turn })}
                 >
                   +{file.added}
                 </button>
                 <button
                   type="button"
                   className="text-[12px] font-semibold tabular-nums text-[#c4554d] hover:underline"
-                  onClick={() => revealContentEdit(file.path, file.jump_line)}
+                  onClick={() => revealContentEdit(file.path, file.jump_line, { sessionId, turn })}
                 >
                   −{file.removed}
                 </button>

--- a/packages/core-editor/src/web/content-jump.test.ts
+++ b/packages/core-editor/src/web/content-jump.test.ts
@@ -68,6 +68,7 @@ test('applyContentJump navigate still moves the caret when asked', () => {
   const editor = editorOf(md)
   applyContentJump(editor, md, { path: '/pages/home', start_line: 5, end_line: 5 }, { navigate: true })
   assert.match(textAtCaret(editor), /UNIQUE_NAV_ANCHOR/)
+  assert.match(editor.view.dom.innerHTML, /page-agent-edit/)
   editor.destroy()
 })
 

--- a/packages/core-editor/src/web/content-jump.ts
+++ b/packages/core-editor/src/web/content-jump.ts
@@ -60,16 +60,16 @@ function jumpHostOk(editor: Editor) {
   return editorHostIsLive(editor)
 }
 
-function scheduleConsume() {
+function scheduleConsume(ms = 0) {
   if (typeof window === 'undefined') {
     pending = null
     return
   }
-  if (consumeTimer) return
+  if (consumeTimer) window.clearTimeout(consumeTimer)
   consumeTimer = window.setTimeout(() => {
     consumeTimer = 0
     pending = null
-  }, 0)
+  }, ms)
 }
 
 export function stripMarkdownLine(line: string) {
@@ -166,7 +166,7 @@ export function tryContentJump(editor: Editor, markdown: string, recordId: strin
   const needle = jumpNeedle(markdown, pending)
   if (!force && needle && posRangeForOverlap(editor.state.doc, needle) == null) return false
   applyContentJump(editor, markdown, pending, { navigate: pending.navigate === true })
-  scheduleConsume()
+  scheduleConsume(pending.navigate ? 400 : 0)
   return true
 }
 
@@ -202,6 +202,7 @@ export function applyContentJump(
     /* jsdom 没有 layout */
   }
   scrollCaret(editor, pos)
+  applyAgentEditMark(editor, range)
 }
 
 function scrollCaret(editor: Editor, pos: number) {

--- a/packages/core-editor/src/web/page-editor.tsx
+++ b/packages/core-editor/src/web/page-editor.tsx
@@ -40,10 +40,12 @@ export function recentlyLocalEdit(typedAt: number, now = Date.now()) {
 }
 
 function jumpToPending(editor: Editor, markdown: string, recordId: string, force = false) {
-  requestAnimationFrame(() => {
+  const run = () => {
     if (editor.isDestroyed) return
     tryContentJump(editor, markdown, recordId, force)
-  })
+  }
+  run()
+  requestAnimationFrame(run)
 }
 
 function asMarkdown(value: unknown) {
@@ -495,7 +497,7 @@ export function PageEditor({ record, value, writable, onChange, path }: FsConten
     if (!editor || editor.isDestroyed) return
     const onJump = () => {
       if (editor.isDestroyed) return
-      jumpToPending(editor, asMarkdown(value), record.id)
+      jumpToPending(editor, asMarkdown(value), record.id, true)
     }
     window.addEventListener(CONTENT_JUMP_EVENT, onJump)
     return () => window.removeEventListener(CONTENT_JUMP_EVENT, onJump)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在「数据改动」里点文件跳进检查器时，用这次新增片段定位 TipTap 起止光标，落地后同样加上红字红底。跳转后再标一次，避免 focus/打开面板把高亮冲掉。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

