### PR TITLE
fix(plugins): 插件 npm 依赖走沙箱，不再挂宿主

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,6 @@
         "@tiptap/react": "^3.30.5",
         "@tiptap/starter-kit": "^3.30.5",
         "@tiptap/suggestion": "^3.30.5",
-        "@xterm/addon-fit": "^0.10.0",
-        "@xterm/xterm": "^5.5.0",
         "@xyflow/react": "^12.11.3",
         "antd": "^6.6.1",
         "cordis": "4.0.0-rc.8",
@@ -5392,21 +5390,6 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
-    },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
-      "integrity": "sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@xterm/xterm": "^5.0.0"
-      }
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
-      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
     },
     "node_modules/@xyflow/react": {
       "version": "12.11.3",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "@tiptap/react": "^3.30.5",
     "@tiptap/starter-kit": "^3.30.5",
     "@tiptap/suggestion": "^3.30.5",
-    "@xterm/addon-fit": "^0.10.0",
-    "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.11.3",
     "antd": "^6.6.1",
     "cordis": "4.0.0-rc.8",

--- a/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
+++ b/packages/core-plugin-system/src/host/dual-terminal-plugins.test.ts
@@ -39,6 +39,17 @@ describe('terminal store plugins', () => {
     }
   })
 
+  it('installs xterm from the plugin package.json instead of the host', async () => {
+    const src = await readFile(resolve(import.meta.dirname, './plugin-create.ts'), 'utf8')
+    const pagePkg = JSON.parse(await readFile(pluginFile('page-terminal', 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+    }
+    assert.match(src, /ensureSandboxNpm/)
+    assert.doesNotMatch(src, /nodePaths/)
+    assert.ok(pagePkg.dependencies?.['@xterm/xterm'])
+    assert.ok(pagePkg.dependencies?.['@xterm/addon-fit'])
+  })
+
   it('documents the complete page block fence', async () => {
     const readme = await readFile(pluginFile('page-terminal', 'README.md'), 'utf8')
     assert.match(readme, /:::pageBlock \{kind=terminal plugin=page-terminal\}/)

--- a/packages/core-plugin-system/src/host/plugin-create.test.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.test.ts
@@ -310,6 +310,7 @@ test('sandbox/pack live on the plugins collection, not as tools', () => {
   assert.equal(sandbox?.allowMissing, true)
   assert.match(JSON.stringify(sandbox?.parameters), /listing\.shell/)
   assert.match(String(pack?.parameters?.description ?? ''), /host\.ts/)
+  assert.match(String(pack?.parameters?.description ?? ''), /沙箱 package.json/)
 })
 
 test('pack web jsx uses globalThis.React instead of bundling npm react', async () => {
@@ -401,6 +402,45 @@ test('pack bundles npm deps but keeps react on globalThis', async () => {
     assert.match(webJs, /pong/)
     assert.match(webJs, /globalThis\.React/)
     assert.doesNotMatch(webJs, /from ['"]react['"]/)
+    assert.doesNotMatch(webJs, /from ['"]tiny-ping['"]/)
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('pack installs sandbox package.json deps without host node_modules', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-sandbox-npm-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const store = new PluginStoreService(
+      ctx,
+      join(dir, '.plugin'),
+      join(dir, 'store.json'),
+      join(dir, '.plugin-dev'),
+    ).open()
+    await store.initSandbox({
+      id: 'store-file-dep',
+      name: 'File dep',
+      headless: true,
+    })
+    const sandbox = join(dir, '.plugin-dev', 'store-file-dep')
+    const vendor = join(sandbox, 'vendor', 'tiny-ping')
+    const { mkdir } = await import('node:fs/promises')
+    await mkdir(vendor, { recursive: true })
+    await writeFile(join(vendor, 'package.json'), JSON.stringify({ name: 'tiny-ping', type: 'module', main: 'index.js' }))
+    await writeFile(join(vendor, 'index.js'), `export const ping = 'from-sandbox'\n`)
+    await writeFile(
+      join(sandbox, 'package.json'),
+      `${JSON.stringify({ name: 'store-file-dep', private: true, dependencies: { 'tiny-ping': 'file:./vendor/tiny-ping' } }, null, 2)}\n`,
+    )
+    await writeFile(
+      join(sandbox, 'web.tsx'),
+      `import { ping } from 'tiny-ping'\nexport const name = 'store-file-dep'\nexport function apply() { return ping }\n`,
+    )
+    await store.pack('store-file-dep')
+    const webJs = await readFile(join(dir, '.plugin', 'store-file-dep', 'web.js'), 'utf8')
+    assert.match(webJs, /from-sandbox/)
     assert.doesNotMatch(webJs, /from ['"]tiny-ping['"]/)
   } finally {
     await rm(dir, { recursive: true, force: true })

--- a/packages/core-plugin-system/src/host/plugin-create.ts
+++ b/packages/core-plugin-system/src/host/plugin-create.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { readFile, writeFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
 import { dirname, extname, join, resolve } from 'node:path'
 import type { Plugin as EsbuildPlugin } from 'esbuild'
 import { declaredStoreShell, parseStoreShell, requireDeclaredShell, type StoreShell } from '../shell.ts'
@@ -269,8 +270,37 @@ function storeBundlePlugins(kind: 'host' | 'web'): EsbuildPlugin[] {
   return plugins
 }
 
-/** 沙箱入口打包：相对 import + npm（react / @biu/* 除外）。 */
+/** 沙箱自己的 npm 依赖：pack 时装进 .plugin-dev/<id>/node_modules，再打进 bundle。不走宿主 package.json。 */
+export function ensureSandboxNpm(sandbox: string) {
+  const pkgFile = join(sandbox, 'package.json')
+  if (!existsSync(pkgFile)) return
+  let pkg: { dependencies?: Record<string, string> }
+  try {
+    pkg = JSON.parse(readFileSync(pkgFile, 'utf8')) as { dependencies?: Record<string, string> }
+  } catch {
+    throw new Error(`invalid package.json: ${pkgFile}`)
+  }
+  const deps = pkg.dependencies ?? {}
+  const names = Object.keys(deps)
+  if (!names.length) return
+  if (names.every((name) => existsSync(join(sandbox, 'node_modules', name, 'package.json')))) return
+  try {
+    execFileSync('npm', ['install', '--omit=dev', '--no-audit', '--no-fund', '--ignore-scripts'], {
+      cwd: sandbox,
+      encoding: 'utf8',
+      timeout: 120_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, npm_config_update_notifier: 'false' },
+    })
+  } catch (error) {
+    const detail = error instanceof Error && 'stderr' in error ? String((error as { stderr?: string }).stderr || error.message) : String(error)
+    throw new Error(`plugin npm install failed in ${sandbox}: ${detail.trim()}`)
+  }
+}
+
+/** 沙箱入口打包：相对 import + 沙箱 npm（react / @biu/* 除外）。 */
 export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') {
+  ensureSandboxNpm(dirname(entryFile))
   const { build } = await import('esbuild')
   const result = await build({
     absWorkingDir: dirname(entryFile),
@@ -293,8 +323,6 @@ export async function bundleStoreEntry(entryFile: string, kind: 'host' | 'web') 
     },
     conditions: ['production', 'import', 'module', 'browser', 'default'],
     plugins: storeBundlePlugins(kind),
-    // 沙箱目录通常没有自己的 node_modules；从仓库根解析 npm（如 @xterm/*）
-    nodePaths: [join(process.cwd(), 'node_modules')],
     // 原生模块不能打进 host.js，运行时走宿主 node_modules
     external: kind === 'host' ? ['node-pty'] : [],
   })
@@ -316,7 +344,7 @@ export async function readSandboxManifest(dir: string) {
 }
 
 const CONTRACT = [
-  '契约：id 与 export const name 相同。可以 import npm，pack 会打进 host.js/web.js。不要 import react / react-dom / @biu/*：Web 用宿主 globalThis.React、ReactDOM 与 ReactJSXRuntime；宿主服务用 inject。安装路径只有 sandbox + pack：db_action /plugins/<id> action=sandbox 建 .plugin-dev/<id>/，写完再用 action=pack。不要直写 .plugin。不要改 packages/ 或 cordis.plugins.json。',
+  '契约：id 与 export const name 相同。可以 import npm；依赖写在沙箱 package.json，pack 会在沙箱 npm install 再打进 host.js/web.js，不要写进宿主 package.json。不要 import react / react-dom / @biu/*：Web 用宿主 globalThis.React、ReactDOM 与 ReactJSXRuntime；宿主服务用 inject。安装路径只有 sandbox + pack：db_action /plugins/<id> action=sandbox 建 .plugin-dev/<id>/，写完再用 action=pack。不要直写 .plugin。不要改 packages/ 或 cordis.plugins.json。',
   '有窗口的 Web：ctx.slots.place("plugin-store-extras", Comp, { key, props: () => ({ Icon }) })。Icon 可选。运行窗口会给 extras 套操纵栏（关/缩；resizable 才有全屏），key 尽量用插件 id。',
   '无头插件：manifest 写 headless: true。有 web 也不要 shell，不要 place plugin-store-extras，不要操纵栏。只在 apply 里登记服务（如 pageEditor、databaseUi）。pageEditor.registerBlock 必须带 plugin（与本插件 id / export const name 相同），并用 blockType 声明块类型：basic 进斜杠「基础模块」，其它值（如 excalidraw、algorithm）各自成组，不要混进基础。写入文档后编辑器按这个 id 引导启用，不要让编辑器猜插件。页面块插件的 README（介绍）必须含「示例写法」和完整 :::pageBlock 围栏（含 kind、plugin、体），让 agent 读 /plugins/<id> 介绍就知道语法。集合自定义整页模式用 databaseUi.registerView(path, { id, label, plugin, View })。只换每一行的样子用 databaseUi.registerRowView(path 或 "*", { id, label, plugin, Row })，plugin 填本插件 id，宿主会打 data-biu-plugin，选取内部元素也能改这个插件。外壳和可见列由 File System 绑；Row 收到 record、fields、onOpen。',
   '有窗口的 web 必须在 manifest / 本动作 shell 参数里写 width 与 height。无头插件不要写 shell。',
@@ -334,6 +362,7 @@ export const PLUGIN_SANDBOX_DESCRIPTION = [
 export const PLUGIN_PACK_DESCRIPTION = [
   '把 .plugin-dev/<id>/ 沙箱打包进 .plugin/<id>/（manifest.json + bundle 后的 host.js / web.js）。',
   '入口：host.ts|tsx|js 与 web.tsx|ts|js，至少要有一个。有窗口的 web 必须已写 shell.width/height；无头插件写 headless: true 即可。已打开的插件会重新挂上。',
+  'npm 依赖写在沙箱 package.json，pack 会在该目录 install，打进 bundle；不要把插件依赖加到宿主 package.json。',
 ].join(' ')
 
 export function createArgs(args: Record<string, unknown>): PluginCreateInput {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上次把 `@xterm/*` 加进宿主 `package.json` 是错的：那是插件自己的依赖，不该污染全局。

- 从根 `package.json` 拿掉 `@xterm/xterm` / `@xterm/addon-fit`
- pack 时读沙箱 `.plugin-dev/<id>/package.json`，在该目录 `npm install`，再打进 `host.js` / `web.js`
- `node-pty` 仍是宿主 native 模块（external），和 UI 库不是一类

拉 `file-system` 后，对 page-terminal 再 pack 一次即可；不必在仓库根安装 xterm。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

