### PR TITLE
Page terminal uses the real host shell

### DIFF
--- a/.plugin-dev/page-terminal/README.md
+++ b/.plugin-dev/page-terminal/README.md
@@ -1,31 +1,32 @@
 # 终端（page-terminal）
 
-在页面里用 `/` 插入一个 **终端卡片**：像真终端一样输入命令、看输出，右上角可以**全屏放大**（Esc 退出）。无头插件，不占运行窗口。
+在页面里用 `/` 插入一个 **终端卡片**：输入命令、看宿主回传的输出，右上角可以**全屏放大**（Esc 退出）。无头插件，不占运行窗口。
 
-> 这是**本地演示终端**：命令表在 `shell.ts` 里，纯前端模拟（ls / cat / tree / echo / date / neofetch / open / help / demo / clear），**不会**执行宿主真 shell。要接真 shell 请改成 host 侧服务。
+这是 **工作区真 shell**：回车后走 host `POST /api/page-terminal/run`，和 agent 的 `bash` 工具同一套 `ctx.shell`（工作区 `/bin/sh -c`，超时约 15 秒）。`node -v`、`node -e "console.log(1)"`、脚本路径都会拿到真实 stdout/stderr。`clear` 只清卡片，不进 shell。
+
+不是 PTY：没有交互式 TTY（vim、裸 `node` REPL 会等到超时）。一次回车一条命令。
 
 ## 设计要点
 
 - 卡片自带标题栏：左侧写「Terminal」，右侧 `clear`（清屏）和 `⤢`（放大）。
-- 放大 = 真全屏：覆盖层直接挂到 `document.body`（`position: fixed; inset: 0`，最高 z-index），并临时把沿途祖先的 `overflow` 放开，所以不会像 HTML 块那样被编辑区裁掉。Esc 或再点 ⤢ 退出，退出后祖先样式原样还原。
-- 放大前后**会话不丢**：输入过的命令、输出都在。
-- **命令记录存在块详情里**：写在块 `data.session.history`（不是浏览器 localStorage），刷新、换设备、导出 markdown 后在。围栏字段 `cwd` / `prompt` / `lines` 只当开场白，首次挂载灌一次，之后以 `session` 为准。正在输入、还没回车的那半截命令**不落盘**。
-- 输入行永远在最底部，Enter 执行；`help` 看命令表，`demo` 看引导。
+- 放大 = 真全屏：覆盖层直接挂到 `document.body`。Esc 或再点 ⤢ 退出。
+- **命令记录存在块详情里**：写在块 `data.session.history`。正在输入、还没回车的那半截命令**不落盘**。
+- 输入行永远在最底部，Enter 执行。
 - 高度写在围栏头 `height=`（默认 320，最小 120），超出滚动。
 
 ## 示例写法
 
-围栏头：`kind=terminal plugin=page-terminal`。围栏体是 JSON：`cwd`、`prompt`、`lines`（开场输出，数组）、`height`。
+围栏头：`kind=terminal plugin=page-terminal`。
 
 ```md
 :::pageBlock {kind=terminal plugin=page-terminal}
 {
-  "cwd": "~/demo",
+  "cwd": ".",
   "prompt": "$",
-  "lines": ["Welcome to the demo terminal.", "输入 `help` 看命令，`demo` 看引导。"],
+  "lines": ["工作区 shell。回车执行真实命令，例如 node -v。"],
   "height": 340
 }
 :::
 ```
 
-写入页面用 `db_content` 对应 page 的 markdown，按上面围栏粘贴或替换。斜杠插入时编辑器会补 `id=`；手写围栏可省略 `id`。
+改完沙箱后必须 `db_action /plugins/page-terminal action=pack` 才会打进已安装插件。

--- a/.plugin-dev/page-terminal/host.test.ts
+++ b/.plugin-dev/page-terminal/host.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { apply } from './host.ts'
+
+test('page-terminal host runs the workspace shell and returns stdout', async () => {
+  const calls: string[] = []
+  let handler: ((route: { json: () => Promise<unknown>; send: (status: number, body: unknown) => void }) => unknown) | undefined
+  apply({
+    http: {
+      route(_method, path, next) {
+        assert.equal(path, '/api/page-terminal/run')
+        handler = next
+      },
+    },
+    shell: {
+      async run(command) {
+        calls.push(command)
+        return { code: 0, stdout: 'v22\n', stderr: '' }
+      },
+    },
+  })
+  assert.ok(handler)
+  let sent: { status: number; body: unknown } | undefined
+  await handler!({
+    json: async () => ({ command: 'node -v' }),
+    send: (status, body) => {
+      sent = { status, body }
+    },
+  })
+  assert.deepEqual(calls, ['node -v'])
+  assert.equal(sent?.status, 200)
+  assert.deepEqual(sent?.body, { code: 0, stdout: 'v22\n', stderr: '' })
+})

--- a/.plugin-dev/page-terminal/host.ts
+++ b/.plugin-dev/page-terminal/host.ts
@@ -1,3 +1,36 @@
 export const name = 'page-terminal'
+export const inject = ['http', 'shell']
 
-export function apply() {}
+type ShellResult = { code: number | null; stdout: string; stderr: string }
+
+type Route = {
+  json: () => Promise<unknown>
+  send: (status: number, body: unknown) => void
+}
+
+const OUTPUT_CAP = 80_000
+
+function clip(text: string) {
+  if (text.length <= OUTPUT_CAP) return text
+  return `${text.slice(0, OUTPUT_CAP)}\n…(output truncated)`
+}
+
+export function apply(ctx: {
+  http: { route: (method: string, path: string, handler: (route: Route) => unknown) => void }
+  shell: { run: (command: string, signal?: AbortSignal) => Promise<ShellResult> }
+}) {
+  ctx.http.route('POST', '/api/page-terminal/run', async (route) => {
+    const body = ((await route.json()) ?? {}) as { command?: unknown }
+    const command = String(body.command ?? '').trim()
+    if (!command) {
+      route.send(200, { code: 0, stdout: '', stderr: '' })
+      return
+    }
+    const result = await ctx.shell.run(command)
+    route.send(200, {
+      code: result.code,
+      stdout: clip(String(result.stdout ?? '')),
+      stderr: clip(String(result.stderr ?? '')),
+    })
+  })
+}

--- a/.plugin-dev/page-terminal/manifest.json
+++ b/.plugin-dev/page-terminal/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "page-terminal",
   "name": "终端",
-  "blurb": "页面里用 /terminal 插入一个可交互终端卡片：输入命令、看输出，右上角可全屏放大。",
+  "blurb": "页面里用 /terminal 插入终端卡片：回车在宿主工作区执行真实 shell（含 node），输出写回卡片。右上角可全屏放大。",
   "tags": [
     "page",
     "editor",

--- a/.plugin-dev/page-terminal/shell.ts
+++ b/.plugin-dev/page-terminal/shell.ts
@@ -1,120 +1,7 @@
 /**
- * 演示终端的内置命令表：纯前端模拟，不碰宿主的真 shell。
- * 想接真 shell 的话，可以把这里换成 host 侧服务。
- *
- * 另含「会话 <-> 块 data.session」的序列化：命令记录存在页面块详情里，
- * 刷新/换设备也在，格式对人可读（data.session.history）。
+ * 命令记录存在页面块 data.session 里（不是 localStorage）。
+ * 真正执行走 host `/api/page-terminal/run`（工作区 POSIX shell / Node）。
  */
-
-export type TerminalResult = {
-  /** 输出文本；clear 时忽略 */
-  output: string
-  /** 非零退出：输出按错误色显示 */
-  failed?: boolean
-  type?: 'clear'
-}
-
-const FILES: Record<string, string> = {
-  'readme.md': '# Demo workspace\n\nA tiny fake file system for the terminal card.\n',
-  'notes.txt': 'buy milk\nwrite the deck\nship it\n',
-  'src/index.ts': "export const hello = () => 'hi'\n",
-}
-
-const TREE = `demo/
-├── readme.md
-├── notes.txt
-└── src/
-    └── index.ts`
-
-const HELP = `可用命令
-  help            显示这份帮助
-  demo            逐条演示常见命令
-  ls [path]       列目录
-  cat <file>      看文件
-  echo <text>     原样输出
-  pwd             当前目录
-  date            当前时间
-  whoami          当前用户
-  tree            目录树
-  neofetch        系统信息
-  open <url>      在新标签打开链接
-  clear           清屏
-
-未识别的命令会返回 command not found。`
-
-function nowText() {
-  const d = new Date()
-  const p = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
-}
-
-function normalizeUrl(raw: string) {
-  const text = raw.trim()
-  if (!text) return ''
-  if (/^https?:\/\//i.test(text)) return text
-  if (/^[\w-]+(\.[\w-]+)+(\/\S*)?$/.test(text)) return `https://${text}`
-  return ''
-}
-
-export function runTerminalCommand(raw: string): TerminalResult {
-  const line = raw.trim()
-  if (!line) return { output: '' }
-  const [head, ...rest] = line.split(/\s+/)
-  const cmd = head.toLowerCase()
-  const arg = rest.join(' ')
-  switch (cmd) {
-    case 'help':
-    case '?':
-      return { output: HELP }
-    case 'demo':
-      return { output: '试试：ls → cat readme.md → tree → open example.com' }
-    case 'ls': {
-      const names = Object.keys(FILES).sort()
-      return { output: names.join('\n') }
-    }
-    case 'cat': {
-      if (!arg) return { output: '✗ cat: 需要一个文件名', failed: true }
-      const hit = FILES[arg]
-      if (hit == null) return { output: `✗ cat: ${arg}: No such file`, failed: true }
-      return { output: hit }
-    }
-    case 'echo':
-      return { output: arg }
-    case 'pwd':
-      return { output: '/home/demo' }
-    case 'date':
-      return { output: nowText() }
-    case 'whoami':
-      return { output: 'demo' }
-    case 'tree':
-      return { output: TREE }
-    case 'neofetch':
-      return {
-        output: [
-          'demo@biu',
-          '-------',
-          'OS: 页面终端卡片',
-          'Shell: page-terminal',
-          'Runtime: 宿主浏览器',
-          `Time: ${nowText()}`,
-        ].join('\n'),
-      }
-    case 'open': {
-      const url = normalizeUrl(arg)
-      if (!url) return { output: '✗ open: 需要 http(s) 链接', failed: true }
-      if (typeof window !== 'undefined') window.open(url, '_blank', 'noopener')
-      return { output: `→ 已打开 ${url}` }
-    }
-    case 'clear':
-      return { output: '', type: 'clear' }
-    case 'sudo':
-      return { output: '✗ 这里是演示终端，没有真 shell 可以提权', failed: true }
-    default:
-      return { output: `✗ command not found: ${head}（输入 help 看命令）`, failed: true }
-  }
-}
-
-/* ---------------- 会话持久化（写进页面块 data，不是宿主本地存储） ---------------- */
 
 export type SavedLine = { kind: 'in' | 'out' | 'err'; text: string }
 
@@ -174,7 +61,7 @@ export function packSession(session: TerminalSession): TerminalSession {
   let chars = history.reduce((n, line) => n + line.text.length, 0)
   let head = 0
   while (chars > SESSION_MAX_CHARS && head < history.length - 1) {
-    chars -= history[head].text.length
+    chars -= history[head]!.text.length
     head += 1
   }
   if (head > 0) history = history.slice(head)
@@ -188,8 +75,34 @@ export function packSession(session: TerminalSession): TerminalSession {
 
 /** 内容一样就别写，省得每次回车都触发文档更新。 */
 export function sameSession(a: TerminalSession, b: TerminalSession) {
-  return a.input === b.input && a.cwd === b.cwd && a.history.length === b.history.length && a.history.every((line, i) => {
-    const other = b.history[i]
-    return other != null && other.kind === line.kind && other.text === line.text
-  }) && a.seeded === b.seeded
+  return (
+    a.input === b.input &&
+    a.cwd === b.cwd &&
+    a.history.length === b.history.length &&
+    a.history.every((line, i) => {
+      const other = b.history[i]
+      return other != null && other.kind === line.kind && other.text === line.text
+    }) &&
+    a.seeded === b.seeded
+  )
+}
+
+export async function runHostCommand(command: string) {
+  const res = await fetch('/api/page-terminal/run', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ command }),
+  })
+  const body = (await res.json().catch(() => ({}))) as {
+    code?: number | null
+    stdout?: string
+    stderr?: string
+    error?: string
+  }
+  if (!res.ok) throw new Error(body.error || res.statusText)
+  return {
+    code: body.code ?? null,
+    stdout: String(body.stdout ?? ''),
+    stderr: String(body.stderr ?? ''),
+  }
 }

--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -2,7 +2,7 @@ import { createPortal } from 'react-dom'
 import {
   packSession,
   parseSession,
-  runTerminalCommand,
+  runHostCommand,
   sameSession,
   stripDraft,
   type TerminalSession,
@@ -24,9 +24,9 @@ const ERR = '#ff7b72'
 const MAX_LINES = 400
 
 const SAMPLE = {
-  cwd: '~/demo',
+  cwd: '.',
   prompt: '$',
-  lines: ['Welcome to the demo terminal.', 'Type `help` for commands, `demo` for a tour.'],
+  lines: ['工作区 shell。回车执行真实命令，例如 node -v 或 node -e "console.log(1)"。'],
 }
 
 type Line = { kind: 'in' | 'out' | 'err'; text: string }
@@ -103,8 +103,7 @@ function TerminalSurface({
       push({ kind: 'in', text: echo })
       return
     }
-    const result = runTerminalCommand(cmd)
-    if (result.type === 'clear') {
+    if (cmd === 'clear') {
       session.history = []
       onChange()
       return
@@ -112,9 +111,20 @@ function TerminalSurface({
     busyRef.current = true
     setBusy(true)
     push({ kind: 'in', text: echo })
-    for (const text of result.output.split('\n')) {
-      push({ kind: result.failed ? 'err' : 'out', text })
-      await new Promise((resolve) => setTimeout(resolve, 45))
+    try {
+      const result = await runHostCommand(cmd)
+      const chunks = [
+        ...String(result.stdout).split('\n').map((text) => ({ kind: 'out' as const, text })),
+        ...String(result.stderr).split('\n').map((text) => ({ kind: 'err' as const, text })),
+      ].filter((line) => line.text.length > 0)
+      if (!chunks.length && result.code && result.code !== 0) {
+        push({ kind: 'err', text: `exit ${result.code}` })
+      } else {
+        for (const line of chunks) push(line)
+        if (result.code && result.code !== 0) push({ kind: 'err', text: `exit ${result.code}` })
+      }
+    } catch (error) {
+      push({ kind: 'err', text: String(error) })
     }
     busyRef.current = false
     setBusy(false)
@@ -281,7 +291,7 @@ function TerminalCard({
   update: (patch: Record<string, unknown>) => void
   writable: boolean
 }) {
-  const cwd = String(data.cwd ?? '~/demo')
+  const cwd = String(data.cwd ?? '.')
   const prompt = String(data.prompt ?? '$')
   const sample = parseLines(data.lines)
   const [zoom, setZoom] = useState(false)
@@ -414,7 +424,7 @@ function TerminalCard({
             color: 'rgba(201,209,217,.4)',
           }}
         >
-          help · demo · ls · tree
+          workspace shell · node
         </span>
       ) : null}
       {overlayEl ? createPortal(surface(true), overlayEl) : null}
@@ -447,7 +457,7 @@ export function apply(ctx: {
     label: '终端',
     blockType: 'terminal',
     blockTypeLabel: '终端',
-    hint: '可交互终端卡片，输入命令看输出；右上角可放大到全屏',
+    hint: '工作区真 shell：回车在宿主执行命令（node / ls 等），右上角可放大',
     aliases: ['terminal', 'shell', '终端', '命令行', 'console', 'cmd'],
     defaults: () => ({ ...SAMPLE }),
     View: TerminalCard,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`page-terminal` 之前是浏览器里写死的假命令表（help / ls / cat / neofetch），不会跑 Node，也不会碰宿主 shell。

现在回车走 `POST /api/page-terminal/run`，用和 agent `bash` 工具同一套 `ctx.shell`（工作区 `/bin/sh -c`）。`node -v`、`node -e`、脚本会拿到真实 stdout/stderr。`clear` 仍只清卡片。

这还不是 PTY：没有交互式 TTY。改完沙箱后需要 pack 插件才会进已安装目录。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

