### PR TITLE
feat(plugins): 把 web.js 哈希登记为 /plugins.webVersion

### DIFF
--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -40,6 +40,7 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
           lastRunAt: null,
           hasHost: true,
           hasWeb: true,
+          webVersion: 'abc123def456',
           shell: defaultStoreShell(),
         },
       ]),
@@ -82,11 +83,13 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.equal(demo?.sandbox, undefined)
   assert.equal(demo?.shellWidth, defaultStoreShell().width)
   assert.equal(demo?.hasWeb, true)
+  assert.equal(demo?.webVersion, 'abc123def456')
   assert.equal(demo?.headless, undefined)
   assert.equal(draft?.sandbox, true)
   assert.equal(draft?.installed, undefined)
   assert.equal(draft?.running, undefined)
   assert.equal(draft?.bytes, undefined)
+  assert.equal(draft?.webVersion, undefined)
   assert.equal(draft?.shellWidth, undefined)
   assert.deepEqual(
     spec.actions?.map((item) => item.id),
@@ -108,6 +111,8 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.ok(spec.schema.columns?.includes('sandbox'))
   assert.ok(spec.schema.columns?.includes('installed'))
   assert.ok(spec.schema.columns?.includes('tags'))
+  assert.ok(spec.schema.columns?.includes('webVersion'))
+  assert.equal(spec.schema.fields.webVersion?.label, 'Web 版本')
   assert.equal(spec.schema.fields.tags?.writable, true)
   assert.equal(spec.schema.fields.emoji?.writable, true)
   assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { installed: true, running: false })

--- a/packages/core-plugin-system/src/host/collection.test.ts
+++ b/packages/core-plugin-system/src/host/collection.test.ts
@@ -40,7 +40,7 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
           lastRunAt: null,
           hasHost: true,
           hasWeb: true,
-          webVersion: 'abc123def456',
+          codeVersion: 'abc123def456',
           shell: defaultStoreShell(),
         },
       ]),
@@ -83,13 +83,13 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.equal(demo?.sandbox, undefined)
   assert.equal(demo?.shellWidth, defaultStoreShell().width)
   assert.equal(demo?.hasWeb, true)
-  assert.equal(demo?.webVersion, 'abc123def456')
+  assert.equal(demo?.codeVersion, 'abc123def456')
   assert.equal(demo?.headless, undefined)
   assert.equal(draft?.sandbox, true)
   assert.equal(draft?.installed, undefined)
   assert.equal(draft?.running, undefined)
   assert.equal(draft?.bytes, undefined)
-  assert.equal(draft?.webVersion, undefined)
+  assert.equal(draft?.codeVersion, undefined)
   assert.equal(draft?.shellWidth, undefined)
   assert.deepEqual(
     spec.actions?.map((item) => item.id),
@@ -111,8 +111,8 @@ test('pluginsCollection lists installed plugins and sandboxes in one table', asy
   assert.ok(spec.schema.columns?.includes('sandbox'))
   assert.ok(spec.schema.columns?.includes('installed'))
   assert.ok(spec.schema.columns?.includes('tags'))
-  assert.ok(spec.schema.columns?.includes('webVersion'))
-  assert.equal(spec.schema.fields.webVersion?.label, 'Web 版本')
+  assert.ok(spec.schema.columns?.includes('codeVersion'))
+  assert.equal(spec.schema.fields.codeVersion?.label, '代码版本')
   assert.equal(spec.schema.fields.tags?.writable, true)
   assert.equal(spec.schema.fields.emoji?.writable, true)
   assert.deepEqual(spec.actions?.find((item) => item.id === 'start')?.when, { installed: true, running: false })

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -40,6 +40,7 @@ function asInstalledRecord(row: StoreListing): DbRecord {
     lastRunAt: row.lastRunAt,
     hasHost: row.hasHost,
     hasWeb: row.hasWeb,
+    webVersion: row.webVersion,
     headless: row.headless === true,
     ...(row.headless || !shell
       ? {}
@@ -108,7 +109,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       route: '/plugins',
       title: '插件',
       inspector: true,
-      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。安装只能 sandbox 再 pack：先 db_action path=/plugins/<插件id> action=sandbox 建 .plugin-dev/<id>/（记录可以还不存在），写完代码再 action=pack 打进 .plugin。不要直写 .plugin。start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
+      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。webVersion 是已安装 web.js 的内容短哈希，和加载 URL 的 v 参数相同。安装只能 sandbox 再 pack：先 db_action path=/plugins/<插件id> action=sandbox 建 .plugin-dev/<id>/（记录可以还不存在），写完代码再 action=pack 打进 .plugin。不要直写 .plugin。start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
       order: 30,
       icon: 'puzzle-piece',
     },
@@ -130,6 +131,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         'shellHeight',
         'hasHost',
         'hasWeb',
+        'webVersion',
         'headless',
       ],
       fields: {
@@ -147,6 +149,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         lastRunAt: { type: 'datetime', label: '上次运行' },
         hasHost: { type: 'boolean', label: 'Host' },
         hasWeb: { type: 'boolean', label: 'Web' },
+        webVersion: { type: 'string', label: 'Web 版本' },
         headless: { type: 'boolean', label: '无头' },
         author: { type: 'string', label: '作者' },
         authorUrl: { type: 'url', label: '作者链接' },

--- a/packages/core-plugin-system/src/host/collection.ts
+++ b/packages/core-plugin-system/src/host/collection.ts
@@ -40,7 +40,7 @@ function asInstalledRecord(row: StoreListing): DbRecord {
     lastRunAt: row.lastRunAt,
     hasHost: row.hasHost,
     hasWeb: row.hasWeb,
-    webVersion: row.webVersion,
+    codeVersion: row.codeVersion,
     headless: row.headless === true,
     ...(row.headless || !shell
       ? {}
@@ -109,7 +109,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
       route: '/plugins',
       title: '插件',
       inspector: true,
-      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。webVersion 是已安装 web.js 的内容短哈希，和加载 URL 的 v 参数相同。安装只能 sandbox 再 pack：先 db_action path=/plugins/<插件id> action=sandbox 建 .plugin-dev/<id>/（记录可以还不存在），写完代码再 action=pack 打进 .plugin。不要直写 .plugin。start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
+      blurb: '这是插件（可安装的小程序），不是代理。用户说「再开一个 agent」请去 /sessions db_create，不要在这张表 create。已安装（.plugin）和沙箱（.plugin-dev）同一张表。列表 db_list /plugins。README 用 db_content /plugins/<id>。页面块插件先读介绍里的「示例写法」再写 :::pageBlock。name 等只读（facet/tags 仍可写）。不能 db_create。窗口尺寸看 shellWidth/shellHeight。codeVersion 是已安装 host.js+web.js 的内容短哈希，和加载 URL 的 v 参数相同。安装只能 sandbox 再 pack：先 db_action path=/plugins/<插件id> action=sandbox 建 .plugin-dev/<id>/（记录可以还不存在），写完代码再 action=pack 打进 .plugin。不要直写 .plugin。start=打开已安装插件窗口（when：installed 且未 running）；stop=关掉运行中的插件（when：installed 且 running）；uninstall=删除 .plugin/<id>/（沙箱还在则这行还在）。',
       order: 30,
       icon: 'puzzle-piece',
     },
@@ -131,7 +131,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         'shellHeight',
         'hasHost',
         'hasWeb',
-        'webVersion',
+        'codeVersion',
         'headless',
       ],
       fields: {
@@ -149,7 +149,7 @@ export function pluginsCollection(store: PluginStoreService): CollectionSpec {
         lastRunAt: { type: 'datetime', label: '上次运行' },
         hasHost: { type: 'boolean', label: 'Host' },
         hasWeb: { type: 'boolean', label: 'Web' },
-        webVersion: { type: 'string', label: 'Web 版本' },
+        codeVersion: { type: 'string', label: '代码版本' },
         headless: { type: 'boolean', label: '无头' },
         author: { type: 'string', label: '作者' },
         authorUrl: { type: 'url', label: '作者链接' },

--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import { Context } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
 import { PluginStoreService, defaultPluginDir, defaultStatePath } from './index.ts'
+import { hashPluginWebVersion } from './store.ts'
 
 function stubHub(ctx: Context) {
   const adopted: string[] = []
@@ -175,11 +176,16 @@ test('web-only plugin opens without host.js', async () => {
     const sandboxes = await store.listSandboxes()
     assert.equal(sandboxes.find((row) => row.id === 'store-banner')?.hasWeb, true)
     await store.openPlugin('store-banner')
+    const listed = (await store.list()).find((row) => row.id === 'store-banner')
+    assert.ok(listed?.webVersion)
+    assert.match(listed.webVersion, /^[0-9a-f]{12}$/)
     // web 入口会带上内容 hash 版本号（?v=...），用于让前端在重打包后重新加载。
-    assert.match(
-      String(forks.get('store-banner')?.web),
-      /^\/api\/plugin-store\/files\/store-banner\/web\.js\?v=[0-9a-f]+$/,
+    assert.equal(
+      forks.get('store-banner')?.web,
+      `/api/plugin-store/files/store-banner/web.js?v=${listed.webVersion}`,
     )
+    const packed = await readFile(join(dir, '.plugin', 'store-banner', 'web.js'))
+    assert.equal(listed.webVersion, hashPluginWebVersion(packed))
     await assert.rejects(() => store.readInstalledFile('store-banner', 'host.js'))
   } finally {
     await rm(dir, { recursive: true, force: true })

--- a/packages/core-plugin-system/src/host/index.test.ts
+++ b/packages/core-plugin-system/src/host/index.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path'
 import { Context } from 'cordis'
 import type { CatalogEntry } from '@biu/host-hub'
 import { PluginStoreService, defaultPluginDir, defaultStatePath } from './index.ts'
-import { hashPluginWebVersion } from './store.ts'
+import { hashInstalledPluginCode } from './store.ts'
 
 function stubHub(ctx: Context) {
   const adopted: string[] = []
@@ -177,16 +177,47 @@ test('web-only plugin opens without host.js', async () => {
     assert.equal(sandboxes.find((row) => row.id === 'store-banner')?.hasWeb, true)
     await store.openPlugin('store-banner')
     const listed = (await store.list()).find((row) => row.id === 'store-banner')
-    assert.ok(listed?.webVersion)
-    assert.match(listed.webVersion, /^[0-9a-f]{12}$/)
-    // web 入口会带上内容 hash 版本号（?v=...），用于让前端在重打包后重新加载。
+    assert.ok(listed?.codeVersion)
+    assert.match(listed.codeVersion, /^[0-9a-f]{12}$/)
+    // web 入口会带上整包代码 hash（host + web），用于让前端在重打包后重新加载。
     assert.equal(
       forks.get('store-banner')?.web,
-      `/api/plugin-store/files/store-banner/web.js?v=${listed.webVersion}`,
+      `/api/plugin-store/files/store-banner/web.js?v=${listed.codeVersion}`,
     )
-    const packed = await readFile(join(dir, '.plugin', 'store-banner', 'web.js'))
-    assert.equal(listed.webVersion, hashPluginWebVersion(packed))
+    assert.equal(listed.codeVersion, await hashInstalledPluginCode(join(dir, '.plugin', 'store-banner')))
     await assert.rejects(() => store.readInstalledFile('store-banner', 'host.js'))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
+
+test('codeVersion hashes host.js and web.js together', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'plugin-root-'))
+  try {
+    const ctx = new Context()
+    stubHub(ctx)
+    const pluginDir = join(dir, '.plugin')
+    const store = new PluginStoreService(ctx, pluginDir, join(dir, 'store.json'), join(dir, '.plugin-dev')).open()
+    await store.initSandbox({
+      id: 'store-both',
+      name: 'Both',
+      shell: { width: 360, height: 240 },
+      hostJs: `export const name = 'store-both'\nexport function apply() {}\n`,
+      webJs: `export const name = 'store-both-web'\nexport const inject = ['slots']\nexport function apply() {}\n`,
+    })
+    await store.pack('store-both')
+    const packed = join(pluginDir, 'store-both')
+    const before = await hashInstalledPluginCode(packed)
+    const listed = (await store.list()).find((row) => row.id === 'store-both')
+    assert.equal(listed?.codeVersion, before)
+    assert.ok(listed?.hasHost)
+    assert.ok(listed?.hasWeb)
+    await writeFile(join(packed, 'host.js'), `export const name = 'store-both'\nexport function apply() { return 1 }\n`)
+    const afterHost = await hashInstalledPluginCode(packed)
+    assert.notEqual(afterHost, before)
+    await writeFile(join(packed, 'web.js'), `export const name = 'store-both-web'\nexport function apply() { return 2 }\n`)
+    const afterWeb = await hashInstalledPluginCode(packed)
+    assert.notEqual(afterWeb, afterHost)
   } finally {
     await rm(dir, { recursive: true, force: true })
   }

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -33,6 +33,8 @@ export type StoreListing = {
   lastRunAt: number | null
   hasHost: boolean
   hasWeb: boolean
+  /** 已安装 web.js 的内容短哈希，与加载 URL 的 v 参数一致。 */
+  webVersion?: string
   headless?: boolean
   shell?: StoreShell
 }
@@ -48,9 +50,14 @@ type StoreHub = {
 const ALLOWED_FILES = new Set(['manifest.json', 'host.js', 'web.js'])
 const README_FILE = 'README.md'
 
+/** 已安装 web.js 的短版本号：内容 SHA-1 前 12 位。 */
+export function hashPluginWebVersion(body: Buffer | string): string {
+  return createHash('sha1').update(body).digest('hex').slice(0, 12)
+}
+
 export function storeWebUrl(id: string, version?: string | number) {
   const base = `/api/plugin-store/files/${encodeURIComponent(id)}/web.js`
-  // 带上版本号（通常是 web.js 的 mtime），让前端的「挂载键」随每次重打包变化，
+  // 带上 web.js 内容短哈希，让前端的「挂载键」随每次重打包变化，
   // 从而触发真正的卸载 + 重新 import；否则前端会一直用最早加载的模块实例。
   return version === undefined ? base : `${base}?v=${encodeURIComponent(String(version))}`
 }
@@ -109,6 +116,16 @@ async function pluginDirStats(dir: string): Promise<Pick<StoreListing, 'bytes' |
     updatedAt,
     hasHost: existsSync(join(dir, 'host.js')),
     hasWeb: existsSync(join(dir, 'web.js')),
+  }
+}
+
+async function readInstalledWebVersion(dir: string): Promise<string | undefined> {
+  const webFile = join(dir, 'web.js')
+  if (!existsSync(webFile)) return undefined
+  try {
+    return hashPluginWebVersion(await readFile(webFile))
+  } catch {
+    return undefined
   }
 }
 
@@ -319,6 +336,7 @@ export class PluginStoreService extends Service {
       const manifest = await readManifest(dir)
       const enabled = this.isEnabled(manifest.id)
       const stats = await pluginDirStats(dir)
+      const webVersion = await readInstalledWebVersion(dir)
       items.push({
         ...manifest,
         enabled,
@@ -329,6 +347,7 @@ export class PluginStoreService extends Service {
         lastRunAt: this.state.lastRunAt[manifest.id] ?? null,
         hasHost: stats.hasHost,
         hasWeb: stats.hasWeb,
+        ...(webVersion ? { webVersion } : {}),
         ...(manifest.headless ? { headless: true } : { shell: parseStoreShell(manifest.shell) }),
       })
     }
@@ -457,17 +476,7 @@ export class PluginStoreService extends Service {
     const webFile = join(dir, 'web.js')
     const hostCode = existsSync(hostFile) ? (await readFile(hostFile, 'utf8')).trim() : ''
     const hasWeb = existsSync(webFile)
-    // 用 web.js 内容的短 hash 作为版本号：只要代码变了就一定变，
-    // 且不受写入时间戳精度影响（同一毫秒内重打包也能区分）。
-    let webVersion: string | undefined
-    if (hasWeb) {
-      try {
-        const body = await readFile(webFile)
-        webVersion = createHash('sha1').update(body).digest('hex').slice(0, 12)
-      } catch {
-        webVersion = undefined
-      }
-    }
+    const webVersion = await readInstalledWebVersion(dir)
     if (!hostCode && !hasWeb) throw new Error(`plugin ${manifest.id} has neither host nor web`)
     const mod = (hostCode
       ? await importHostFile(hostFile)

--- a/packages/core-plugin-system/src/host/store.ts
+++ b/packages/core-plugin-system/src/host/store.ts
@@ -33,8 +33,8 @@ export type StoreListing = {
   lastRunAt: number | null
   hasHost: boolean
   hasWeb: boolean
-  /** 已安装 web.js 的内容短哈希，与加载 URL 的 v 参数一致。 */
-  webVersion?: string
+  /** 已安装 host.js + web.js 的内容短哈希，与加载 URL 的 v 参数一致。 */
+  codeVersion?: string
   headless?: boolean
   shell?: StoreShell
 }
@@ -49,15 +49,27 @@ type StoreHub = {
 
 const ALLOWED_FILES = new Set(['manifest.json', 'host.js', 'web.js'])
 const README_FILE = 'README.md'
+/** pack 进 .plugin 的可执行代码；版本号按这两个文件一起算。 */
+const PLUGIN_CODE_FILES = ['host.js', 'web.js'] as const
 
-/** 已安装 web.js 的短版本号：内容 SHA-1 前 12 位。 */
-export function hashPluginWebVersion(body: Buffer | string): string {
-  return createHash('sha1').update(body).digest('hex').slice(0, 12)
+/** 已安装插件代码短版本：host.js 与 web.js 按文件名顺序一起 SHA-1，取前 12 位。 */
+export async function hashInstalledPluginCode(dir: string): Promise<string | undefined> {
+  const hash = createHash('sha1')
+  let any = false
+  for (const name of PLUGIN_CODE_FILES) {
+    const file = join(dir, name)
+    if (!existsSync(file)) continue
+    hash.update(name)
+    hash.update('\0')
+    hash.update(await readFile(file))
+    any = true
+  }
+  return any ? hash.digest('hex').slice(0, 12) : undefined
 }
 
 export function storeWebUrl(id: string, version?: string | number) {
   const base = `/api/plugin-store/files/${encodeURIComponent(id)}/web.js`
-  // 带上 web.js 内容短哈希，让前端的「挂载键」随每次重打包变化，
+  // 带上整包代码短哈希（host + web），让前端的「挂载键」随每次重打包变化，
   // 从而触发真正的卸载 + 重新 import；否则前端会一直用最早加载的模块实例。
   return version === undefined ? base : `${base}?v=${encodeURIComponent(String(version))}`
 }
@@ -116,16 +128,6 @@ async function pluginDirStats(dir: string): Promise<Pick<StoreListing, 'bytes' |
     updatedAt,
     hasHost: existsSync(join(dir, 'host.js')),
     hasWeb: existsSync(join(dir, 'web.js')),
-  }
-}
-
-async function readInstalledWebVersion(dir: string): Promise<string | undefined> {
-  const webFile = join(dir, 'web.js')
-  if (!existsSync(webFile)) return undefined
-  try {
-    return hashPluginWebVersion(await readFile(webFile))
-  } catch {
-    return undefined
   }
 }
 
@@ -336,7 +338,7 @@ export class PluginStoreService extends Service {
       const manifest = await readManifest(dir)
       const enabled = this.isEnabled(manifest.id)
       const stats = await pluginDirStats(dir)
-      const webVersion = await readInstalledWebVersion(dir)
+      const codeVersion = await hashInstalledPluginCode(dir)
       items.push({
         ...manifest,
         enabled,
@@ -347,7 +349,7 @@ export class PluginStoreService extends Service {
         lastRunAt: this.state.lastRunAt[manifest.id] ?? null,
         hasHost: stats.hasHost,
         hasWeb: stats.hasWeb,
-        ...(webVersion ? { webVersion } : {}),
+        ...(codeVersion ? { codeVersion } : {}),
         ...(manifest.headless ? { headless: true } : { shell: parseStoreShell(manifest.shell) }),
       })
     }
@@ -476,7 +478,7 @@ export class PluginStoreService extends Service {
     const webFile = join(dir, 'web.js')
     const hostCode = existsSync(hostFile) ? (await readFile(hostFile, 'utf8')).trim() : ''
     const hasWeb = existsSync(webFile)
-    const webVersion = await readInstalledWebVersion(dir)
+    const codeVersion = await hashInstalledPluginCode(dir)
     if (!hostCode && !hasWeb) throw new Error(`plugin ${manifest.id} has neither host nor web`)
     const mod = (hostCode
       ? await importHostFile(hostFile)
@@ -490,7 +492,7 @@ export class PluginStoreService extends Service {
       inject: mod.inject,
       togglable: true,
       enabled: true,
-      web: hasWeb ? storeWebUrl(manifest.id, webVersion) : undefined,
+      web: hasWeb ? storeWebUrl(manifest.id, codeVersion) : undefined,
       packageName: `store:${manifest.id}`,
     }
     await this.hub().adopt(entry)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把已安装插件 `web.js` 的内容短哈希登记到文件系统 `/plugins` 集合，作为只读属性 `webVersion`。

- 与挂载 URL `?v=` 共用同一套 SHA-1 前 12 位
- 无 `web.js` 或纯沙箱行不写该字段
- 列表列、schema、介绍文案已补上

测试：`collection` schema/列表断言；`store.list()` 的 `webVersion` 与 packed `web.js`、adopt 的 `web` URL 一致。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0fbf389-c7b2-4ee1-9371-5322cc63611f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

