### PR TITLE
Fix chat /ws handshake after page-terminal PTY

### DIFF
--- a/packages/host-http/src/host/index.test.ts
+++ b/packages/host-http/src/host/index.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Context } from 'cordis'
+import { WebSocket } from 'ws'
+import * as http from './index.ts'
+
+async function freePort() {
+  return await new Promise<number>((resolve, reject) => {
+    const server = createServer()
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('no port'))
+        return
+      }
+      const port = addr.port
+      server.close((error) => (error ? reject(error) : resolve(port)))
+    })
+    server.on('error', reject)
+  })
+}
+
+test('extra ws path does not abort the hub /ws handshake', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'cordis-http-ws-'))
+  const publicDir = join(base, 'public')
+  await mkdir(publicDir, { recursive: true })
+  await writeFile(join(publicDir, 'index.html'), '<html></html>')
+  const port = await freePort()
+  const ctx = new Context()
+  const ready = new Promise<void>((resolve) => {
+    ctx.on('http/ready', () => resolve())
+  })
+  const fiber = await ctx.plugin(http, { port, host: '127.0.0.1', publicDir })
+  await ready
+  try {
+    ctx.http.ws('/ws/page-terminal', (socket) => {
+      socket.send('pty')
+    })
+
+    const hub = await new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
+      ws.on('message', (raw) => {
+        resolve(String(raw))
+        ws.close()
+      })
+      ws.on('error', reject)
+    })
+    assert.match(hub, /"type":"hello"/)
+
+    const extra = await new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws/page-terminal`)
+      ws.on('message', (raw) => {
+        resolve(String(raw))
+        ws.close()
+      })
+      ws.on('error', reject)
+    })
+    assert.equal(extra, 'pty')
+  } finally {
+    await fiber.dispose()
+  }
+})

--- a/packages/host-http/src/host/index.ts
+++ b/packages/host-http/src/host/index.ts
@@ -1,6 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import { extname, join } from 'node:path'
 import { readFile } from 'node:fs/promises'
+import type { Duplex } from 'node:stream'
 import { Service, type Context } from 'cordis'
 import { WebSocketServer, type WebSocket } from 'ws'
 import { HUB_CHANGE } from '@biu/type-http'
@@ -66,10 +67,20 @@ function resolveListenConfig(config?: HttpListenConfig) {
   }
 }
 
+function upgradePath(req: IncomingMessage) {
+  try {
+    return new URL(req.url ?? '/', 'http://localhost').pathname
+  } catch {
+    return '/'
+  }
+}
+
 export class HttpService extends Service {
   private routes: Route[] = []
   private sockets = new Set<WebSocket>()
   private server: Server | null = null
+  /** 同一 HTTP server 上只能有一条 upgrade 路由；多挂几个 `ws.Server({ server })` 会互相 abort 握手。 */
+  private wsServers = new Map<string, WebSocketServer>()
 
   constructor(ctx: Context, public config: { port: number; host: string; publicDir: string }) {
     super(ctx, 'http')
@@ -78,12 +89,24 @@ export class HttpService extends Service {
         void this.dispatch(req, res)
       })
       this.server = server
-      const wss = new WebSocketServer({ server, path: '/ws' })
-      wss.on('connection', (socket) => {
+      const hub = new WebSocketServer({ noServer: true })
+      this.wsServers.set('/ws', hub)
+      hub.on('connection', (socket) => {
         this.sockets.add(socket)
         socket.send(JSON.stringify({ type: 'hello', payload: { ok: true } }))
         socket.on('close', () => this.sockets.delete(socket))
       })
+      const onUpgrade = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+        const wss = this.wsServers.get(upgradePath(req))
+        if (!wss) {
+          socket.destroy()
+          return
+        }
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit('connection', ws, req)
+        })
+      }
+      server.on('upgrade', onUpgrade)
       ctx.on('session/event', (payload) => this.broadcast('session', payload))
       ctx.on('agent/status', (payload) => this.broadcast('agent', payload))
       ctx.on('agent/inbox', (payload) => this.broadcast('inbox', payload))
@@ -105,7 +128,9 @@ export class HttpService extends Service {
       return () =>
         new Promise<void>((resolve) => {
           for (const socket of this.sockets) socket.close()
-          wss.close()
+          server.off('upgrade', onUpgrade)
+          hub.close()
+          this.wsServers.delete('/ws')
           this.server = null
           server.close(() => resolve())
         })
@@ -126,21 +151,15 @@ export class HttpService extends Service {
     }, `http.route ${method} ${pattern}`)
   }
 
-  /** 在已有 HTTP 服务上再挂一条 WebSocket 路径。 */
+  /** 在已有 HTTP 服务上再挂一条 WebSocket 路径（和 /ws 共用一条 upgrade 分发，互不 abort）。 */
   ws(path: string, handler: (socket: WebSocket, request: IncomingMessage) => void) {
     return this.ctx.effect(() => {
-      let wss: WebSocketServer | undefined
-      const attach = () => {
-        if (!this.server || wss) return
-        wss = new WebSocketServer({ server: this.server, path })
-        wss.on('connection', handler)
-      }
-      attach()
-      const off = this.ctx.on('http/ready', () => attach())
+      const wss = new WebSocketServer({ noServer: true })
+      wss.on('connection', handler)
+      this.wsServers.set(path, wss)
       return () => {
-        if (typeof off === 'function') off()
-        wss?.close()
-        wss = undefined
+        if (this.wsServers.get(path) === wss) this.wsServers.delete(path)
+        wss.close()
       }
     }, `http.ws ${path}`)
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面终端为了挂 `/ws/page-terminal`，在同一个 HTTP server 上又 `new WebSocketServer({ server })`。`ws` 对 path 不匹配的 upgrade 会直接 abortHandshake(400)，把前端聊天用的 `/ws` 掐掉，于是 assistant chunk 进不来，聊天窗口没字。

改成一条 upgrade 分发：`/ws` 仍是 hub，`http.ws(path)` 只注册 `noServer` 的路径。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

