### PR TITLE
fix(plugins): 移除终端首屏多余空行

### DIFF
--- a/.plugin-dev/global-terminal/terminal.tsx
+++ b/.plugin-dev/global-terminal/terminal.tsx
@@ -146,9 +146,13 @@ export function TerminalSurface({
             window.clearTimeout(startupTimer)
             startupTimer = window.setTimeout(() => {
               if (disposed || hasUserInput || !terminal) return
-              terminal.clear()
-              terminal.scrollToBottom()
-              terminal.refresh(0, terminal.rows - 1)
+              const buffer = terminal.buffer.active
+              const prompt = buffer.getLine(buffer.baseY + buffer.cursorY)?.translateToString(true) ?? ''
+              if (!prompt.trim()) return
+              terminal.write(`\u001b[2J\u001b[H${prompt}`, () => {
+                terminal?.scrollToBottom()
+                terminal?.refresh(0, terminal.rows - 1)
+              })
             }, 120)
           })
         })

--- a/.plugin-dev/global-terminal/terminal.tsx
+++ b/.plugin-dev/global-terminal/terminal.tsx
@@ -52,6 +52,8 @@ export function TerminalSurface({
     let socket: WebSocket | null = null
     let input: { dispose(): void } | null = null
     let resize: { dispose(): void } | null = null
+    let startupTimer = 0
+    let hasUserInput = false
     setState('connecting')
 
     const isVisible = () => {
@@ -124,7 +126,11 @@ export function TerminalSurface({
           boxSizing: 'border-box',
         })
         socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
-        input = terminal.onData((data) => send({ type: 'input', data }))
+        input = terminal.onData((data) => {
+          hasUserInput = true
+          window.clearTimeout(startupTimer)
+          send({ type: 'input', data })
+        })
         resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
         socket.addEventListener('open', () => {
           if (disposed || !terminal) return
@@ -134,7 +140,17 @@ export function TerminalSurface({
           if (autoFocus && activeRef.current) terminal.focus()
         })
         socket.addEventListener('message', (event) => {
-          if (!disposed && terminal) terminal.write(typeof event.data === 'string' ? event.data : '')
+          if (disposed || !terminal) return
+          terminal.write(typeof event.data === 'string' ? event.data : '', () => {
+            if (disposed || hasUserInput || !terminal) return
+            window.clearTimeout(startupTimer)
+            startupTimer = window.setTimeout(() => {
+              if (disposed || hasUserInput || !terminal) return
+              terminal.clear()
+              terminal.scrollToBottom()
+              terminal.refresh(0, terminal.rows - 1)
+            }, 120)
+          })
         })
         socket.addEventListener('error', () => {
           if (!disposed) setState('error')
@@ -153,6 +169,7 @@ export function TerminalSurface({
     const scheduleFit = () => {
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
+      window.clearTimeout(startupTimer)
       frame = requestAnimationFrame(() => {
         openVisibleTerminal()
         // Font metrics and the xterm viewport settle one frame after the first fit.

--- a/.plugin-dev/page-terminal/terminal.tsx
+++ b/.plugin-dev/page-terminal/terminal.tsx
@@ -146,9 +146,13 @@ export function TerminalSurface({
             window.clearTimeout(startupTimer)
             startupTimer = window.setTimeout(() => {
               if (disposed || hasUserInput || !terminal) return
-              terminal.clear()
-              terminal.scrollToBottom()
-              terminal.refresh(0, terminal.rows - 1)
+              const buffer = terminal.buffer.active
+              const prompt = buffer.getLine(buffer.baseY + buffer.cursorY)?.translateToString(true) ?? ''
+              if (!prompt.trim()) return
+              terminal.write(`\u001b[2J\u001b[H${prompt}`, () => {
+                terminal?.scrollToBottom()
+                terminal?.refresh(0, terminal.rows - 1)
+              })
             }, 120)
           })
         })

--- a/.plugin-dev/page-terminal/terminal.tsx
+++ b/.plugin-dev/page-terminal/terminal.tsx
@@ -52,6 +52,8 @@ export function TerminalSurface({
     let socket: WebSocket | null = null
     let input: { dispose(): void } | null = null
     let resize: { dispose(): void } | null = null
+    let startupTimer = 0
+    let hasUserInput = false
     setState('connecting')
 
     const isVisible = () => {
@@ -124,7 +126,11 @@ export function TerminalSurface({
           boxSizing: 'border-box',
         })
         socket = new WebSocket(socketUrl(endpoint, terminal.cols, terminal.rows))
-        input = terminal.onData((data) => send({ type: 'input', data }))
+        input = terminal.onData((data) => {
+          hasUserInput = true
+          window.clearTimeout(startupTimer)
+          send({ type: 'input', data })
+        })
         resize = terminal.onResize(({ cols, rows }) => send({ type: 'resize', cols, rows }))
         socket.addEventListener('open', () => {
           if (disposed || !terminal) return
@@ -134,7 +140,17 @@ export function TerminalSurface({
           if (autoFocus && activeRef.current) terminal.focus()
         })
         socket.addEventListener('message', (event) => {
-          if (!disposed && terminal) terminal.write(typeof event.data === 'string' ? event.data : '')
+          if (disposed || !terminal) return
+          terminal.write(typeof event.data === 'string' ? event.data : '', () => {
+            if (disposed || hasUserInput || !terminal) return
+            window.clearTimeout(startupTimer)
+            startupTimer = window.setTimeout(() => {
+              if (disposed || hasUserInput || !terminal) return
+              terminal.clear()
+              terminal.scrollToBottom()
+              terminal.refresh(0, terminal.rows - 1)
+            }, 120)
+          })
         })
         socket.addEventListener('error', () => {
           if (!disposed) setState('error')
@@ -153,6 +169,7 @@ export function TerminalSurface({
     const scheduleFit = () => {
       cancelAnimationFrame(frame)
       cancelAnimationFrame(secondFrame)
+      window.clearTimeout(startupTimer)
       frame = requestAnimationFrame(() => {
         openVisibleTerminal()
         // Font metrics and the xterm viewport settle one frame after the first fit.

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -71,4 +71,15 @@ describe('terminal store plugins', () => {
     const global = await readFile(pluginFile('global-terminal', 'web.tsx'), 'utf8')
     assert.match(global, /active=\{tab\.id === active\}/)
   })
+
+  it('removes shell startup padding only before the first user input', async () => {
+    for (const id of ['page-terminal', 'global-terminal']) {
+      const terminal = await readFile(pluginFile(id, 'terminal.tsx'), 'utf8')
+      assert.match(terminal, /hasUserInput = true/)
+      assert.match(terminal, /if \(disposed \|\| hasUserInput \|\| !terminal\) return/)
+      assert.match(terminal, /terminal\.clear\(\)/)
+      assert.match(terminal, /terminal\.scrollToBottom\(\)/)
+      assert.match(terminal, /window\.clearTimeout\(startupTimer\)/)
+    }
+  })
 })

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -79,7 +79,7 @@ describe('terminal store plugins', () => {
       assert.match(terminal, /if \(disposed \|\| hasUserInput \|\| !terminal\) return/)
       assert.match(terminal, /buffer\.getLine\(buffer\.baseY \+ buffer\.cursorY\)/)
       assert.match(terminal, /\\u001b\[2J\\u001b\[H/)
-      assert.match(terminal, /terminal\.scrollToBottom\(\)/)
+      assert.match(terminal, /terminal\?\.scrollToBottom\(\)/)
       assert.match(terminal, /window\.clearTimeout\(startupTimer\)/)
     }
   })

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -77,7 +77,8 @@ describe('terminal store plugins', () => {
       const terminal = await readFile(pluginFile(id, 'terminal.tsx'), 'utf8')
       assert.match(terminal, /hasUserInput = true/)
       assert.match(terminal, /if \(disposed \|\| hasUserInput \|\| !terminal\) return/)
-      assert.match(terminal, /terminal\.clear\(\)/)
+      assert.match(terminal, /buffer\.getLine\(buffer\.baseY \+ buffer\.cursorY\)/)
+      assert.match(terminal, /\\u001b\[2J\\u001b\[H/)
       assert.match(terminal, /terminal\.scrollToBottom\(\)/)
       assert.match(terminal, /window\.clearTimeout\(startupTimer\)/)
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
- 在用户首次输入前等待 shell 启动输出稳定
- 仅整理一次启动缓冲，将最终提示符移动到终端首行
- 用户一旦输入即永久取消整理，避免清除正常命令与历史
- 页面终端和全局终端行为保持一致

## 验证
- 待执行零输入真实浏览器首屏检查、输入及滚动回归
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08c43268-6e45-45b3-b557-658443e9c891?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08c43268-6e45-45b3-b557-658443e9c891&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

