### PR TITLE
fix(plugins): 修复终端持续连接状态

### DIFF
--- a/.plugin-dev/global-terminal/terminal.tsx
+++ b/.plugin-dev/global-terminal/terminal.tsx
@@ -58,11 +58,6 @@ export function TerminalSurface({
       if (disposed || !element.isConnected) return
       const bounds = element.getBoundingClientRect()
       if (!activeRef.current || bounds.width < 20 || bounds.height < 20) return false
-      try {
-        if (element.checkVisibility && !element.checkVisibility()) return false
-      } catch {
-        // Older Chromium versions may expose a partial checkVisibility implementation.
-      }
       const style = window.getComputedStyle(element)
       return style.display !== 'none' && style.visibility !== 'hidden' && style.contentVisibility !== 'hidden'
     }
@@ -121,6 +116,13 @@ export function TerminalSurface({
         }
         terminal.textarea.setAttribute('aria-label', '全局终端输入')
         terminal.textarea.setAttribute('autocomplete', 'off')
+        Object.assign(terminal.element.style, {
+          width: '100%',
+          height: '100%',
+          padding: '9px 8px 5px 10px',
+          overflow: 'hidden',
+          boxSizing: 'border-box',
+        })
         socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
         input = terminal.onData((data) => send({ type: 'input', data }))
         resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
@@ -190,20 +192,45 @@ export function TerminalSurface({
     <div
       className={`biu-terminal-surface ${className}`}
       data-terminal-state={state}
+      style={{
+        position: 'relative',
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        minHeight: 0,
+        overflow: 'hidden',
+        background: '#111318',
+        boxSizing: 'border-box',
+        contain: 'strict',
+      }}
       onMouseDown={(event) => {
         event.stopPropagation()
         instance.current?.focus()
       }}
       onWheel={(event) => event.stopPropagation()}
     >
-      <div ref={host} className="biu-terminal-mount" />
-      {state === 'connecting' ? <div className="biu-terminal-status">正在连接终端…</div> : null}
+      <div ref={host} className="biu-terminal-mount" style={{ position: 'absolute', inset: 0, overflow: 'hidden', boxSizing: 'border-box' }} />
+      {state === 'connecting' ? <div className="biu-terminal-status" style={statusStyle}>正在连接终端…</div> : null}
       {state === 'closed' || state === 'error' ? (
-        <div className="biu-terminal-status biu-terminal-status-error">
+        <div className="biu-terminal-status biu-terminal-status-error" style={{ ...statusStyle, background: 'rgb(17 19 24 / 92%)' }}>
           <span>{state === 'error' ? '终端连接失败' : '终端已退出'}</span>
           <button type="button" onClick={reconnect}>重新打开</button>
         </div>
       ) : null}
     </div>
   )
+}
+
+const statusStyle = {
+  position: 'absolute',
+  inset: 0,
+  zIndex: 2,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 10,
+  color: '#9ba3b2',
+  background: '#111318',
+  font: '12px ui-sans-serif, system-ui, sans-serif',
 }

--- a/.plugin-dev/page-terminal/terminal.tsx
+++ b/.plugin-dev/page-terminal/terminal.tsx
@@ -58,11 +58,6 @@ export function TerminalSurface({
       if (disposed || !element.isConnected) return
       const bounds = element.getBoundingClientRect()
       if (!activeRef.current || bounds.width < 20 || bounds.height < 20) return false
-      try {
-        if (element.checkVisibility && !element.checkVisibility()) return false
-      } catch {
-        // Older Chromium versions may expose a partial checkVisibility implementation.
-      }
       const style = window.getComputedStyle(element)
       return style.display !== 'none' && style.visibility !== 'hidden' && style.contentVisibility !== 'hidden'
     }
@@ -121,6 +116,13 @@ export function TerminalSurface({
         }
         terminal.textarea.setAttribute('aria-label', '页面终端输入')
         terminal.textarea.setAttribute('autocomplete', 'off')
+        Object.assign(terminal.element.style, {
+          width: '100%',
+          height: '100%',
+          padding: '9px 8px 5px 10px',
+          overflow: 'hidden',
+          boxSizing: 'border-box',
+        })
         socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
         input = terminal.onData((data) => send({ type: 'input', data }))
         resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
@@ -190,20 +192,45 @@ export function TerminalSurface({
     <div
       className={`biu-terminal-surface ${className}`}
       data-terminal-state={state}
+      style={{
+        position: 'relative',
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        minWidth: 0,
+        minHeight: 0,
+        overflow: 'hidden',
+        background: '#111318',
+        boxSizing: 'border-box',
+        contain: 'strict',
+      }}
       onMouseDown={(event) => {
         event.stopPropagation()
         instance.current?.focus()
       }}
       onWheel={(event) => event.stopPropagation()}
     >
-      <div ref={host} className="biu-terminal-mount" />
-      {state === 'connecting' ? <div className="biu-terminal-status">正在连接终端…</div> : null}
+      <div ref={host} className="biu-terminal-mount" style={{ position: 'absolute', inset: 0, overflow: 'hidden', boxSizing: 'border-box' }} />
+      {state === 'connecting' ? <div className="biu-terminal-status" style={statusStyle}>正在连接终端…</div> : null}
       {state === 'closed' || state === 'error' ? (
-        <div className="biu-terminal-status biu-terminal-status-error">
+        <div className="biu-terminal-status biu-terminal-status-error" style={{ ...statusStyle, background: 'rgb(17 19 24 / 92%)' }}>
           <span>{state === 'error' ? '终端连接失败' : '终端已退出'}</span>
           <button type="button" onClick={reconnect}>重新打开</button>
         </div>
       ) : null}
     </div>
   )
+}
+
+const statusStyle = {
+  position: 'absolute',
+  inset: 0,
+  zIndex: 2,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 10,
+  color: '#9ba3b2',
+  background: '#111318',
+  font: '12px ui-sans-serif, system-ui, sans-serif',
 }

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -57,13 +57,16 @@ describe('terminal store plugins', () => {
     }
   })
 
-  it('defers xterm opening until its page or tab is visible', async () => {
+  it('defers xterm opening until its page or tab has visible dimensions', async () => {
     for (const id of ['page-terminal', 'global-terminal']) {
       const terminal = await readFile(pluginFile(id, 'terminal.tsx'), 'utf8')
-      assert.match(terminal, /element\.checkVisibility/)
       assert.match(terminal, /activeRef\.current/)
       assert.match(terminal, /if \(!isVisible\(\)\) return/)
+      assert.match(terminal, /getBoundingClientRect/)
+      assert.doesNotMatch(terminal, /element\.checkVisibility/)
       assert.match(terminal, /new IntersectionObserver\(scheduleFit\)/)
+      assert.match(terminal, /Object\.assign\(terminal\.element\.style/)
+      assert.match(terminal, /style=\{statusStyle\}/)
     }
     const global = await readFile(pluginFile('global-terminal', 'web.tsx'), 'utf8')
     assert.match(global, /active=\{tab\.id === active\}/)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- 移除会将可见插件窗口误判为隐藏的 `checkVisibility()` 门控
- 保留 active、DOM 连接状态、有效尺寸及 computed style 检查
- 将终端关键容器布局和状态遮罩改为内联兜底，避免运行时 CSS 注入异常导致 xterm 无尺寸
- xterm 自身 padding、宽高和 box-sizing 同样以内联样式保证 FitAddon 计算正确

## 验证
- 待执行真实 Chrome、WebSocket、PTY 输入和滚动验证
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08c43268-6e45-45b3-b557-658443e9c891?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c43268-6e45-45b3-b557-658443e9c891&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

