### PR TITLE
Hide stray terminal input and allow scroll

### DIFF
--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -48,12 +48,28 @@ function PtyPane({ active }: { active: boolean }) {
       cursorBlink: true,
       fontSize: 13,
       fontFamily: MONO,
+      scrollback: 10_000,
       allowProposedApi: false,
       theme: { background: INK, foreground: PAPER, cursor: GREEN },
     })
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(el)
+    const helper = el.querySelector('textarea')
+    if (helper instanceof HTMLTextAreaElement) {
+      helper.setAttribute('tabindex', '-1')
+      helper.setAttribute('aria-hidden', 'true')
+      helper.style.cssText =
+        'position:absolute;opacity:0;left:0;top:0;width:0;height:0;margin:0;padding:0;border:0;overflow:hidden;resize:none;pointer-events:none;color:transparent;caret-color:transparent;background:transparent'
+    }
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) return
+      const dy = event.deltaY
+      if (!dy) return
+      const lines = Math.max(1, Math.round(Math.abs(dy) / 24)) * (dy > 0 ? 1 : -1)
+      term.scrollLines(lines)
+    }
+    el.addEventListener('wheel', onWheel, { passive: true })
     fit.fit()
     termRef.current = term
     fitRef.current = fit
@@ -85,6 +101,7 @@ function PtyPane({ active }: { active: boolean }) {
       resized.dispose()
       ro.disconnect()
       window.removeEventListener('resize', onFit)
+      el.removeEventListener('wheel', onWheel)
       socket.close()
       term.dispose()
       termRef.current = null

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -3,6 +3,7 @@
   height: 100%;
   width: 100%;
   min-height: 0;
+  overflow: hidden;
 }
 .page-terminal-pty .xterm {
   position: relative;
@@ -21,25 +22,31 @@
   position: absolute;
   top: 0;
   z-index: 5;
+  pointer-events: none;
 }
-.page-terminal-pty .xterm .xterm-helper-textarea {
-  position: absolute;
-  opacity: 0;
-  left: -9999em;
-  top: 0;
-  width: 0;
-  height: 0;
-  z-index: -5;
-  white-space: nowrap;
-  overflow: hidden;
-  resize: none;
-  padding: 0;
-  border: 0;
-  margin: 0;
+/* xterm 用来接键盘的 textarea：必须藏掉，否则左上角会露出一块输入框 */
+.page-terminal-pty textarea,
+.page-terminal-pty .xterm-helper-textarea {
+  position: absolute !important;
+  opacity: 0 !important;
+  left: 0 !important;
+  top: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  resize: none !important;
+  overflow: hidden !important;
+  color: transparent !important;
+  caret-color: transparent !important;
+  background: transparent !important;
+  pointer-events: none !important;
+  z-index: -1 !important;
 }
 .page-terminal-pty .xterm .xterm-viewport {
   background-color: #0b0e14;
-  overflow-y: scroll;
+  overflow-y: auto !important;
   cursor: default;
   position: absolute;
   right: 0;
@@ -76,6 +83,7 @@
   z-index: 10;
   color: transparent;
   overflow: hidden;
+  pointer-events: none;
 }
 .page-terminal-pty .live-region {
   position: absolute;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
左上角那块是 xterm 接键盘的隐藏 textarea 露出来了，已藏掉。缓冲加了 scrollback，滚轮可以上下翻看超出卡片的输出。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

