### PR TITLE
fix(plugins): 修复终端布局、输入与滚动

### DIFF
--- a/.plugin-dev/global-terminal/terminal.css
+++ b/.plugin-dev/global-terminal/terminal.css
@@ -1,26 +1,39 @@
 .biu-terminal-surface {
   position: relative;
+  display: block;
   width: 100%;
   height: 100%;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: #111318;
+  box-sizing: border-box;
+  contain: strict;
 }
 
 .biu-terminal-mount {
   position: absolute;
   inset: 0;
   padding: 9px 8px 5px 10px;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .biu-terminal-mount .xterm {
+  width: 100%;
   height: 100%;
+  padding: 0;
 }
 
 .biu-terminal-mount .xterm-viewport {
+  overflow-y: scroll !important;
+  overscroll-behavior: contain;
   scrollbar-color: #444b59 transparent;
   scrollbar-width: thin;
+}
+
+.biu-terminal-mount .xterm-screen {
+  margin: 0 !important;
 }
 
 .biu-terminal-status {

--- a/.plugin-dev/global-terminal/terminal.css
+++ b/.plugin-dev/global-terminal/terminal.css
@@ -14,7 +14,6 @@
 .biu-terminal-mount {
   position: absolute;
   inset: 0;
-  padding: 9px 8px 5px 10px;
   overflow: hidden;
   box-sizing: border-box;
 }
@@ -22,14 +21,24 @@
 .biu-terminal-mount .xterm {
   width: 100%;
   height: 100%;
-  padding: 0;
+  padding: 9px 8px 5px 10px;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .biu-terminal-mount .xterm-viewport {
-  overflow-y: scroll !important;
   overscroll-behavior: contain;
+}
+
+.biu-terminal-mount .xterm-scrollable-element {
+  max-width: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}
+
+.biu-terminal-mount .xterm-scrollable-element > .vertical.scrollbar {
+  right: 0 !important;
   scrollbar-color: #444b59 transparent;
-  scrollbar-width: thin;
 }
 
 .biu-terminal-mount .xterm-screen {

--- a/.plugin-dev/global-terminal/terminal.tsx
+++ b/.plugin-dev/global-terminal/terminal.tsx
@@ -20,14 +20,18 @@ export function TerminalSurface({
   endpoint,
   className = '',
   autoFocus = false,
+  active = true,
 }: {
   endpoint: string
   className?: string
   autoFocus?: boolean
+  active?: boolean
 }) {
   const host = useRef<HTMLDivElement | null>(null)
   const instance = useRef<Terminal | null>(null)
   const layout = useRef<() => void>(() => {})
+  const activeRef = useRef(active)
+  activeRef.current = active
   const [attempt, setAttempt] = useState(0)
   const [state, setState] = useState<ConnectionState>('connecting')
 
@@ -43,59 +47,102 @@ export function TerminalSurface({
     let disposed = false
     let frame = 0
     let secondFrame = 0
+    let terminal: Terminal | null = null
+    let fit: FitAddon | null = null
+    let socket: WebSocket | null = null
+    let input: { dispose(): void } | null = null
+    let resize: { dispose(): void } | null = null
     setState('connecting')
-    const terminal = new Terminal({
-      allowProposedApi: false,
-      convertEol: false,
-      cursorBlink: true,
-      cursorStyle: 'block',
-      fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
-      fontSize: 13,
-      lineHeight: 1.18,
-      scrollback: 5000,
-      theme: {
-        background: '#111318',
-        foreground: '#d6d9df',
-        cursor: '#f2f4f8',
-        cursorAccent: '#111318',
-        selectionBackground: '#355070aa',
-        black: '#20242c',
-        red: '#ff6b6b',
-        green: '#8bd49c',
-        yellow: '#e5c07b',
-        blue: '#61afef',
-        magenta: '#c678dd',
-        cyan: '#56b6c2',
-        white: '#d6d9df',
-        brightBlack: '#626a78',
-        brightRed: '#ff8787',
-        brightGreen: '#b2f2bb',
-        brightYellow: '#ffe066',
-        brightBlue: '#74c0fc',
-        brightMagenta: '#da77f2',
-        brightCyan: '#66d9e8',
-        brightWhite: '#ffffff',
-      },
-    })
-    const fit = new FitAddon()
-    terminal.loadAddon(fit)
-    terminal.open(element)
-    instance.current = terminal
-    if (!terminal.element || !terminal.textarea) {
-      instance.current = null
-      terminal.dispose()
-      setState('error')
-      return
-    }
-    terminal.textarea.setAttribute('aria-label', '全局终端输入')
-    terminal.textarea.setAttribute('autocomplete', 'off')
 
-    const fitVisibleTerminal = () => {
+    const isVisible = () => {
       if (disposed || !element.isConnected) return
       const bounds = element.getBoundingClientRect()
-      if (bounds.width < 20 || bounds.height < 20) return
+      if (!activeRef.current || bounds.width < 20 || bounds.height < 20) return false
       try {
-        fit.fit()
+        if (element.checkVisibility && !element.checkVisibility()) return false
+      } catch {
+        // Older Chromium versions may expose a partial checkVisibility implementation.
+      }
+      const style = window.getComputedStyle(element)
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.contentVisibility !== 'hidden'
+    }
+
+    const send = (message: Record<string, unknown>) => {
+      if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message))
+    }
+
+    const openVisibleTerminal = () => {
+      if (!isVisible()) return
+      if (!terminal) {
+        terminal = new Terminal({
+          allowProposedApi: false,
+          convertEol: false,
+          cursorBlink: true,
+          cursorStyle: 'block',
+          fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+          fontSize: 13,
+          lineHeight: 1.18,
+          scrollback: 5000,
+          theme: {
+            background: '#111318',
+            foreground: '#d6d9df',
+            cursor: '#f2f4f8',
+            cursorAccent: '#111318',
+            selectionBackground: '#355070aa',
+            black: '#20242c',
+            red: '#ff6b6b',
+            green: '#8bd49c',
+            yellow: '#e5c07b',
+            blue: '#61afef',
+            magenta: '#c678dd',
+            cyan: '#56b6c2',
+            white: '#d6d9df',
+            brightBlack: '#626a78',
+            brightRed: '#ff8787',
+            brightGreen: '#b2f2bb',
+            brightYellow: '#ffe066',
+            brightBlue: '#74c0fc',
+            brightMagenta: '#da77f2',
+            brightCyan: '#66d9e8',
+            brightWhite: '#ffffff',
+          },
+        })
+        fit = new FitAddon()
+        terminal.loadAddon(fit)
+        terminal.open(element)
+        instance.current = terminal
+        if (!terminal.element || !terminal.textarea) {
+          instance.current = null
+          terminal.dispose()
+          terminal = null
+          fit = null
+          setState('error')
+          return
+        }
+        terminal.textarea.setAttribute('aria-label', '全局终端输入')
+        terminal.textarea.setAttribute('autocomplete', 'off')
+        socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
+        input = terminal.onData((data) => send({ type: 'input', data }))
+        resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
+        socket.addEventListener('open', () => {
+          if (disposed || !terminal) return
+          setState('open')
+          scheduleFit()
+          send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
+          if (autoFocus && activeRef.current) terminal.focus()
+        })
+        socket.addEventListener('message', (event) => {
+          if (!disposed && terminal) terminal.write(typeof event.data === 'string' ? event.data : '')
+        })
+        socket.addEventListener('error', () => {
+          if (!disposed) setState('error')
+        })
+        socket.addEventListener('close', () => {
+          if (!disposed) setState((current) => (current === 'error' ? current : 'closed'))
+        })
+      }
+      try {
+        fit?.fit()
         terminal.refresh(0, terminal.rows - 1)
       } catch {
         // Ignore transient zero-size layouts while a tab is hidden.
@@ -105,58 +152,39 @@ export function TerminalSurface({
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
       frame = requestAnimationFrame(() => {
-        fitVisibleTerminal()
+        openVisibleTerminal()
         // Font metrics and the xterm viewport settle one frame after the first fit.
-        secondFrame = requestAnimationFrame(fitVisibleTerminal)
+        secondFrame = requestAnimationFrame(openVisibleTerminal)
       })
     }
     layout.current = scheduleFit
-    scheduleFit()
-
-    const socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
-    const send = (message: Record<string, unknown>) => {
-      if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message))
-    }
-    const input = terminal.onData((data) => send({ type: 'input', data }))
-    const resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
     const observer = new ResizeObserver(scheduleFit)
     observer.observe(element)
-
-    socket.addEventListener('open', () => {
-      if (disposed) return
-      setState('open')
-      scheduleFit()
-      send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
-      if (autoFocus) terminal.focus()
-    })
-    socket.addEventListener('message', (event) => {
-      if (!disposed) terminal.write(typeof event.data === 'string' ? event.data : '')
-    })
-    socket.addEventListener('error', () => {
-      if (!disposed) setState('error')
-    })
-    socket.addEventListener('close', () => {
-      if (!disposed) setState((current) => (current === 'error' ? current : 'closed'))
-    })
+    const intersection = typeof IntersectionObserver === 'undefined' ? null : new IntersectionObserver(scheduleFit)
+    intersection?.observe(element)
+    document.addEventListener('visibilitychange', scheduleFit)
+    scheduleFit()
 
     return () => {
       disposed = true
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
       observer.disconnect()
-      input.dispose()
-      resize.dispose()
-      socket.close()
+      intersection?.disconnect()
+      document.removeEventListener('visibilitychange', scheduleFit)
+      input?.dispose()
+      resize?.dispose()
+      socket?.close()
       layout.current = () => {}
       if (instance.current === terminal) instance.current = null
-      terminal.dispose()
+      terminal?.dispose()
     }
   }, [endpoint, attempt])
 
   useEffect(() => {
     layout.current()
-    if (autoFocus && state === 'open') instance.current?.focus()
-  }, [autoFocus, state])
+    if (active && autoFocus && state === 'open') instance.current?.focus()
+  }, [active, autoFocus, state])
 
   return (
     <div

--- a/.plugin-dev/global-terminal/terminal.tsx
+++ b/.plugin-dev/global-terminal/terminal.tsx
@@ -1,11 +1,10 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
-import { WebglAddon } from '@xterm/addon-webgl'
 import '@xterm/xterm/css/xterm.css'
 import './terminal.css'
 
 const React = globalThis.React
-const { useCallback, useEffect, useRef, useState } = React
+const { useCallback, useEffect, useLayoutEffect, useRef, useState } = React
 
 type ConnectionState = 'connecting' | 'open' | 'closed' | 'error'
 
@@ -28,6 +27,7 @@ export function TerminalSurface({
 }) {
   const host = useRef<HTMLDivElement | null>(null)
   const instance = useRef<Terminal | null>(null)
+  const layout = useRef<() => void>(() => {})
   const [attempt, setAttempt] = useState(0)
   const [state, setState] = useState<ConnectionState>('connecting')
 
@@ -36,12 +36,14 @@ export function TerminalSurface({
     setAttempt((value) => value + 1)
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = host.current
     if (!element) return
 
     let disposed = false
     let frame = 0
+    let secondFrame = 0
+    setState('connecting')
     const terminal = new Terminal({
       allowProposedApi: false,
       convertEol: false,
@@ -79,24 +81,37 @@ export function TerminalSurface({
     terminal.loadAddon(fit)
     terminal.open(element)
     instance.current = terminal
-
-    try {
-      const webgl = new WebglAddon()
-      webgl.onContextLoss(() => webgl.dispose())
-      terminal.loadAddon(webgl)
-    } catch {
-      // Canvas renderer is a supported fallback.
+    if (!terminal.element || !terminal.textarea) {
+      instance.current = null
+      terminal.dispose()
+      setState('error')
+      return
     }
+    terminal.textarea.setAttribute('aria-label', '全局终端输入')
+    terminal.textarea.setAttribute('autocomplete', 'off')
 
-    const doFit = () => {
-      if (disposed || element.clientWidth < 20 || element.clientHeight < 20) return
+    const fitVisibleTerminal = () => {
+      if (disposed || !element.isConnected) return
+      const bounds = element.getBoundingClientRect()
+      if (bounds.width < 20 || bounds.height < 20) return
       try {
         fit.fit()
+        terminal.refresh(0, terminal.rows - 1)
       } catch {
-        // Layout can briefly be zero while a window is resizing.
+        // Ignore transient zero-size layouts while a tab is hidden.
       }
     }
-    doFit()
+    const scheduleFit = () => {
+      cancelAnimationFrame(frame)
+      cancelAnimationFrame(secondFrame)
+      frame = requestAnimationFrame(() => {
+        fitVisibleTerminal()
+        // Font metrics and the xterm viewport settle one frame after the first fit.
+        secondFrame = requestAnimationFrame(fitVisibleTerminal)
+      })
+    }
+    layout.current = scheduleFit
+    scheduleFit()
 
     const socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
     const send = (message: Record<string, unknown>) => {
@@ -104,16 +119,13 @@ export function TerminalSurface({
     }
     const input = terminal.onData((data) => send({ type: 'input', data }))
     const resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
-    const observer = new ResizeObserver(() => {
-      cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(doFit)
-    })
+    const observer = new ResizeObserver(scheduleFit)
     observer.observe(element)
 
     socket.addEventListener('open', () => {
       if (disposed) return
       setState('open')
-      doFit()
+      scheduleFit()
       send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
       if (autoFocus) terminal.focus()
     })
@@ -130,21 +142,32 @@ export function TerminalSurface({
     return () => {
       disposed = true
       cancelAnimationFrame(frame)
+      cancelAnimationFrame(secondFrame)
       observer.disconnect()
       input.dispose()
       resize.dispose()
       socket.close()
+      layout.current = () => {}
       if (instance.current === terminal) instance.current = null
       terminal.dispose()
     }
   }, [endpoint, attempt])
 
   useEffect(() => {
+    layout.current()
     if (autoFocus && state === 'open') instance.current?.focus()
   }, [autoFocus, state])
 
   return (
-    <div className={`biu-terminal-surface ${className}`} data-terminal-state={state}>
+    <div
+      className={`biu-terminal-surface ${className}`}
+      data-terminal-state={state}
+      onMouseDown={(event) => {
+        event.stopPropagation()
+        instance.current?.focus()
+      }}
+      onWheel={(event) => event.stopPropagation()}
+    >
       <div ref={host} className="biu-terminal-mount" />
       {state === 'connecting' ? <div className="biu-terminal-status">正在连接终端…</div> : null}
       {state === 'closed' || state === 'error' ? (

--- a/.plugin-dev/global-terminal/web.tsx
+++ b/.plugin-dev/global-terminal/web.tsx
@@ -133,7 +133,7 @@ function GlobalTerminal() {
             aria-hidden={tab.id !== active}
             style={{ position: 'absolute', inset: 0, display: tab.id === active ? 'block' : 'none' }}
           >
-            <TerminalSurface endpoint="/ws/global-terminal" autoFocus={tab.id === active} />
+            <TerminalSurface endpoint="/ws/global-terminal" active={tab.id === active} autoFocus={tab.id === active} />
           </div>
         ))}
       </div>

--- a/.plugin-dev/page-terminal/terminal.css
+++ b/.plugin-dev/page-terminal/terminal.css
@@ -1,26 +1,39 @@
 .biu-terminal-surface {
   position: relative;
+  display: block;
   width: 100%;
   height: 100%;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: #111318;
+  box-sizing: border-box;
+  contain: strict;
 }
 
 .biu-terminal-mount {
   position: absolute;
   inset: 0;
   padding: 9px 8px 5px 10px;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .biu-terminal-mount .xterm {
+  width: 100%;
   height: 100%;
+  padding: 0;
 }
 
 .biu-terminal-mount .xterm-viewport {
+  overflow-y: scroll !important;
+  overscroll-behavior: contain;
   scrollbar-color: #444b59 transparent;
   scrollbar-width: thin;
+}
+
+.biu-terminal-mount .xterm-screen {
+  margin: 0 !important;
 }
 
 .biu-terminal-status {

--- a/.plugin-dev/page-terminal/terminal.css
+++ b/.plugin-dev/page-terminal/terminal.css
@@ -14,7 +14,6 @@
 .biu-terminal-mount {
   position: absolute;
   inset: 0;
-  padding: 9px 8px 5px 10px;
   overflow: hidden;
   box-sizing: border-box;
 }
@@ -22,14 +21,24 @@
 .biu-terminal-mount .xterm {
   width: 100%;
   height: 100%;
-  padding: 0;
+  padding: 9px 8px 5px 10px;
+  overflow: hidden;
+  box-sizing: border-box;
 }
 
 .biu-terminal-mount .xterm-viewport {
-  overflow-y: scroll !important;
   overscroll-behavior: contain;
+}
+
+.biu-terminal-mount .xterm-scrollable-element {
+  max-width: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}
+
+.biu-terminal-mount .xterm-scrollable-element > .vertical.scrollbar {
+  right: 0 !important;
   scrollbar-color: #444b59 transparent;
-  scrollbar-width: thin;
 }
 
 .biu-terminal-mount .xterm-screen {

--- a/.plugin-dev/page-terminal/terminal.tsx
+++ b/.plugin-dev/page-terminal/terminal.tsx
@@ -1,11 +1,10 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
-import { WebglAddon } from '@xterm/addon-webgl'
 import '@xterm/xterm/css/xterm.css'
 import './terminal.css'
 
 const React = globalThis.React
-const { useCallback, useEffect, useRef, useState } = React
+const { useCallback, useEffect, useLayoutEffect, useRef, useState } = React
 
 type ConnectionState = 'connecting' | 'open' | 'closed' | 'error'
 
@@ -28,6 +27,7 @@ export function TerminalSurface({
 }) {
   const host = useRef<HTMLDivElement | null>(null)
   const instance = useRef<Terminal | null>(null)
+  const layout = useRef<() => void>(() => {})
   const [attempt, setAttempt] = useState(0)
   const [state, setState] = useState<ConnectionState>('connecting')
 
@@ -36,12 +36,14 @@ export function TerminalSurface({
     setAttempt((value) => value + 1)
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = host.current
     if (!element) return
 
     let disposed = false
     let frame = 0
+    let secondFrame = 0
+    setState('connecting')
     const terminal = new Terminal({
       allowProposedApi: false,
       convertEol: false,
@@ -79,24 +81,37 @@ export function TerminalSurface({
     terminal.loadAddon(fit)
     terminal.open(element)
     instance.current = terminal
-
-    try {
-      const webgl = new WebglAddon()
-      webgl.onContextLoss(() => webgl.dispose())
-      terminal.loadAddon(webgl)
-    } catch {
-      // Canvas renderer is a supported fallback.
+    if (!terminal.element || !terminal.textarea) {
+      instance.current = null
+      terminal.dispose()
+      setState('error')
+      return
     }
+    terminal.textarea.setAttribute('aria-label', '页面终端输入')
+    terminal.textarea.setAttribute('autocomplete', 'off')
 
-    const doFit = () => {
-      if (disposed || element.clientWidth < 20 || element.clientHeight < 20) return
+    const fitVisibleTerminal = () => {
+      if (disposed || !element.isConnected) return
+      const bounds = element.getBoundingClientRect()
+      if (bounds.width < 20 || bounds.height < 20) return
       try {
         fit.fit()
+        terminal.refresh(0, terminal.rows - 1)
       } catch {
-        // Layout can briefly be zero while a page is switching.
+        // Ignore transient zero-size layouts while the page is switching.
       }
     }
-    doFit()
+    const scheduleFit = () => {
+      cancelAnimationFrame(frame)
+      cancelAnimationFrame(secondFrame)
+      frame = requestAnimationFrame(() => {
+        fitVisibleTerminal()
+        // Font metrics and the xterm viewport settle one frame after the first fit.
+        secondFrame = requestAnimationFrame(fitVisibleTerminal)
+      })
+    }
+    layout.current = scheduleFit
+    scheduleFit()
 
     const socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
     const send = (message: Record<string, unknown>) => {
@@ -104,16 +119,13 @@ export function TerminalSurface({
     }
     const input = terminal.onData((data) => send({ type: 'input', data }))
     const resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
-    const observer = new ResizeObserver(() => {
-      cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(doFit)
-    })
+    const observer = new ResizeObserver(scheduleFit)
     observer.observe(element)
 
     socket.addEventListener('open', () => {
       if (disposed) return
       setState('open')
-      doFit()
+      scheduleFit()
       send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
       if (autoFocus) terminal.focus()
     })
@@ -130,21 +142,32 @@ export function TerminalSurface({
     return () => {
       disposed = true
       cancelAnimationFrame(frame)
+      cancelAnimationFrame(secondFrame)
       observer.disconnect()
       input.dispose()
       resize.dispose()
       socket.close()
+      layout.current = () => {}
       if (instance.current === terminal) instance.current = null
       terminal.dispose()
     }
   }, [endpoint, attempt])
 
   useEffect(() => {
+    layout.current()
     if (autoFocus && state === 'open') instance.current?.focus()
   }, [autoFocus, state])
 
   return (
-    <div className={`biu-terminal-surface ${className}`} data-terminal-state={state}>
+    <div
+      className={`biu-terminal-surface ${className}`}
+      data-terminal-state={state}
+      onMouseDown={(event) => {
+        event.stopPropagation()
+        instance.current?.focus()
+      }}
+      onWheel={(event) => event.stopPropagation()}
+    >
       <div ref={host} className="biu-terminal-mount" />
       {state === 'connecting' ? <div className="biu-terminal-status">正在连接终端…</div> : null}
       {state === 'closed' || state === 'error' ? (

--- a/.plugin-dev/page-terminal/terminal.tsx
+++ b/.plugin-dev/page-terminal/terminal.tsx
@@ -20,14 +20,18 @@ export function TerminalSurface({
   endpoint,
   className = '',
   autoFocus = false,
+  active = true,
 }: {
   endpoint: string
   className?: string
   autoFocus?: boolean
+  active?: boolean
 }) {
   const host = useRef<HTMLDivElement | null>(null)
   const instance = useRef<Terminal | null>(null)
   const layout = useRef<() => void>(() => {})
+  const activeRef = useRef(active)
+  activeRef.current = active
   const [attempt, setAttempt] = useState(0)
   const [state, setState] = useState<ConnectionState>('connecting')
 
@@ -43,59 +47,102 @@ export function TerminalSurface({
     let disposed = false
     let frame = 0
     let secondFrame = 0
+    let terminal: Terminal | null = null
+    let fit: FitAddon | null = null
+    let socket: WebSocket | null = null
+    let input: { dispose(): void } | null = null
+    let resize: { dispose(): void } | null = null
     setState('connecting')
-    const terminal = new Terminal({
-      allowProposedApi: false,
-      convertEol: false,
-      cursorBlink: true,
-      cursorStyle: 'block',
-      fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
-      fontSize: 13,
-      lineHeight: 1.18,
-      scrollback: 5000,
-      theme: {
-        background: '#111318',
-        foreground: '#d6d9df',
-        cursor: '#f2f4f8',
-        cursorAccent: '#111318',
-        selectionBackground: '#355070aa',
-        black: '#20242c',
-        red: '#ff6b6b',
-        green: '#8bd49c',
-        yellow: '#e5c07b',
-        blue: '#61afef',
-        magenta: '#c678dd',
-        cyan: '#56b6c2',
-        white: '#d6d9df',
-        brightBlack: '#626a78',
-        brightRed: '#ff8787',
-        brightGreen: '#b2f2bb',
-        brightYellow: '#ffe066',
-        brightBlue: '#74c0fc',
-        brightMagenta: '#da77f2',
-        brightCyan: '#66d9e8',
-        brightWhite: '#ffffff',
-      },
-    })
-    const fit = new FitAddon()
-    terminal.loadAddon(fit)
-    terminal.open(element)
-    instance.current = terminal
-    if (!terminal.element || !terminal.textarea) {
-      instance.current = null
-      terminal.dispose()
-      setState('error')
-      return
-    }
-    terminal.textarea.setAttribute('aria-label', '页面终端输入')
-    terminal.textarea.setAttribute('autocomplete', 'off')
 
-    const fitVisibleTerminal = () => {
+    const isVisible = () => {
       if (disposed || !element.isConnected) return
       const bounds = element.getBoundingClientRect()
-      if (bounds.width < 20 || bounds.height < 20) return
+      if (!activeRef.current || bounds.width < 20 || bounds.height < 20) return false
       try {
-        fit.fit()
+        if (element.checkVisibility && !element.checkVisibility()) return false
+      } catch {
+        // Older Chromium versions may expose a partial checkVisibility implementation.
+      }
+      const style = window.getComputedStyle(element)
+      return style.display !== 'none' && style.visibility !== 'hidden' && style.contentVisibility !== 'hidden'
+    }
+
+    const send = (message: Record<string, unknown>) => {
+      if (socket?.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message))
+    }
+
+    const openVisibleTerminal = () => {
+      if (!isVisible()) return
+      if (!terminal) {
+        terminal = new Terminal({
+          allowProposedApi: false,
+          convertEol: false,
+          cursorBlink: true,
+          cursorStyle: 'block',
+          fontFamily: '"SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+          fontSize: 13,
+          lineHeight: 1.18,
+          scrollback: 5000,
+          theme: {
+            background: '#111318',
+            foreground: '#d6d9df',
+            cursor: '#f2f4f8',
+            cursorAccent: '#111318',
+            selectionBackground: '#355070aa',
+            black: '#20242c',
+            red: '#ff6b6b',
+            green: '#8bd49c',
+            yellow: '#e5c07b',
+            blue: '#61afef',
+            magenta: '#c678dd',
+            cyan: '#56b6c2',
+            white: '#d6d9df',
+            brightBlack: '#626a78',
+            brightRed: '#ff8787',
+            brightGreen: '#b2f2bb',
+            brightYellow: '#ffe066',
+            brightBlue: '#74c0fc',
+            brightMagenta: '#da77f2',
+            brightCyan: '#66d9e8',
+            brightWhite: '#ffffff',
+          },
+        })
+        fit = new FitAddon()
+        terminal.loadAddon(fit)
+        terminal.open(element)
+        instance.current = terminal
+        if (!terminal.element || !terminal.textarea) {
+          instance.current = null
+          terminal.dispose()
+          terminal = null
+          fit = null
+          setState('error')
+          return
+        }
+        terminal.textarea.setAttribute('aria-label', '页面终端输入')
+        terminal.textarea.setAttribute('autocomplete', 'off')
+        socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
+        input = terminal.onData((data) => send({ type: 'input', data }))
+        resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
+        socket.addEventListener('open', () => {
+          if (disposed || !terminal) return
+          setState('open')
+          scheduleFit()
+          send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
+          if (autoFocus && activeRef.current) terminal.focus()
+        })
+        socket.addEventListener('message', (event) => {
+          if (!disposed && terminal) terminal.write(typeof event.data === 'string' ? event.data : '')
+        })
+        socket.addEventListener('error', () => {
+          if (!disposed) setState('error')
+        })
+        socket.addEventListener('close', () => {
+          if (!disposed) setState((current) => (current === 'error' ? current : 'closed'))
+        })
+      }
+      try {
+        fit?.fit()
         terminal.refresh(0, terminal.rows - 1)
       } catch {
         // Ignore transient zero-size layouts while the page is switching.
@@ -105,58 +152,39 @@ export function TerminalSurface({
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
       frame = requestAnimationFrame(() => {
-        fitVisibleTerminal()
+        openVisibleTerminal()
         // Font metrics and the xterm viewport settle one frame after the first fit.
-        secondFrame = requestAnimationFrame(fitVisibleTerminal)
+        secondFrame = requestAnimationFrame(openVisibleTerminal)
       })
     }
     layout.current = scheduleFit
-    scheduleFit()
-
-    const socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
-    const send = (message: Record<string, unknown>) => {
-      if (socket.readyState === WebSocket.OPEN) socket.send(JSON.stringify(message))
-    }
-    const input = terminal.onData((data) => send({ type: 'input', data }))
-    const resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
     const observer = new ResizeObserver(scheduleFit)
     observer.observe(element)
-
-    socket.addEventListener('open', () => {
-      if (disposed) return
-      setState('open')
-      scheduleFit()
-      send({ type: 'resize', cols: terminal.cols, rows: terminal.rows })
-      if (autoFocus) terminal.focus()
-    })
-    socket.addEventListener('message', (event) => {
-      if (!disposed) terminal.write(typeof event.data === 'string' ? event.data : '')
-    })
-    socket.addEventListener('error', () => {
-      if (!disposed) setState('error')
-    })
-    socket.addEventListener('close', () => {
-      if (!disposed) setState((current) => (current === 'error' ? current : 'closed'))
-    })
+    const intersection = typeof IntersectionObserver === 'undefined' ? null : new IntersectionObserver(scheduleFit)
+    intersection?.observe(element)
+    document.addEventListener('visibilitychange', scheduleFit)
+    scheduleFit()
 
     return () => {
       disposed = true
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
       observer.disconnect()
-      input.dispose()
-      resize.dispose()
-      socket.close()
+      intersection?.disconnect()
+      document.removeEventListener('visibilitychange', scheduleFit)
+      input?.dispose()
+      resize?.dispose()
+      socket?.close()
       layout.current = () => {}
       if (instance.current === terminal) instance.current = null
-      terminal.dispose()
+      terminal?.dispose()
     }
   }, [endpoint, attempt])
 
   useEffect(() => {
     layout.current()
-    if (autoFocus && state === 'open') instance.current?.focus()
-  }, [autoFocus, state])
+    if (active && autoFocus && state === 'open') instance.current?.focus()
+  }, [active, autoFocus, state])
 
   return (
     <div

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@tiptap/starter-kit": "^3.30.5",
         "@tiptap/suggestion": "^3.30.5",
         "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "@xyflow/react": "^12.11.3",
         "antd": "^6.6.1",
@@ -5398,12 +5397,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
-      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@tiptap/starter-kit": "^3.30.5",
     "@tiptap/suggestion": "^3.30.5",
     "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.11.3",
     "antd": "^6.6.1",

--- a/packages/core-editor/src/web/page-block-view.tsx
+++ b/packages/core-editor/src/web/page-block-view.tsx
@@ -93,7 +93,11 @@ export function PageBlockView({ node, updateAttributes, editor, getPos }: NodeVi
 
   const onMouseDown = (event: MouseEvent) => {
     if (!editor.isEditable || editor.isDestroyed) return
-    if (event.target instanceof Element && event.target.closest('textarea, input, select, button, a')) return
+    if (event.target instanceof Element) {
+      if (event.target.closest('textarea, input, select, button, a')) return
+      const capture = event.target.closest('[data-page-block-capture]')
+      if (capture && capture !== event.currentTarget) return
+    }
     const pos = getPos()
     if (typeof pos !== 'number') return
     editor.chain().setNodeSelection(pos).run()

--- a/packages/core-editor/src/web/page-block.test.ts
+++ b/packages/core-editor/src/web/page-block.test.ts
@@ -288,6 +288,7 @@ test('pageBlock capture includes every registered block shell', async () => {
   assert.match(src, /closest\('\.page-block/)
   assert.match(src, /data-page-block-capture/)
   assert.match(view, /data-page-block-capture=""/)
+  assert.match(view, /capture && capture !== event\.currentTarget/)
   assert.match(view, /bindPageBlockPlugin/)
   assert.match(view, /data-biu-plugin=\{plugin \|\| undefined\}/)
   assert.match(view, /data-biu-kind="plugin"/)

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -56,4 +56,16 @@ describe('terminal store plugins', () => {
       assert.match(css, /\.xterm-scrollable-element/)
     }
   })
+
+  it('defers xterm opening until its page or tab is visible', async () => {
+    for (const id of ['page-terminal', 'global-terminal']) {
+      const terminal = await readFile(pluginFile(id, 'terminal.tsx'), 'utf8')
+      assert.match(terminal, /element\.checkVisibility/)
+      assert.match(terminal, /activeRef\.current/)
+      assert.match(terminal, /if \(!isVisible\(\)\) return/)
+      assert.match(terminal, /new IntersectionObserver\(scheduleFit\)/)
+    }
+    const global = await readFile(pluginFile('global-terminal', 'web.tsx'), 'utf8')
+    assert.match(global, /active=\{tab\.id === active\}/)
+  })
 })

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -43,4 +43,17 @@ describe('terminal store plugins', () => {
     assert.match(readme, /:::pageBlock \{kind=terminal plugin=page-terminal\}/)
     assert.match(readme, /"height": 360/)
   })
+
+  it('puts padding on xterm so FitAddon subtracts it from the grid', async () => {
+    for (const id of ['page-terminal', 'global-terminal']) {
+      const css = await readFile(pluginFile(id, 'terminal.css'), 'utf8')
+      const mountRule = css.match(/\.biu-terminal-mount\s*\{([^}]*)\}/)?.[1] ?? ''
+      const xtermRule = css.match(/\.biu-terminal-mount \.xterm\s*\{([^}]*)\}/)?.[1] ?? ''
+
+      assert.doesNotMatch(mountRule, /padding:/)
+      assert.match(xtermRule, /padding:/)
+      assert.match(xtermRule, /box-sizing:\s*border-box/)
+      assert.match(css, /\.xterm-scrollable-element/)
+    }
+  })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- 对照 Code OSS 的可见容器挂载约束，改为 layout effect 中初始化 xterm
- 仅在容器已连接且尺寸有效时执行 FitAddon，并在下一帧二次稳定布局
- 明确终端容器、xterm 根节点和 viewport 的完整尺寸及滚动样式
- 点击终端时阻止页面编辑器抢走焦点，并主动聚焦 xterm 输入
- 移除不必要且容易引入渲染差异的 WebGL addon，使用稳定的 canvas renderer

## 待验证
- 页面终端输入、长输出滚动与尺寸变化
- 全局终端多标签、长输出滚动与窗口缩放
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08c43268-6e45-45b3-b557-658443e9c891?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c43268-6e45-45b3-b557-658443e9c891&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

