### PR TITLE
Page-terminal: mount xterm the way VS Code does

### DIFF
--- a/.plugin-dev/page-terminal/README.md
+++ b/.plugin-dev/page-terminal/README.md
@@ -1,6 +1,6 @@
 # 终端（page-terminal）
 
-页面里 `/terminal` 插入终端卡片：外壳是细顶栏 + 会话 Tab（没有红绿灯），正文是 **xterm.js**（和 VS Code 同一套模拟器），按键进本机 `$SHELL` PTY。
+页面里 `/terminal` 插入终端卡片：外壳是细顶栏 + 会话 Tab。正文按 VS Code 同一套接法——官方 `xterm.css` + FitAddon 按容器像素 fit + WebGL 渲染（失败则回落到 canvas）。滚动交给 xterm 视口，不改它的 helper DOM。
 
 改完沙箱后 `db_action /plugins/page-terminal action=pack`，然后重启 host。
 

--- a/.plugin-dev/page-terminal/web.tsx
+++ b/.plugin-dev/page-terminal/web.tsx
@@ -1,5 +1,6 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
+import { WebglAddon } from '@xterm/addon-webgl'
 import { createPortal } from 'react-dom'
 import '@xterm/xterm/css/xterm.css'
 import './xterm-skin.css'
@@ -48,7 +49,6 @@ function PtyPane({ active }: { active: boolean }) {
       cursorStyle: 'bar',
       fontSize: 13,
       fontFamily: MONO,
-      lineHeight: 1,
       scrollback: 10_000,
       theme: {
         background: TERM_BG,
@@ -62,32 +62,23 @@ function PtyPane({ active }: { active: boolean }) {
     const fit = new FitAddon()
     term.loadAddon(fit)
     term.open(el)
-    const helper = el.querySelector('textarea.xterm-helper-textarea, textarea')
-    const buryHelper = () => {
-      if (!(helper instanceof HTMLTextAreaElement)) return
-      helper.setAttribute('aria-hidden', 'true')
-      helper.tabIndex = -1
-      helper.style.setProperty('outline', 'none', 'important')
-      helper.style.setProperty('box-shadow', 'none', 'important')
-      helper.style.setProperty('opacity', '0', 'important')
-      helper.style.setProperty('color', 'transparent', 'important')
-      helper.style.setProperty('caret-color', 'transparent', 'important')
-      helper.style.setProperty('background', 'transparent', 'important')
-      helper.style.setProperty('left', '-9999em', 'important')
-      helper.style.setProperty('width', '0', 'important')
-      helper.style.setProperty('height', '0', 'important')
-    }
-    buryHelper()
-    const helperWatch = helper instanceof HTMLTextAreaElement ? new MutationObserver(buryHelper) : null
-    if (helper instanceof HTMLTextAreaElement) {
-      helperWatch?.observe(helper, { attributes: true, attributeFilter: ['style', 'class'] })
-      helper.addEventListener('focus', buryHelper)
-    }
     try {
-      fit.fit()
+      const webgl = new WebglAddon()
+      webgl.onContextLoss(() => webgl.dispose())
+      term.loadAddon(webgl)
     } catch {
-      /* 折叠时尺寸为 0 */
+      /* 无 WebGL 时用默认 canvas 渲染，和 VS Code 降级一样 */
     }
+    const doFit = () => {
+      if (el.clientWidth < 8 || el.clientHeight < 8) return
+      try {
+        fit.fit()
+      } catch {
+        /* ignore */
+      }
+    }
+    doFit()
+    requestAnimationFrame(doFit)
     termRef.current = term
     fitRef.current = fit
     const socket = new WebSocket(socketUrl(term.cols, term.rows))
@@ -105,37 +96,17 @@ function PtyPane({ active }: { active: boolean }) {
     socket.onmessage = (event) => {
       if (typeof event.data === 'string') term.write(event.data)
       else term.write(new Uint8Array(event.data as ArrayBuffer))
-      term.scrollToBottom()
     }
-    const onFit = () => {
-      try {
-        fit.fit()
-      } catch {
-        /* ignore */
-      }
-    }
-    window.addEventListener('resize', onFit)
-    const ro = new ResizeObserver(onFit)
+    window.addEventListener('resize', doFit)
+    const ro = new ResizeObserver(doFit)
     ro.observe(el)
-    const pane = el.parentElement
-    if (pane) ro.observe(pane)
-    const onWheel = (event: WheelEvent) => {
-      if (event.ctrlKey) return
-      event.stopPropagation()
-      const dy = event.deltaY
-      if (!dy) return
-      event.preventDefault()
-      const lines = Math.max(1, Math.round(Math.abs(dy) / 24)) * (dy > 0 ? 1 : -1)
-      term.scrollLines(lines)
-    }
-    el.addEventListener('wheel', onWheel, { capture: true, passive: false })
+    const onWheel = (event: WheelEvent) => event.stopPropagation()
+    el.addEventListener('wheel', onWheel, { capture: true })
     return () => {
       write.dispose()
       resized.dispose()
       ro.disconnect()
-      window.removeEventListener('resize', onFit)
-      helperWatch?.disconnect()
-      if (helper instanceof HTMLTextAreaElement) helper.removeEventListener('focus', buryHelper)
+      window.removeEventListener('resize', doFit)
       el.removeEventListener('wheel', onWheel, true)
       socket.close()
       term.dispose()
@@ -163,18 +134,17 @@ function PtyPane({ active }: { active: boolean }) {
       data-testid="page-terminal-xterm"
       data-page-block-capture=""
       style={{
-        display: active ? 'flex' : 'none',
-        flexDirection: 'column',
+        display: active ? 'block' : 'none',
         flex: 1,
         minHeight: 0,
         width: '100%',
-        height: 'auto',
+        height: '100%',
         position: 'relative',
         overflow: 'hidden',
         background: TERM_BG,
       }}
     >
-      <div ref={hostRef} style={{ flex: 1, minHeight: 0, width: '100%', height: 'auto' }} />
+      <div ref={hostRef} style={{ position: 'absolute', inset: 0 }} />
       {!ready ? (
         <div
           style={{

--- a/.plugin-dev/page-terminal/xterm-skin.css
+++ b/.plugin-dev/page-terminal/xterm-skin.css
@@ -1,112 +1,42 @@
-/* 只作用在终端卡片内。 */
+/* 容器尺寸交给 FitAddon；不要改 xterm 内部 helper / canvas 结构。 */
 .page-terminal-pty {
-  height: auto;
+  position: relative;
   width: 100%;
+  height: 100%;
   min-height: 0;
   overflow: hidden;
 }
 .page-terminal-pty .xterm {
-  position: relative;
   height: 100%;
   width: 100%;
   padding: 0;
-  cursor: text;
 }
-.page-terminal-pty .xterm:focus,
-.page-terminal-pty .xterm.focus {
-  outline: none;
-}
-.page-terminal-pty .xterm .xterm-helpers {
-  position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 0 !important;
-  height: 0 !important;
-  overflow: hidden !important;
-  z-index: 5;
-  pointer-events: none;
-}
-.page-terminal-pty textarea.xterm-helper-textarea,
-.page-terminal-pty .xterm-helper-textarea,
 .page-terminal-pty .xterm-helper-textarea:focus,
 .page-terminal-pty .xterm-helper-textarea:focus-visible {
-  position: absolute !important;
-  opacity: 0 !important;
-  color: transparent !important;
-  caret-color: transparent !important;
-  background: transparent !important;
-  border: 0 !important;
   outline: none !important;
   box-shadow: none !important;
-  resize: none !important;
-  overflow: hidden !important;
-  padding: 0 !important;
-  margin: 0 !important;
-  width: 0 !important;
-  height: 0 !important;
-  left: -9999em !important;
-  top: 0 !important;
-  white-space: nowrap !important;
-  -webkit-appearance: none !important;
 }
-.page-terminal-pty .xterm .xterm-viewport {
-  background-color: #1c1c1e !important;
+.page-terminal-pty .xterm-viewport {
   overflow-y: auto !important;
-  cursor: default;
-  position: absolute;
-  inset: 0;
   scrollbar-width: thin;
   scrollbar-color: color-mix(in srgb, var(--dsw-label-3) 55%, transparent) transparent;
 }
-.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar {
+.page-terminal-pty .xterm-viewport::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
-.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-track {
+.page-terminal-pty .xterm-viewport::-webkit-scrollbar-track {
   background: transparent;
   border-radius: 999px;
 }
-.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-thumb {
+.page-terminal-pty .xterm-viewport::-webkit-scrollbar-thumb {
   background: color-mix(in srgb, var(--dsw-label-3) 55%, transparent);
   border-radius: 999px;
   border: 2px solid transparent;
   background-clip: padding-box;
   min-height: 32px;
 }
-.page-terminal-pty .xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+.page-terminal-pty .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: color-mix(in srgb, var(--dsw-label-2) 70%, transparent);
   background-clip: padding-box;
-}
-.page-terminal-pty .xterm .xterm-screen {
-  position: relative;
-}
-.page-terminal-pty .xterm .xterm-screen canvas {
-  position: absolute;
-  left: 0;
-  top: 0;
-}
-.page-terminal-pty .xterm .xterm-scroll-area {
-  visibility: hidden;
-}
-.page-terminal-pty .xterm-char-measure-element {
-  display: inline-block;
-  visibility: hidden;
-  position: absolute;
-  top: 0;
-  left: -9999em;
-  line-height: normal;
-}
-.page-terminal-pty .xterm-accessibility,
-.page-terminal-pty .xterm-accessibility-tree,
-.page-terminal-pty .xterm-message,
-.page-terminal-pty .live-region {
-  position: absolute !important;
-  left: 0 !important;
-  top: 0 !important;
-  width: 0 !important;
-  height: 0 !important;
-  overflow: hidden !important;
-  opacity: 0 !important;
-  color: transparent !important;
-  pointer-events: none !important;
 }

--- a/.plugin-dev/page-terminal/zoom.test.ts
+++ b/.plugin-dev/page-terminal/zoom.test.ts
@@ -8,11 +8,10 @@ import { makeOverlay, watchZoom } from './zoom.ts'
 const dir = dirname(fileURLToPath(import.meta.url))
 const skin = readFileSync(join(dir, 'xterm-skin.css'), 'utf8')
 
-test('skin hides helper textarea and accessibility tree from layout', () => {
+test('skin keeps official xterm layout and only restyles the scrollbar', () => {
   assert.match(skin, /xterm-helper-textarea/)
-  assert.match(skin, /left: -9999em/)
   assert.match(skin, /outline: none/)
-  assert.match(skin, /xterm-accessibility-tree/)
+  assert.doesNotMatch(skin, /xterm-accessibility-tree/)
   assert.match(skin, /overflow-y: auto/)
   assert.match(skin, /scrollbar-width: thin/)
   assert.match(skin, /xterm-viewport::-webkit-scrollbar/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@tiptap/starter-kit": "^3.30.5",
         "@tiptap/suggestion": "^3.30.5",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.3",
         "antd": "^6.6.1",
@@ -5397,6 +5398,15 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
       "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.18.0.tgz",
+      "integrity": "sha512-xCnfMBTI+/HKPdRnSOHaJDRqEpq2Ugy8LEj9GiY4J3zJObo3joylIFaMvzBwbYRg8zLtkO0KQaStCeSfoaI2/w==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@tiptap/starter-kit": "^3.30.5",
     "@tiptap/suggestion": "^3.30.5",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.3",
     "antd": "^6.6.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
VS Code 的终端也是 xterm.js，但接法很克制：容器有明确宽高、`FitAddon.fit()`、打开后再挂 WebGL，**不去改 helper / accessibility DOM**，滚动交给视口。

我们这边一直在和内部结构对着干（把 textarea 强制 0 尺寸、自己 `preventDefault` 滚轮、每条 PTY 数据 `scrollToBottom`），所以才会空行、假字符、滑不动。

这次按同一套接法重接，滚动条仍用全站细条。

请 `db_action /plugins/page-terminal action=pack` 后重启 host。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6148a3ff-b9da-479f-bd20-b370cbe4460e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6148a3ff-b9da-479f-bd20-b370cbe4460e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

