### PR TITLE
Page terminal PTY lives in the plugin only

### DIFF
--- a/.plugin-dev/page-terminal/README.md
+++ b/.plugin-dev/page-terminal/README.md
@@ -1,10 +1,8 @@
 # 终端（page-terminal）
 
-页面里 `/terminal` 插入一张 **真终端卡片**：xterm 连宿主 **PTY**，登录你本机 `$SHELL`（`-il`），和系统终端同一套环境：`cd`、别名、`node`、vim 都不做包装。
+页面里 `/terminal` 插入一张 **真终端卡片**。PTY 和 WebSocket 都在本插件的 `host.ts`（pack 进 `.plugin/page-terminal`），**不改** `packages/host-terminal`。前端 xterm 连 `/ws/page-terminal`，登录本机 `$SHELL -il`。一张卡片可开多个 Tab。
 
-一张卡片可以 **+ 开多个 Tab**，每个 Tab 是独立的 PTY。右上角放大；Esc 退出放大。聊天通道 `/ws` 不受影响（终端走 `/ws/page-terminal`，HTTP upgrade 按路径分发）。
-
-改完沙箱后 `db_action /plugins/page-terminal action=pack`。
+聊天仍走 `/ws`。改完沙箱后 `db_action /plugins/page-terminal action=pack`。
 
 ## 示例写法
 

--- a/.plugin-dev/page-terminal/host.test.ts
+++ b/.plugin-dev/page-terminal/host.test.ts
@@ -1,0 +1,18 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { apply } from './host.ts'
+
+test('page-terminal host registers a plugin WebSocket, not host-terminal', () => {
+  const paths: string[] = []
+  apply({
+    sandbox: {
+      wrap: () => ({ cwd: process.cwd(), env: process.env }),
+    },
+    http: {
+      ws(path) {
+        paths.push(path)
+      },
+    },
+  })
+  assert.deepEqual(paths, ['/ws/page-terminal'])
+})

--- a/.plugin-dev/page-terminal/host.ts
+++ b/.plugin-dev/page-terminal/host.ts
@@ -1,3 +1,106 @@
-export const name = 'page-terminal'
+import { existsSync } from 'node:fs'
+import type { IncomingMessage } from 'node:http'
+import * as pty from 'node-pty'
+import type { IPty } from 'node-pty'
 
-export function apply() {}
+export const name = 'page-terminal'
+export const inject = ['http', 'sandbox']
+
+function userShell() {
+  const fromEnv = String(process.env.SHELL ?? '').trim()
+  if (fromEnv) return fromEnv
+  if (process.platform !== 'win32' && existsSync('/bin/bash')) return '/bin/bash'
+  return '/bin/sh'
+}
+
+function socketData(raw: unknown) {
+  if (typeof raw === 'string') return raw
+  if (Buffer.isBuffer(raw)) return raw.toString('utf8')
+  if (Array.isArray(raw)) return Buffer.concat(raw.filter((item): item is Buffer => Buffer.isBuffer(item))).toString('utf8')
+  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString('utf8')
+  return String(raw ?? '')
+}
+
+function isResize(text: string) {
+  if (!text.startsWith('{"type":"resize"')) return null
+  try {
+    const msg = JSON.parse(text) as { type?: string; cols?: number; rows?: number }
+    if (msg.type !== 'resize') return null
+    return { cols: Number(msg.cols) || 80, rows: Number(msg.rows) || 24 }
+  } catch {
+    return null
+  }
+}
+
+type Socket = {
+  readyState: number
+  OPEN: number
+  send: (data: string) => void
+  close: (code?: number, reason?: string) => void
+  on: (event: 'message' | 'close' | 'error', fn: (...args: unknown[]) => void) => void
+}
+
+export function apply(ctx: {
+  sandbox: { wrap: (req: { argv: string[] }) => { cwd: string; env: NodeJS.ProcessEnv } }
+  http: { ws: (path: string, handler: (socket: Socket, request: IncomingMessage) => void) => void }
+}) {
+  const terms = new Map<string, IPty>()
+
+  const open = (cols: number, rows: number) => {
+    const id = crypto.randomUUID().slice(0, 8)
+    const sh = userShell()
+    const wrapped = ctx.sandbox.wrap({ argv: [sh] })
+    const login = process.platform !== 'win32' || !/cmd\.exe$/i.test(sh)
+    const child = pty.spawn(sh, login ? ['-il'] : [], {
+      name: 'xterm-256color',
+      cols,
+      rows,
+      cwd: wrapped.cwd,
+      env: {
+        ...process.env,
+        ...wrapped.env,
+        TERM: 'xterm-256color',
+        COLORTERM: 'truecolor',
+      },
+    })
+    terms.set(id, child)
+    child.onExit(() => terms.delete(id))
+    return { id, child }
+  }
+
+  ctx.http.ws('/ws/page-terminal', (socket, request) => {
+    const url = new URL(request.url ?? '/', 'http://localhost')
+    const cols = Number(url.searchParams.get('cols') ?? 80)
+    const rows = Number(url.searchParams.get('rows') ?? 24)
+    let opened: { id: string; child: IPty }
+    try {
+      opened = open(Math.max(20, cols), Math.max(8, rows))
+    } catch (error) {
+      socket.close(1011, String(error))
+      return
+    }
+    const listen = opened.child.onData((data) => {
+      if (socket.readyState === socket.OPEN) socket.send(data)
+    })
+    socket.on('message', (raw) => {
+      const text = socketData(raw)
+      const size = isResize(text)
+      if (size) {
+        opened.child.resize(Math.max(20, size.cols), Math.max(8, size.rows))
+        return
+      }
+      opened.child.write(text)
+    })
+    const hangup = () => {
+      listen.dispose()
+      try {
+        opened.child.kill()
+      } catch {
+        /* already gone */
+      }
+      terms.delete(opened.id)
+    }
+    socket.on('close', hangup)
+    socket.on('error', hangup)
+  })
+}

--- a/packages/core-editor/src/web/page-block.ts
+++ b/packages/core-editor/src/web/page-block.ts
@@ -181,7 +181,7 @@ export const pageBlock = Node.create({
       },
       stopEvent: ({ event }) => {
         const target = event.target as HTMLElement | null
-        return Boolean(target?.closest('.page-block, [data-page-block-capture], textarea, input, select, button, canvas, .excalidraw, .xterm'))
+        return Boolean(target?.closest('.page-block, [data-page-block-capture], textarea, input, select, button, canvas, .excalidraw'))
       },
     })
   },

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -293,6 +293,8 @@ export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') 
     },
     conditions: ['production', 'import', 'module', 'browser', 'default'],
     plugins: storeBundlePlugins(kind),
+    // 原生模块不能打进 host.js，运行时走宿主 node_modules
+    external: kind === 'host' ? ['node-pty'] : [],
   })
   const text = result.outputFiles?.[0]?.text
   if (!text?.trim()) throw new Error(`${kind} bundle is empty`)

--- a/packages/host-terminal/package.json
+++ b/packages/host-terminal/package.json
@@ -10,8 +10,5 @@
   },
   "peerDependencies": {
     "cordis": "4.0.0-rc.8"
-  },
-  "dependencies": {
-    "node-pty": "^1.0.0"
   }
 }

--- a/packages/host-terminal/src/host/index.test.ts
+++ b/packages/host-terminal/src/host/index.test.ts
@@ -1,33 +1,14 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
-import { createServer } from 'node:http'
+import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
 import { Context } from 'cordis'
-import { WebSocket } from 'ws'
 import * as tools from '@biu/host-tools'
 import * as fs from '@biu/host-fs'
 import * as sandbox from '@biu/host-sandbox'
 import * as subprocess from '@biu/host-subprocess'
-import * as http from '@biu/host-http'
 import * as terminal from './index.ts'
-
-async function freePort() {
-  return await new Promise<number>((resolve, reject) => {
-    const server = createServer()
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address()
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('no port'))
-        return
-      }
-      const port = addr.port
-      server.close((error) => (error ? reject(error) : resolve(port)))
-    })
-    server.on('error', reject)
-  })
-}
 
 test('persistent terminal open/write/read/close', async () => {
   const ctx = new Context()
@@ -49,56 +30,4 @@ test('persistent terminal open/write/read/close', async () => {
   const closed = (await ctx.tools.invoke('terminal_close', { id: opened.id })) as { closed: boolean }
   assert.equal(closed.closed, true)
   assert.match(output, /term-ok/)
-})
-
-test('page-terminal websocket is a real PTY and leaves hub /ws alone', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'cordis-pty-ws-'))
-  const publicDir = join(base, 'public')
-  await mkdir(publicDir, { recursive: true })
-  await writeFile(join(publicDir, 'index.html'), '<html></html>')
-  const port = await freePort()
-  const ctx = new Context()
-  const ready = new Promise<void>((resolve) => {
-    ctx.on('http/ready', () => resolve())
-  })
-  await ctx.plugin(tools)
-  await ctx.plugin(fs, { root: base })
-  await ctx.plugin(sandbox)
-  await ctx.plugin(subprocess)
-  const httpFiber = await ctx.plugin(http, { port, host: '127.0.0.1', publicDir })
-  await ctx.plugin(terminal)
-  await ready
-  try {
-    const hello = await new Promise<string>((resolve, reject) => {
-      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`)
-      ws.on('message', (raw) => {
-        resolve(String(raw))
-        ws.close()
-      })
-      ws.on('error', reject)
-    })
-    assert.match(hello, /"type":"hello"/)
-
-    const pty = new WebSocket(`ws://127.0.0.1:${port}/ws/page-terminal?cols=80&rows=24`)
-    let out = ''
-    pty.on('message', (raw) => {
-      out += String(raw)
-    })
-    await new Promise<void>((resolve, reject) => {
-      pty.on('open', () => resolve())
-      pty.on('error', reject)
-    })
-    await new Promise((r) => setTimeout(r, 250))
-    pty.send('cd /tmp && pwd && echo native-ok\n')
-    const deadline = Date.now() + 4000
-    while (Date.now() < deadline) {
-      if (out.includes('native-ok') && out.includes('/tmp')) break
-      await new Promise((r) => setTimeout(r, 40))
-    }
-    pty.close()
-    assert.match(out, /native-ok/)
-    assert.match(out, /\/tmp/)
-  } finally {
-    await httpFiber.dispose()
-  }
 })

--- a/packages/host-terminal/src/host/index.ts
+++ b/packages/host-terminal/src/host/index.ts
@@ -1,20 +1,10 @@
-import { existsSync } from 'node:fs'
-import type { IncomingMessage } from 'node:http'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { Service, type Context } from 'cordis'
 import { posixShellBin } from '@biu/host-subprocess'
-import * as pty from 'node-pty'
-import type { IPty } from 'node-pty'
-
-function userShell() {
-  const fromEnv = String(process.env.SHELL ?? '').trim()
-  if (fromEnv) return fromEnv
-  if (process.platform !== 'win32' && existsSync('/bin/bash')) return '/bin/bash'
-  return posixShellBin()
-}
 
 interface Term {
   id: string
-  child: IPty
+  child: ChildProcessWithoutNullStreams
   buffer: string
 }
 
@@ -25,33 +15,22 @@ export class TerminalService extends Service {
     super(ctx, 'terminals')
   }
 
-  open(size?: { cols?: number; rows?: number; login?: boolean }) {
+  open() {
     const id = crypto.randomUUID().slice(0, 8)
-    const sh = userShell()
+    const sh = posixShellBin()
     const wrapped = this.ctx.sandbox.wrap({ argv: [sh] })
-    const cols = Math.max(20, Number(size?.cols) || 80)
-    const rows = Math.max(8, Number(size?.rows) || 24)
-    const login = size?.login === true && (process.platform !== 'win32' || !/cmd\.exe$/i.test(sh))
-    const child = pty.spawn(sh, login ? ['-il'] : [], {
-      name: 'xterm-256color',
-      cols,
-      rows,
+    const child = spawn(sh, [], {
       cwd: wrapped.cwd,
-      env: {
-        ...process.env,
-        ...wrapped.env,
-        TERM: 'xterm-256color',
-        COLORTERM: 'truecolor',
-      },
+      env: wrapped.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
     })
     const term: Term = { id, child, buffer: '' }
-    child.onData((data) => {
-      term.buffer += data
+    const append = (chunk: Buffer) => {
+      term.buffer += chunk.toString('utf8')
       if (term.buffer.length > 32_000) term.buffer = term.buffer.slice(-16_000)
-    })
-    child.onExit(() => {
-      this.terms.delete(id)
-    })
+    }
+    child.stdout.on('data', append)
+    child.stderr.on('data', append)
     this.terms.set(id, term)
     return { id }
   }
@@ -59,14 +38,7 @@ export class TerminalService extends Service {
   write(id: string, data: string) {
     const term = this.terms.get(id)
     if (!term) throw new Error(`unknown terminal: ${id}`)
-    term.child.write(data)
-    return { id, ok: true }
-  }
-
-  resize(id: string, cols: number, rows: number) {
-    const term = this.terms.get(id)
-    if (!term) throw new Error(`unknown terminal: ${id}`)
-    term.child.resize(Math.max(20, cols), Math.max(8, rows))
+    term.child.stdin.write(data)
     return { id, ok: true }
   }
 
@@ -76,20 +48,10 @@ export class TerminalService extends Service {
     return { id, output: term.buffer }
   }
 
-  attach(id: string, send: (data: string) => void) {
-    const term = this.terms.get(id)
-    if (!term) throw new Error(`unknown terminal: ${id}`)
-    return term.child.onData(send)
-  }
-
   close(id: string) {
     const term = this.terms.get(id)
     if (!term) throw new Error(`unknown terminal: ${id}`)
-    try {
-      term.child.kill()
-    } catch {
-      /* already gone */
-    }
+    term.child.kill('SIGTERM')
     this.terms.delete(id)
     return { id, closed: true }
   }
@@ -97,25 +59,6 @@ export class TerminalService extends Service {
 
 export const name = 'terminal'
 export const inject = ['sandbox', 'tools']
-
-function socketData(raw: unknown) {
-  if (typeof raw === 'string') return raw
-  if (Buffer.isBuffer(raw)) return raw.toString('utf8')
-  if (Array.isArray(raw)) return Buffer.concat(raw.filter((item): item is Buffer => Buffer.isBuffer(item))).toString('utf8')
-  if (raw instanceof ArrayBuffer) return Buffer.from(raw).toString('utf8')
-  return String(raw ?? '')
-}
-
-function isResize(text: string) {
-  if (!text.startsWith('{"type":"resize"')) return null
-  try {
-    const msg = JSON.parse(text) as { type?: string; cols?: number; rows?: number }
-    if (msg.type !== 'resize') return null
-    return { cols: Number(msg.cols) || 80, rows: Number(msg.rows) || 24 }
-  } catch {
-    return null
-  }
-}
 
 export function apply(ctx: Context) {
   const terminals = new TerminalService(ctx)
@@ -146,42 +89,5 @@ export function apply(ctx: Context) {
     description: '关闭持久 shell',
     parameters: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
     execute: (args) => terminals.close(String(args.id)),
-  })
-
-  ctx.inject(['http'], (inner) => {
-    inner.http.ws('/ws/page-terminal', (socket, request: IncomingMessage) => {
-      const url = new URL(request.url ?? '/', 'http://localhost')
-      const cols = Number(url.searchParams.get('cols') ?? 80)
-      const rows = Number(url.searchParams.get('rows') ?? 24)
-      let opened: { id: string }
-      try {
-        opened = terminals.open({ cols, rows, login: true })
-      } catch (error) {
-        socket.close(1011, String(error))
-        return
-      }
-      const listen = terminals.attach(opened.id, (data) => {
-        if (socket.readyState === socket.OPEN) socket.send(data)
-      })
-      socket.on('message', (raw) => {
-        const text = socketData(raw)
-        const size = isResize(text)
-        if (size) {
-          terminals.resize(opened.id, size.cols, size.rows)
-          return
-        }
-        terminals.write(opened.id, text)
-      })
-      const hangup = () => {
-        listen.dispose()
-        try {
-          terminals.close(opened.id)
-        } catch {
-          /* already gone */
-        }
-      }
-      socket.on('close', hangup)
-      socket.on('error', hangup)
-    })
   })
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面终端的 PTY / `/ws/page-terminal` 只在插件 `host.ts` 里。`packages/host-terminal` 恢复为原来的 agent spawn 工具，不再为这个插件服务。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

