### PR TITLE
同一记录叶节点检查器去重

### DIFF
--- a/packages/core-file-system/src/web/inspector-database.tsx
+++ b/packages/core-file-system/src/web/inspector-database.tsx
@@ -113,6 +113,7 @@ function useBindInspectorDbPath(paneId: string, tables: CollectionInfo[], seedCo
     const fallback = defaultInspectorDbPath(tables, seedCollection)
     if (fallback) setInspectorDbPath(paneId, fallback)
   }, [inspectorPath, paneId, seedCollection, tables])
+  if (isInspectorPaneAbandoned(paneId)) return inspectorPath
   return inspectorPath || defaultInspectorDbPath(tables, seedCollection)
 }
 

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -182,6 +182,43 @@ test('inspectorPageKey ignores view query', () => {
   assert.equal(inspectorPageKey('/database/pages/record/p1?view=all'), '/database/pages/record/p1')
 })
 
+test('inspectorPageKey treats the same record leaf as one page even with a view in the path', () => {
+  assert.equal(
+    inspectorPageKey('/database/pages/view/all/record/p1'),
+    inspectorPageKey('/database/pages/record/p1'),
+  )
+})
+
+test('opening the same record leaf with a view path focuses the existing pane', () => {
+  const tabs: string[] = []
+  const onTab = (event: Event) => {
+    const detail = (event as CustomEvent).detail
+    if (typeof detail === 'string') tabs.push(detail)
+  }
+  window.addEventListener('biu:inspector-tab', onTab)
+  setInspectorDbPath('database:/pages', '/database/pages/record/p1')
+  showInInspector('/pages', '/database/pages/view/all/record/p1', { unique: true })
+  assert.equal(Object.keys(snapshotInspectorDbPaths()).length, 1)
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/view/all/record/p1')
+  assert.deepEqual(tabs, ['database:/pages'])
+  window.removeEventListener('biu:inspector-tab', onTab)
+})
+
+test('duplicate panes for the same record leaf collapse and keep the canonical tab', () => {
+  const tabs: string[] = []
+  const onTab = (event: Event) => {
+    const detail = (event as CustomEvent).detail
+    if (typeof detail === 'string') tabs.push(detail)
+  }
+  window.addEventListener('biu:inspector-tab', onTab)
+  setInspectorDbPath('database:/pages', '/database/pages/record/p1')
+  showInInspector('/pages', '/database/pages/record/p1', { unique: true })
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p1')
+  assert.equal(Object.keys(snapshotInspectorDbPaths()).filter((id) => id.startsWith('database:/pages')).length, 1)
+  assert.equal(tabs.at(-1), 'database:/pages')
+  window.removeEventListener('biu:inspector-tab', onTab)
+})
+
 test('unique inspector reveal focuses the same page and opens a new pane for a different page', () => {
   setInspectorDbPath('database:/notes', '/database/notes/record/n1')
   showInInspector('/notes', '/database/notes/record/n1?view=all', { unique: true })

--- a/packages/core-file-system/src/web/inspector-db-route.test.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, test } from 'vitest'
 import assert from 'node:assert/strict'
-import { databaseAllViewPath } from './database-path.ts'
+import { databaseAllViewPath, databaseRecordPath } from './database-path.ts'
 import {
   getInspectorDbPath,
   isInspectorDatabasePath,
@@ -100,13 +100,19 @@ test('showRecordInInspector focuses an already-open pane for the same page', () 
   assert.equal(getInspectorDbPath('database:/pages'), '')
 })
 
-test('showRecordInInspector opens a new pane when the collection view is already open', () => {
-  setInspectorDbPath('database:/pages', '/database/pages')
+test('showRecordInInspector reuses the collection pane instead of opening a second copy of the page', () => {
+  setInspectorDbPath('database:/pages', databaseAllViewPath('/pages'))
   showRecordInInspector('/pages', 'p-new')
-  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages')
+  assert.equal(getInspectorDbPath('database:/pages'), '/database/pages/record/p-new')
   const extra = Object.keys(snapshotInspectorDbPaths()).filter((id) => id.startsWith('database:/pages::'))
-  assert.equal(extra.length, 1)
-  assert.equal(getInspectorDbPath(extra[0]!), '/database/pages/record/p-new')
+  assert.equal(extra.length, 0)
+})
+
+test('opening a page from the all-pages list then navigating that pane still keeps one tab', () => {
+  setInspectorDbPath('database:/pages', databaseAllViewPath('/pages'))
+  showRecordInInspector('/pages', 'same-page')
+  setInspectorDbPath('database:/pages', databaseRecordPath('/pages', 'same-page', 'builtin-all:/pages'))
+  assert.equal(Object.keys(snapshotInspectorDbPaths()).filter((id) => id.startsWith('database:/pages')).length, 1)
 })
 
 test('showRecordInInspector opens the inspector on this record', async () => {

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -318,6 +318,14 @@ export function showInInspector(collection: string, href: string, opts?: { uniqu
   const paneIds = paneIdsForTab(tabId)
   if (unique) {
     const live = paneIds.filter((id) => getInspectorDbPath(id))
+    // 从「全部页面」这类列表栏打开同一条记录时，把这一栏切过去，不要再开一栏同页。
+    if (inspectorPathIsRecord(href)) {
+      const listPane = live.find((id) => !inspectorPathIsRecord(getInspectorDbPath(id)))
+      if (listPane) {
+        revealInspectorPane(listPane, href)
+        return
+      }
+    }
     const target = live.length ? nextInspectorPaneId(tabId) : tabId
     revealInspectorPane(target, href)
     return

--- a/packages/core-file-system/src/web/inspector-db-route.ts
+++ b/packages/core-file-system/src/web/inspector-db-route.ts
@@ -1,8 +1,9 @@
 /** 检查器里每个数据库 Tab 有自己的路径，不改中间主界面。 */
 
 import { CONTENT_JUMP_EVENT, parseContentJump } from '@biu/type-file-system'
+import { parseAppPath } from '@biu/web-session-view'
 import { normalizeCollectionPath } from '../paths.ts'
-import { DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath, databaseViewPath } from './database-path.ts'
+import { DATA_MODULE, DATA_MODULE_PATH, databaseAllViewPath, databaseRecordPath, databaseViewPath } from './database-path.ts'
 import { upsertSavedView, savedViewFromRecord } from './view-storage.ts'
 import { type SavedView } from './saved-view.ts'
 
@@ -200,9 +201,14 @@ export function inspectorCollectionTabId(collection: string) {
   return `database:${collection}`
 }
 
-/** 同一数据页：路径不含 query。 */
+/** 同一数据页：记录叶节点忽略视图段和 query。 */
 export function inspectorPageKey(href: string) {
-  return String(href || '').split('?')[0]
+  const path = String(href || '').split('?')[0]
+  const parsed = parseAppPath(path, [DATA_MODULE])
+  if (parsed.kind === 'record' && parsed.recordId) {
+    return `${DATA_MODULE_PATH}${normalizeCollectionPath(parsed.collection)}/record/${parsed.recordId}`
+  }
+  return path
 }
 
 function paneWithHref(tabId: string, href: string) {
@@ -283,8 +289,9 @@ export function reuseInspectorOfferPane(tabId: string, opened: string[]) {
 
 function revealInspectorPane(paneId: string, href: string) {
   setInspectorDbPath(paneId, href)
+  const live = paneWithPageKey(href) ?? paneId
   window.dispatchEvent(new Event('biu:inspector-open'))
-  window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: paneId }))
+  window.dispatchEvent(new CustomEvent('biu:inspector-tab', { detail: live }))
 }
 
 function nextInspectorPaneId(tabId: string) {

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -264,7 +264,7 @@ export const SessionInspector = memo(function SessionInspector({
       if (!next) return
       const allowed = allowedTabs.includes(next) || allowedTabs.includes(slotTabId(next))
       if (!allowed) return
-      if (isInspectorPaneAbandoned(next) && !getInspectorDbPath(next)) return
+      if (isInspectorPaneAbandoned(next)) return
       persistOpened(opened.includes(next) ? opened : [...opened, next])
       setTab(next)
     }

--- a/packages/web-app-shell/src/web/session-inspector.tsx
+++ b/packages/web-app-shell/src/web/session-inspector.tsx
@@ -30,6 +30,8 @@ import { inspectorPanelMatches, inspectorViewProps, nextRepeatableTabId, pruneOp
 import { HeadlessDismiss } from '@biu/public-ui'
 import { SidebarMascot, resolveSessionMascot } from '@biu/public-mascot'
 import {
+  getInspectorDbPath,
+  isInspectorPaneAbandoned,
   restoreInspectorDbPaths,
   reuseInspectorOfferPane,
   snapshotInspectorDbPaths,
@@ -262,6 +264,7 @@ export const SessionInspector = memo(function SessionInspector({
       if (!next) return
       const allowed = allowedTabs.includes(next) || allowedTabs.includes(slotTabId(next))
       if (!allowed) return
+      if (isInspectorPaneAbandoned(next) && !getInspectorDbPath(next)) return
       persistOpened(opened.includes(next) ? opened : [...opened, next])
       setTab(next)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
同一条记录（叶节点）在检查器里只留一栏。`/record/id` 和带视图的 `/view/.../record/id` 视为同一页；合并后切到留下的那栏，不再把刚关掉的重复栏加回去。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

