### PR TITLE
fix(plugins): pack 终端插件需要 @xterm 依赖

### DIFF
--- a/.plugin-dev/global-terminal/package.json
+++ b/.plugin-dev/global-terminal/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "global-terminal",
+  "private": true,
+  "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0"
+  }
+}

--- a/.plugin-dev/page-terminal/package.json
+++ b/.plugin-dev/page-terminal/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "page-terminal",
+  "private": true,
+  "dependencies": {
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,8 @@
         "@tiptap/react": "^3.30.5",
         "@tiptap/starter-kit": "^3.30.5",
         "@tiptap/suggestion": "^3.30.5",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.3",
         "antd": "^6.6.1",
         "cordis": "4.0.0-rc.8",
@@ -5390,6 +5392,21 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
+      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "@tiptap/react": "^3.30.5",
     "@tiptap/starter-kit": "^3.30.5",
     "@tiptap/suggestion": "^3.30.5",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.3",
     "antd": "^6.6.1",
     "cordis": "4.0.0-rc.8",

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -34,6 +34,7 @@ describe('terminal store plugins', () => {
       assert.match(host, /node-pty/)
       assert.match(web, new RegExp(`/ws/${id}`))
       assert.match(web, /type:"resize"/)
+      assert.match(web, /FitAddon|addon-fit/)
       assert.doesNotMatch(web, /from"@biu\//)
     }
   })

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -293,6 +293,8 @@ export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') 
     },
     conditions: ['production', 'import', 'module', 'browser', 'default'],
     plugins: storeBundlePlugins(kind),
+    // 沙箱目录通常没有自己的 node_modules；从仓库根解析 npm（如 @xterm/*）
+    nodePaths: [join(process.cwd(), 'node_modules')],
     // 原生模块不能打进 host.js，运行时走宿主 node_modules
     external: kind === 'host' ? ['node-pty'] : [],
   })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`page-terminal` / `global-terminal` 的 `web.tsx` 会 `import` `@xterm/xterm` 和 `@xterm/addon-fit`。pack 时 esbuild 在沙箱目录解析 npm，仓库根之前没装这两个包，就会报 Could not resolve。

- 根 `package.json` 加上依赖
- pack 增加 `nodePaths` 指向仓库根 `node_modules`
- 沙箱里各放一份 `package.json` 标明依赖

拉下来后需要在仓库根执行一次 `npm install`，再对 page-terminal 做 pack。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

