### PR TITLE
Remove ghost first line in page terminal

### DIFF
--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -1,5 +1,6 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
 import './xterm-skin.css'
 import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
 
@@ -56,11 +57,30 @@ function PtyPane({ active }: { active: boolean }) {
     term.loadAddon(fit)
     term.open(el)
     const helper = el.querySelector('textarea')
-    if (helper instanceof HTMLTextAreaElement) {
-      helper.setAttribute('tabindex', '-1')
+    const buryHelper = () => {
+      if (!(helper instanceof HTMLTextAreaElement)) return
       helper.setAttribute('aria-hidden', 'true')
-      helper.style.cssText =
-        'position:absolute;opacity:0;left:0;top:0;width:0;height:0;margin:0;padding:0;border:0;overflow:hidden;resize:none;pointer-events:none;color:transparent;caret-color:transparent;background:transparent'
+      helper.setAttribute('tabindex', '-1')
+      helper.style.setProperty('opacity', '0', 'important')
+      helper.style.setProperty('color', 'transparent', 'important')
+      helper.style.setProperty('caret-color', 'transparent', 'important')
+      helper.style.setProperty('background', 'transparent', 'important')
+      helper.style.setProperty('left', '-9999px', 'important')
+      helper.style.setProperty('top', '0', 'important')
+      helper.style.setProperty('width', '0', 'important')
+      helper.style.setProperty('height', '0', 'important')
+      helper.style.setProperty('font-size', '0', 'important')
+      helper.style.setProperty('overflow', 'hidden', 'important')
+      helper.style.setProperty('pointer-events', 'none', 'important')
+    }
+    buryHelper()
+    const helperWatch =
+      helper instanceof HTMLTextAreaElement
+        ? new MutationObserver(buryHelper)
+        : null
+    if (helper instanceof HTMLTextAreaElement) {
+      helperWatch?.observe(helper, { attributes: true, attributeFilter: ['style'] })
+      helper.addEventListener('input', buryHelper)
     }
     const onWheel = (event: WheelEvent) => {
       if (event.ctrlKey) return
@@ -101,6 +121,8 @@ function PtyPane({ active }: { active: boolean }) {
       resized.dispose()
       ro.disconnect()
       window.removeEventListener('resize', onFit)
+      helperWatch?.disconnect()
+      if (helper instanceof HTMLTextAreaElement) helper.removeEventListener('input', buryHelper)
       el.removeEventListener('wheel', onWheel)
       socket.close()
       term.dispose()

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -73,22 +73,17 @@
   left: -9999em;
   line-height: normal;
 }
+.page-terminal-pty .xterm .xterm-helpers,
+.page-terminal-pty .xterm .composition-view,
 .page-terminal-pty .xterm .xterm-accessibility,
-.page-terminal-pty .xterm .xterm-message {
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
-  z-index: 10;
-  color: transparent;
-  overflow: hidden;
-  pointer-events: none;
-}
+.page-terminal-pty .xterm .xterm-accessibility-tree,
+.page-terminal-pty .xterm .xterm-message,
 .page-terminal-pty .live-region {
-  position: absolute;
-  left: -9999px;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  opacity: 0 !important;
+  color: transparent !important;
+  pointer-events: none !important;
+}
+.page-terminal-pty .xterm-accessibility-tree {
+  white-space: pre;
+  user-select: none !important;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
最上面那行 `gggg` 不是 shell 打出来的，是 xterm 接键盘的 textarea / 无障碍层画在第一行。已强制藏掉，只留 PTY 画面。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

