### PR TITLE
Fix page-terminal: keep PTY history and show output

### DIFF
--- a/.plugin-dev/page-terminal/buffer.test.ts
+++ b/.plugin-dev/page-terminal/buffer.test.ts
@@ -1,19 +1,27 @@
 import { test } from 'vitest'
 import assert from 'node:assert/strict'
-import { applyPtyChunk } from './buffer.ts'
+import { TerminalBuffer, applyPtyChunk } from './buffer.ts'
 
-test('pty chunk applies newline, carriage return and backspace', () => {
-  let text = applyPtyChunk('', 'hello')
-  text = applyPtyChunk(text, '\r')
-  text = applyPtyChunk(text, 'ok')
-  assert.equal(text, 'ok')
-  text = applyPtyChunk('ab', '\b')
-  assert.equal(text, 'a')
-  text = applyPtyChunk('', 'one\ntwo')
-  assert.equal(text, 'one\ntwo')
+test('bare CR does not wipe the current line', () => {
+  const buf = new TerminalBuffer()
+  buf.apply('hello')
+  buf.apply('\r')
+  assert.equal(buf.text(), 'hello')
 })
 
-test('pty chunk strips ansi color', () => {
-  const text = applyPtyChunk('', '\x1b[32mhi\x1b[0m')
-  assert.equal(text, 'hi')
+test('carriage return overwrites the current line, keeps history', () => {
+  const buf = new TerminalBuffer()
+  buf.apply('one\nhello')
+  buf.apply('\rOK\x1b[K')
+  assert.equal(buf.text(), 'one\nOK')
+})
+
+test('pty chunk keeps previous lines across enter', () => {
+  const text = applyPtyChunk('prompt % ls', '\r\npackages\nprompt % ')
+  assert.match(text, /packages/)
+  assert.match(text, /prompt/)
+})
+
+test('ansi color codes do not stay in the buffer', () => {
+  assert.equal(applyPtyChunk('', '\x1b[32mhi\x1b[0m'), 'hi')
 })

--- a/.plugin-dev/page-terminal/buffer.ts
+++ b/.plugin-dev/page-terminal/buffer.ts
@@ -1,54 +1,137 @@
-const CSI = /^\x1b\[[0-9;?=]*[ -/]*[@-~]/
+const CSI = /^\x1b\[([0-9;]*)([@-~])/
 const OSC = /^\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/
 const CHARSET = /^\x1b[()][0-9A-Za-z]/
 const OTHER = /^\x1b./
 
-/** 把 PTY 字节流收成可滚动的纯文本（处理换行、回车、退格、清屏，丢掉颜色码）。 */
-export function applyPtyChunk(text: string, raw: string): string {
-  let out = text
-  let i = 0
-  while (i < raw.length) {
-    if (raw.charCodeAt(i) === 0x1b) {
-      const rest = raw.slice(i)
-      const esc = rest.match(CSI)?.[0] ?? rest.match(OSC)?.[0] ?? rest.match(CHARSET)?.[0] ?? rest.match(OTHER)?.[0]
-      if (esc) {
-        if (/^\x1b\[2J/.test(esc) || /^\x1b\[3J/.test(esc)) out = ''
-        i += esc.length
+function nums(raw: string) {
+  return raw.split(';').filter(Boolean).map((item) => Number(item) || 0)
+}
+
+/** 按列覆盖的文本缓冲：`\\r` 只回到行首，不会把历史整段删掉。 */
+export class TerminalBuffer {
+  lines = ['']
+  row = 0
+  col = 0
+  cols: number
+  rows: number
+
+  constructor(cols = 80, rows = 24) {
+    this.cols = cols
+    this.rows = rows
+  }
+
+  write(raw: string) {
+    this.apply(raw)
+  }
+
+  resize(cols: number, rows: number) {
+    this.cols = Math.max(1, cols)
+    this.rows = Math.max(1, rows)
+  }
+
+  text() {
+    return this.lines.join('\n')
+  }
+
+  cursor() {
+    let index = 0
+    for (let i = 0; i < this.row; i++) index += this.lines[i].length + 1
+    return index + Math.min(this.col, this.lines[this.row]?.length ?? 0)
+  }
+
+  apply(raw: string) {
+    let i = 0
+    while (i < raw.length) {
+      if (raw.charCodeAt(i) === 0x1b) {
+        const rest = raw.slice(i)
+        const csi = rest.match(CSI)
+        if (csi) {
+          this.csi(csi[1], csi[2])
+          i += csi[0].length
+          continue
+        }
+        const skip = rest.match(OSC)?.[0] ?? rest.match(CHARSET)?.[0] ?? rest.match(OTHER)?.[0]
+        i += skip ? skip.length : 1
         continue
       }
+      const ch = raw[i]
+      if (ch === '\r') this.col = 0
+      else if (ch === '\n') this.newline()
+      else if (ch === '\b') this.col = Math.max(0, this.col - 1)
+      else if (ch === '\x07') {
+        /* bell */
+      } else if (ch === '\t') {
+        const next = Math.floor(this.col / 8) * 8 + 8
+        while (this.col < next) this.put(' ')
+      } else this.put(ch)
       i += 1
-      continue
     }
-    const ch = raw[i]
-    if (ch === '\r') {
-      const nl = out.lastIndexOf('\n')
-      out = out.slice(0, nl + 1)
-      i += 1
-      continue
+    if (this.lines.length > 4000) {
+      const cut = this.lines.length - 3000
+      this.lines = this.lines.slice(cut)
+      this.row = Math.max(0, this.row - cut)
     }
-    if (ch === '\b') {
-      if (out.length && !out.endsWith('\n')) out = out.slice(0, -1)
-      i += 1
-      continue
-    }
-    if (ch === '\n') {
-      out += '\n'
-      i += 1
-      continue
-    }
-    if (ch === '\x07') {
-      i += 1
-      continue
-    }
-    out += ch
-    i += 1
   }
-  if (out.length > 240_000) out = out.slice(-160_000)
-  return out
+
+  private put(ch: string) {
+    const line = this.lines[this.row] ?? ''
+    if (this.col >= line.length) this.lines[this.row] = line + ch
+    else this.lines[this.row] = line.slice(0, this.col) + ch + line.slice(this.col + 1)
+    this.col += 1
+  }
+
+  private newline() {
+    this.row += 1
+    this.col = 0
+    while (this.lines.length <= this.row) this.lines.push('')
+  }
+
+  private csi(args: string, cmd: string) {
+    const n = nums(args)
+    const a = n[0] || 0
+    if (cmd === 'm') return
+    if (cmd === 'C') this.col += a || 1
+    else if (cmd === 'D') this.col = Math.max(0, this.col - (a || 1))
+    else if (cmd === 'G') this.col = Math.max(0, (a || 1) - 1)
+    else if (cmd === 'A') this.row = Math.max(0, this.row - (a || 1))
+    else if (cmd === 'B') {
+      const down = a || 1
+      this.row += down
+      while (this.lines.length <= this.row) this.lines.push('')
+    } else if (cmd === 'H' || cmd === 'f') {
+      this.row = Math.max(0, (n[0] || 1) - 1)
+      this.col = Math.max(0, (n[1] || 1) - 1)
+      while (this.lines.length <= this.row) this.lines.push('')
+    } else if (cmd === 'K') {
+      const line = this.lines[this.row] ?? ''
+      if (a === 2) this.lines[this.row] = ''
+      else if (a === 1) this.lines[this.row] = ' '.repeat(this.col) + line.slice(this.col)
+      else this.lines[this.row] = line.slice(0, this.col)
+    } else if (cmd === 'J') {
+      if (a === 2 || a === 3) {
+        this.lines = ['']
+        this.row = 0
+        this.col = 0
+      } else if (a === 0) {
+        this.lines[this.row] = (this.lines[this.row] ?? '').slice(0, this.col)
+        this.lines = this.lines.slice(0, this.row + 1)
+      }
+    }
+    const line = this.lines[this.row] ?? ''
+    if (this.col > line.length) this.lines[this.row] = line + ' '.repeat(this.col - line.length)
+  }
+}
+
+export function applyPtyChunk(text: string, raw: string) {
+  const buf = new TerminalBuffer()
+  if (text) buf.apply(text)
+  buf.apply(raw)
+  return buf.text()
 }
 
 export function keyToPty(event: KeyboardEvent): string | null {
-  if (event.metaKey && event.key !== 'v') return null
+  if (event.isComposing) return null
+  if (event.metaKey) return null
   if (event.ctrlKey && !event.altKey && event.key.length === 1) {
     const code = event.key.toLowerCase().charCodeAt(0)
     if (code >= 97 && code <= 122) return String.fromCharCode(code - 96)
@@ -77,7 +160,7 @@ export function keyToPty(event: KeyboardEvent): string | null {
     case 'Delete':
       return '\x1b[3~'
     default:
-      if (event.key.length === 1 && !event.ctrlKey && !event.metaKey) return event.key
+      if (event.key.length === 1 && !event.ctrlKey) return event.key
       return null
   }
 }

--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -1,137 +1,245 @@
-import { applyPtyChunk, keyToPty } from './buffer.ts'
-import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
-
 const React = globalThis.React
 const { useEffect, useRef, useState } = React
+type CSSProperties = import('react').CSSProperties
+import { EditorView, keymap, drawSelection } from '@codemirror/view'
+import { Prec, EditorState } from '@codemirror/state'
+import { StreamLanguage, HighlightStyle, syntaxHighlighting } from '@codemirror/language'
+import { tags as t } from '@lezer/highlight'
+import { TerminalBuffer, keyToPty } from './buffer.ts'
+import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
 
 export const name = 'page-terminal'
 export const inject = ['pageEditor']
 
-const MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
-const UI = 'ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
-const BODY = '#202020'
-const INK = 'rgba(255,255,255,.86)'
-const MUTED = 'rgba(255,255,255,.45)'
-const LINE = 'rgba(255,255,255,.08)'
-const TAB_ON = 'rgba(255,255,255,.08)'
+const UI = 'ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+const LINE = 'color-mix(in srgb, var(--text) 8%, transparent)'
+const MUTED = 'color-mix(in srgb, var(--text) 45%, transparent)'
+const INK = 'var(--text)'
+const CARD = 'var(--bg)'
+const BODY = 'color-mix(in srgb, var(--text) 3.5%, var(--bg))'
+const TAB_ON = 'color-mix(in srgb, var(--text) 6%, transparent)'
+const CH = 8.4
+const LH = 18
+
+function socketUrl() {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${location.host}/ws/page-terminal`
+}
 
 function blockHeight(data: Record<string, unknown>) {
   const n = Number(data.height)
-  return Number.isFinite(n) && n >= 160 ? Math.round(n) : 360
+  return Number.isFinite(n) && n >= 160 ? n : 360
 }
 
-function wsUrl(cols: number, rows: number) {
-  const proto = location.protocol === 'https:' ? 'wss' : 'ws'
-  return `${proto}://${location.host}/ws/page-terminal?cols=${cols}&rows=${rows}`
-}
+const termLang = StreamLanguage.define({
+  token(stream) {
+    if (stream.match(/^\$ |^% |^# |^❯ |^➜ /)) return 'meta'
+    if (stream.match(/^(error|Error|ERROR|fatal|Fatal)\b/)) return 'invalid'
+    if (stream.match(/^(warning|Warning|WARN)\b/)) return 'keyword'
+    if (stream.match(/^(\/|[A-Za-z]:\\)[^\s]+/)) return 'string'
+    if (stream.match(/^[0-9]+/)) return 'number'
+    stream.next()
+    return null
+  },
+})
 
-function measure(el: HTMLElement) {
-  const cs = getComputedStyle(el)
-  const padX = Number.parseFloat(cs.paddingLeft) + Number.parseFloat(cs.paddingRight)
-  const padY = Number.parseFloat(cs.paddingTop) + Number.parseFloat(cs.paddingBottom)
-  const probe = document.createElement('span')
-  probe.textContent = '0'
-  probe.style.cssText = `position:absolute;visibility:hidden;font:${cs.font}`
-  el.appendChild(probe)
-  const cw = probe.getBoundingClientRect().width || 8
-  const ch = Number.parseFloat(cs.lineHeight) || 18
-  probe.remove()
-  const cols = Math.max(20, Math.floor((el.clientWidth - padX) / cw))
-  const rows = Math.max(8, Math.floor((el.clientHeight - padY) / ch))
-  return { cols, rows }
-}
+const termHighlight = HighlightStyle.define([
+  { tag: t.meta, color: '#7aa2f7' },
+  { tag: t.invalid, color: '#f7768e' },
+  { tag: t.keyword, color: '#e0af68' },
+  { tag: t.string, color: '#9ece6a' },
+  { tag: t.number, color: '#bb9af7' },
+])
+
+const termTheme = EditorView.theme({
+  '&': {
+    height: '100%',
+    background: 'transparent',
+    fontFamily: MONO,
+    fontSize: '12.5px',
+    color: INK,
+  },
+  '.cm-scroller': {
+    overflow: 'auto',
+    fontFamily: MONO,
+    lineHeight: `${LH}px`,
+    padding: '10px 14px 14px',
+  },
+  '.cm-content': { caretColor: INK, padding: 0, minHeight: '100%' },
+  '.cm-gutters': { display: 'none' },
+  '.cm-cursor': { borderLeftWidth: '2px', borderLeftColor: INK },
+  '&.cm-focused .cm-cursor': { borderLeftColor: INK },
+  '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
+    background: 'color-mix(in srgb, #2f6fed 28%, transparent) !important',
+  },
+})
 
 function PtyPane({ active }: { active: boolean }) {
-  const paneRef = useRef<HTMLDivElement | null>(null)
-  const stick = useRef(true)
-  const socketRef = useRef<WebSocket | null>(null)
-  const [text, setText] = useState('')
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const bufRef = useRef(new TerminalBuffer(80, 24))
+  const sockRef = useRef<WebSocket | null>(null)
+  const sizeRef = useRef({ cols: 80, rows: 24 })
+  const [ready, setReady] = useState(false)
 
   useEffect(() => {
-    const el = paneRef.current
-    if (!el) return
-    const size = measure(el)
-    const socket = new WebSocket(wsUrl(size.cols, size.rows))
-    socketRef.current = socket
-    const decode = (data: unknown) => {
-      if (typeof data === 'string') return data
-      return new TextDecoder().decode(data as ArrayBuffer)
-    }
-    socket.onmessage = (event) => {
-      setText((prev) => applyPtyChunk(prev, decode(event.data)))
-    }
-    const onKey = (event: KeyboardEvent) => {
-      if (event.metaKey && event.key.toLowerCase() === 'v') return
-      const seq = keyToPty(event)
-      if (seq == null) return
+    const host = wrapRef.current
+    if (!host) return
+    const buf = bufRef.current
+
+    const sendKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'c' && !event.shiftKey) {
+        const sel = viewRef.current?.state.selection.main
+        if (sel && !sel.empty) return false
+      }
+      if (event.metaKey && event.key.toLowerCase() === 'v') return false
+      const bytes = keyToPty(event)
+      if (bytes == null) return false
       event.preventDefault()
-      event.stopPropagation()
-      if (socket.readyState === WebSocket.OPEN) socket.send(seq)
+      sockRef.current?.readyState === 1 && sockRef.current.send(bytes)
+      return true
     }
-    const onPaste = (event: ClipboardEvent) => {
-      const paste = event.clipboardData?.getData('text')
-      if (!paste) return
-      event.preventDefault()
-      if (socket.readyState === WebSocket.OPEN) socket.send(paste)
+
+    const view = new EditorView({
+      parent: host,
+      state: EditorState.create({
+        doc: '',
+        extensions: [
+          EditorView.editable.of(true),
+          EditorView.lineWrapping,
+          drawSelection(),
+          syntaxHighlighting(termHighlight),
+          termLang,
+          termTheme,
+          Prec.highest(
+            keymap.of([
+              {
+                any: (_view, event) => sendKey(event),
+              },
+            ]),
+          ),
+          EditorView.inputHandler.of(() => true),
+          EditorView.domEventHandlers({
+            paste(event) {
+              const text = event.clipboardData?.getData('text') ?? ''
+              if (!text) return false
+              event.preventDefault()
+              sockRef.current?.readyState === 1 && sockRef.current.send(text)
+              return true
+            },
+          }),
+        ],
+      }),
+    })
+    viewRef.current = view
+
+    const paint = () => {
+      const next = buf.text()
+      const cur = buf.cursor()
+      const pos = Math.min(next.length, cur)
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: next },
+        selection: { anchor: pos, head: pos },
+        scrollIntoView: true,
+      })
     }
-    const onFit = () => {
-      if (socket.readyState !== WebSocket.OPEN) return
-      const next = measure(el)
-      socket.send(JSON.stringify({ type: 'resize', cols: next.cols, rows: next.rows }))
+
+    const open = () => {
+      const sock = new WebSocket(socketUrl())
+      sock.binaryType = 'arraybuffer'
+      sockRef.current = sock
+      sock.onopen = () => {
+        setReady(true)
+        sock.send(JSON.stringify({ type: 'resize', cols: sizeRef.current.cols, rows: sizeRef.current.rows }))
+      }
+      sock.onclose = () => setReady(false)
+      sock.onmessage = (event) => {
+        const data = event.data
+        if (typeof data === 'string') {
+          if (data.startsWith('{"type":"exit"')) {
+            try {
+              const msg = JSON.parse(data) as { reason?: string }
+              buf.write(`\r\n[进程结束${msg.reason ? `: ${msg.reason}` : ''}]\r\n`)
+              paint()
+              return
+            } catch {
+              /* pty text */
+            }
+          }
+          buf.write(data)
+          paint()
+          return
+        }
+        buf.write(new TextDecoder().decode(data instanceof ArrayBuffer ? data : new Uint8Array(data)))
+        paint()
+      }
     }
-    el.addEventListener('keydown', onKey)
-    el.addEventListener('paste', onPaste)
-    const ro = new ResizeObserver(onFit)
-    ro.observe(el)
+    open()
+
+    const fit = () => {
+      const scroller = view.scrollDOM
+      const w = scroller.clientWidth
+      const h = scroller.clientHeight
+      if (w < 40 || h < 40) return
+      const cols = Math.max(20, Math.floor((w - 8) / CH))
+      const rows = Math.max(8, Math.floor(h / LH))
+      if (cols === sizeRef.current.cols && rows === sizeRef.current.rows) return
+      sizeRef.current = { cols, rows }
+      buf.resize(cols, rows)
+      sockRef.current?.readyState === 1 && sockRef.current.send(JSON.stringify({ type: 'resize', cols, rows }))
+    }
+    fit()
+    const ro = new ResizeObserver(fit)
+    ro.observe(host)
+
     return () => {
-      el.removeEventListener('keydown', onKey)
-      el.removeEventListener('paste', onPaste)
       ro.disconnect()
-      socket.close()
-      socketRef.current = null
+      sockRef.current?.close()
+      sockRef.current = null
+      view.destroy()
+      viewRef.current = null
     }
   }, [])
 
   useEffect(() => {
-    const el = paneRef.current
-    if (!el || !active) return
-    if (stick.current) el.scrollTop = el.scrollHeight
-    el.focus()
-  }, [text, active])
+    if (!active) return
+    const id = requestAnimationFrame(() => viewRef.current?.focus())
+    return () => cancelAnimationFrame(id)
+  }, [active])
 
   return (
     <div
-      ref={paneRef}
-      data-testid="page-terminal-body"
-      data-page-block-capture=""
-      tabIndex={0}
-      spellCheck={false}
-      onClick={() => paneRef.current?.focus()}
-      onScroll={(event) => {
-        const box = event.currentTarget
-        stick.current = box.scrollHeight - box.scrollTop - box.clientHeight < 28
-      }}
+      ref={wrapRef}
+      data-testid="page-terminal-xterm"
+      onMouseDown={() => viewRef.current?.focus()}
       style={{
-        display: active ? 'block' : 'none',
+        display: active ? 'flex' : 'none',
+        flexDirection: 'column',
         flex: 1,
         minHeight: 0,
-        width: '100%',
-        overflow: 'auto',
-        outline: 'none',
-        padding: '12px 14px 16px',
-        boxSizing: 'border-box',
-        whiteSpace: 'pre-wrap',
-        wordBreak: 'break-word',
-        fontFamily: MONO,
-        fontSize: 13,
-        lineHeight: 1.45,
-        color: INK,
-        background: BODY,
+        position: 'relative',
         cursor: 'text',
-        caretColor: 'transparent',
       }}
     >
-      {text}
+      {!ready ? (
+        <div
+          style={{
+            position: 'absolute',
+            zIndex: 1,
+            inset: 0,
+            pointerEvents: 'none',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontFamily: UI,
+            fontSize: 12,
+            color: MUTED,
+          }}
+        >
+          连接中…
+        </div>
+      ) : null}
     </div>
   )
 }
@@ -155,37 +263,33 @@ function TerminalSurface({
   onAdd: () => void
   onRemove: (id: string) => void
 }) {
-  const quiet: Record<string, unknown> = {
-    cursor: 'pointer',
+  const quiet: CSSProperties = {
+    appearance: 'none',
     border: 'none',
     background: 'transparent',
     color: MUTED,
     fontFamily: UI,
     fontSize: 12,
     fontWeight: 500,
+    lineHeight: 1,
     padding: '4px 8px',
     borderRadius: 6,
+    cursor: 'pointer',
   }
-
   return (
     <div
-      data-testid="page-terminal-surface"
       style={{
-        position: 'relative',
         flex: 1,
         minHeight: 0,
-        width: '100%',
-        background: BODY,
-        border: zoomed ? 'none' : `1px solid ${LINE}`,
-        borderRadius: zoomed ? 0 : 8,
-        boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        background: CARD,
+        border: `1px solid ${LINE}`,
+        borderRadius: zoomed ? 0 : 10,
       }}
     >
       <div
-        data-biu-ignore
         style={{
           display: 'flex',
           alignItems: 'center',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面终端遇到 zsh 提示符里的 `\r` 会把整段缓冲清空，所以看起来只有空行、没有输出、历史也没了。

这次改成按列覆盖的 `TerminalBuffer`，并用 CodeMirror 画可滚动输出和闪烁光标。按键仍发给 PTY，不在编辑器里本地插字。

改完后需要 `db_action /plugins/page-terminal action=pack` 并重启 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

