### PR TITLE
Fix duplicate page-block ids after paste

### DIFF
--- a/packages/core-editor/src/host/index.ts
+++ b/packages/core-editor/src/host/index.ts
@@ -4,11 +4,14 @@ export const name = 'core-editor'
 export const inject: string[] = []
 
 export {
+  createPageBlockId,
+  isPageBlockId,
   listPageBlockFences,
   pageBlockData,
   pageBlockRecordId,
   parsePageBlockRecordId,
   patchPageBlockMarkdown,
+  uniquifyPageBlockMarkdown,
 } from '../page-block-fence.ts'
 export type { PageBlockAttrsPatch, PageBlockFence } from '../page-block-fence.ts'
 

--- a/packages/core-editor/src/page-block-fence.test.ts
+++ b/packages/core-editor/src/page-block-fence.test.ts
@@ -6,6 +6,7 @@ import {
   pageBlockRecordId,
   parsePageBlockRecordId,
   patchPageBlockMarkdown,
+  uniquifyPageBlockMarkdown,
 } from './page-block-fence.ts'
 
 const doc = `前言
@@ -70,6 +71,25 @@ test('html fence with inline styles still yields the poster html', () => {
   assert.equal(fences[0]?.kind, 'html')
   assert.match(String(pageBlockData(fences[0]!).html), /番附/)
   assert.match(String(pageBlockData(fences[0]!).html), /height:100%/)
+})
+
+test('uniquifyPageBlockMarkdown keeps the first id and rewrites duplicates', () => {
+  const dup = `:::pageBlock {kind=html plugin=page-html-blocks id=ab12cd34}
+<div>a</div>
+:::
+
+:::pageBlock {kind=html plugin=page-html-blocks id=ab12cd34}
+<div>b</div>
+:::
+`
+  const next = uniquifyPageBlockMarkdown(dup)
+  assert.equal(next.changed, true)
+  const ids = listPageBlockFences(next.markdown).map((item) => item.id)
+  assert.equal(ids.length, 2)
+  assert.equal(ids[0], 'ab12cd34')
+  assert.notEqual(ids[1], ids[0])
+  assert.match(ids[1]!, /^[a-z0-9]{8}$/i)
+  assert.equal(uniquifyPageBlockMarkdown(next.markdown).changed, false)
 })
 
 test('pageBlock record id is page::block', () => {

--- a/packages/core-editor/src/page-block-fence.ts
+++ b/packages/core-editor/src/page-block-fence.ts
@@ -20,6 +20,14 @@ export type PageBlockAttrsPatch = {
   replace?: boolean
 }
 
+export function createPageBlockId() {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
+}
+
+export function isPageBlockId(raw: unknown) {
+  return typeof raw === 'string' && /^[a-z0-9]{6,32}$/i.test(raw.trim())
+}
+
 export function pageBlockRecordId(pageId: string, blockId: string) {
   return `${pageId}::${blockId}`
 }
@@ -56,6 +64,34 @@ export function listPageBlockFences(markdown: string): PageBlockFence[] {
 
 export function pageBlockData(fence: PageBlockFence) {
   return parsePageBlockData(fence.kind, fence.body, fence.extras)
+}
+
+/** 同一页里缺 id / 坏 id / 重复 id 的围栏各换一个；重启索引也走这里。 */
+export function uniquifyPageBlockMarkdown(markdown: string) {
+  const fences = listPageBlockFences(markdown)
+  const seen = new Set<string>()
+  const replacements: { start: number; end: number; next: string }[] = []
+  for (const fence of fences) {
+    const current = isPageBlockId(fence.id) ? fence.id.trim() : ''
+    if (current && !seen.has(current)) {
+      seen.add(current)
+      continue
+    }
+    let next = createPageBlockId()
+    while (seen.has(next)) next = createPageBlockId()
+    seen.add(next)
+    replacements.push({
+      start: fence.start,
+      end: fence.end,
+      next: formatPageBlockFence(fence.kind, fence.plugin, pageBlockData(fence), next),
+    })
+  }
+  if (!replacements.length) return { markdown, changed: false }
+  let out = markdown
+  for (const item of replacements.slice().sort((a, b) => b.start - a.start)) {
+    out = `${out.slice(0, item.start)}${item.next}${out.slice(item.end)}`
+  }
+  return { markdown: out, changed: true }
 }
 
 export function patchPageBlockMarkdown(markdown: string, id: string, patch: PageBlockAttrsPatch): string {

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -248,7 +248,7 @@ test('copied pageBlocks do not share an id', () => {
   editor.destroy()
 })
 
-test('duplicate ids are not rewritten until the whole document is replaced', () => {
+test('pasted pageBlocks with the same id are rewritten immediately', () => {
   const editor = new Editor({
     extensions: pageEditorExtensions(),
     content: {
@@ -263,14 +263,10 @@ test('duplicate ids are not rewritten until the whole document is replaced', () 
   const live = (editor.getJSON().content ?? [])
     .filter((node) => node.type === 'pageBlock')
     .map((node) => String(node.attrs?.id ?? ''))
-  assert.deepEqual(live, ['ab12cd34', 'ab12cd34'])
-  editor.commands.setContent(editor.getMarkdown(), { contentType: 'markdown', emitUpdate: false })
-  const calibrated = (editor.getJSON().content ?? [])
-    .filter((node) => node.type === 'pageBlock')
-    .map((node) => String(node.attrs?.id ?? ''))
-  assert.equal(calibrated[0], 'ab12cd34')
-  assert.notEqual(calibrated[1], calibrated[0])
-  assert.match(calibrated[1]!, /^[a-z0-9]{8}$/i)
+  assert.equal(live.length, 2)
+  assert.equal(live[0], 'ab12cd34')
+  assert.notEqual(live[1], live[0])
+  assert.match(live[1]!, /^[a-z0-9]{8}$/i)
   editor.destroy()
 })
 

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -2,10 +2,12 @@ import { mergeAttributes, Node } from '@tiptap/core'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state'
 import type { Node as PmNode } from '@tiptap/pm/model'
-import { ReplaceStep } from '@tiptap/pm/transform'
 import { PageBlockView } from './page-block-view.tsx'
 import { getPageEditor } from './service.ts'
 import { formatPageBlockFence, parsePageBlockData, parsePageBlockMeta } from './page-block-meta.ts'
+import { createPageBlockId, isPageBlockId } from '../page-block-fence.ts'
+
+export { createPageBlockId, isPageBlockId }
 
 const metaKey = new PluginKey('page-block-meta')
 const uniqueFilesKey = new PluginKey('page-block-unique-files')
@@ -42,29 +44,15 @@ export function duplicateAssetPath(file: string) {
   return `assets/${stem}-copy-${id}${ext}`
 }
 
-export function createPageBlockId() {
-  return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
-}
-
-export function isPageBlockId(raw: unknown) {
-  return typeof raw === 'string' && /^[a-z0-9]{6,32}$/i.test(raw.trim())
-}
-
 function nodePageBlockId(node: PmNode) {
   return isPageBlockId(node.attrs.id) ? String(node.attrs.id).trim() : ''
 }
 
-/** 整篇换文档（打开、离开源码、setContent）时再扫；日常编辑不跟。 */
-function shouldAssignPageBlockIds(transactions: readonly Transaction[], oldDoc: PmNode) {
-  return transactions.some((item) => {
-    if (item.getMeta(assignIdsKey)) return true
-    if (!item.docChanged) return false
-    const size = oldDoc.content.size
-    return item.steps.some((step) => step instanceof ReplaceStep && step.from === 0 && step.to === size)
-  })
+function shouldAssignPageBlockIds(transactions: readonly Transaction[]) {
+  return transactions.some((item) => item.docChanged || item.getMeta(assignIdsKey))
 }
 
-/** 打开旧文档、源码贴完切回、agent 整篇写入时：缺 id / 坏 id / 重复 id 各补一次。 */
+/** 粘贴、插入、整篇写入：缺 id / 坏 id / 重复 id 立刻各补一次。 */
 export function assignPageBlockIds(state: EditorState): Transaction | null {
   const seen = new Set<string>()
   const patch: { pos: number; node: PmNode }[] = []
@@ -232,8 +220,8 @@ export const pageBlock = Node.create({
       }),
       new Plugin({
         key: assignIdsKey,
-        appendTransaction(transactions, oldState, state) {
-          if (!shouldAssignPageBlockIds(transactions, oldState.doc)) return null
+        appendTransaction(transactions, _oldState, state) {
+          if (!shouldAssignPageBlockIds(transactions)) return null
           return assignPageBlockIds(state)
         },
       }),

--- a/packages/core-page/src/host/index.test.ts
+++ b/packages/core-page/src/host/index.test.ts
@@ -188,6 +188,27 @@ test('clearing the last pageBlock fence drops the index row immediately', async 
   assert.equal((await index.list()).length, 0)
 })
 
+test('reindex rewrites duplicate pageBlock ids instead of crashing', async () => {
+  const ctx = new Context()
+  await ctx.plugin(tools)
+  const root = await mkdtemp(join(tmpdir(), 'page-block-dup-'))
+  await ctx.plugin(fsPlugin, { root })
+  const store = new PagesStore(ctx.fs.workspace as never, join(root, '.biu/assets'))
+  const index = new PageBlocksIndex(store, { hotWindowMs: 60_000, hotLimit: 8, warmLimit: 8 })
+  const fence = (id: string, body: string) => `:::pageBlock {kind=html plugin=page-html-blocks id=${id}}\n<div>${body}</div>\n:::\n`
+  const created = await store.create({ title: '粘贴崩了', notes: fence('ab12cd34', 'a') + fence('ab12cd34', 'b') })
+  await index.reindexPage(created)
+  const listed = await index.list()
+  assert.equal(listed.length, 2)
+  const ids = listed.map((row) => String(row.blockId)).sort()
+  assert.equal(new Set(ids).size, 2)
+  assert.equal(ids.includes('ab12cd34'), true)
+  const md = await readFile(join(root, `.page/${created.id}.md`), 'utf8')
+  const fences = md.match(/id=([a-z0-9]+)/gi) ?? []
+  assert.equal(fences.length, 2)
+  assert.notEqual(fences[0], fences[1])
+})
+
 test('page-block index scans a hot batch instead of every page', async () => {
   const ctx = new Context()
   await ctx.plugin(tools)

--- a/packages/core-page/src/host/page-blocks-index.ts
+++ b/packages/core-page/src/host/page-blocks-index.ts
@@ -1,6 +1,6 @@
 import type { DbRecord } from '@biu/type-file-system'
 import { recordBuiltinValues } from '@biu/type-file-system'
-import { listPageBlockFences, pageBlockData, pageBlockRecordId, parsePageBlockRecordId } from '@biu/core-editor/host'
+import { listPageBlockFences, pageBlockData, pageBlockRecordId, parsePageBlockRecordId, uniquifyPageBlockMarkdown } from '@biu/core-editor/host'
 import type { PagesStore, PageRow } from './store.ts'
 
 export const PAGE_BLOCK_HOT_WINDOW_MS = 5 * 60 * 1000
@@ -111,32 +111,37 @@ export class PageBlocksIndex {
   }
 
   async reindexPage(page: PageRow) {
+    const unique = uniquifyPageBlockMarkdown(page.notes)
+    const row = unique.changed ? await this.store.update(page.id, { notes: unique.markdown }) : page
     const db = await this.db()
-    const fences = listPageBlockFences(page.notes).filter((item) => item.id)
+    const fences = listPageBlockFences(row.notes).filter((item) => item.id)
     db.exec('BEGIN')
     try {
-      db.prepare('DELETE FROM page_block_index WHERE page_id = ?').run(page.id)
+      db.prepare('DELETE FROM page_block_index WHERE page_id = ?').run(row.id)
       const insert = db.prepare(`
         INSERT INTO page_block_index(
           page_id, block_id, kind, plugin, title, data_json, page_created_at, page_updated_at
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       `)
+      const seen = new Set<string>()
       for (const fence of fences) {
+        if (seen.has(fence.id)) continue
+        seen.add(fence.id)
         const data = pageBlockData(fence)
         insert.run(
-          page.id,
+          row.id,
           fence.id,
           fence.kind,
           fence.plugin,
           blockTitle(fence.kind, data),
           JSON.stringify(data),
-          page.createdAt,
-          page.updatedAt,
+          row.createdAt,
+          row.updatedAt,
         )
       }
       db.prepare(
         'INSERT INTO page_block_cover(page_id, page_updated_at) VALUES(?, ?) ON CONFLICT(page_id) DO UPDATE SET page_updated_at=excluded.page_updated_at',
-      ).run(page.id, page.updatedAt)
+      ).run(row.id, row.updatedAt)
       db.exec('COMMIT')
     } catch (error) {
       db.exec('ROLLBACK')
@@ -171,7 +176,12 @@ export class PageBlocksIndex {
     const batch = [...takeHot, ...warm]
     for (const slim of batch) {
       const page = await this.store.get(slim.id)
-      if (page) await this.reindexPage(page)
+      if (!page) continue
+      try {
+        await this.reindexPage(page)
+      } catch {
+        /* 单页索引失败不拖垮 host */
+      }
     }
     await this.writeMeta('last_run_at', String(now))
     await this.writeMeta('last_batch', String(batch.length))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
详情页里全选复制粘贴会带上插件块原来的 id，同一页出现重复 `block_id`。索引写入 `page_block_index` 时撞 UNIQUE，host 直接崩掉。

改动：
- 编辑器每次文档变更都给缺 id / 重复 id 的 pageBlock 换新 id（粘贴立刻生效）
- 重启/reindex 时把正文里的重复 id 改写进 markdown 再入库；单页失败不再拖垮进程
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

