### PR TITLE
Page-terminal: app scrollbar, body fullscreen overlay

### DIFF
--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -1,8 +1,9 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { createPortal } from 'react-dom'
 import '@xterm/xterm/css/xterm.css'
 import './xterm-skin.css'
-import { relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
+import { makeOverlay, relockAncestors, unlockAncestors, watchZoom } from './zoom.ts'
 
 const React = globalThis.React
 const { useEffect, useRef, useState } = React
@@ -47,7 +48,7 @@ function PtyPane({ active }: { active: boolean }) {
       cursorStyle: 'bar',
       fontSize: 13,
       fontFamily: MONO,
-      lineHeight: 1.35,
+      lineHeight: 1,
       scrollback: 10_000,
       theme: {
         background: TERM_BG,
@@ -104,6 +105,7 @@ function PtyPane({ active }: { active: boolean }) {
     socket.onmessage = (event) => {
       if (typeof event.data === 'string') term.write(event.data)
       else term.write(new Uint8Array(event.data as ArrayBuffer))
+      term.scrollToBottom()
     }
     const onFit = () => {
       try {
@@ -115,6 +117,8 @@ function PtyPane({ active }: { active: boolean }) {
     window.addEventListener('resize', onFit)
     const ro = new ResizeObserver(onFit)
     ro.observe(el)
+    const pane = el.parentElement
+    if (pane) ro.observe(pane)
     const onWheel = (event: WheelEvent) => {
       if (event.ctrlKey) return
       event.stopPropagation()
@@ -164,13 +168,13 @@ function PtyPane({ active }: { active: boolean }) {
         flex: 1,
         minHeight: 0,
         width: '100%',
-        height: '100%',
+        height: 'auto',
         position: 'relative',
         overflow: 'hidden',
         background: TERM_BG,
       }}
     >
-      <div ref={hostRef} style={{ flex: 1, minHeight: 0, width: '100%', height: '100%' }} />
+      <div ref={hostRef} style={{ flex: 1, minHeight: 0, width: '100%', height: 'auto' }} />
       {!ready ? (
         <div
           style={{
@@ -313,20 +317,26 @@ function TerminalCard({ data }: { data: Record<string, unknown>; update: (patch:
   const [zoom, setZoom] = useState(false)
   const height = blockHeight(data)
   const hostRef = useRef<HTMLDivElement | null>(null)
+  const [overlayEl, setOverlayEl] = useState<HTMLElement | null>(null)
   const [tabs, setTabs] = useState<string[]>(() => [newTabId()])
   const [active, setActive] = useState(() => tabs[0] ?? newTabId())
 
   useEffect(() => {
-    const host = hostRef.current
-    if (!host || !zoom) {
+    if (!zoom) {
+      setOverlayEl(null)
       relockAncestors()
       return
     }
-    unlockAncestors(host)
-    const stop = watchZoom(() => setZoom(false), host)
+    const host = hostRef.current
+    if (host) unlockAncestors(host)
+    const el = makeOverlay('page-terminal-zoom-host', TERM_BG)
+    setOverlayEl(el)
+    const stop = watchZoom(() => setZoom(false), el)
     return () => {
       stop()
+      el.remove()
       relockAncestors()
+      setOverlayEl(null)
     }
   }, [zoom])
 
@@ -345,31 +355,34 @@ function TerminalCard({ data }: { data: Record<string, unknown>; update: (patch:
     })
   }
 
+  const surface = (
+    <TerminalSurface
+      tabs={tabs}
+      active={active}
+      zoomed={zoom}
+      onZoom={() => setZoom(true)}
+      onClose={() => setZoom(false)}
+      onSelect={setActive}
+      onAdd={addTab}
+      onRemove={removeTab}
+    />
+  )
+
   return (
     <div
       ref={hostRef}
       data-testid="page-terminal"
       style={{
-        position: zoom ? 'fixed' : 'relative',
-        inset: zoom ? 0 : undefined,
-        zIndex: zoom ? 2147483000 : undefined,
+        position: 'relative',
         width: '100%',
-        height: zoom ? '100%' : height,
-        display: 'flex',
+        height: zoom ? 0 : height,
+        overflow: zoom ? 'hidden' : undefined,
+        display: zoom ? 'block' : 'flex',
         padding: zoom ? 0 : '2px 0 4px',
         boxSizing: 'border-box',
       }}
     >
-      <TerminalSurface
-        tabs={tabs}
-        active={active}
-        zoomed={zoom}
-        onZoom={() => setZoom(true)}
-        onClose={() => setZoom(false)}
-        onSelect={setActive}
-        onAdd={addTab}
-        onRemove={removeTab}
-      />
+      {overlayEl ? createPortal(surface, overlayEl) : surface}
     </div>
   )
 }

--- a/.plugin-dev/page-terminal/xterm-layout.test.ts
+++ b/.plugin-dev/page-terminal/xterm-layout.test.ts
@@ -1,0 +1,11 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { Terminal } from '@xterm/xterm'
+
+test('xterm buffer keeps history and can scroll back', () => {
+  const term = new Terminal({ cols: 80, rows: 12, scrollback: 200 })
+  for (let i = 0; i < 40; i++) term.write(`line-${i}\r\n`)
+  assert.ok(term.buffer.active.length >= 12)
+  term.scrollLines(-8)
+  term.dispose()
+})

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -1,6 +1,6 @@
 /* 只作用在终端卡片内。 */
 .page-terminal-pty {
-  height: 100%;
+  height: auto;
   width: 100%;
   min-height: 0;
   overflow: hidden;
@@ -17,9 +17,12 @@
   outline: none;
 }
 .page-terminal-pty .xterm .xterm-helpers {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
   z-index: 5;
   pointer-events: none;
 }
@@ -52,6 +55,27 @@
   cursor: default;
   position: absolute;
   inset: 0;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--dsw-label-3) 55%, transparent) transparent;
+}
+.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 999px;
+}
+.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--dsw-label-3) 55%, transparent);
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  min-height: 32px;
+}
+.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--dsw-label-2) 70%, transparent);
+  background-clip: padding-box;
 }
 .page-terminal-pty .xterm .xterm-screen {
   position: relative;
@@ -71,4 +95,18 @@
   top: 0;
   left: -9999em;
   line-height: normal;
+}
+.page-terminal-pty .xterm-accessibility,
+.page-terminal-pty .xterm-accessibility-tree,
+.page-terminal-pty .xterm-message,
+.page-terminal-pty .live-region {
+  position: absolute !important;
+  left: 0 !important;
+  top: 0 !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  opacity: 0 !important;
+  color: transparent !important;
+  pointer-events: none !important;
 }

--- a/.plugin-dev/page-terminal/zoom.test.ts
+++ b/.plugin-dev/page-terminal/zoom.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'vitest'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { makeOverlay, watchZoom } from './zoom.ts'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const skin = readFileSync(join(dir, 'xterm-skin.css'), 'utf8')
+
+test('skin hides helper textarea and accessibility tree from layout', () => {
+  assert.match(skin, /xterm-helper-textarea/)
+  assert.match(skin, /left: -9999em/)
+  assert.match(skin, /outline: none/)
+  assert.match(skin, /xterm-accessibility-tree/)
+  assert.match(skin, /overflow-y: auto/)
+  assert.match(skin, /scrollbar-width: thin/)
+  assert.match(skin, /xterm-viewport::-webkit-scrollbar/)
+})
+
+test('zoom overlay is fixed on document.body, not nested in the page', () => {
+  const el = makeOverlay('page-terminal-zoom-host', '#1c1c1e')
+  assert.equal(el.parentElement, document.body)
+  assert.equal(getComputedStyle(el).position, 'fixed')
+  assert.equal(el.style.inset, '0px')
+  const stop = watchZoom(() => {}, el)
+  stop()
+  el.remove()
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
xterm 默认 `overflow-y: scroll`，在 macOS 上会画出系统粗滚动条。视口改成和全站一样的细条（10px 轨、透明 track、圆角 thumb）。

同时：全屏挂到 `document.body` 的 fixed 层，避免和底下页面叠在一起；helper / accessibility 不再占布局。

请 `db_action /plugins/page-terminal action=pack` 后重启 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

