### PR TITLE
Fix page-terminal helper ghost and viewport scroll

### DIFF
--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -61,6 +61,27 @@ function PtyPane({ active }: { active: boolean }) {
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(el)
+    const helper = el.querySelector('textarea.xterm-helper-textarea, textarea')
+    const buryHelper = () => {
+      if (!(helper instanceof HTMLTextAreaElement)) return
+      helper.setAttribute('aria-hidden', 'true')
+      helper.tabIndex = -1
+      helper.style.setProperty('outline', 'none', 'important')
+      helper.style.setProperty('box-shadow', 'none', 'important')
+      helper.style.setProperty('opacity', '0', 'important')
+      helper.style.setProperty('color', 'transparent', 'important')
+      helper.style.setProperty('caret-color', 'transparent', 'important')
+      helper.style.setProperty('background', 'transparent', 'important')
+      helper.style.setProperty('left', '-9999em', 'important')
+      helper.style.setProperty('width', '0', 'important')
+      helper.style.setProperty('height', '0', 'important')
+    }
+    buryHelper()
+    const helperWatch = helper instanceof HTMLTextAreaElement ? new MutationObserver(buryHelper) : null
+    if (helper instanceof HTMLTextAreaElement) {
+      helperWatch?.observe(helper, { attributes: true, attributeFilter: ['style', 'class'] })
+      helper.addEventListener('focus', buryHelper)
+    }
     try {
       fit.fit()
     } catch {
@@ -94,11 +115,24 @@ function PtyPane({ active }: { active: boolean }) {
     window.addEventListener('resize', onFit)
     const ro = new ResizeObserver(onFit)
     ro.observe(el)
+    const onWheel = (event: WheelEvent) => {
+      if (event.ctrlKey) return
+      event.stopPropagation()
+      const dy = event.deltaY
+      if (!dy) return
+      event.preventDefault()
+      const lines = Math.max(1, Math.round(Math.abs(dy) / 24)) * (dy > 0 ? 1 : -1)
+      term.scrollLines(lines)
+    }
+    el.addEventListener('wheel', onWheel, { capture: true, passive: false })
     return () => {
       write.dispose()
       resized.dispose()
       ro.disconnect()
       window.removeEventListener('resize', onFit)
+      helperWatch?.disconnect()
+      if (helper instanceof HTMLTextAreaElement) helper.removeEventListener('focus', buryHelper)
+      el.removeEventListener('wheel', onWheel, true)
       socket.close()
       term.dispose()
       termRef.current = null
@@ -125,16 +159,18 @@ function PtyPane({ active }: { active: boolean }) {
       data-testid="page-terminal-xterm"
       data-page-block-capture=""
       style={{
-        display: active ? 'block' : 'none',
+        display: active ? 'flex' : 'none',
+        flexDirection: 'column',
         flex: 1,
         minHeight: 0,
         width: '100%',
         height: '100%',
         position: 'relative',
+        overflow: 'hidden',
         background: TERM_BG,
       }}
     >
-      <div ref={hostRef} style={{ width: '100%', height: '100%' }} />
+      <div ref={hostRef} style={{ flex: 1, minHeight: 0, width: '100%', height: '100%' }} />
       {!ready ? (
         <div
           style={{

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -1,18 +1,16 @@
-/* 只作用在终端卡片内，避免 xterm 默认样式漏到编辑器。 */
+/* 只作用在终端卡片内。 */
 .page-terminal-pty {
   height: 100%;
   width: 100%;
   min-height: 0;
   overflow: hidden;
-  padding: 8px 10px 10px;
-  box-sizing: border-box;
 }
 .page-terminal-pty .xterm {
   position: relative;
   height: 100%;
   width: 100%;
-  cursor: text;
   padding: 0;
+  cursor: text;
 }
 .page-terminal-pty .xterm:focus,
 .page-terminal-pty .xterm.focus {
@@ -21,28 +19,47 @@
 .page-terminal-pty .xterm .xterm-helpers {
   position: absolute;
   top: 0;
+  left: 0;
   z-index: 5;
+  pointer-events: none;
 }
-/* 接键盘的 textarea 必须透明，否则左上角会画出一块假输入 */
 .page-terminal-pty textarea.xterm-helper-textarea,
-.page-terminal-pty .xterm-helper-textarea {
+.page-terminal-pty .xterm-helper-textarea,
+.page-terminal-pty .xterm-helper-textarea:focus,
+.page-terminal-pty .xterm-helper-textarea:focus-visible {
+  position: absolute !important;
   opacity: 0 !important;
   color: transparent !important;
   caret-color: transparent !important;
   background: transparent !important;
   border: 0 !important;
+  outline: none !important;
+  box-shadow: none !important;
   resize: none !important;
   overflow: hidden !important;
   padding: 0 !important;
   margin: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  left: -9999em !important;
+  top: 0 !important;
   white-space: nowrap !important;
+  -webkit-appearance: none !important;
 }
 .page-terminal-pty .xterm .xterm-viewport {
+  background-color: #1c1c1e !important;
   overflow-y: auto !important;
+  cursor: default;
+  position: absolute;
+  inset: 0;
 }
-.page-terminal-pty .xterm .composition-view {
-  color: inherit;
-  opacity: 1;
+.page-terminal-pty .xterm .xterm-screen {
+  position: relative;
+}
+.page-terminal-pty .xterm .xterm-screen canvas {
+  position: absolute;
+  left: 0;
+  top: 0;
 }
 .page-terminal-pty .xterm .xterm-scroll-area {
   visibility: hidden;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
xterm 接键盘的 helper textarea 在 macOS 上会画出蓝色焦点框，看起来像顶部空行。卡片还有内边距，画布被裁掉，滚轮进不了视口，所以看起来不能往下滚。

这次去掉内边距、按可见区域 fit、把 helper 移出画面并关掉 outline，滚轮交给 `scrollLines`。

请 `db_action /plugins/page-terminal action=pack` 后重启 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

