### PR TITLE
Restore xterm.js in page-terminal with a quieter card chrome

### DIFF
--- a/.plugin-dev/page-terminal/README.md
+++ b/.plugin-dev/page-terminal/README.md
@@ -1,8 +1,8 @@
 # 终端（page-terminal）
 
-页面里 `/terminal` 插入终端卡片：自己画的界面（借鉴 Notion / 苹果的留白和字重，没有红绿灯、不用 xterm）。点进正文打字，按键进本机 `$SHELL` PTY，输出可滚动。
+页面里 `/terminal` 插入终端卡片：外壳是细顶栏 + 会话 Tab（没有红绿灯），正文是 **xterm.js**（和 VS Code 同一套模拟器），按键进本机 `$SHELL` PTY。
 
-改完沙箱后 `db_action /plugins/page-terminal action=pack`。
+改完沙箱后 `db_action /plugins/page-terminal action=pack`，然后重启 host。
 
 ## 示例写法
 

--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -1,12 +1,12 @@
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import './xterm-skin.css'
+import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
+
 const React = globalThis.React
 const { useEffect, useRef, useState } = React
 type CSSProperties = import('react').CSSProperties
-import { EditorView, keymap, drawSelection } from '@codemirror/view'
-import { Prec, EditorState } from '@codemirror/state'
-import { StreamLanguage, HighlightStyle, syntaxHighlighting } from '@codemirror/language'
-import { tags as t } from '@lezer/highlight'
-import { TerminalBuffer, keyToPty } from './buffer.ts'
-import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
 
 export const name = 'page-terminal'
 export const inject = ['pageEditor']
@@ -17,216 +17,128 @@ const LINE = 'color-mix(in srgb, var(--text) 8%, transparent)'
 const MUTED = 'color-mix(in srgb, var(--text) 45%, transparent)'
 const INK = 'var(--text)'
 const CARD = 'var(--bg)'
-const BODY = 'color-mix(in srgb, var(--text) 3.5%, var(--bg))'
 const TAB_ON = 'color-mix(in srgb, var(--text) 6%, transparent)'
-const CH = 8.4
-const LH = 18
-
-function socketUrl() {
-  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
-  return `${proto}//${location.host}/ws/page-terminal`
-}
+const TERM_BG = '#1c1c1e'
+const TERM_FG = '#e8e8ed'
+const TERM_CURSOR = '#e8e8ed'
+const TERM_SEL = '#3a6ff0'
 
 function blockHeight(data: Record<string, unknown>) {
   const n = Number(data.height)
   return Number.isFinite(n) && n >= 160 ? n : 360
 }
 
-const termLang = StreamLanguage.define({
-  token(stream) {
-    if (stream.match(/^\$ |^% |^# |^❯ |^➜ /)) return 'meta'
-    if (stream.match(/^(error|Error|ERROR|fatal|Fatal)\b/)) return 'invalid'
-    if (stream.match(/^(warning|Warning|WARN)\b/)) return 'keyword'
-    if (stream.match(/^(\/|[A-Za-z]:\\)[^\s]+/)) return 'string'
-    if (stream.match(/^[0-9]+/)) return 'number'
-    stream.next()
-    return null
-  },
-})
-
-const termHighlight = HighlightStyle.define([
-  { tag: t.meta, color: '#7aa2f7' },
-  { tag: t.invalid, color: '#f7768e' },
-  { tag: t.keyword, color: '#e0af68' },
-  { tag: t.string, color: '#9ece6a' },
-  { tag: t.number, color: '#bb9af7' },
-])
-
-const termTheme = EditorView.theme({
-  '&': {
-    height: '100%',
-    background: 'transparent',
-    fontFamily: MONO,
-    fontSize: '12.5px',
-    color: INK,
-  },
-  '.cm-scroller': {
-    overflow: 'auto',
-    fontFamily: MONO,
-    lineHeight: `${LH}px`,
-    padding: '10px 14px 14px',
-  },
-  '.cm-content': { caretColor: INK, padding: 0, minHeight: '100%' },
-  '.cm-gutters': { display: 'none' },
-  '.cm-cursor': { borderLeftWidth: '2px', borderLeftColor: INK },
-  '&.cm-focused .cm-cursor': { borderLeftColor: INK },
-  '.cm-selectionBackground, &.cm-focused .cm-selectionBackground': {
-    background: 'color-mix(in srgb, #2f6fed 28%, transparent) !important',
-  },
-})
+function socketUrl(cols: number, rows: number) {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${proto}//${location.host}/ws/page-terminal?cols=${cols}&rows=${rows}`
+}
 
 function PtyPane({ active }: { active: boolean }) {
-  const wrapRef = useRef<HTMLDivElement | null>(null)
-  const viewRef = useRef<EditorView | null>(null)
-  const bufRef = useRef(new TerminalBuffer(80, 24))
-  const sockRef = useRef<WebSocket | null>(null)
-  const sizeRef = useRef({ cols: 80, rows: 24 })
+  const hostRef = useRef<HTMLDivElement | null>(null)
+  const termRef = useRef<Terminal | null>(null)
+  const fitRef = useRef<FitAddon | null>(null)
   const [ready, setReady] = useState(false)
 
   useEffect(() => {
-    const host = wrapRef.current
-    if (!host) return
-    const buf = bufRef.current
-
-    const sendKey = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'c' && !event.shiftKey) {
-        const sel = viewRef.current?.state.selection.main
-        if (sel && !sel.empty) return false
-      }
-      if (event.metaKey && event.key.toLowerCase() === 'v') return false
-      const bytes = keyToPty(event)
-      if (bytes == null) return false
-      event.preventDefault()
-      sockRef.current?.readyState === 1 && sockRef.current.send(bytes)
-      return true
-    }
-
-    const view = new EditorView({
-      parent: host,
-      state: EditorState.create({
-        doc: '',
-        extensions: [
-          EditorView.editable.of(true),
-          EditorView.lineWrapping,
-          drawSelection(),
-          syntaxHighlighting(termHighlight),
-          termLang,
-          termTheme,
-          Prec.highest(
-            keymap.of([
-              {
-                any: (_view, event) => sendKey(event),
-              },
-            ]),
-          ),
-          EditorView.inputHandler.of(() => true),
-          EditorView.domEventHandlers({
-            paste(event) {
-              const text = event.clipboardData?.getData('text') ?? ''
-              if (!text) return false
-              event.preventDefault()
-              sockRef.current?.readyState === 1 && sockRef.current.send(text)
-              return true
-            },
-          }),
-        ],
-      }),
+    const el = hostRef.current
+    if (!el) return
+    const term = new Terminal({
+      cursorBlink: true,
+      cursorStyle: 'bar',
+      fontSize: 13,
+      fontFamily: MONO,
+      lineHeight: 1.35,
+      scrollback: 10_000,
+      theme: {
+        background: TERM_BG,
+        foreground: TERM_FG,
+        cursor: TERM_CURSOR,
+        cursorAccent: TERM_BG,
+        selectionBackground: TERM_SEL,
+        selectionForeground: TERM_FG,
+      },
     })
-    viewRef.current = view
-
-    const paint = () => {
-      const next = buf.text()
-      const cur = buf.cursor()
-      const pos = Math.min(next.length, cur)
-      view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: next },
-        selection: { anchor: pos, head: pos },
-        scrollIntoView: true,
-      })
+    const fit = new FitAddon()
+    term.loadAddon(fit)
+    term.open(el)
+    try {
+      fit.fit()
+    } catch {
+      /* 折叠时尺寸为 0 */
     }
-
-    const open = () => {
-      const sock = new WebSocket(socketUrl())
-      sock.binaryType = 'arraybuffer'
-      sockRef.current = sock
-      sock.onopen = () => {
-        setReady(true)
-        sock.send(JSON.stringify({ type: 'resize', cols: sizeRef.current.cols, rows: sizeRef.current.rows }))
+    termRef.current = term
+    fitRef.current = fit
+    const socket = new WebSocket(socketUrl(term.cols, term.rows))
+    socket.binaryType = 'arraybuffer'
+    const write = term.onData((data) => {
+      if (socket.readyState === WebSocket.OPEN) socket.send(data)
+    })
+    const resized = term.onResize(({ cols, rows }) => {
+      if (socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: 'resize', cols, rows }))
       }
-      sock.onclose = () => setReady(false)
-      sock.onmessage = (event) => {
-        const data = event.data
-        if (typeof data === 'string') {
-          if (data.startsWith('{"type":"exit"')) {
-            try {
-              const msg = JSON.parse(data) as { reason?: string }
-              buf.write(`\r\n[进程结束${msg.reason ? `: ${msg.reason}` : ''}]\r\n`)
-              paint()
-              return
-            } catch {
-              /* pty text */
-            }
-          }
-          buf.write(data)
-          paint()
-          return
-        }
-        buf.write(new TextDecoder().decode(data instanceof ArrayBuffer ? data : new Uint8Array(data)))
-        paint()
+    })
+    socket.onopen = () => setReady(true)
+    socket.onclose = () => setReady(false)
+    socket.onmessage = (event) => {
+      if (typeof event.data === 'string') term.write(event.data)
+      else term.write(new Uint8Array(event.data as ArrayBuffer))
+    }
+    const onFit = () => {
+      try {
+        fit.fit()
+      } catch {
+        /* ignore */
       }
     }
-    open()
-
-    const fit = () => {
-      const scroller = view.scrollDOM
-      const w = scroller.clientWidth
-      const h = scroller.clientHeight
-      if (w < 40 || h < 40) return
-      const cols = Math.max(20, Math.floor((w - 8) / CH))
-      const rows = Math.max(8, Math.floor(h / LH))
-      if (cols === sizeRef.current.cols && rows === sizeRef.current.rows) return
-      sizeRef.current = { cols, rows }
-      buf.resize(cols, rows)
-      sockRef.current?.readyState === 1 && sockRef.current.send(JSON.stringify({ type: 'resize', cols, rows }))
-    }
-    fit()
-    const ro = new ResizeObserver(fit)
-    ro.observe(host)
-
+    window.addEventListener('resize', onFit)
+    const ro = new ResizeObserver(onFit)
+    ro.observe(el)
     return () => {
+      write.dispose()
+      resized.dispose()
       ro.disconnect()
-      sockRef.current?.close()
-      sockRef.current = null
-      view.destroy()
-      viewRef.current = null
+      window.removeEventListener('resize', onFit)
+      socket.close()
+      term.dispose()
+      termRef.current = null
+      fitRef.current = null
     }
   }, [])
 
   useEffect(() => {
     if (!active) return
-    const id = requestAnimationFrame(() => viewRef.current?.focus())
+    const id = requestAnimationFrame(() => {
+      try {
+        fitRef.current?.fit()
+      } catch {
+        /* ignore */
+      }
+      termRef.current?.focus()
+    })
     return () => cancelAnimationFrame(id)
   }, [active])
 
   return (
     <div
-      ref={wrapRef}
+      className="page-terminal-pty"
       data-testid="page-terminal-xterm"
-      onMouseDown={() => viewRef.current?.focus()}
+      data-page-block-capture=""
       style={{
-        display: active ? 'flex' : 'none',
-        flexDirection: 'column',
+        display: active ? 'block' : 'none',
         flex: 1,
         minHeight: 0,
+        width: '100%',
+        height: '100%',
         position: 'relative',
-        cursor: 'text',
+        background: TERM_BG,
       }}
     >
+      <div ref={hostRef} style={{ width: '100%', height: '100%' }} />
       {!ready ? (
         <div
           style={{
             position: 'absolute',
-            zIndex: 1,
             inset: 0,
             pointerEvents: 'none',
             display: 'flex',
@@ -234,7 +146,7 @@ function PtyPane({ active }: { active: boolean }) {
             justifyContent: 'center',
             fontFamily: UI,
             fontSize: 12,
-            color: MUTED,
+            color: 'rgba(232,232,237,.45)',
           }}
         >
           连接中…
@@ -278,6 +190,7 @@ function TerminalSurface({
   }
   return (
     <div
+      data-testid="page-terminal-surface"
       style={{
         flex: 1,
         minHeight: 0,
@@ -290,6 +203,7 @@ function TerminalSurface({
       }}
     >
       <div
+        data-biu-ignore
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -346,7 +260,7 @@ function TerminalSurface({
           {zoomed ? '收起' : '全屏'}
         </button>
       </div>
-      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: BODY }}>
+      <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', background: TERM_BG }}>
         {tabs.map((id) => (
           <PtyPane key={id} active={id === active} />
         ))}

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -1,0 +1,57 @@
+/* 只作用在终端卡片内，避免 xterm 默认样式漏到编辑器。 */
+.page-terminal-pty {
+  height: 100%;
+  width: 100%;
+  min-height: 0;
+  overflow: hidden;
+  padding: 8px 10px 10px;
+  box-sizing: border-box;
+}
+.page-terminal-pty .xterm {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  cursor: text;
+  padding: 0;
+}
+.page-terminal-pty .xterm:focus,
+.page-terminal-pty .xterm.focus {
+  outline: none;
+}
+.page-terminal-pty .xterm .xterm-helpers {
+  position: absolute;
+  top: 0;
+  z-index: 5;
+}
+/* 接键盘的 textarea 必须透明，否则左上角会画出一块假输入 */
+.page-terminal-pty textarea.xterm-helper-textarea,
+.page-terminal-pty .xterm-helper-textarea {
+  opacity: 0 !important;
+  color: transparent !important;
+  caret-color: transparent !important;
+  background: transparent !important;
+  border: 0 !important;
+  resize: none !important;
+  overflow: hidden !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  white-space: nowrap !important;
+}
+.page-terminal-pty .xterm .xterm-viewport {
+  overflow-y: auto !important;
+}
+.page-terminal-pty .xterm .composition-view {
+  color: inherit;
+  opacity: 1;
+}
+.page-terminal-pty .xterm .xterm-scroll-area {
+  visibility: hidden;
+}
+.page-terminal-pty .xterm-char-measure-element {
+  display: inline-block;
+  visibility: hidden;
+  position: absolute;
+  top: 0;
+  left: -9999em;
+  line-height: normal;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@tiptap/react": "^3.30.5",
         "@tiptap/starter-kit": "^3.30.5",
         "@tiptap/suggestion": "^3.30.5",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.3",
         "antd": "^6.6.1",
         "cordis": "4.0.0-rc.8",
@@ -5390,6 +5392,21 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "@tiptap/react": "^3.30.5",
     "@tiptap/starter-kit": "^3.30.5",
     "@tiptap/suggestion": "^3.30.5",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.3",
     "antd": "^6.6.1",
     "cordis": "4.0.0-rc.8",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
页面终端改回 **xterm.js**（和 VS Code 同一套模拟器），输入、回显、滚动历史交给它。

外壳保留细顶栏和会话 Tab，没有红绿灯。xterm 接键盘的 helper textarea 做成全透明，避免左上角再画出假第一行。

改完后需要 `db_action /plugins/page-terminal action=pack` 并重启 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

